### PR TITLE
Fix inconsistency between inner cache and cluster resources

### DIFF
--- a/pkg/model-serving-controller/controller/model_serving_controller.go
+++ b/pkg/model-serving-controller/controller/model_serving_controller.go
@@ -571,13 +571,14 @@ func (c *ModelServingController) manageServingGroupReplicas(ctx context.Context,
 	}
 	for idx := 0; idx < expectedCount; idx++ {
 		if replicas[idx] == nil {
-			// Insert new ServingGroup to global storage
-			c.store.AddServingGroup(utils.GetNamespaceName(mi), idx, newRevision)
 			// Create pods for ServingGroup
 			err = c.CreatePodsForServingGroup(ctx, mi, idx, newRevision)
 			if err != nil {
 				// I think that after create a pod failed, a period of time should pass before joining the coordination queue.
 				return fmt.Errorf("create Serving group failed: %v", err)
+			} else {
+				// Insert new ServingGroup to global storage
+				c.store.AddServingGroup(utils.GetNamespaceName(mi), idx, newRevision)
 			}
 		}
 	}
@@ -770,12 +771,13 @@ func (c *ModelServingController) manageRoleReplicas(ctx context.Context, mi *wor
 					return
 				}
 			}
-			// Insert new Role to global storage
-			c.store.AddRole(utils.GetNamespaceName(mi), groupName, targetRole.Name, utils.GenerateRoleID(targetRole.Name, idx), newRevision)
 			// Create pods for role
 			err = c.CreatePodByRole(ctx, *targetRole.DeepCopy(), mi, idx, servingGroupOrdinal, newRevision)
 			if err != nil {
 				klog.Errorf("create role %s for ServingGroup %s failed: %v", utils.GenerateRoleID(targetRole.Name, idx), groupName, err)
+			} else {
+				// Insert new Role to global storage
+				c.store.AddRole(utils.GetNamespaceName(mi), groupName, targetRole.Name, utils.GenerateRoleID(targetRole.Name, idx), newRevision)
 			}
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:
The processing logic during scaling up has been modified.  Previously, the cache was updated first, and then pods were created in the cluster. When pod creation in the cluster failed, corresponding entries were also added to the cache. This caused inconsistency between the cache and the pods in the cluster.

After modification, ensure that the cache is updated only after the pods in the cluster are successfully created. This ensures consistency between the cache and the pod resources in the cluster.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
