### PR TITLE
add schedulerName config for modelBooster

### DIFF
--- a/charts/kthena/charts/workload/crds/workload.serving.volcano.sh_modelboosters.yaml
+++ b/charts/kthena/charts/workload/crds/workload.serving.volcano.sh_modelboosters.yaml
@@ -632,6 +632,10 @@ spec:
                       format: int32
                       minimum: 0
                       type: integer
+                    schedulerName:
+                      description: SchedulerName defines the name of the scheduler
+                        used by ModelServing for this backend.
+                      type: string
                     type:
                       description: Type is the type of the backend.
                       enum:

--- a/charts/kthena/charts/workload/templates/kthena-controller-manager/rbac/cluster-role.yaml
+++ b/charts/kthena/charts/workload/templates/kthena-controller-manager/rbac/cluster-role.yaml
@@ -115,6 +115,7 @@ rules:
     resources:
       - podgroups
     verbs:
+      - create
       - get
       - list
       - watch

--- a/client-go/applyconfiguration/workload/v1alpha1/modelbackend.go
+++ b/client-go/applyconfiguration/workload/v1alpha1/modelbackend.go
@@ -41,6 +41,7 @@ type ModelBackendApplyConfiguration struct {
 	Workers                []ModelWorkerApplyConfiguration          `json:"workers,omitempty"`
 	LoraAdapters           []LoraAdapterApplyConfiguration          `json:"loraAdapters,omitempty"`
 	AutoscalingPolicy      *AutoscalingPolicySpecApplyConfiguration `json:"autoscalingPolicy,omitempty"`
+	SchedulerName          *string                                  `json:"schedulerName,omitempty"`
 }
 
 // ModelBackendApplyConfiguration constructs a declarative configuration of the ModelBackend type for use with
@@ -172,5 +173,13 @@ func (b *ModelBackendApplyConfiguration) WithLoraAdapters(values ...*LoraAdapter
 // If called multiple times, the AutoscalingPolicy field is set to the value of the last call.
 func (b *ModelBackendApplyConfiguration) WithAutoscalingPolicy(value *AutoscalingPolicySpecApplyConfiguration) *ModelBackendApplyConfiguration {
 	b.AutoscalingPolicy = value
+	return b
+}
+
+// WithSchedulerName sets the SchedulerName field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the SchedulerName field is set to the value of the last call.
+func (b *ModelBackendApplyConfiguration) WithSchedulerName(value string) *ModelBackendApplyConfiguration {
+	b.SchedulerName = &value
 	return b
 }

--- a/docs/kthena/docs/reference/crd/workload.serving.volcano.sh.md
+++ b/docs/kthena/docs/reference/crd/workload.serving.volcano.sh.md
@@ -354,6 +354,7 @@ _Appears in:_
 | `workers` _[ModelWorker](#modelworker) array_ | Workers is the list of workers associated with this backend. |  | MaxItems: 1000 <br />MinItems: 1 <br /> |
 | `loraAdapters` _[LoraAdapter](#loraadapter) array_ | LoraAdapter is a list of LoRA adapters. |  |  |
 | `autoscalingPolicy` _[AutoscalingPolicySpec](#autoscalingpolicyspec)_ | AutoscalingPolicyRef references the autoscaling policy for this backend. |  |  |
+| `schedulerName` _string_ | SchedulerName defines the name of the scheduler used by ModelServing for this backend. |  |  |
 
 
 #### ModelBackendStatus

--- a/pkg/apis/workload/v1alpha1/model_booster_types.go
+++ b/pkg/apis/workload/v1alpha1/model_booster_types.go
@@ -124,6 +124,9 @@ type ModelBackend struct {
 	// AutoscalingPolicyRef references the autoscaling policy for this backend.
 	// +optional
 	AutoscalingPolicy *AutoscalingPolicySpec `json:"autoscalingPolicy,omitempty"`
+	// SchedulerName defines the name of the scheduler used by ModelServing for this backend.
+	// +optional
+	SchedulerName string `json:"schedulerName,omitempty"`
 }
 
 // LoraAdapter defines a LoRA (Low-Rank Adaptation) adapter configuration.

--- a/pkg/model-booster-controller/convert/model_serving.go
+++ b/pkg/model-booster-controller/convert/model_serving.go
@@ -199,6 +199,7 @@ func buildVllmDisaggregatedModelServing(model *workload.ModelBooster, idx int) (
 		"ENGINE_DECODE_IMAGE":                workersMap[workload.ModelWorkerTypeDecode].Image,
 		"ENGINE_PREFILL_RESOURCES":           workersMap[workload.ModelWorkerTypePrefill].Resources,
 		"ENGINE_PREFILL_IMAGE":               workersMap[workload.ModelWorkerTypePrefill].Image,
+		"SCHEDULER_NAME":                     backend.SchedulerName,
 	}
 	return loadModelServingTemplate(VllmDisaggregatedTemplatePath, &data)
 }
@@ -303,6 +304,7 @@ func buildVllmModelServing(model *workload.ModelBooster, idx int) (*workload.Mod
 		"ENGINE_SERVER_IMAGE":                workersMap[workload.ModelWorkerTypeServer].Image,
 		"ENGINE_SERVER_COMMAND":              commands,
 		"WORKER_REPLICAS":                    workersMap[workload.ModelWorkerTypeServer].Pods - 1,
+		"SCHEDULER_NAME":                     backend.SchedulerName,
 	}
 	return loadModelServingTemplate(VllmTemplatePath, &data)
 }

--- a/pkg/model-booster-controller/convert/templates/vllm-pd.yaml
+++ b/pkg/model-booster-controller/convert/templates/vllm-pd.yaml
@@ -2,10 +2,14 @@ apiVersion: workload.serving.volcano.sh/v1alpha1
 kind: ModelServing
 metadata: ${MODEL_SERVING_TEMPLATE_METADATA}
 spec:
-  schedulerName: volcano
+  schedulerName: ${SCHEDULER_NAME}
   replicas: ${BACKEND_REPLICAS}
   template:
     restartGracePeriodSeconds: 60
+    gangPolicy:
+      minRoleReplicas:
+        prefill: ${PREFILL_REPLICAS}
+        decode: ${DECODE_REPLICAS}
     roles:
       - name: prefill
         replicas: ${PREFILL_REPLICAS}

--- a/pkg/model-booster-controller/convert/templates/vllm.yaml
+++ b/pkg/model-booster-controller/convert/templates/vllm.yaml
@@ -2,6 +2,7 @@ apiVersion: workload.serving.volcano.sh/v1alpha1
 kind: ModelServing
 metadata: ${MODEL_SERVING_TEMPLATE_METADATA}
 spec:
+  schedulerName: ${SCHEDULER_NAME}
   topologySpreadConstraints:
     - maxSkew: 1
       topologyKey: kubernetes.io/hostname
@@ -12,6 +13,9 @@ spec:
   replicas: ${BACKEND_REPLICAS}
   template:
     restartGracePeriodSeconds: 60
+    gangPolicy:
+      minRoleReplicas:
+        leader: ${SERVER_REPLICAS}
     roles:
       - name: leader
         replicas: ${SERVER_REPLICAS}

--- a/pkg/model-booster-controller/convert/testdata/expected/disaggregated-model-serving.yaml
+++ b/pkg/model-booster-controller/convert/testdata/expected/disaggregated-model-serving.yaml
@@ -6,7 +6,7 @@ metadata:
     workload.serving.volcano.sh/managed-by: workload.serving.volcano.sh
     workload.serving.volcano.sh/model-name: ds-r1-qwen-7b-pd
     workload.serving.volcano.sh/model-uid: randomUID
-    workload.serving.volcano.sh/revision: 67cc57ffd4
+    workload.serving.volcano.sh/revision: 666d87766
   name: ds-r1-qwen-7b-pd-ds-r1-qwen-7b-pd
   namespace: demo
   ownerReferences:
@@ -16,9 +16,13 @@ metadata:
       uid: randomUID
 spec:
   replicas: 1
-  schedulerName: volcano
+  schedulerName: "volcano"
   template:
     restartGracePeriodSeconds: 60
+    gangPolicy:
+      minRoleReplicas:
+        prefill: 1
+        decode: 1
     roles:
       - entryTemplate:
           spec:

--- a/pkg/model-booster-controller/convert/testdata/expected/model-serving.yaml
+++ b/pkg/model-booster-controller/convert/testdata/expected/model-serving.yaml
@@ -6,7 +6,7 @@ metadata:
     workload.serving.volcano.sh/managed-by: workload.serving.volcano.sh
     workload.serving.volcano.sh/model-name: test-model
     workload.serving.volcano.sh/model-uid: randomUID
-    workload.serving.volcano.sh/revision: 69978bb886
+    workload.serving.volcano.sh/revision: 75dd7c596d
   name: test-model-backend1
   namespace: default
   ownerReferences:
@@ -19,6 +19,9 @@ spec:
   schedulerName: ""
   template:
     restartGracePeriodSeconds: 60
+    gangPolicy:
+      minRoleReplicas:
+        leader: 0
     roles:
       - entryTemplate:
           metadata:
@@ -27,7 +30,7 @@ spec:
               workload.serving.volcano.sh/managed-by: workload.serving.volcano.sh
               workload.serving.volcano.sh/model-name: test-model
               workload.serving.volcano.sh/model-uid: randomUID
-              workload.serving.volcano.sh/revision: 69978bb886
+              workload.serving.volcano.sh/revision: 75dd7c596d
           spec:
             containers:
               - args:

--- a/pkg/model-booster-controller/convert/testdata/input/pd-disaggregated-model.yaml
+++ b/pkg/model-booster-controller/convert/testdata/input/pd-disaggregated-model.yaml
@@ -12,6 +12,7 @@ spec:
       type: "vLLMDisaggregated"
       modelURI: s3://aios_models/deepseek-ai/DeepSeek-R1-Distill-Qwen-7B
       cacheURI: hostpath:///cache
+      schedulerName: volcano
       maxReplicas: 2
       minReplicas: 1
       env:

--- a/pkg/model-serving-controller/utils/utils.go
+++ b/pkg/model-serving-controller/utils/utils.go
@@ -99,6 +99,7 @@ func GenerateEntryPod(role workloadv1alpha1.Role, mi *workloadv1alpha1.ModelServ
 	entryPod.ObjectMeta.Labels[workloadv1alpha1.EntryLabelKey] = Entry
 	addPodLabelAndAnnotation(entryPod, role.EntryTemplate.Metadata)
 	entryPod.Spec = role.EntryTemplate.Spec
+	entryPod.Spec.SchedulerName = mi.Spec.SchedulerName
 	// Build environment variables into each container of all pod
 	envVars := createCommonEnvVars(role, entryPod, 0)
 	addPodEnvVars(entryPod, envVars...)
@@ -110,6 +111,7 @@ func GenerateWorkerPod(role workloadv1alpha1.Role, mi *workloadv1alpha1.ModelSer
 	workerPod := createBasePod(role, mi, workerPodName, groupName, revision, roleIndex)
 	addPodLabelAndAnnotation(workerPod, role.WorkerTemplate.Metadata)
 	workerPod.Spec = role.WorkerTemplate.Spec
+	entryPod.Spec.SchedulerName = mi.Spec.SchedulerName
 	// Build environment variables into each container of all pod
 	envVars := createCommonEnvVars(role, entryPod, podIndex)
 	addPodEnvVars(workerPod, envVars...)


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Currently when submitting ModelBooster, we can not set schedulerName, so we can not use the gang policy by scheduler like volcano. This PR does:
1. add schedulerName to ModelBooster CRD
2. update ModelBooster/ModelServing templates to include schedulerName
3. update ModelServing controller to really set the passed-in schedulerName

<img width="942" height="692" alt="image" src="https://github.com/user-attachments/assets/4f9267ce-7b58-479b-86d0-82fb05b171bf" />
<img width="1080" height="524" alt="image" src="https://github.com/user-attachments/assets/09964fe9-5da7-4b50-ba6d-2670ce6fbf65" />
<img width="1292" height="1344" alt="image" src="https://github.com/user-attachments/assets/c71c502d-cf6f-47d7-9574-dca084c0a753" />
<img width="1004" height="1362" alt="image" src="https://github.com/user-attachments/assets/abeaff43-eb76-43fd-834b-1ec1461faeec" />

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Yes, users may set schedulerName in ModelBooster. If not set, it will use the default scheduler
```
