### PR TITLE
test:add unit tests for calculateRoleScore and calculateServingGroupScore functions

### DIFF
--- a/pkg/model-serving-controller/controller/binpack_scaledown_test.go
+++ b/pkg/model-serving-controller/controller/binpack_scaledown_test.go
@@ -49,7 +49,6 @@ func (f *fakeModelServingController) calculateRoleScore(
 	mi *workloadv1alpha1.ModelServing,
 	groupName, roleName, roleID string,
 ) (int, error) {
-
 	roleIDValue := fmt.Sprintf("%s/%s/%s/%s", mi.Namespace, groupName, roleName, roleID)
 
 	pods, err := f.getPodsByIndex(RoleIDKey, roleIDValue)
@@ -68,7 +67,6 @@ func (f *fakeModelServingController) calculateServingGroupScore(
 	mi *workloadv1alpha1.ModelServing,
 	groupName string,
 ) (int, error) {
-
 	groupNameValue := fmt.Sprintf("%s/%s", mi.Namespace, groupName)
 
 	pods, err := f.getPodsByIndex(GroupNameKey, groupNameValue)


### PR DESCRIPTION

/kind cleanup

**What this PR does / why we need it**:
This PR adds unit test coverage for the pod deletion cost scoring logic in
ModelServingController. The covered logic determines pod deletion priority
during scale-down operations and is critical for ensuring correct and stable
model serving behavior.

The added tests validate deletion cost parsing, score aggregation at role and
serving-group levels, and proper error handling when pod index lookups fail.
This improves reliability and prevents regressions in scale-down decisions.

**Which issue(s) this PR fixes**:
Fixes #636 

**Special notes for your reviewer**:
- This is a test-only change; no production logic is modified.
- Tests are pure unit tests and do not rely on informers or indexers.
- The fake controller implementation is used to isolate scoring logic.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
