### PR TITLE
Fix missing scheme for nixl connector

### DIFF
--- a/pkg/infer-gateway/connectors/nixl.go
+++ b/pkg/infer-gateway/connectors/nixl.go
@@ -69,7 +69,8 @@ func (n *NIXLConnector) Proxy(c *gin.Context, reqBody map[string]interface{}, pr
 // executePrefillRequest builds and executes the prefill request, returns kv_transfer_params
 func (n *NIXLConnector) executePrefillRequest(req *http.Request, prefillAddr string) (interface{}, error) {
 	req.URL.Host = prefillAddr
-	klog.V(4).Infof("NIXL prefill: sending to %s", prefillAddr)
+	req.URL.Scheme = "http"
+	klog.V(4).Infof("NIXL prefill: sending to %s", req.URL.String())
 
 	// Send prefill request
 	resp, err := http.DefaultTransport.RoundTrip(req)
@@ -118,8 +119,9 @@ func (n *NIXLConnector) buildDecodeRequest(c *gin.Context, reqBody map[string]in
 func (n *NIXLConnector) executeDecodeRequest(c *gin.Context, req *http.Request, decodeAddr string) (int, error) {
 	// Set kv_transfer_params from prefill response
 	req.URL.Host = decodeAddr
+	req.URL.Scheme = "http"
 
-	klog.V(4).Infof("NIXL decode: sending to %s", decodeAddr)
+	klog.V(4).Infof("NIXL decode: sending to %s", req.URL.String())
 
 	// Use decoderProxy to handle the decode response with proper streaming
 	return decoderProxy(c, req)
@@ -149,6 +151,7 @@ func (n *NIXLConnector) buildPrefillRequest(req *http.Request, reqBody map[strin
 	}
 
 	prefillReq := req.Clone(req.Context())
+	prefillReq.URL.Scheme = "http"
 	prefillReq.Body = io.NopCloser(bytes.NewBuffer(body))
 	prefillReq.ContentLength = int64(len(body))
 


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:

https://github.com/gin-gonic/gin/issues/1233

This is because gin ctx.Request,URL.Scheme is empty

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
