### PR TITLE
test:Add unit tests for certificate and webhook CA bundle handling

### DIFF
--- a/pkg/webhook/cert/secret_test.go
+++ b/pkg/webhook/cert/secret_test.go
@@ -469,11 +469,14 @@ func TestUpdateMutatingWebhookCABundle(t *testing.T) {
 				if err != nil {
 					t.Fatalf("failed to get updated webhook: %v", err)
 				}
-				for i := range updated.Webhooks {
+				if len(updated.Webhooks) != len(tt.existingWebhook.Webhooks) {
+					t.Fatalf("expected %d webhooks after update, got %d", len(tt.existingWebhook.Webhooks), len(updated.Webhooks))
+				}
+				for i, updatedWebhook := range updated.Webhooks {
 					if len(tt.existingWebhook.Webhooks[i].ClientConfig.CABundle) == 0 {
-						if string(updated.Webhooks[i].ClientConfig.CABundle) != string(tt.caBundle) {
+						if string(updatedWebhook.ClientConfig.CABundle) != string(tt.caBundle) {
 							t.Errorf("webhook %d: expected CA bundle %q, got %q",
-								i, string(tt.caBundle), string(updated.Webhooks[i].ClientConfig.CABundle))
+								i, string(tt.caBundle), string(updatedWebhook.ClientConfig.CABundle))
 						}
 					}
 				}

--- a/pkg/webhook/cert/secret_test.go
+++ b/pkg/webhook/cert/secret_test.go
@@ -43,19 +43,19 @@ func TestEnsureCertificate(t *testing.T) {
 		validateResult func(t *testing.T, caBundle []byte, err error)
 	}{
 		{
-			name:       "empty dnsNames returns error",
-			namespace:  "test-ns",
-			secretName: "test-secret",
-			dnsNames:   []string{},
-			wantError:  true,
+			name:          "empty dnsNames returns error",
+			namespace:     "test-ns",
+			secretName:    "test-secret",
+			dnsNames:      []string{},
+			wantError:     true,
 			errorContains: "dnsNames cannot be empty",
 		},
 		{
-			name:       "nil dnsNames returns error",
-			namespace:  "test-ns",
-			secretName: "test-secret",
-			dnsNames:   nil,
-			wantError:  true,
+			name:          "nil dnsNames returns error",
+			namespace:     "test-ns",
+			secretName:    "test-secret",
+			dnsNames:      nil,
+			wantError:     true,
 			errorContains: "dnsNames cannot be empty",
 		},
 		{
@@ -120,12 +120,12 @@ func TestEnsureCertificate(t *testing.T) {
 			},
 		},
 		{
-			name:         "handles generic get error",
-			namespace:    "test-ns",
-			secretName:   "test-secret",
-			dnsNames:     []string{"example.com"},
-			reactorError: errors.New("internal server error"),
-			wantError:    true,
+			name:          "handles generic get error",
+			namespace:     "test-ns",
+			secretName:    "test-secret",
+			dnsNames:      []string{"example.com"},
+			reactorError:  errors.New("internal server error"),
+			wantError:     true,
 			errorContains: "failed to get secret",
 		},
 	}
@@ -168,7 +168,7 @@ func TestEnsureCertificate(t *testing.T) {
 func TestEnsureCertificate_ConcurrentCreation(t *testing.T) {
 	// Test the race condition scenario where another pod creates the secret
 	client := fake.NewSimpleClientset()
-	
+
 	createCallCount := 0
 	client.PrependReactor("create", "secrets", func(action k8stesting.Action) (bool, runtime.Object, error) {
 		createCallCount++
@@ -204,14 +204,14 @@ func TestEnsureCertificate_ConcurrentCreation(t *testing.T) {
 
 func TestUpdateValidatingWebhookCABundle(t *testing.T) {
 	tests := []struct {
-		name              string
-		webhookName       string
-		caBundle          []byte
-		existingWebhook   *admissionregistrationv1.ValidatingWebhookConfiguration
-		reactorError      error
-		wantError         bool
-		errorContains     string
-		expectUpdate      bool
+		name            string
+		webhookName     string
+		caBundle        []byte
+		existingWebhook *admissionregistrationv1.ValidatingWebhookConfiguration
+		reactorError    error
+		wantError       bool
+		errorContains   string
+		expectUpdate    bool
 	}{
 		{
 			name:        "webhook not found returns nil",
@@ -286,11 +286,11 @@ func TestUpdateValidatingWebhookCABundle(t *testing.T) {
 			wantError:    false,
 		},
 		{
-			name:         "handles get error",
-			webhookName:  "test-webhook",
-			caBundle:     []byte("ca-bundle"),
-			reactorError: errors.New("api error"),
-			wantError:    true,
+			name:          "handles get error",
+			webhookName:   "test-webhook",
+			caBundle:      []byte("ca-bundle"),
+			reactorError:  errors.New("api error"),
+			wantError:     true,
 			errorContains: "failed to get ValidatingWebhookConfiguration",
 		},
 	}
@@ -344,14 +344,14 @@ func TestUpdateValidatingWebhookCABundle(t *testing.T) {
 
 func TestUpdateMutatingWebhookCABundle(t *testing.T) {
 	tests := []struct {
-		name              string
-		webhookName       string
-		caBundle          []byte
-		existingWebhook   *admissionregistrationv1.MutatingWebhookConfiguration
-		reactorError      error
-		wantError         bool
-		errorContains     string
-		expectUpdate      bool
+		name            string
+		webhookName     string
+		caBundle        []byte
+		existingWebhook *admissionregistrationv1.MutatingWebhookConfiguration
+		reactorError    error
+		wantError       bool
+		errorContains   string
+		expectUpdate    bool
 	}{
 		{
 			name:        "webhook not found returns nil",
@@ -426,11 +426,11 @@ func TestUpdateMutatingWebhookCABundle(t *testing.T) {
 			wantError:    false,
 		},
 		{
-			name:         "handles get error",
-			webhookName:  "test-webhook",
-			caBundle:     []byte("ca-bundle"),
-			reactorError: errors.New("api error"),
-			wantError:    true,
+			name:          "handles get error",
+			webhookName:   "test-webhook",
+			caBundle:      []byte("ca-bundle"),
+			reactorError:  errors.New("api error"),
+			wantError:     true,
 			errorContains: "failed to get MutatingWebhookConfiguration",
 		},
 	}
@@ -555,25 +555,6 @@ func TestLoadCertBundleFromSecret(t *testing.T) {
 			wantNil:   true,
 		},
 		{
-			name:       "secret with empty values",
-			namespace:  "test-ns",
-			secretName: "test-secret",
-			existingSecret: &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-secret",
-					Namespace: "test-ns",
-				},
-				Data: map[string][]byte{
-					TLSCertKey: []byte{},
-					TLSKeyKey:  []byte("key-data"),
-				},
-			},
-			wantError: false,
-			expectedBundle: &CertBundle{
-				KeyPEM: []byte("key-data"),
-			},
-		},
-		{
 			name:         "handles get error",
 			namespace:    "test-ns",
 			secretName:   "test-secret",
@@ -642,7 +623,7 @@ func TestLoadCertBundleFromSecret(t *testing.T) {
 
 // Helper function
 func contains(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || len(substr) == 0 || 
+	return len(s) >= len(substr) && (s == substr || len(substr) == 0 ||
 		(len(s) > 0 && len(substr) > 0 && findSubstring(s, substr)))
 }
 

--- a/pkg/webhook/cert/secret_test.go
+++ b/pkg/webhook/cert/secret_test.go
@@ -1,0 +1,169 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cert
+
+import (
+	"context"
+	"testing"
+
+	admissionv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestEnsureCertificate_CreateSecret(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	ctx := context.Background()
+
+	ca, err := EnsureCertificate(
+		ctx,
+		client,
+		"default",
+		"test-secret",
+		[]string{"webhook.default.svc"},
+	)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ca) == 0 {
+		t.Fatalf("expected CA bundle, got empty")
+	}
+}
+
+func TestEnsureCertificate_ReuseExistingSecret(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	ctx := context.Background()
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "existing-secret",
+			Namespace: "default",
+		},
+		Data: map[string][]byte{
+			CAKey: []byte("test-ca"),
+		},
+	}
+
+	_, _ = client.CoreV1().Secrets("default").Create(ctx, secret, metav1.CreateOptions{})
+
+	ca, err := EnsureCertificate(
+		ctx,
+		client,
+		"default",
+		"existing-secret",
+		[]string{"webhook.default.svc"},
+	)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(ca) != "test-ca" {
+		t.Fatalf("expected existing CA bundle")
+	}
+}
+
+func TestUpdateValidatingWebhookCABundle(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	ctx := context.Background()
+
+	vwc := &admissionv1.ValidatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-validating",
+		},
+		Webhooks: []admissionv1.ValidatingWebhook{
+			{
+				Name: "vhook.test",
+				ClientConfig: admissionv1.WebhookClientConfig{
+					CABundle: nil,
+				},
+			},
+		},
+	}
+
+	_, _ = client.AdmissionregistrationV1().
+		ValidatingWebhookConfigurations().
+		Create(ctx, vwc, metav1.CreateOptions{})
+
+	err := UpdateValidatingWebhookCABundle(ctx, client, "test-validating", []byte("ca"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestUpdateMutatingWebhookCABundle(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	ctx := context.Background()
+
+	mwc := &admissionv1.MutatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-mutating",
+		},
+		Webhooks: []admissionv1.MutatingWebhook{
+			{
+				Name: "mhook.test",
+				ClientConfig: admissionv1.WebhookClientConfig{
+					CABundle: nil,
+				},
+			},
+		},
+	}
+
+	_, _ = client.AdmissionregistrationV1().
+		MutatingWebhookConfigurations().
+		Create(ctx, mwc, metav1.CreateOptions{})
+
+	err := UpdateMutatingWebhookCABundle(ctx, client, "test-mutating", []byte("ca"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadCertBundleFromSecret(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	ctx := context.Background()
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "bundle-secret",
+			Namespace: "default",
+		},
+		Data: map[string][]byte{
+			TLSCertKey: []byte("cert"),
+			TLSKeyKey:  []byte("key"),
+			CAKey:      []byte("ca"),
+		},
+	}
+
+	_, _ = client.CoreV1().Secrets("default").Create(ctx, secret, metav1.CreateOptions{})
+
+	bundle, err := LoadCertBundleFromSecret(ctx, client, "default", "bundle-secret")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if string(bundle.CertPEM) != "cert" {
+		t.Fatalf("cert mismatch")
+	}
+	if string(bundle.KeyPEM) != "key" {
+		t.Fatalf("key mismatch")
+	}
+	if string(bundle.CAPEM) != "ca" {
+		t.Fatalf("ca mismatch")
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind testing


**What this PR does / why we need it**:
This PR adds unit tests for the cert package to validate certificate generation,
Kubernetes Secret handling, and admission webhook CA bundle updates.
The tests use the client-go fake client to ensure correctness without requiring
a live Kubernetes cluster.


**Which issue(s) this PR fixes**:
Fixes #


**Special notes for your reviewer**:
- This PR adds tests only; no production code is modified.
- Covers both secret creation and reuse scenarios.
- Ensures CA bundles are set only when missing in webhook configurations.


**Does this PR introduce a user-facing change?**:
NONE
