### PR TITLE
add imagePullSecrets in helm chart

### DIFF
--- a/charts/kthena/charts/networking/templates/kthena-router/component/deployment.yaml
+++ b/charts/kthena/charts/networking/templates/kthena-router/component/deployment.yaml
@@ -137,3 +137,7 @@ spec:
             optional: true
         {{- end }}
       serviceAccountName: kthena-router
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/kthena/charts/workload/templates/kthena-controller-manager/component/deployment.yaml
+++ b/charts/kthena/charts/workload/templates/kthena-controller-manager/component/deployment.yaml
@@ -59,3 +59,7 @@ spec:
             secretName: {{ .Values.controllerManager.webhook.tls.certSecretName }}
             optional: true
       serviceAccountName: kthena-controller-manager
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/kthena/values.yaml
+++ b/charts/kthena/values.yaml
@@ -72,3 +72,4 @@ global:
     # This is ONLY required when certManagementMode is set to "manual".
     # You can generate it with: cat /path/to/your/ca.crt | base64 | tr -d '\n'
     caBundle: ""
+  imagePullSecrets: []


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

/kind enhancement

**What this PR does / why we need it**:

Add imagePullSecrets in helm chart, so we can helm install like:

`
helm upgrade --install kthena .. --namespace kthena-system --create-namespace --version 1.0.0 --set global.imagePullSecrets[0].name=docker-login
`


