### PR TITLE
The `workerReplicas` parameter has been made an optional field.

### DIFF
--- a/charts/kthena/charts/workload/crds/workload.serving.volcano.sh_modelservings.yaml
+++ b/charts/kthena/charts/workload/crds/workload.serving.volcano.sh_modelservings.yaml
@@ -8857,6 +8857,7 @@ spec:
                           format: int32
                           type: integer
                         workerReplicas:
+                          default: 0
                           description: |-
                             WorkerReplicas defines the number for the worker pod of a role.
                             Required: Need to set the number of worker-pod replicas.
@@ -17495,7 +17496,6 @@ spec:
                       required:
                       - entryTemplate
                       - name
-                      - workerReplicas
                       type: object
                     maxItems: 4
                     minItems: 1

--- a/docs/kthena/docs/reference/crd/workload.serving.volcano.sh.md
+++ b/docs/kthena/docs/reference/crd/workload.serving.volcano.sh.md
@@ -661,7 +661,7 @@ _Appears in:_
 | `name` _string_ | The name of a role. Name must be unique within an ServingGroup |  | MaxLength: 12 <br />Pattern: `^[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?$` <br /> |
 | `replicas` _integer_ | The number of a certain role.<br />For example, in Disaggregated Prefilling, setting the replica count for both the P and D roles to 1 results in 1P1D deployment configuration.<br />This approach can similarly be applied to configure a xPyD deployment scenario.<br />Default to 1. | 1 |  |
 | `entryTemplate` _[PodTemplateSpec](#podtemplatespec)_ | EntryTemplate defines the template for the entry pod of a role.<br />Required: Currently, a role must have only one entry-pod. |  |  |
-| `workerReplicas` _integer_ | WorkerReplicas defines the number for the worker pod of a role.<br />Required: Need to set the number of worker-pod replicas. |  |  |
+| `workerReplicas` _integer_ | WorkerReplicas defines the number for the worker pod of a role.<br />Required: Need to set the number of worker-pod replicas. | 0 |  |
 | `workerTemplate` _[PodTemplateSpec](#podtemplatespec)_ | WorkerTemplate defines the template for the worker pod of a role. |  |  |
 
 

--- a/pkg/apis/workload/v1alpha1/servinggroup_types.go
+++ b/pkg/apis/workload/v1alpha1/servinggroup_types.go
@@ -72,7 +72,9 @@ type Role struct {
 
 	// WorkerReplicas defines the number for the worker pod of a role.
 	// Required: Need to set the number of worker-pod replicas.
-	WorkerReplicas int32 `json:"workerReplicas"`
+	// +optional
+	// +kubebuilder:default=0
+	WorkerReplicas int32 `json:"workerReplicas,omitempty"`
 
 	// WorkerTemplate defines the template for the worker pod of a role.
 	// +optional

--- a/pkg/model-serving-controller/controller/model_serving_controller_test.go
+++ b/pkg/model-serving-controller/controller/model_serving_controller_test.go
@@ -3765,10 +3765,8 @@ func TestManageHeadlessService(t *testing.T) {
 					Template: workloadv1alpha1.ServingGroup{
 						Roles: []workloadv1alpha1.Role{
 							{
-								Name:           "prefill",
-								Replicas:       ptr.To[int32](1),
-								WorkerReplicas: 0,
-								WorkerTemplate: nil, // No worker template
+								Name:     "prefill",
+								Replicas: ptr.To[int32](1),
 							},
 						},
 					},


### PR DESCRIPTION
**What type of PR is this?**
/kind enhancement
<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:
```yaml
	// Calculate expected pod count for this role replica
	// Each role replica has 1 entry pod + workerReplicas worker pods
	expectedPods := 1 + int(targetRole.WorkerReplicas)
```
To:

```yaml
	// WorkerReplicas defines the number for the worker pod of a role.
	// Required: Need to set the number of worker-pod replicas.
	// +optional
	// +kubebuilder:default=0
	WorkerReplicas *int32 `json:"workerReplicas,omitempty"
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
