### PR TITLE
bugfix: fix worker pod schedulerName

### DIFF
--- a/pkg/model-serving-controller/utils/utils.go
+++ b/pkg/model-serving-controller/utils/utils.go
@@ -111,7 +111,7 @@ func GenerateWorkerPod(role workloadv1alpha1.Role, mi *workloadv1alpha1.ModelSer
 	workerPod := createBasePod(role, mi, workerPodName, groupName, revision, roleIndex)
 	addPodLabelAndAnnotation(workerPod, role.WorkerTemplate.Metadata)
 	workerPod.Spec = role.WorkerTemplate.Spec
-	entryPod.Spec.SchedulerName = mi.Spec.SchedulerName
+	workerPod.Spec.SchedulerName = mi.Spec.SchedulerName
 	// Build environment variables into each container of all pod
 	envVars := createCommonEnvVars(role, entryPod, podIndex)
 	addPodEnvVars(workerPod, envVars...)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:

```yaml
➜  kthena kubectl get pods -o custom-columns=NAME:.metadata.name,SCHEDULER:.spec.schedulerName \
  | grep -E 'NAME|vllm-sim'
NAME                             SCHEDULER
vllm-sim-pd-0-decode-0-0         volcano
vllm-sim-pd-0-decode-0-1         default-scheduler
vllm-sim-pd-0-decode-0-2         default-scheduler
vllm-sim-pd-0-decode-0-3         default-scheduler
vllm-sim-pd-0-decode-1-0         volcano
vllm-sim-pd-0-decode-1-1         default-scheduler
vllm-sim-pd-0-decode-1-2         default-scheduler
vllm-sim-pd-0-decode-1-3         default-scheduler
vllm-sim-pd-0-prefill-0-0        volcano
vllm-sim-pd-0-prefill-0-1        default-scheduler
vllm-sim-pd-0-prefill-0-2        default-scheduler
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
None
```
