### PR TITLE
fix: wrong order for `gen-docs` and `gen-copyright`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,10 +63,12 @@ gen-docs: crd-ref-docs ## Generate CRD and CLI reference documentation
 	go run ./cli/kthena/internal/tools/docgen/main.go
 
 .PHONY: generate
-generate: controller-gen gen-crd gen-docs gen-copyright ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
+generate: gen-crd ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 	go mod tidy
 	./hack/update-codegen.sh
+	$(MAKE) gen-docs
+	$(MAKE) gen-copyright
 
 .PHONY: gen-check
 gen-check: generate


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
**What this PR does / why we need it**:
`gen-docs` and `gen-copyright` should be after `generate code`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
