### PR TITLE
docs: fix incorrect minTaskMember generation description in multi-node-inference guide

### DIFF
--- a/docs/kthena/docs/user-guide/multi-node-inference.md
+++ b/docs/kthena/docs/user-guide/multi-node-inference.md
@@ -329,7 +329,7 @@ Kthena creates PodGroups based on the ModelServing. Among these, the important f
 
 ### MinRoleReplicas and PodGroup Mapping
 
-The `MinRoleReplicas` map is used to generate the PodGroup's `spec.minTaskMember` field. Each entry becomes a key-value pair where the key is `{roleName}-{index}` and the value is the number of pods per role replica (`1 + workerReplicas`). Only role replicas with an index less than the corresponding `minRoleReplicas` value for that role are included, allowing the gang to start before all replicas are ready.
+The `MinRoleReplicas` map is used to generate the PodGroup's `spec.minTaskMember` field. Each entry becomes a key-value pair where the key is `{roleName}-{index}` and the value is the total number of pods per role replica (`1 + workerReplicas`). Only role replicas with an index less than the corresponding `minRoleReplicas` value for that role are included, allowing the gang to start before all replicas are ready.
 
 **Example:** In the `multi-node.yaml` example, the gang policy is defined as:
 


### PR DESCRIPTION

**What type of PR is this?**

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

/kind documentation

**What this PR does / why we need it**:

Fix incorrect documentation for gang scheduling's `minTaskMember` mapping. The previous description incorrectly stated the key format as roleName and the value as coming from `role.replicas`. 

This PR corrects it to show the actual key format `{roleName}-{index}` and clarifies that the value represents the total pods per role replica (1 entry + workerReplicas).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
