### PR TITLE
Reorganize model server creation flow

### DIFF
--- a/pkg/model-controller/controller/model_controller.go
+++ b/pkg/model-controller/controller/model_controller.go
@@ -182,6 +182,14 @@ func (mc *ModelController) reconcile(ctx context.Context, namespaceAndName strin
 					return err
 				}
 			}
+			if err := mc.createModelServer(ctx, model); err != nil {
+				updateError := mc.setModelServerFailedCondition(ctx, model)
+				if updateError != nil {
+					return updateError
+				}
+				return err
+			}
+			// todo: create model route
 			meta.SetStatusCondition(&model.Status.Conditions, newCondition(string(registryv1alpha1.ModelStatusConditionTypeInitializing),
 				metav1.ConditionTrue, ModelInitsReason, "Model is initializing"))
 			if err := mc.updateModelStatus(ctx, model); err != nil {
@@ -189,14 +197,6 @@ func (mc *ModelController) reconcile(ctx context.Context, namespaceAndName strin
 				return err
 			}
 		}
-		if err := mc.createModelServer(ctx, model); err != nil {
-			updateError := mc.setModelServerFailedCondition(ctx, model)
-			if updateError != nil {
-				return updateError
-			}
-			return err
-		}
-		// todo: create model route
 	}
 	if model.Generation != model.Status.ObservedGeneration {
 		klog.V(4).Info("model generation is not equal to observed generation, update model infer, model server and model route")


### PR DESCRIPTION

**What type of PR is this?**
/kind enhancement

**What this PR does / why we need it**:
Before: model server and model route will be created after model infer is available.
After: model server and model route will be created with model infer at the same time.

- Update log verbosity levels and add a TODO comment for model route creation
- Move model server creation logic to be grouped with other creation operations 

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
None
```
