### PR TITLE
Add observedGeneration in modelinfer status

### DIFF
--- a/charts/matrixinfer/charts/workload/crds/workload.matrixinfer.ai_modelinfers.yaml
+++ b/charts/matrixinfer/charts/workload/crds/workload.matrixinfer.ai_modelinfers.yaml
@@ -16840,6 +16840,12 @@ spec:
                   the ModelInfer controller from the ModelInfer version
                 format: int32
                 type: integer
+              observedGeneration:
+                description: |-
+                  observedGeneration is the most recent generation observed for ModelInfer. It corresponds to the
+                  ModelInfer's generation, which is updated on mutation by the API Server.
+                format: int64
+                type: integer
               replicas:
                 description: Replicas track the total number of InferGroup that have
                   been created (updated or not, ready or not)

--- a/client-go/applyconfiguration/workload/v1alpha1/modelinferstatus.go
+++ b/client-go/applyconfiguration/workload/v1alpha1/modelinferstatus.go
@@ -25,17 +25,26 @@ import (
 // ModelInferStatusApplyConfiguration represents a declarative configuration of the ModelInferStatus type for use
 // with apply.
 type ModelInferStatusApplyConfiguration struct {
-	Replicas          *int32                           `json:"replicas,omitempty"`
-	CurrentReplicas   *int32                           `json:"currentReplicas,omitempty"`
-	UpdatedReplicas   *int32                           `json:"updatedReplicas,omitempty"`
-	AvailableReplicas *int32                           `json:"availableReplicas,omitempty"`
-	Conditions        []v1.ConditionApplyConfiguration `json:"conditions,omitempty"`
+	ObservedGeneration *int64                           `json:"observedGeneration,omitempty"`
+	Replicas           *int32                           `json:"replicas,omitempty"`
+	CurrentReplicas    *int32                           `json:"currentReplicas,omitempty"`
+	UpdatedReplicas    *int32                           `json:"updatedReplicas,omitempty"`
+	AvailableReplicas  *int32                           `json:"availableReplicas,omitempty"`
+	Conditions         []v1.ConditionApplyConfiguration `json:"conditions,omitempty"`
 }
 
 // ModelInferStatusApplyConfiguration constructs a declarative configuration of the ModelInferStatus type for use with
 // apply.
 func ModelInferStatus() *ModelInferStatusApplyConfiguration {
 	return &ModelInferStatusApplyConfiguration{}
+}
+
+// WithObservedGeneration sets the ObservedGeneration field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the ObservedGeneration field is set to the value of the last call.
+func (b *ModelInferStatusApplyConfiguration) WithObservedGeneration(value int64) *ModelInferStatusApplyConfiguration {
+	b.ObservedGeneration = &value
+	return b
 }
 
 // WithReplicas sets the Replicas field in the declarative configuration to the given value

--- a/docs/matrixinfer/docs/crd/workload.matrixinfer.ai.md
+++ b/docs/matrixinfer/docs/crd/workload.matrixinfer.ai.md
@@ -143,6 +143,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
+| `observedGeneration` _integer_ | observedGeneration is the most recent generation observed for ModelInfer. It corresponds to the<br />ModelInfer's generation, which is updated on mutation by the API Server. |  |  |
 | `replicas` _integer_ | Replicas track the total number of InferGroup that have been created (updated or not, ready or not) |  |  |
 | `currentReplicas` _integer_ | CurrentReplicas is the number of InferGroup created by the ModelInfer controller from the ModelInfer version |  |  |
 | `updatedReplicas` _integer_ | UpdatedReplicas track the number of InferGroup that have been updated (ready or not). |  |  |

--- a/pkg/apis/workload/v1alpha1/modelinfer_types.go
+++ b/pkg/apis/workload/v1alpha1/modelinfer_types.go
@@ -178,6 +178,11 @@ const (
 
 // ModelInferStatus defines the observed state of ModelInfer
 type ModelInferStatus struct {
+	// observedGeneration is the most recent generation observed for ModelInfer. It corresponds to the
+	// ModelInfer's generation, which is updated on mutation by the API Server.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+
 	// Replicas track the total number of InferGroup that have been created (updated or not, ready or not)
 	Replicas int32 `json:"replicas,omitempty"`
 

--- a/pkg/infer-controller/controller/modelinfer_controller.go
+++ b/pkg/infer-controller/controller/modelinfer_controller.go
@@ -480,6 +480,11 @@ func (c *ModelInferController) UpdateModelInferStatus(mi *workloadv1alpha1.Model
 		}
 	}
 
+	if copy.Status.ObservedGeneration != mi.Generation {
+		shouldUpdate = true
+		copy.Status.ObservedGeneration = mi.Generation
+	}
+
 	if shouldUpdate {
 		_, err := c.modelInferClient.WorkloadV1alpha1().ModelInfers(copy.GetNamespace()).UpdateStatus(context.TODO(), copy, metav1.UpdateOptions{})
 		if err != nil {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:

Add observedGeneration field when reporting modelinfer status to track the controller's processing of modelinfer

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
