### PR TITLE
[release] [workflow] Simplifies release workflow

### DIFF
--- a/.github/workflows/build-push-release.yml
+++ b/.github/workflows/build-push-release.yml
@@ -198,5 +198,4 @@ jobs:
           generate_release_notes: true
           files: |
             ./kthena-${{ needs.setup.outputs.version }}.tgz
-            ./kthena-install-${{ needs.setup.outputs.version }}.yaml
             ./kthena-install.yaml


### PR DESCRIPTION
Removes the version-specific naming of release artifacts and the generation of release notes from the workflow. This simplifies the release process by using a consistent name for the install YAML and streamlining the artifact uploads.

**What type of PR is this?**
/kind enhancement

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Before**
<img width="1479" height="813" alt="image" src="https://github.com/user-attachments/assets/2e091354-711d-40f6-8dbe-7736767ccc46" />

**After**
<img width="1247" height="614" alt="image" src="https://github.com/user-attachments/assets/da0ecd27-32bb-4a6b-aeba-eb972235c719" />

---
I found an good example project on how to manage release note.
https://github.com/CherryHQ/cherry-studio/releases

First of all, they have `generated release note` enabled, which auto generates `change logs` for the release verison.

They use the generated release note in 3 different ways.
1. they **don't change** the generated release note at all
2. or they **append** new content like feature introduction to the generated release note
3. or they completely **replace** the generated release note
---

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```
