### PR TITLE
fix wrong labels for release

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -8,17 +8,17 @@ changelog:
     # If PR has multiple labels, it will be added to the first matching category
     - title: Breaking Changes 🛠
       labels:
-        - breaking-change
+        - kind/breaking-change
     - title: Exciting New Features 🎉
       labels:
-        - enhancement
-        - feature
+        - kind/enhancement
+        - kind/feature
     - title: Bug fixes 🐛
       labels:
-        - bug
+        - kind/bug
     - title: Documentation Updates 📚
       labels:
-        - documentation
+        - kind/documentation
     - title: Other Changes 🔄
       labels:
         - "*"


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Release will use labels on PR to classify. The labels on PR is `kind/xxx`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
