### PR TITLE
Add Dockerfile for mooncake-npu-a3

### DIFF
--- a/docker/Dockerfile.mooncake-npu-a3
+++ b/docker/Dockerfile.mooncake-npu-a3
@@ -1,0 +1,27 @@
+FROM quay.io/ascend/vllm-ascend:v0.10.1rc1-a3 as builder
+
+ARG MOONCAKE_REPO=https://github.com/kvcache-ai/Mooncake.git
+ARG MOONCAKE_TAG=0.3.5
+ARG TARGETARCH
+
+WORKDIR /build
+
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/Ascend/ascend-toolkit/latest/${TARGETARCH}-linux/include/hccl/:/usr/local/Ascend/ascend-toolkit/latest/${TARGETARCH}-linux/devlib/
+RUN git config --global http.sslVerify false && \
+    git clone --depth 1 $MOONCAKE_REPO --branch v${MOONCAKE_TAG} && \
+    sed -i 's/cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5 ../cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DUSE_ASCEND=ON ../' ./Mooncake/scripts/ascend/dependencies_ascend.sh && \
+    sed -i 's/add_subdirectory(tests)/# add_subdirectory(tests)/' ./Mooncake/mooncake-store/CMakeLists.txt && \
+    find /usr/local/Ascend/ascend-toolkit/ -name "libascend_protobuf.a" -print0 | xargs -0 -I {} mv -- {} {}.backup && \
+    bash ./Mooncake/scripts/ascend/dependencies_ascend.sh
+
+WORKDIR /app
+
+ENV LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages:$LD_LIBRARY_PATH
+RUN echo '#!/bin/bash' > entrypoint.sh && \
+    echo '[ -z "$AscendRealDevices" ] && echo "WARNING: AscendRealDevices NOT SET" >&2 && exit 1' >> entrypoint.sh && \
+    echo 'export PHYSICAL_DEVICES=$(echo "$AscendRealDevices" | tr '\'', '\'' '\''\n'\'' | awk -F'\''-'\'' '\''{print $2}'\'' | sort -n | tr '\''\n'\'' '\'', '\'' | sed '\''s/,$//'\'')' >> entrypoint.sh && \
+    echo 'exec vllm serve "$@"' >> entrypoint.sh && \
+    chmod +x entrypoint.sh
+
+ENTRYPOINT ["/bin/bash", "/app/entrypoint.sh"]
+


### PR DESCRIPTION
**What type of PR is this?**

<!--
/kind enhancement
-->

**What this PR does / why we need it**
Add Dockerfile of NPU-A3+Mooncake+vLLM-Ascend-v0.10.1rc1

**Which issue(s) this PR fixes**:
Fixes #401 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
NOTE: When the current Mooncake Connector runs on an NPU, it is necessary to specify the actual node-level number of the NPU via the environment variable PHYSICAL_DEVICES (https://github.com/vllm-project/vllm-ascend/blob/v0.10.1rc1/vllm_ascend/distributed/mooncake_connector.py#L767).
In a Kubernetes (K8S) scenario, the NPU assigned to each Pod is usually dynamic, so this environment variable also needs to be obtained dynamically. However, running the npu-smi command inside a container often fails to retrieve the device ID properly due to permission issues.
Therefore, this PR leverages the feature of HuaweiCloud CCE—where the real NPU number is set to the metadata.annotations field "huawei.com/AscendReal" when a Pod is created—to implement a relatively native solution. During image building, a startup script is injected; this script identifies the environment variable AscendRealDevices (mapped from "huawei.com/AscendReal") and converts it into PHYSICAL_DEVICES through string processing.
As such, this PR only provides a simple workaround, and the built image theoretically supports only the HuaweiCloud CCE scenario.

