### PR TITLE
[Bug] fix bug about one pod role delete will not recreate

### DIFF
--- a/pkg/model-serving-controller/controller/model_serving_controller.go
+++ b/pkg/model-serving-controller/controller/model_serving_controller.go
@@ -839,6 +839,14 @@ func (c *ModelServingController) DeleteRole(ctx context.Context, mi *workloadv1a
 			klog.Errorf("failed to delete service %s/%s: %v", mi.Namespace, svc.Name, err)
 		}
 	}
+
+	// Ensure that the role of an individual pod can be successfully enqueue.
+	if c.isRoleDeleted(mi, groupName, roleName, roleID) {
+		// role has been deleted, so the storage needs to be updated and need to reconcile.
+		klog.V(2).Infof("role %s of servingGroup %s has been deleted", roleID, groupName)
+		c.store.DeleteRole(utils.GetNamespaceName(mi), groupName, roleName, roleID)
+		c.enqueueModelServing(mi)
+	}
 }
 
 func (c *ModelServingController) manageServingGroupRollingUpdate(mi *workloadv1alpha1.ModelServing, revision string) error {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:

When performing deleteRole, add handling for individual pod roles to prevent the role from being recreated when a single pod's role is deleted.

**Which issue(s) this PR fixes**:
Fixes #517 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
