### PR TITLE
Pod should match the inferGroup revision instead of modelInfer revision

### DIFF
--- a/pkg/infer-controller/datastore/store.go
+++ b/pkg/infer-controller/datastore/store.go
@@ -31,6 +31,7 @@ import (
 // Store is an interface for storing and retrieving data
 type Store interface {
 	GetInferGroupByModelInfer(modelInferName types.NamespacedName) ([]InferGroup, error)
+	GetInferGroup(modelInferName types.NamespacedName, inferGroupName string) *InferGroup
 	GetRunningPodNumByInferGroup(modelInferName types.NamespacedName, inferGroupName string) (int, error)
 	GetInferGroupStatus(modelInferName types.NamespacedName, inferGroupName string) InferGroupStatus
 	DeleteModelInfer(modelInferName types.NamespacedName)
@@ -111,6 +112,18 @@ func (s *store) GetRunningPodNumByInferGroup(modelInferName types.NamespacedName
 		return 0, nil
 	}
 	return len(group.runningPods), nil
+}
+
+// GetInferGroup returns the GetInferGroup
+func (s *store) GetInferGroup(modelInferName types.NamespacedName, inferGroupName string) *InferGroup {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+	groups, ok := s.inferGroup[modelInferName]
+	if !ok {
+		return nil
+	}
+
+	return groups[inferGroupName]
 }
 
 // GetInferGroupStatus returns the status of inferGroup

--- a/pkg/infer-controller/utils/revision_util.go
+++ b/pkg/infer-controller/utils/revision_util.go
@@ -22,10 +22,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/rand"
 )
 
-// HashModelInferRevision hashes the contents of modelinfer using FNV hashing.
-func HashModelInferRevision(revision interface{}) string {
+// Revision calculates the revision of an object using FNV hashing.
+func Revision(obj interface{}) string {
 	hasher := fnv.New32()
-	DeepHashObject(hasher, revision)
+	DeepHashObject(hasher, obj)
 	return rand.SafeEncodeString(fmt.Sprint(hasher.Sum32()))
 }
 

--- a/pkg/infer-controller/utils/revision_util_test.go
+++ b/pkg/infer-controller/utils/revision_util_test.go
@@ -59,9 +59,9 @@ func TestHashModelInferRevision(t *testing.T) {
 		WorkerTemplate: nil,
 	}
 
-	hash1 := HashModelInferRevision(role1)
-	hash2 := HashModelInferRevision(role2)
-	hash3 := HashModelInferRevision(role3)
+	hash1 := Revision(role1)
+	hash2 := Revision(role2)
+	hash3 := Revision(role3)
 
 	if hash1 == hash2 {
 		t.Errorf("Hash should be different for different objects, got %s and %s", hash1, hash3)

--- a/pkg/infer-controller/utils/utils.go
+++ b/pkg/infer-controller/utils/utils.go
@@ -266,6 +266,11 @@ func CheckPodRevision(pod *corev1.Pod, revision string) bool {
 	return podRevision == revision
 }
 
+// PodRevision returns the revision label of the pod.
+func PodRevision(pod *corev1.Pod) string {
+	return pod.Labels[workloadv1alpha1.RevisionLabelKey]
+}
+
 func isPodReady(pod *corev1.Pod) bool {
 	return isPodReadyConditionTrue(pod.Status)
 }


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:

In the corner case a partition is not set to 0, it can fallinto a dead loop creating -> deleting->creating infergroup  

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
