### PR TITLE
Fix helm args bug

### DIFF
--- a/charts/matrixinfer/charts/registry/templates/autoscaler/component/deployment.yaml
+++ b/charts/matrixinfer/charts/registry/templates/autoscaler/component/deployment.yaml
@@ -21,7 +21,8 @@ spec:
       containers:
         - name: autoscaler
           image: "{{ .Values.autoscaler.image.repository }}:{{ .Values.autoscaler.image.tag }}"
-          args: {{ .Values.autoscaler.image.args }}
+          args:
+            {{- toYaml .Values.autoscaler.image.args | nindent 12 }}
           imagePullPolicy: {{ .Values.autoscaler.image.pullPolicy }}
           resources:
             {{- toYaml .Values.autoscaler.resource | nindent 12 }}

--- a/charts/matrixinfer/charts/registry/templates/model-controller/component/deployment.yaml
+++ b/charts/matrixinfer/charts/registry/templates/model-controller/component/deployment.yaml
@@ -21,7 +21,8 @@ spec:
       containers:
         - name: model-controller
           image: "{{ .Values.modelController.image.repository }}:{{ .Values.modelController.image.tag }}"
-          args: {{ .Values.modelController.image.args }}
+          args:
+            {{- toYaml .Values.modelController.image.args | nindent 12 }}
           imagePullPolicy: {{ .Values.modelController.image.pullPolicy }}
           resources:
             {{- toYaml .Values.modelController.resource | nindent 12 }}

--- a/charts/matrixinfer/charts/workload/templates/infer-controller/component/deployment.yaml
+++ b/charts/matrixinfer/charts/workload/templates/infer-controller/component/deployment.yaml
@@ -22,6 +22,7 @@ spec:
         - name: infer-controller
           image: "{{ .Values.inferController.image.repository }}:{{ .Values.inferController.image.tag }}"
           imagePullPolicy: {{ .Values.inferController.image.pullPolicy }}
-          args: {{ .Values.inferController.image.args }}
+          args:
+            {{- toYaml .Values.inferController.image.args | nindent 12 }}
           resources: {{- toYaml .Values.inferController.resource | nindent 12 }}
       serviceAccountName: {{ include "matrixinfer.name" . }}-infer-controller


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Args are an array. If there are multiple args, the result will be `--arg1=x --arg2=y`. And it's wrong. The expected result should be 
`--arg1=x`
`--arg2=y`

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```
