### PR TITLE
[feat] implement status-aware priority-based scale-down for ModelServing

### DIFF
--- a/pkg/model-serving-controller/controller/binpack_scaledown.go
+++ b/pkg/model-serving-controller/controller/binpack_scaledown.go
@@ -21,25 +21,87 @@ import (
 	"strconv"
 
 	workloadv1alpha1 "github.com/volcano-sh/kthena/pkg/apis/workload/v1alpha1"
+	"github.com/volcano-sh/kthena/pkg/model-serving-controller/datastore"
+	"github.com/volcano-sh/kthena/pkg/model-serving-controller/utils"
 	corev1 "k8s.io/api/core/v1"
 )
 
 const (
 	PodDeletionCostAnnotation = corev1.PodDeletionCost
+
+	// Status priority constants: lower number = higher deletion priority (delete first)
+	// Priority levels:
+	//   0: Highest deletion priority - unhealthy or terminating states
+	//   1: Lowest deletion priority - healthy running state
+	//
+	// ServingGroup priorities:
+	PriorityServingGroupCreating = 0
+	PriorityServingGroupDeleting = 0
+	PriorityServingGroupScaling  = 0
+	PriorityServingGroupNotFound = 0
+	PriorityServingGroupRunning  = 1
+
+	// Role priorities:
+	PriorityRoleCreating = 0
+	PriorityRoleDeleting = 0
+	PriorityRoleNotFound = 0
+	PriorityRoleRunning  = 1
 )
 
-// ServingGroupWithScore stores serving group name and its score
+// ServingGroupWithScore stores serving group deletion priority information
+// Priority order: Status (primary) > Deletion cost (secondary) > Index (tertiary)
 type ServingGroupWithScore struct {
-	Name  string
-	Score int
-	Index int
+	Name         string
+	Priority     int // Status priority from getServingGroupStatusPriority()
+	DeletionCost int // Higher cost = more protected (lower deletion priority)
+	Index        int
 }
 
-// RoleWithScore stores role name and its score
+// RoleWithScore stores role deletion priority information
+// Priority order: Status (primary) > Deletion cost (secondary) > Index (tertiary)
 type RoleWithScore struct {
-	Name  string
-	Score int
-	Index int
+	Name         string
+	Priority     int // Status priority from getRoleStatusPriority()
+	DeletionCost int // Higher cost = more protected (lower deletion priority)
+	Index        int
+}
+
+// getServingGroupStatusPriority returns the deletion priority for a serving group status.
+// Lower priority value means higher deletion priority (delete first).
+func getServingGroupStatusPriority(status datastore.ServingGroupStatus) int {
+	switch status {
+	case datastore.ServingGroupRunning:
+		return PriorityServingGroupRunning
+	case datastore.ServingGroupCreating:
+		return PriorityServingGroupCreating
+	case datastore.ServingGroupDeleting:
+		return PriorityServingGroupDeleting
+	case datastore.ServingGroupScaling:
+		return PriorityServingGroupScaling
+	case datastore.ServingGroupNotFound:
+		return PriorityServingGroupNotFound
+	default:
+		// Unknown status - treat as highest deletion priority (safety first)
+		return 0
+	}
+}
+
+// getRoleStatusPriority returns the deletion priority for a role status.
+// Lower priority value means higher deletion priority (delete first).
+func getRoleStatusPriority(status datastore.RoleStatus) int {
+	switch status {
+	case datastore.RoleRunning:
+		return PriorityRoleRunning
+	case datastore.RoleCreating:
+		return PriorityRoleCreating
+	case datastore.RoleDeleting:
+		return PriorityRoleDeleting
+	case datastore.RoleNotFound:
+		return PriorityRoleNotFound
+	default:
+		// Unknown status - treat as highest deletion priority (safety first)
+		return 0
+	}
 }
 
 // getPodDeletionCost retrieves the pod deletion cost from the pod's annotations.
@@ -53,34 +115,76 @@ func (c *ModelServingController) getPodDeletionCost(pod *corev1.Pod) int {
 	return 0
 }
 
-// calculateRoleScore calculates the total deletion cost for all pods in a given role.
-func (c *ModelServingController) calculateRoleScore(mi *workloadv1alpha1.ModelServing, groupName, roleName, roleID string) (int, error) {
+// calculateRoleScore calculates priority information for role scale-down that considers:
+// 1. Role readiness (primary factor): Running vs not-running
+// 2. Pod deletion cost (secondary factor)
+func (c *ModelServingController) calculateRoleScore(mi *workloadv1alpha1.ModelServing, groupName, roleName, roleID string) RoleWithScore {
+	// Get role status from store
+	roleStatus := c.store.GetRoleStatus(utils.GetNamespaceName(mi), groupName, roleName, roleID)
+	priority := getRoleStatusPriority(roleStatus)
+
+	// Get pod deletion cost as secondary factor
 	roleIDValue := fmt.Sprintf("%s/%s/%s/%s", mi.Namespace, groupName, roleName, roleID)
 	pods, err := c.getPodsByIndex(RoleIDKey, roleIDValue)
 	if err != nil {
-		return 0, fmt.Errorf("failed to get pods for role %s: %v", roleID, err)
+		_, index := utils.GetParentNameAndOrdinal(roleID)
+		return RoleWithScore{
+			Name:         roleID,
+			Priority:     priority,
+			DeletionCost: 0, // Default to 0 on error
+			Index:        index,
+		}
 	}
 
-	score := 0
+	// Sum pod deletion costs (0 if not set)
+	deletionCost := 0
 	for _, pod := range pods {
-		score += c.getPodDeletionCost(pod)
+		deletionCost += c.getPodDeletionCost(pod)
 	}
 
-	return score, nil
+	_, index := utils.GetParentNameAndOrdinal(roleID)
+
+	return RoleWithScore{
+		Name:         roleID,
+		Priority:     priority,
+		DeletionCost: deletionCost,
+		Index:        index,
+	}
 }
 
-// calculateServingGroupScore calculates the total deletion cost for all pods in a given serving group.
-func (c *ModelServingController) calculateServingGroupScore(mi *workloadv1alpha1.ModelServing, groupName string) (int, error) {
+// calculateServingGroupScore calculates priority information for serving group scale-down with two-level sorting:
+// 1. Status readiness (primary): Not-ready groups should be deleted first
+// 2. Pod deletion cost (secondary): Among groups with same status, lower cost = delete first
+func (c *ModelServingController) calculateServingGroupScore(mi *workloadv1alpha1.ModelServing, groupName string) ServingGroupWithScore {
+	// Get serving group status from store
+	groupStatus := c.store.GetServingGroupStatus(utils.GetNamespaceName(mi), groupName)
+	priority := getServingGroupStatusPriority(groupStatus)
+
+	// Get pod deletion cost as secondary factor
 	groupNameValue := fmt.Sprintf("%s/%s", mi.Namespace, groupName)
 	pods, err := c.getPodsByIndex(GroupNameKey, groupNameValue)
 	if err != nil {
-		return 0, fmt.Errorf("failed to get pods for serving group %s: %v", groupName, err)
+		_, index := utils.GetParentNameAndOrdinal(groupName)
+		return ServingGroupWithScore{
+			Name:         groupName,
+			Priority:     priority,
+			DeletionCost: 0, // Default to 0 on error
+			Index:        index,
+		}
 	}
 
-	score := 0
+	// Sum pod deletion costs (0 if not set)
+	deletionCost := 0
 	for _, pod := range pods {
-		score += c.getPodDeletionCost(pod)
+		deletionCost += c.getPodDeletionCost(pod)
 	}
 
-	return score, nil
+	_, index := utils.GetParentNameAndOrdinal(groupName)
+
+	return ServingGroupWithScore{
+		Name:         groupName,
+		Priority:     priority,
+		DeletionCost: deletionCost,
+		Index:        index,
+	}
 }

--- a/pkg/model-serving-controller/datastore/store.go
+++ b/pkg/model-serving-controller/datastore/store.go
@@ -82,6 +82,7 @@ type RoleStatus string
 
 const (
 	RoleCreating RoleStatus = "Creating"
+	RoleRunning  RoleStatus = "Running"
 	RoleDeleting RoleStatus = "Deleting"
 	RoleNotFound RoleStatus = "NotFound"
 )


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind enhancement
-->

**What this PR does / why we need it**:

Implements status-aware priority-based scale-down to improve replica selection during autoscaling operations.

Key changes:

Prioritizes deletion of Creating resources (not serving traffic) over Running ones (actively serving)
Adds two-tier priority system: Role status (primary) + Pod deletion cost (secondary)
Introduces RoleRunning status with proper lifecycle transitions
Prevents disruption of healthy, running replicas during scale-down
Why it matters:

Improves availability by minimizing service disruption during scale-down
Enhances bin-packing optimization in cost-driven autoscaling
Better handles partial failures and rolling update scenarios

**Which issue(s) this PR fixes**:
Fixes #578 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE

```
