### PR TITLE
[FixBug] Runtime support vLLMDisaggregated

### DIFF
--- a/python/matrixinfer/runtime/standard.py
+++ b/python/matrixinfer/runtime/standard.py
@@ -22,7 +22,7 @@ from matrixinfer.runtime.metric import MetricOperator, RenameMetric
 class EngineType(Enum):
     VLLM = "vllm"
     SGLANG = "sglang"
-    vLLMDisaggregated = "vllmdisaggregated"
+    VLLM_DISAGGREGATED = "vllmdisaggregated"
 
 
 class StandardMetricNames:
@@ -90,7 +90,7 @@ class MetricStandard:
     def _get_real_engine_type(self) -> EngineType:
         if self.engine.lower() in {
             EngineType.VLLM.value,
-            EngineType.vLLMDisaggregated.value,
+            EngineType.VLLM_DISAGGREGATED.value,
         }:
             return EngineType.VLLM
         if self.engine.lower() == EngineType.SGLANG.value:


### PR DESCRIPTION
**What type of PR is this?**

 <!--
 Add one of the following kinds:

 /kind bug
 /kind cleanup
 /kind enhancement
 /kind security
 /kind documentation

 -->

/kind enhancement

**What this PR does / why we need it**: 
This PR enhances the runtime module to support the vLLMDisaggregated engine type. It adds proper handling for the disaggregated vLLM engine by introducing a mechanism to map it to the existing VLLM processing rules.

**Which issue(s) this PR fixes**: 
Fixes #

**Special notes for your reviewer**: 
- Added a new `vLLMDisaggregated` enum value to `EngineType`
- Implemented a `_get_real_engine_type` method to map engine types to their actual processing logic
- Modified the `__init__` method to use the new mapping mechanism
- vLLMDisaggregated is now processed using the same rules as VLLM

**Does this PR introduce a user-facing change?**: 
<!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required.
-->
```release-note
Added support for vLLMDisaggregated engine type in the runtime module.
```
        