### PR TITLE
Add PD disaggregation example configuration and documentation

### DIFF
--- a/docs/matrixinfer/docs/user-guide/prefill-decode-disaggregation.md
+++ b/docs/matrixinfer/docs/user-guide/prefill-decode-disaggregation.md
@@ -1,10 +1,26 @@
-# Prefill-Decode Disaggregation
+import QuickStartYaml from '../../../../examples/model/pd-disaggregation.yaml?raw';
+import CodeBlock from '@theme/CodeBlock';
 
-This page describes the PD (Placement Driver) separation feature in MatrixInfer.
+# Prefill-Decode Disaggregation
 
 ## Overview
 
-<!-- Add overview here -->
+Matrixinfer support vLLM PD disaggregation feature, which allows users to offload the prefill and decode stages of a
+model inference to different sets of GPUs. This can help optimize resource utilization and improve performance for
+large-scale inference workloads. For more details, please refer to the vLLM
+documentation:  [Disaggregated Prefill](https://docs.vllm.ai/en/stable/features/disagg_prefill.html)
+
+## Quick Start
+
+An example configuration for prefill-decode disaggregation is as follows:
+
+<CodeBlock language="yaml">
+{QuickStartYaml}
+</CodeBlock>
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/matrixinfer-ai/matrixinfer/refs/heads/main/examples/model/pd-disaggregation.yaml
+```
 
 ## Architecture
 

--- a/examples/model/pd-disaggregation.yaml
+++ b/examples/model/pd-disaggregation.yaml
@@ -1,0 +1,102 @@
+apiVersion: registry.matrixinfer.ai/v1
+kind: Model
+metadata:
+  name: ds-v3-671b-pd
+  namespace: demo
+spec:
+  name: ds-pd-test
+  owner: example
+  backends:
+    - cacheURI: hostpath:///tmp/cache/
+      env:
+        - name: HF_ENDPOINT
+          value: https://hf-mirror.com/
+      maxReplicas: 1
+      minReplicas: 1
+      modelURI: hf://deepseek-ai/DeepSeek-V2-Lite
+      name: ds-pd-test
+      routeWeight: 100
+      type: vLLMDisaggregated
+      workers:
+        - config:
+            enforce-eager: ""
+            gpu-memory-utilization: 0.8
+            kv-transfer-config: |
+              {"kv_connector": "MooncakeConnectorV1",
+                "kv_buffer_device": "npu",
+                "kv_role": "kv_producer",
+                "kv_parallel_size": 1,
+                "kv_port": "20001",
+                "engine_id": "0",
+                "kv_rank": 0,
+                "kv_connector_module_path": "vllm_ascend.distributed.mooncake_connector",
+                "kv_connector_extra_config": {
+                  "prefill": {
+                    "dp_size": 2,
+                    "tp_size": 2
+                  },
+                  "decode": {
+                    "dp_size": 2,
+                    "tp_size": 2
+                  }
+                }
+              }
+            max-model-len: 2000
+            max-num-batched-tokens: 2000
+            served-model-name: deepseek-ai/DeepSeekV2
+            tensor-parallel-size: 2
+            trust-remote-code: ""
+          image: vllm-ascend_v0.10.1rc1_mooncake_v0.3.5 # todo: we need build this
+          pods: 1
+          replicas: 1
+          resources:
+            limits:
+              cpu: "8"
+              huawei.com/ascend-1980: "4"
+              memory: 64Gi
+            requests:
+              cpu: "8"
+              huawei.com/ascend-1980: "4"
+              memory: 64Gi
+          type: prefill
+        - config:
+            enforce-eager: ""
+            gpu-memory-utilization: 0.8
+            kv-transfer-config: |
+              {"kv_connector": "MooncakeConnectorV1",
+                "kv_buffer_device": "npu",
+                "kv_role": "kv_consumer",
+                "kv_parallel_size": 1,
+                "kv_port": "20002",
+                "engine_id": "1",
+                "kv_rank": 1,
+                "kv_connector_module_path": "vllm_ascend.distributed.mooncake_connector",
+                "kv_connector_extra_config": {
+                  "prefill": {
+                    "dp_size": 2,
+                    "tp_size": 2
+                  },
+                  "decode": {
+                    "dp_size": 2,
+                    "tp_size": 2
+                  }
+                }
+              }
+            max-model-len: 2000
+            max-num-batched-tokens: 2000
+            served-model-name: deepseek-ai/DeepSeekV2
+            tensor-parallel-size: 2
+            trust-remote-code: ""
+          image: vllm-ascend_v0.10.1rc1_mooncake_v0.3.5 # todo: we need build this
+          pods: 1
+          replicas: 1
+          resources:
+            limits:
+              cpu: "8"
+              huawei.com/ascend-1980: "4"
+              memory: 64Gi
+            requests:
+              cpu: "8"
+              huawei.com/ascend-1980: "4"
+              memory: 64Gi
+          type: decode


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
This pull request adds comprehensive documentation and an example configuration for enabling prefill-decode disaggregation in MatrixInfer, which allows users to offload the prefill and decode stages of model inference to different sets of GPUs. This improves resource utilization and performance for large-scale inference workloads.

**Documentation improvements:**

* Expanded the user guide at `docs/matrixinfer/docs/user-guide/prefill-decode-disaggregation.md` to explain the prefill-decode disaggregation feature, provide an overview, and include a quick start section with an embedded YAML configuration example and usage instructions.

**Example configuration:**

* Added a new example model configuration file `examples/model/pd-disaggregation.yaml` that demonstrates how to set up a vLLMDisaggregated backend with separate worker groups for prefill and decode, including resource allocation and connector settings for distributed inference.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
