### PR TITLE
Fix a bug that cause model can't create model infer

### DIFF
--- a/pkg/model-controller/convert/templates/vllm-pd.yaml
+++ b/pkg/model-controller/convert/templates/vllm-pd.yaml
@@ -2,7 +2,7 @@ apiVersion: workload.matrixinfer.ai/v1alpha1
 kind: modelinfer
 metadata: ${MODEL_INFER_TEMPLATE_METADATA}
 spec:
-  recoveryPolicy: InferGroupRestart
+  recoveryPolicy: InferGroupRecreate
   rolloutStrategy:
     rollingUpdate:
       maxSurge: 25%

--- a/pkg/model-controller/convert/templates/vllm.yaml
+++ b/pkg/model-controller/convert/templates/vllm.yaml
@@ -2,7 +2,7 @@ apiVersion: workload.matrixinfer.ai/v1alpha1
 kind: modelinfer
 metadata: ${MODEL_INFER_TEMPLATE_METADATA}
 spec:
-  recoveryPolicy: InferGroupRestart
+  recoveryPolicy: InferGroupRecreate
   rolloutStrategy:
     rollingUpdate:
       maxSurge: 25%


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
`recoveryPolicy` is hardcoded in the model controller. #243 changed the value of it from `InferGroupRestart` to `InferGroupRecreate`. 

`recoveryPolicy` is an enum validated by K8s, `+kubebuilder:validation:Enum={InferGroupRecreate,RoleRecreate,None}`, so the unit testcase can not cover it. I think we'd better have e2e test to cover it.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```
