### PR TITLE
[Bug] Headless services not be deleted when remving a serving group.

### DIFF
--- a/pkg/model-serving-controller/controller/model_serving_controller_test.go
+++ b/pkg/model-serving-controller/controller/model_serving_controller_test.go
@@ -3839,6 +3839,7 @@ func TestManageHeadlessService(t *testing.T) {
 			for _, role := range tt.existingRoles {
 				controller.store.AddRole(utils.GetNamespaceName(tt.modelServing), groupName, "prefill", role.Name, role.Revision)
 				controller.store.UpdateRoleStatus(utils.GetNamespaceName(tt.modelServing), groupName, "prefill", role.Name, role.Status)
+				controller.store.UpdateServingGroupStatus(utils.GetNamespaceName(tt.modelServing), groupName, datastore.ServingGroupRunning)
 			}
 
 			// Add existing services to the fake client


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:
The status of the serviceGroup is checked when a headless service is being rebuilt, preventing unexpected rebuilds.

when delete servingGroup, will update servingGroup status to `Deleting`.
https://github.com/volcano-sh/kthena/blob/b706dd7e7151675574f0294e5008a194dc5f2aaf/pkg/model-serving-controller/controller/model_serving_controller.go#L1584-L1590

When a pod is deleted, if the servingGroup status is detected as deleting, will return.
https://github.com/volcano-sh/kthena/blob/b706dd7e7151675574f0294e5008a194dc5f2aaf/pkg/model-serving-controller/controller/model_serving_controller.go#L305-L316

As a result, when the servingGroup is deleted, the role status is not updated. The `manageHeadlessService` is called, the corresponding headless service is recreated because the role status is not deleting. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
