### PR TITLE
[Docs] Enable automatic doc publication

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -1,6 +1,7 @@
 name: Deploy Documentation to GitHub Pages
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:
With this PR, we can publish documentation to github pages automatically when `main` branch gets updated.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Currently, kthena documentation is already able to be deployed manually like in the image below.
This PR will enable the workflow to the triggered automatically.

<img width="2098" height="680" alt="image" src="https://github.com/user-attachments/assets/23493a38-e31d-40fc-9c8c-c905c71201bd" />

About releasing,    
The documentation release is triggered by merging an approved release branch into main, which automatically starts the Docusaurus deployment workflow.

Unlike other artifacts (like Helm charts or container images), documentation releases are not triggered by pushing a v* tag, but by updates to the main branch.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```
