### PR TITLE
Fix point is nil panic

### DIFF
--- a/manifests/crd/bases/workload.matrixinfer.ai_modelinfers.yaml
+++ b/manifests/crd/bases/workload.matrixinfer.ai_modelinfers.yaml
@@ -8502,9 +8502,9 @@ spec:
                               format: int32
                               type: integer
                             workerReplicas:
-                              default: 0
-                              description: WorkerReplicas defines the number for the
-                                worker pod of a role.
+                              description: |-
+                                WorkerReplicas defines the number for the worker pod of a role.
+                                Required: Need to set the number of worker-pod replicas.
                               format: int32
                               type: integer
                             workerTemplate:
@@ -16833,6 +16833,7 @@ spec:
                           required:
                           - entryTemplate
                           - name
+                          - workerReplicas
                           type: object
                         type: array
                     required:

--- a/pkg/apis/workload/v1alpha1/infergroup_types.go
+++ b/pkg/apis/workload/v1alpha1/infergroup_types.go
@@ -70,9 +70,8 @@ type Role struct {
 	EntryTemplate corev1.PodTemplateSpec `json:"entryTemplate"`
 
 	// WorkerReplicas defines the number for the worker pod of a role.
-	// +optional
-	// +kubebuilder:default=0
-	WorkerReplicas *int32 `json:"workerReplicas,omitempty"`
+	// Required: Need to set the number of worker-pod replicas.
+	WorkerReplicas int32 `json:"workerReplicas"`
 
 	// WorkerTemplate defines the template for the worker pod of a role.
 	// +optional

--- a/pkg/apis/workload/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/workload/v1alpha1/zz_generated.deepcopy.go
@@ -240,11 +240,6 @@ func (in *Role) DeepCopyInto(out *Role) {
 		(*in).DeepCopyInto(*out)
 	}
 	in.EntryTemplate.DeepCopyInto(&out.EntryTemplate)
-	if in.WorkerReplicas != nil {
-		in, out := &in.WorkerReplicas, &out.WorkerReplicas
-		*out = new(int32)
-		**out = **in
-	}
 	if in.WorkerTemplate != nil {
 		in, out := &in.WorkerTemplate, &out.WorkerTemplate
 		*out = new(v1.PodTemplateSpec)

--- a/pkg/infer-controller/controller/modelinfer_controller.go
+++ b/pkg/infer-controller/controller/modelinfer_controller.go
@@ -391,7 +391,7 @@ func (mic *ModelInferController) CreatePodByRole(ctx context.Context, role workl
 		return err
 	}
 	// Create worker pods
-	for podIndex := range int(*role.WorkerReplicas) {
+	for podIndex := range int(role.WorkerReplicas) {
 		workerPod := utils.GenerateWorkerPod(role, mi, entryPod, groupName, roleIndex, podIndex+1) // worker-pod sequence number starts from 1, so we use index+1 here.
 		_, err = mic.kubeClientSet.CoreV1().Pods(mi.Namespace).Create(ctx, workerPod, metav1.CreateOptions{})
 		if err != nil {

--- a/pkg/infer-controller/utils/utils.go
+++ b/pkg/infer-controller/utils/utils.go
@@ -106,7 +106,7 @@ func createCommonEnvVars(role workloadv1alpha1.Role, mi *workloadv1alpha1.ModelI
 	return []corev1.EnvVar{
 		{
 			Name:  workloadv1alpha1.GroupSizeEnv,
-			Value: strconv.Itoa(int(*role.WorkerReplicas) + 1),
+			Value: strconv.Itoa(int(role.WorkerReplicas) + 1),
 		},
 		{
 			Name:  workloadv1alpha1.EntryAddressEnv,


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:

If we do not set a default value for workerReplicas, when the user does not set workerReplicas, a null pointer will be passed in, causing a panic when calculating groupsize.
https://github.com/matrixinfer-ai/matrixinfer/blob/main/pkg/infer-controller/utils/utils.go#L109
![image](https://github.com/user-attachments/assets/147034e0-feef-479e-97ef-5891b4722081)



**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
