### PR TITLE
strip token usage chunk if this not user explicitly requested

### DIFF
--- a/pkg/infer-gateway/router/router.go
+++ b/pkg/infer-gateway/router/router.go
@@ -393,10 +393,22 @@ func buildPrefillRequest(req *http.Request, modelRequest ModelRequest) (*http.Re
 	return reqCopy, nil
 }
 
+func isTokenUsageEnabled(modelRequest ModelRequest) bool {
+	// Check if token usage is enabled in the model request
+	if v, ok := modelRequest["stream_options"]; ok {
+		if streamOptions, isMap := v.(map[string]interface{}); isMap {
+			if includeUsage, isBool := streamOptions["include_usage"].(bool); isBool && includeUsage {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func buildDecodeRequest(c *gin.Context, req *http.Request, modelRequest ModelRequest) (*http.Request, error) {
 	// Check if streaming is enabled
 	if isStreaming(modelRequest) {
-		if modelRequest["stream_options"] == nil {
+		if !isTokenUsageEnabled(modelRequest) {
 			// For streaming requests, add stream_options to include token usage
 			modelRequest["stream_options"] = map[string]interface{}{
 				"include_usage": true,

--- a/pkg/infer-gateway/router/router_test.go
+++ b/pkg/infer-gateway/router/router_test.go
@@ -453,3 +453,77 @@ func TestRouter_HandlerFunc_ScheduleFailure(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 	assert.Contains(t, w.Body.String(), "can't schedule to target pod")
 }
+func TestIsTokenUsageEnabled(t *testing.T) {
+	tests := []struct {
+		name         string
+		modelRequest ModelRequest
+		expected     bool
+	}{
+		{
+			name:         "no stream_options",
+			modelRequest: ModelRequest{"model": "test"},
+			expected:     false,
+		},
+		{
+			name: "stream_options exists but no include_usage",
+			modelRequest: ModelRequest{
+				"model":          "test",
+				"stream_options": map[string]interface{}{},
+			},
+			expected: false,
+		},
+		{
+			name: "include_usage is not a boolean",
+			modelRequest: ModelRequest{
+				"model": "test",
+				"stream_options": map[string]interface{}{
+					"include_usage": "true",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "include_usage is boolean false",
+			modelRequest: ModelRequest{
+				"model": "test",
+				"stream_options": map[string]interface{}{
+					"include_usage": false,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "include_usage is boolean true",
+			modelRequest: ModelRequest{
+				"model": "test",
+				"stream_options": map[string]interface{}{
+					"include_usage": true,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "stream_options is not a map",
+			modelRequest: ModelRequest{
+				"model":          "test",
+				"stream_options": "invalid",
+			},
+			expected: false,
+		},
+		{
+			name: "stream_options is not a map",
+			modelRequest: ModelRequest{
+				"model":          "test",
+				"stream_options": nil,
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isTokenUsageEnabled(tt.modelRequest)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:

Respond according to user request, not add token usage unexpectedly

**Which issue(s) this PR fixes**:
Fixes  https://github.com/matrixinfer-ai/matrixinfer/issues/199#issuecomment-3125087670

**Special notes for your reviewer**:
```
Request:
  First, the API call must include stream: true and stream_options: { include_usage: true }.

  ---

  Stream Event 1: Content Chunks
  The stream begins by sending delta chunks containing the generated content. The usage field in these initial chunks is present but null.

   1 data: {"id":"chatcmpl-xyz","object":"chat.completion.chunk","created":1700000000,"model":"gpt-4","choices":[{"index":0,"delta":{"role":"assistant","content":"Large "},"finish_reason":null}],
     "usage":null}

   1 data: {"id":"chatcmpl-xyz","object":"chat.completion.chunk","created":1700000000,"model":"gpt-4","choices":[{"index":0,"delta":{"content":"Language "},"finish_reason":null}],"usage":null}

   1 data: {"id":"chatcmpl-xyz","object":"chat.completion.chunk","created":1700000000,"model":"gpt-4","choices":[{"index":0,"delta":{"content":"Models..."},"finish_reason":null}],"usage":null}

  ---

  Stream Event 2: Final Content Chunk
  This chunk signals that the model has finished generating tokens. Its delta is empty, and it provides the finish_reason.

   1 data: {"id":"chatcmpl-xyz","object":"chat.completion.chunk","created":1700000000,"model":"gpt-4","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":null}

  ---

  Stream Event 3: The Usage Chunk
  This is the crucial event. It is sent after all content is delivered. You can identify it because the `choices` array is empty and the `usage` object is populated.

   1 data: {"id":"chatcmpl-xyz","object":"chat.completion.chunk","created":1700000000,"model":"gpt-4","choices":[],"usage":{"prompt_tokens":10,"completion_tokens":45,"total_tokens":55}}

  ---

  Stream Event 4: The Termination Message
  Finally, the stream is closed with the [DONE] message. No more data will be sent.

   1 data: [DONE]
```