### PR TITLE
revert change to the calculation of gpu cache usage score filter

### DIFF
--- a/pkg/infer-gateway/scheduler/plugins/gpu.go
+++ b/pkg/infer-gateway/scheduler/plugins/gpu.go
@@ -25,7 +25,7 @@ func (g *GPUCacheUsage) Name() string {
 func (g *GPUCacheUsage) Score(ctx *framework.Context, pods []*datastore.PodInfo) map[*datastore.PodInfo]int {
 	scoreResults := make(map[*datastore.PodInfo]int)
 	for _, info := range pods {
-		score := int(100 - info.GPUCacheUsage)
+		score := int((1.0 - info.GPUCacheUsage) * 100)
 		scoreResults[info] = score
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Actually this PR is to revert #128 , Because I was misled by the LLM simulator of AIBrix whose value range of `gpu_cache_usage_perc` is from 0 to 100 (ref: https://github.com/vllm-project/aibrix/blob/main/development/app/app.py#L497), but according to the definition of that metric, 1 means 100 percent (ref: https://github.com/vllm-project/aibrix/blob/main/development/app/app.py#L553).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
