### PR TITLE
[Docs] add search bar for doc web page

### DIFF
--- a/docs/kthena/docusaurus.config.ts
+++ b/docs/kthena/docusaurus.config.ts
@@ -192,18 +192,6 @@ const config: Config = {
       // Optional: see doc section below
       contextualSearch: true,
 
-      // Optional: Specify domains where the navigation should occur through window.location instead on history.push. Useful when our Algolia config crawls multiple documentation sites and we want to navigate with window.location.href to them.
-      externalUrlRegex: 'external\\.com|domain\\.com',
-
-      // Optional: Replace parts of the item URLs from Algolia. Useful when using the same search index for multiple deployments using a different baseUrl. You can use regexp or string in the `from` param. For example: localhost:3000 vs myCompany.com/docs
-      replaceSearchResultPathname: {
-        from: '/docs/', // or as RegExp: /\/docs\//
-        to: '/',
-      },
-
-      // Optional: Algolia search parameters
-      searchParameters: {},
-
       // Optional: path for search page that enabled by default (`false` to disable it)
       searchPagePath: 'search',
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:
1. we want to add search bar for doc web page
2. we'll use [algolia-docsearch](https://docusaurus.io/docs/search#using-algolia-docsearch) for search, because it's recommended by docusaurus, and its integration is relatively easy.
3. To algolia-docsearch, we need to add verification tag to our doc website

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
what the search bar looks like

<img width="419" height="178" alt="image" src="https://github.com/user-attachments/assets/7f9e76cf-6e77-44a5-9af5-4230f1665905" />


<img width="958" height="730" alt="image" src="https://github.com/user-attachments/assets/bb38dcf9-d689-4eb5-a2bc-41bba61c27c9" />


Actually, you can just try it on https://docusaurus.io/

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
User will have a search bar to use on https://kthena.volcano.sh
```
