### PR TITLE
Remove network topology settings from model 

### DIFF
--- a/pkg/model-controller/convert/templates/vllm.yaml
+++ b/pkg/model-controller/convert/templates/vllm.yaml
@@ -26,9 +26,6 @@ spec:
     roles:
       - name: leader
         replicas: ${SERVER_REPLICAS}
-        networkTopology:
-          mode: hard
-          highestTierAllowed: 2
         entryTemplate:
           metadata: ${SERVER_ENTRY_TEMPLATE_METADATA}
           spec:

--- a/pkg/model-controller/convert/testdata/expected/model-infer.yaml
+++ b/pkg/model-controller/convert/testdata/expected/model-infer.yaml
@@ -223,9 +223,6 @@ spec:
                   type: DirectoryOrCreate
                 name: backend1-weights
         name: leader
-        networkTopology:
-          highestTierAllowed: 2
-          mode: hard
         replicas: 0
         workerReplicas: 1
         workerTemplate:


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
#284 deleted `networkTopology` in role. So the Model should also delete it.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
