### PR TITLE
Add scale subresource to modelServing

### DIFF
--- a/charts/kthena/charts/workload/crds/workload.serving.volcano.sh_modelservings.yaml
+++ b/charts/kthena/charts/workload/crds/workload.serving.volcano.sh_modelservings.yaml
@@ -17593,6 +17593,10 @@ spec:
                   by the ModelServing controller from the ModelServing version
                 format: int32
                 type: integer
+              labelSelector:
+                description: LabelSelector is a label query over pods that should
+                  match the replica count.
+                type: string
               observedGeneration:
                 description: |-
                   observedGeneration is the most recent generation observed for ModelServing. It corresponds to the
@@ -17614,4 +17618,8 @@ spec:
     served: true
     storage: true
     subresources:
+      scale:
+        labelSelectorPath: .status.labelSelector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
       status: {}

--- a/client-go/applyconfiguration/workload/v1alpha1/modelservingstatus.go
+++ b/client-go/applyconfiguration/workload/v1alpha1/modelservingstatus.go
@@ -31,6 +31,7 @@ type ModelServingStatusApplyConfiguration struct {
 	UpdatedReplicas    *int32                           `json:"updatedReplicas,omitempty"`
 	AvailableReplicas  *int32                           `json:"availableReplicas,omitempty"`
 	Conditions         []v1.ConditionApplyConfiguration `json:"conditions,omitempty"`
+	LabelSelector      *string                          `json:"labelSelector,omitempty"`
 }
 
 // ModelServingStatusApplyConfiguration constructs a declarative configuration of the ModelServingStatus type for use with
@@ -89,5 +90,13 @@ func (b *ModelServingStatusApplyConfiguration) WithConditions(values ...*v1.Cond
 		}
 		b.Conditions = append(b.Conditions, *values[i])
 	}
+	return b
+}
+
+// WithLabelSelector sets the LabelSelector field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the LabelSelector field is set to the value of the last call.
+func (b *ModelServingStatusApplyConfiguration) WithLabelSelector(value string) *ModelServingStatusApplyConfiguration {
+	b.LabelSelector = &value
 	return b
 }

--- a/docs/kthena/docs/reference/crd/workload.serving.volcano.sh.md
+++ b/docs/kthena/docs/reference/crd/workload.serving.volcano.sh.md
@@ -527,6 +527,7 @@ _Appears in:_
 | `currentReplicas` _integer_ | CurrentReplicas is the number of ServingGroup created by the ModelServing controller from the ModelServing version |  |  |
 | `updatedReplicas` _integer_ | UpdatedReplicas track the number of ServingGroup that have been updated (ready or not). |  |  |
 | `availableReplicas` _integer_ | AvailableReplicas track the number of ServingGroup that are in ready state (updated or not). |  |  |
+| `labelSelector` _string_ | LabelSelector is a label query over pods that should match the replica count. |  |  |
 
 
 #### ModelStatus

--- a/pkg/apis/workload/v1alpha1/model_serving_types.go
+++ b/pkg/apis/workload/v1alpha1/model_serving_types.go
@@ -168,10 +168,14 @@ type ModelServingStatus struct {
 
 	// Conditions track the condition of the ModelServing.
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
+
+	// LabelSelector is a label query over pods that should match the replica count.
+	LabelSelector string `json:"labelSelector,omitempty"`
 }
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.labelSelector
 // +kubebuilder:storageversion
 // +genclient
 


### PR DESCRIPTION
**What type of PR is this?**
/kind enhancement
<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:

- Add scale subresource to modelServing.Spec.Replicas
- Add a LabelSelector field to the ModelServingStatus structure for use by the HPA.

**Which issue(s) this PR fixes**:
Fixes #564 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
