### PR TITLE
[router] build a general abstraction layer for both ModelRoute/ModelServer and Gateway API/Inference Extension

### DIFF
--- a/pkg/kthena-router/datastore/store.go
+++ b/pkg/kthena-router/datastore/store.go
@@ -40,6 +40,7 @@ import (
 
 	aiv1alpha1 "github.com/volcano-sh/kthena/pkg/apis/networking/v1alpha1"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/backend"
+	"github.com/volcano-sh/kthena/pkg/kthena-router/translation"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/utils"
 	inferencev1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 )
@@ -270,6 +271,14 @@ type store struct {
 	httpRouteMutex sync.RWMutex
 	httpRoutes     map[string]*gatewayv1.HTTPRoute // key: namespace/name, value: *gatewayv1.HTTPRoute
 	gatewayRoutes  map[string]sets.Set[string]     // key: gateway key (namespace/name), value: set of HTTPRoute keys
+
+	// Translation tracking maps
+	translationMutex         sync.RWMutex
+	translatedModelServers   map[string]*translation.TranslationMetadata // key: translated ModelServer name (namespace/name)
+	translatedModelRoutes    map[string]*translation.TranslationMetadata // key: translated ModelRoute name (namespace/name)
+	pathBasedRoutes          map[string][]*aiv1alpha1.ModelRoute         // key: path pattern prefix, value: list of ModelRoutes
+	wildcardRoutes           []*aiv1alpha1.ModelRoute                    // ModelRoutes with wildcard model name for path-based matching
+
 	// New fields for callback management
 	callbacks map[string][]CallbackFunc
 
@@ -282,19 +291,23 @@ type store struct {
 
 func New() Store {
 	return &store{
-		modelServer:         sync.Map{},
-		pods:                sync.Map{},
-		routeInfo:           make(map[string]*modelRouteInfo),
-		routes:              make(map[string][]*aiv1alpha1.ModelRoute),
-		loraRoutes:          make(map[string][]*aiv1alpha1.ModelRoute),
-		gatewayModelRoutes:  make(map[string]sets.Set[string]),
-		gateways:            make(map[string]*gatewayv1.Gateway),
-		inferencePools:      make(map[string]*inferencev1.InferencePool),
-		httpRoutes:          make(map[string]*gatewayv1.HTTPRoute),
-		gatewayRoutes:       make(map[string]sets.Set[string]),
-		callbacks:           make(map[string][]CallbackFunc),
-		initialSynced:       &atomic.Bool{},
-		requestWaitingQueue: sync.Map{},
+		modelServer:             sync.Map{},
+		pods:                    sync.Map{},
+		routeInfo:               make(map[string]*modelRouteInfo),
+		routes:                  make(map[string][]*aiv1alpha1.ModelRoute),
+		loraRoutes:              make(map[string][]*aiv1alpha1.ModelRoute),
+		gatewayModelRoutes:      make(map[string]sets.Set[string]),
+		gateways:                make(map[string]*gatewayv1.Gateway),
+		inferencePools:          make(map[string]*inferencev1.InferencePool),
+		httpRoutes:              make(map[string]*gatewayv1.HTTPRoute),
+		gatewayRoutes:           make(map[string]sets.Set[string]),
+		translatedModelServers:  make(map[string]*translation.TranslationMetadata),
+		translatedModelRoutes:   make(map[string]*translation.TranslationMetadata),
+		pathBasedRoutes:         make(map[string][]*aiv1alpha1.ModelRoute),
+		wildcardRoutes:          make([]*aiv1alpha1.ModelRoute, 0),
+		callbacks:               make(map[string][]CallbackFunc),
+		initialSynced:           &atomic.Bool{},
+		requestWaitingQueue:     sync.Map{},
 		// Create token tracker with environment-based configuration
 		tokenTracker: createTokenTracker(),
 	}
@@ -791,11 +804,10 @@ func (s *store) MatchModelServer(model string, req *http.Request, gatewayKey str
 	} else {
 		// Try to find routes by lora name
 		loraRoutes, ok := s.loraRoutes[model]
-		if !ok {
-			return types.NamespacedName{}, false, nil, fmt.Errorf("not found route rules for model %s", model)
+		if ok {
+			candidateRoutes = loraRoutes
+			isLora = true
 		}
-		candidateRoutes = loraRoutes
-		isLora = true
 	}
 
 	// Try each ModelRoute until we find one that matches
@@ -836,8 +848,86 @@ func (s *store) MatchModelServer(model string, req *http.Request, gatewayKey str
 		return types.NamespacedName{Namespace: mr.Namespace, Name: dst.ModelServerName}, isLora, mr, nil
 	}
 
+	// Fallback to path-based routes (for translated HTTPRoute->ModelRoute)
+	if req != nil {
+		if result, mr, err := s.matchPathBasedRoute(req, gatewayKey); err == nil {
+			return result, false, mr, nil
+		}
+	}
+
 	// No matching ModelRoute found
 	return types.NamespacedName{}, false, nil, fmt.Errorf("no matching ModelRoute found for model %s", model)
+}
+
+// matchPathBasedRoute matches a request against path-based routes (translated from HTTPRoute)
+// Must be called with routeMutex held
+func (s *store) matchPathBasedRoute(req *http.Request, gatewayKey string) (types.NamespacedName, *aiv1alpha1.ModelRoute, error) {
+	s.translationMutex.RLock()
+	wildcardRoutes := s.wildcardRoutes
+	s.translationMutex.RUnlock()
+
+	if len(wildcardRoutes) == 0 {
+		return types.NamespacedName{}, nil, fmt.Errorf("no path-based routes available")
+	}
+
+	// Try each wildcard route
+	for _, mr := range wildcardRoutes {
+		// Check parentRefs if specified
+		if len(mr.Spec.ParentRefs) > 0 {
+			if gatewayKey != "" {
+				if !s.matchesSpecificGateway(mr, gatewayKey) {
+					continue
+				}
+			} else {
+				continue
+			}
+		} else {
+			if gatewayKey != "" {
+				continue
+			}
+		}
+
+		// Try to match rules by path
+		for _, rule := range mr.Spec.Rules {
+			if rule.ModelMatch == nil {
+				// No match condition means match all
+				dst, err := s.selectDestination(rule.TargetModels)
+				if err != nil {
+					continue
+				}
+				return types.NamespacedName{Namespace: mr.Namespace, Name: dst.ModelServerName}, mr, nil
+			}
+
+			// Check URI match
+			if rule.ModelMatch.Uri != nil {
+				if !matchString(rule.ModelMatch.Uri, req.URL.Path) {
+					continue
+				}
+			}
+
+			// Check header matches
+			headersMatched := true
+			for key, sm := range rule.ModelMatch.Headers {
+				reqValue := req.Header.Get(key)
+				if !matchString(sm, reqValue) {
+					headersMatched = false
+					break
+				}
+			}
+			if !headersMatched {
+				continue
+			}
+
+			// Found a match
+			dst, err := s.selectDestination(rule.TargetModels)
+			if err != nil {
+				continue
+			}
+			return types.NamespacedName{Namespace: mr.Namespace, Name: dst.ModelServerName}, mr, nil
+		}
+	}
+
+	return types.NamespacedName{}, nil, fmt.Errorf("no matching path-based route found")
 }
 
 // matchesSpecificGateway checks if the ModelRoute matches a specific gateway
@@ -1420,10 +1510,63 @@ func (s *store) AddOrUpdateInferencePool(inferencePool *inferencev1.InferencePoo
 	s.inferencePoolMutex.Unlock()
 
 	klog.V(4).Infof("Added or updated InferencePool: %s", key)
+
+	// Translate InferencePool to ModelServer
+	translatedMS := translation.TranslateInferencePoolToModelServer(inferencePool)
+	if translatedMS != nil {
+		// Store the translated ModelServer
+		msName := types.NamespacedName{
+			Namespace: translatedMS.Namespace,
+			Name:      translatedMS.Name,
+		}
+		if err := s.AddOrUpdateModelServer(translatedMS, nil); err != nil {
+			klog.Errorf("Failed to store translated ModelServer for InferencePool %s: %v", key, err)
+			return err
+		}
+
+		// Track the translation
+		s.translationMutex.Lock()
+		s.translatedModelServers[fmt.Sprintf("%s/%s", msName.Namespace, msName.Name)] = &translation.TranslationMetadata{
+			OriginKind:      translation.OriginKindInferencePool,
+			OriginName:      inferencePool.Name,
+			OriginNamespace: inferencePool.Namespace,
+		}
+		s.translationMutex.Unlock()
+
+		klog.V(4).Infof("Created translated ModelServer %s/%s for InferencePool %s", msName.Namespace, msName.Name, key)
+	}
+
 	return nil
 }
 
 func (s *store) DeleteInferencePool(key string) error {
+	// Parse namespace/name from key
+	parts := strings.Split(key, "/")
+	if len(parts) != 2 {
+		klog.Warningf("Invalid InferencePool key format: %s", key)
+		s.inferencePoolMutex.Lock()
+		delete(s.inferencePools, key)
+		s.inferencePoolMutex.Unlock()
+		return nil
+	}
+	namespace, name := parts[0], parts[1]
+
+	// Delete the translated ModelServer first
+	translatedMSName := translation.GenerateTranslatedModelServerName(namespace, name)
+	translatedMSKey := fmt.Sprintf("%s/%s", namespace, translatedMSName)
+
+	s.translationMutex.Lock()
+	delete(s.translatedModelServers, translatedMSKey)
+	s.translationMutex.Unlock()
+
+	// Delete the ModelServer
+	if err := s.DeleteModelServer(types.NamespacedName{Namespace: namespace, Name: translatedMSName}); err != nil {
+		klog.V(4).Infof("No translated ModelServer to delete for InferencePool %s: %v", key, err)
+	} else {
+		klog.V(4).Infof("Deleted translated ModelServer %s for InferencePool %s", translatedMSKey, key)
+	}
+
+	// Delete the InferencePool
 	s.inferencePoolMutex.Lock()
 	delete(s.inferencePools, key)
 	s.inferencePoolMutex.Unlock()
@@ -1514,10 +1657,126 @@ func (s *store) AddOrUpdateHTTPRoute(httpRoute *gatewayv1.HTTPRoute) error {
 	s.httpRouteMutex.Unlock()
 
 	klog.V(4).Infof("Added or updated HTTPRoute: %s", key)
+
+	// Translate HTTPRoute to ModelRoute
+	translatedMR := translation.TranslateHTTPRouteToModelRoute(httpRoute, s)
+	if translatedMR != nil {
+		// Store the translated ModelRoute
+		if err := s.AddOrUpdateModelRoute(translatedMR); err != nil {
+			klog.Errorf("Failed to store translated ModelRoute for HTTPRoute %s: %v", key, err)
+			return err
+		}
+
+		mrKey := fmt.Sprintf("%s/%s", translatedMR.Namespace, translatedMR.Name)
+
+		// Track the translation
+		s.translationMutex.Lock()
+		s.translatedModelRoutes[mrKey] = &translation.TranslationMetadata{
+			OriginKind:      translation.OriginKindHTTPRoute,
+			OriginName:      httpRoute.Name,
+			OriginNamespace: httpRoute.Namespace,
+		}
+
+		// Index by path patterns for path-based routing
+		s.indexPathBasedRoute(translatedMR)
+		s.translationMutex.Unlock()
+
+		klog.V(4).Infof("Created translated ModelRoute %s for HTTPRoute %s", mrKey, key)
+	}
+
 	return nil
 }
 
+// indexPathBasedRoute indexes a ModelRoute for path-based matching
+// Must be called with translationMutex held
+func (s *store) indexPathBasedRoute(mr *aiv1alpha1.ModelRoute) {
+	// Check if this is a wildcard model route (for path-based routing)
+	if mr.Spec.ModelName != "*" {
+		return
+	}
+
+	// Remove from existing indexes first (for updates)
+	s.removePathBasedRouteIndex(mr)
+
+	// Add to wildcard routes
+	s.wildcardRoutes = append(s.wildcardRoutes, mr)
+
+	// Index by path prefixes from rules
+	for _, rule := range mr.Spec.Rules {
+		if rule.ModelMatch != nil && rule.ModelMatch.Uri != nil {
+			if rule.ModelMatch.Uri.Prefix != nil {
+				prefix := *rule.ModelMatch.Uri.Prefix
+				s.pathBasedRoutes[prefix] = append(s.pathBasedRoutes[prefix], mr)
+			}
+		}
+	}
+}
+
+// removePathBasedRouteIndex removes a ModelRoute from path-based indexes
+// Must be called with translationMutex held
+func (s *store) removePathBasedRouteIndex(mr *aiv1alpha1.ModelRoute) {
+	mrKey := fmt.Sprintf("%s/%s", mr.Namespace, mr.Name)
+
+	// Remove from wildcard routes
+	newWildcardRoutes := make([]*aiv1alpha1.ModelRoute, 0, len(s.wildcardRoutes))
+	for _, r := range s.wildcardRoutes {
+		if fmt.Sprintf("%s/%s", r.Namespace, r.Name) != mrKey {
+			newWildcardRoutes = append(newWildcardRoutes, r)
+		}
+	}
+	s.wildcardRoutes = newWildcardRoutes
+
+	// Remove from path-based routes
+	for prefix, routes := range s.pathBasedRoutes {
+		newRoutes := make([]*aiv1alpha1.ModelRoute, 0, len(routes))
+		for _, r := range routes {
+			if fmt.Sprintf("%s/%s", r.Namespace, r.Name) != mrKey {
+				newRoutes = append(newRoutes, r)
+			}
+		}
+		if len(newRoutes) == 0 {
+			delete(s.pathBasedRoutes, prefix)
+		} else {
+			s.pathBasedRoutes[prefix] = newRoutes
+		}
+	}
+}
+
 func (s *store) DeleteHTTPRoute(key string) error {
+	// Parse namespace/name from key
+	parts := strings.Split(key, "/")
+	if len(parts) != 2 {
+		klog.Warningf("Invalid HTTPRoute key format: %s", key)
+		s.httpRouteMutex.Lock()
+		delete(s.httpRoutes, key)
+		s.httpRouteMutex.Unlock()
+		return nil
+	}
+	namespace, name := parts[0], parts[1]
+
+	// Delete the translated ModelRoute first
+	translatedMRName := translation.GenerateTranslatedModelRouteName(namespace, name)
+	translatedMRKey := fmt.Sprintf("%s/%s", namespace, translatedMRName)
+
+	// Get the translated ModelRoute before deleting to remove from path indexes
+	s.translationMutex.Lock()
+	if _, exists := s.translatedModelRoutes[translatedMRKey]; exists {
+		// Find and remove from path-based indexes
+		if mr := s.GetModelRoute(translatedMRKey); mr != nil {
+			s.removePathBasedRouteIndex(mr)
+		}
+		delete(s.translatedModelRoutes, translatedMRKey)
+	}
+	s.translationMutex.Unlock()
+
+	// Delete the ModelRoute
+	if err := s.DeleteModelRoute(translatedMRKey); err != nil {
+		klog.V(4).Infof("No translated ModelRoute to delete for HTTPRoute %s: %v", key, err)
+	} else {
+		klog.V(4).Infof("Deleted translated ModelRoute %s for HTTPRoute %s", translatedMRKey, key)
+	}
+
+	// Delete the HTTPRoute
 	s.httpRouteMutex.Lock()
 	_, exists := s.httpRoutes[key]
 	if exists {

--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -48,6 +48,7 @@ import (
 	"github.com/volcano-sh/kthena/pkg/kthena-router/scheduler"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/scheduler/framework"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/scheduler/plugins/conf"
+	"github.com/volcano-sh/kthena/pkg/kthena-router/translation"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/utils"
 )
 
@@ -267,7 +268,6 @@ func (r *Router) HandlerFunc() gin.HandlerFunc {
 func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest) {
 	modelName := modelRequest["model"].(string)
 
-	// Check if this is an InferencePool request from HTTPRoute
 	var pods []*datastore.PodInfo
 	var port int32
 	var modelServerName types.NamespacedName
@@ -284,71 +284,40 @@ func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest) {
 
 	var isLora bool
 	var err error
-	// Try to match ModelRoute first
+
+	// Unified path - MatchModelServer handles both native and translated routes
 	modelServerName, isLora, modelRoute, err = r.store.MatchModelServer(modelName, c.Request, gatewayKey)
 	if err != nil {
-		accesslog.SetError(c, "model_server_matching", fmt.Sprintf("can't find corresponding model server: %v", err))
-	}
-
-	if err == nil && strings.HasPrefix(c.Request.URL.Path, "/v1/") {
-		// Regular ModelServer request
-		// step 3: Find pods and model server details
-		klog.V(4).Infof("modelServer is %v, is_lora: %v", modelServerName, isLora)
-
-		pods, modelServer, err = r.getPodsAndServer(modelServerName)
-		if err != nil || len(pods) == 0 {
-			klog.Errorf("failed to get pods and model server: %v, %v", modelServerName, err)
-			accesslog.SetError(c, "pod_discovery", fmt.Sprintf("can't find model server: %v", modelServerName))
-			c.AbortWithStatusJSON(http.StatusNotFound, fmt.Sprintf("can't find model server: %v", modelServerName))
-			return
-		}
-
-		model := modelServer.Spec.Model
-		if model != nil && !isLora {
-			modelRequest["model"] = *model
-		}
-
-		port = modelServer.Spec.WorkloadPort.Port
-	} else if matched, inferencePoolName := r.handleHTTPRoute(c, gatewayKey); matched {
-		// If ModelRoute is not matched, try to match HTTPRoute
-
-		// Get InferencePool from store
-		inferencePoolKey := fmt.Sprintf("%s/%s", inferencePoolName.Namespace, inferencePoolName.Name)
-		inferencePool := r.store.GetInferencePool(inferencePoolKey)
-		if inferencePool == nil {
-			klog.Errorf("failed to get inference pool: %v", inferencePoolName)
-			accesslog.SetError(c, "inference_pool_discovery", fmt.Sprintf("can't find inference pool: %v", inferencePoolName))
-			c.AbortWithStatusJSON(http.StatusNotFound, fmt.Sprintf("can't find inference pool: %v", inferencePoolName))
-			return
-		}
-
-		// Get pods from InferencePool
-		pods, err = r.store.GetPodsByInferencePool(inferencePoolName)
-		if err != nil || len(pods) == 0 {
-			klog.Errorf("failed to get pods for inference pool: %v, %v", inferencePoolName, err)
-			accesslog.SetError(c, "pod_discovery", fmt.Sprintf("can't find pods for inference pool: %v", inferencePoolName))
-			c.AbortWithStatusJSON(http.StatusNotFound, fmt.Sprintf("can't find pods for inference pool: %v", inferencePoolName))
-			return
-		}
-
-		// Get target port from InferencePool
-		if len(inferencePool.Spec.TargetPorts) == 0 {
-			klog.Errorf("inference pool %v has no target ports", inferencePoolName)
-			accesslog.SetError(c, "port_discovery", fmt.Sprintf("inference pool %v has no target ports", inferencePoolName))
-			c.AbortWithStatusJSON(http.StatusBadRequest, fmt.Sprintf("inference pool %v has no target ports", inferencePoolName))
-			return
-		}
-		// Use the first target port
-		port = int32(inferencePool.Spec.TargetPorts[0].Number)
-
-		klog.V(4).Infof("InferencePool is %v, pods count: %d, port: %d", inferencePoolName, len(pods), port)
-	} else {
-		accesslog.SetError(c, "route_not_found", "route not found")
-		c.AbortWithStatusJSON(http.StatusNotFound, "route not found")
+		accesslog.SetError(c, "route_not_found", fmt.Sprintf("can't find corresponding route: %v", err))
+		c.AbortWithStatusJSON(http.StatusNotFound, fmt.Sprintf("route not found: %v", err))
 		return
 	}
 
-	// Common scheduling logic for both ModelServer and InferencePool
+	klog.V(4).Infof("modelServer is %v, is_lora: %v", modelServerName, isLora)
+
+	// Get pods and model server details
+	pods, modelServer, err = r.getPodsAndServer(modelServerName)
+	if err != nil || len(pods) == 0 {
+		klog.Errorf("failed to get pods and model server: %v, %v", modelServerName, err)
+		accesslog.SetError(c, "pod_discovery", fmt.Sprintf("can't find model server: %v", modelServerName))
+		c.AbortWithStatusJSON(http.StatusNotFound, fmt.Sprintf("can't find model server: %v", modelServerName))
+		return
+	}
+
+	// Apply model name override if specified (only for non-lora requests)
+	model := modelServer.Spec.Model
+	if model != nil && !isLora {
+		modelRequest["model"] = *model
+	}
+
+	port = modelServer.Spec.WorkloadPort.Port
+
+	// Apply URL rewrite if this is a translated route
+	if modelRoute != nil {
+		r.applyTranslatedRouteURLRewrite(c, modelRoute)
+	}
+
+	// Common scheduling logic
 	prompt, err := utils.ParsePrompt(modelRequest)
 	if err != nil {
 		accesslog.SetError(c, "prompt_parsing", "prompt not found")
@@ -364,9 +333,9 @@ func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest) {
 		}
 	}
 
-	// Get PDGroup if available (only for ModelServer)
+	// Get PDGroup if available
 	var pdGroup *v1alpha1.PDGroup
-	if modelServer != nil && modelServer.Spec.WorkloadSelector != nil {
+	if modelServer.Spec.WorkloadSelector != nil {
 		pdGroup = modelServer.Spec.WorkloadSelector.PDGroup
 	}
 
@@ -407,6 +376,49 @@ func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest) {
 		klog.Errorf("request failed reqID: %s: %v", c.Request.Header.Get("x-request-id"), err)
 		accesslog.SetError(c, "proxy", "request processing failed")
 		c.AbortWithStatusJSON(http.StatusInternalServerError, "request processing failed")
+	}
+}
+
+// applyTranslatedRouteURLRewrite applies URL rewrite rules from translated ModelRoute annotations
+func (r *Router) applyTranslatedRouteURLRewrite(c *gin.Context, modelRoute *v1alpha1.ModelRoute) {
+	if modelRoute == nil || modelRoute.Annotations == nil {
+		return
+	}
+
+	configs := translation.GetURLRewriteConfigs(modelRoute.Annotations)
+	if len(configs) == 0 {
+		return
+	}
+
+	// Apply the first matching config (simplified - could be enhanced for rule matching)
+	config := configs[0]
+
+	// Apply hostname rewrite
+	if config.Hostname != "" {
+		c.Request.Host = config.Hostname
+		klog.V(4).Infof("Rewrote hostname to: %s", config.Hostname)
+	}
+
+	// Apply path rewrite
+	if config.Type != "" {
+		originalPath := c.Request.URL.Path
+		newPath := originalPath
+
+		switch config.Type {
+		case string(gatewayv1.FullPathHTTPPathModifier):
+			if config.ReplaceFullPath != "" {
+				newPath = config.ReplaceFullPath
+				klog.V(4).Infof("Rewrote full path from %s to %s", originalPath, newPath)
+			}
+		case string(gatewayv1.PrefixMatchHTTPPathModifier):
+			if config.ReplacePrefixMatch != "" && config.MatchedPrefix != "" {
+				newPath = config.ReplacePrefixMatch + strings.TrimPrefix(originalPath, config.MatchedPrefix)
+				klog.V(4).Infof("Rewrote path prefix from %s to %s (matched prefix: %s)", originalPath, newPath, config.MatchedPrefix)
+			}
+		}
+
+		c.Request.URL.Path = newPath
+		c.Request.URL.RawPath = ""
 	}
 }
 

--- a/pkg/kthena-router/translation/translator.go
+++ b/pkg/kthena-router/translation/translator.go
@@ -1,0 +1,406 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package translation
+
+import (
+	"encoding/json"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	aiv1alpha1 "github.com/volcano-sh/kthena/pkg/apis/networking/v1alpha1"
+	inferencev1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
+)
+
+// InferencePoolLookup is an interface for looking up InferencePool resources
+type InferencePoolLookup interface {
+	GetInferencePool(key string) *inferencev1.InferencePool
+}
+
+// GenerateTranslatedModelServerName generates a name for a translated ModelServer
+func GenerateTranslatedModelServerName(namespace, name string) string {
+	return fmt.Sprintf("%s-%s-%s", TranslatedPrefix, namespace, name)
+}
+
+// GenerateTranslatedModelRouteName generates a name for a translated ModelRoute
+func GenerateTranslatedModelRouteName(namespace, name string) string {
+	return fmt.Sprintf("%s-%s-%s", TranslatedPrefix, namespace, name)
+}
+
+// TranslateInferencePoolToModelServer translates an InferencePool to a ModelServer
+func TranslateInferencePoolToModelServer(ip *inferencev1.InferencePool) *aiv1alpha1.ModelServer {
+	if ip == nil {
+		return nil
+	}
+
+	// Log warning if multiple ports
+	if len(ip.Spec.TargetPorts) > 1 {
+		klog.Warningf("InferencePool %s/%s has %d target ports, using first port only",
+			ip.Namespace, ip.Name, len(ip.Spec.TargetPorts))
+	}
+
+	// Get the first target port, default to 8000 if not specified
+	var port int32 = 8000
+	if len(ip.Spec.TargetPorts) > 0 {
+		port = int32(ip.Spec.TargetPorts[0].Number)
+	}
+
+	// Convert selector labels
+	matchLabels := make(map[string]string)
+	for k, v := range ip.Spec.Selector.MatchLabels {
+		matchLabels[string(k)] = string(v)
+	}
+
+	ms := &aiv1alpha1.ModelServer{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "networking.kthena.volcano.sh/v1alpha1",
+			Kind:       "ModelServer",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      GenerateTranslatedModelServerName(ip.Namespace, ip.Name),
+			Namespace: ip.Namespace,
+			Annotations: map[string]string{
+				AnnotationTranslatedFrom:  fmt.Sprintf("%s/%s", ip.Namespace, ip.Name),
+				AnnotationOriginKind:      OriginKindInferencePool,
+				AnnotationOriginName:      ip.Name,
+				AnnotationOriginNamespace: ip.Namespace,
+			},
+		},
+		Spec: aiv1alpha1.ModelServerSpec{
+			// Model is nil - will be determined from request body
+			Model: nil,
+			// Default to vLLM inference engine
+			InferenceEngine: aiv1alpha1.VLLM,
+			WorkloadSelector: &aiv1alpha1.WorkloadSelector{
+				MatchLabels: matchLabels,
+			},
+			WorkloadPort: aiv1alpha1.WorkloadPort{
+				Port:     port,
+				Protocol: "http",
+			},
+		},
+	}
+
+	return ms
+}
+
+// TranslateHTTPRouteToModelRoute translates an HTTPRoute to a ModelRoute
+// poolLookup is used to resolve InferencePool backend references
+func TranslateHTTPRouteToModelRoute(hr *gatewayv1.HTTPRoute, poolLookup InferencePoolLookup) *aiv1alpha1.ModelRoute {
+	if hr == nil {
+		return nil
+	}
+
+	// Find InferencePool backend references and collect rules
+	var rules []*aiv1alpha1.Rule
+	var urlRewriteConfigs []URLRewriteConfig
+
+	for ruleIdx, rule := range hr.Spec.Rules {
+		var targetModels []*aiv1alpha1.TargetModel
+		var urlRewrite *URLRewriteConfig
+
+		// Extract URL rewrite filter if present
+		for _, filter := range rule.Filters {
+			if filter.Type == gatewayv1.HTTPRouteFilterURLRewrite && filter.URLRewrite != nil {
+				urlRewrite = extractURLRewriteConfig(filter.URLRewrite, rule.Matches)
+				break
+			}
+		}
+
+		// Find InferencePool backend references
+		for _, backendRef := range rule.BackendRefs {
+			if backendRef.Group != nil && *backendRef.Group == "inference.networking.k8s.io" &&
+				backendRef.Kind != nil && *backendRef.Kind == "InferencePool" {
+
+				// Determine namespace
+				namespace := hr.Namespace
+				if backendRef.Namespace != nil {
+					namespace = string(*backendRef.Namespace)
+				}
+
+				// Create target model pointing to translated ModelServer
+				targetModel := &aiv1alpha1.TargetModel{
+					ModelServerName: GenerateTranslatedModelServerName(namespace, string(backendRef.Name)),
+				}
+
+				// Set weight if specified
+				if backendRef.Weight != nil {
+					weight := uint32(*backendRef.Weight)
+					targetModel.Weight = &weight
+				}
+
+				targetModels = append(targetModels, targetModel)
+			}
+		}
+
+		// Skip rules without InferencePool backends
+		if len(targetModels) == 0 {
+			continue
+		}
+
+		// Convert matches to ModelMatch
+		modelMatch := translateHTTPRouteMatches(rule.Matches)
+
+		// Store URL rewrite config if present
+		if urlRewrite != nil {
+			// Add matched prefix from path matches if available
+			if modelMatch != nil && modelMatch.Uri != nil && modelMatch.Uri.Prefix != nil {
+				urlRewrite.MatchedPrefix = *modelMatch.Uri.Prefix
+			}
+			urlRewriteConfigs = append(urlRewriteConfigs, *urlRewrite)
+		}
+
+		// Create rule
+		aiRule := &aiv1alpha1.Rule{
+			Name:         fmt.Sprintf("rule-%d", ruleIdx),
+			ModelMatch:   modelMatch,
+			TargetModels: targetModels,
+		}
+
+		rules = append(rules, aiRule)
+	}
+
+	// Skip if no rules with InferencePool backends were found
+	if len(rules) == 0 {
+		klog.V(4).Infof("HTTPRoute %s/%s has no InferencePool backend references, skipping translation",
+			hr.Namespace, hr.Name)
+		return nil
+	}
+
+	// Build annotations
+	annotations := map[string]string{
+		AnnotationTranslatedFrom:  fmt.Sprintf("%s/%s", hr.Namespace, hr.Name),
+		AnnotationOriginKind:      OriginKindHTTPRoute,
+		AnnotationOriginName:      hr.Name,
+		AnnotationOriginNamespace: hr.Namespace,
+	}
+
+	// Store URL rewrite config in annotation if present
+	if len(urlRewriteConfigs) > 0 {
+		rewriteJSON, err := json.Marshal(urlRewriteConfigs)
+		if err == nil {
+			annotations[AnnotationURLRewrite] = string(rewriteJSON)
+		} else {
+			klog.Warningf("Failed to marshal URL rewrite config for HTTPRoute %s/%s: %v",
+				hr.Namespace, hr.Name, err)
+		}
+	}
+
+	mr := &aiv1alpha1.ModelRoute{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "networking.kthena.volcano.sh/v1alpha1",
+			Kind:       "ModelRoute",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        GenerateTranslatedModelRouteName(hr.Namespace, hr.Name),
+			Namespace:   hr.Namespace,
+			Annotations: annotations,
+		},
+		Spec: aiv1alpha1.ModelRouteSpec{
+			// Use wildcard for path-based routing
+			ModelName:  "*",
+			ParentRefs: hr.Spec.ParentRefs,
+			Rules:      rules,
+		},
+	}
+
+	return mr
+}
+
+// translateHTTPRouteMatches converts HTTPRoute matches to ModelMatch
+func translateHTTPRouteMatches(matches []gatewayv1.HTTPRouteMatch) *aiv1alpha1.ModelMatch {
+	if len(matches) == 0 {
+		return nil
+	}
+
+	// For simplicity, use the first match
+	match := matches[0]
+	modelMatch := &aiv1alpha1.ModelMatch{}
+	hasContent := false
+
+	// Convert path match
+	if match.Path != nil {
+		modelMatch.Uri = convertPathMatch(match.Path)
+		if modelMatch.Uri != nil {
+			hasContent = true
+		}
+	}
+
+	// Convert header matches
+	if len(match.Headers) > 0 {
+		modelMatch.Headers = make(map[string]*aiv1alpha1.StringMatch)
+		for _, header := range match.Headers {
+			sm := convertHeaderMatch(&header)
+			if sm != nil {
+				modelMatch.Headers[string(header.Name)] = sm
+				hasContent = true
+			}
+		}
+	}
+
+	if !hasContent {
+		return nil
+	}
+
+	return modelMatch
+}
+
+// convertPathMatch converts HTTPPathMatch to StringMatch
+func convertPathMatch(pathMatch *gatewayv1.HTTPPathMatch) *aiv1alpha1.StringMatch {
+	if pathMatch == nil || pathMatch.Value == nil {
+		return nil
+	}
+
+	sm := &aiv1alpha1.StringMatch{}
+	pathType := gatewayv1.PathMatchPathPrefix // default
+	if pathMatch.Type != nil {
+		pathType = *pathMatch.Type
+	}
+
+	switch pathType {
+	case gatewayv1.PathMatchExact:
+		sm.Exact = pathMatch.Value
+	case gatewayv1.PathMatchPathPrefix:
+		sm.Prefix = pathMatch.Value
+	case gatewayv1.PathMatchRegularExpression:
+		sm.Regex = pathMatch.Value
+	default:
+		sm.Prefix = pathMatch.Value
+	}
+
+	return sm
+}
+
+// convertHeaderMatch converts HTTPHeaderMatch to StringMatch
+func convertHeaderMatch(headerMatch *gatewayv1.HTTPHeaderMatch) *aiv1alpha1.StringMatch {
+	if headerMatch == nil {
+		return nil
+	}
+
+	sm := &aiv1alpha1.StringMatch{}
+	headerType := gatewayv1.HeaderMatchExact // default
+	if headerMatch.Type != nil {
+		headerType = *headerMatch.Type
+	}
+
+	value := string(headerMatch.Value)
+	switch headerType {
+	case gatewayv1.HeaderMatchExact:
+		sm.Exact = &value
+	case gatewayv1.HeaderMatchRegularExpression:
+		sm.Regex = &value
+	default:
+		sm.Exact = &value
+	}
+
+	return sm
+}
+
+// extractURLRewriteConfig extracts URL rewrite configuration from HTTPURLRewriteFilter
+func extractURLRewriteConfig(urlRewrite *gatewayv1.HTTPURLRewriteFilter, matches []gatewayv1.HTTPRouteMatch) *URLRewriteConfig {
+	if urlRewrite == nil {
+		return nil
+	}
+
+	config := &URLRewriteConfig{}
+	hasContent := false
+
+	if urlRewrite.Hostname != nil {
+		config.Hostname = string(*urlRewrite.Hostname)
+		hasContent = true
+	}
+
+	if urlRewrite.Path != nil {
+		config.Type = string(urlRewrite.Path.Type)
+		hasContent = true
+
+		switch urlRewrite.Path.Type {
+		case gatewayv1.FullPathHTTPPathModifier:
+			if urlRewrite.Path.ReplaceFullPath != nil {
+				config.ReplaceFullPath = *urlRewrite.Path.ReplaceFullPath
+			}
+		case gatewayv1.PrefixMatchHTTPPathModifier:
+			if urlRewrite.Path.ReplacePrefixMatch != nil {
+				config.ReplacePrefixMatch = *urlRewrite.Path.ReplacePrefixMatch
+			}
+			// Extract matched prefix from the first path match
+			for _, match := range matches {
+				if match.Path != nil && match.Path.Value != nil {
+					if match.Path.Type != nil && *match.Path.Type == gatewayv1.PathMatchPathPrefix {
+						config.MatchedPrefix = *match.Path.Value
+						break
+					}
+				}
+			}
+		}
+	}
+
+	if !hasContent {
+		return nil
+	}
+
+	return config
+}
+
+// IsTranslatedResource checks if a resource was translated from another resource
+func IsTranslatedResource(annotations map[string]string) bool {
+	if annotations == nil {
+		return false
+	}
+	_, exists := annotations[AnnotationTranslatedFrom]
+	return exists
+}
+
+// GetTranslationMetadata extracts translation metadata from annotations
+func GetTranslationMetadata(annotations map[string]string) *TranslationMetadata {
+	if annotations == nil {
+		return nil
+	}
+
+	_, exists := annotations[AnnotationTranslatedFrom]
+	if !exists {
+		return nil
+	}
+
+	return &TranslationMetadata{
+		OriginKind:      annotations[AnnotationOriginKind],
+		OriginName:      annotations[AnnotationOriginName],
+		OriginNamespace: annotations[AnnotationOriginNamespace],
+	}
+}
+
+// GetURLRewriteConfigs extracts URL rewrite configs from ModelRoute annotations
+func GetURLRewriteConfigs(annotations map[string]string) []URLRewriteConfig {
+	if annotations == nil {
+		return nil
+	}
+
+	rewriteJSON, exists := annotations[AnnotationURLRewrite]
+	if !exists {
+		return nil
+	}
+
+	var configs []URLRewriteConfig
+	if err := json.Unmarshal([]byte(rewriteJSON), &configs); err != nil {
+		klog.Warningf("Failed to unmarshal URL rewrite config: %v", err)
+		return nil
+	}
+
+	return configs
+}

--- a/pkg/kthena-router/translation/translator_test.go
+++ b/pkg/kthena-router/translation/translator_test.go
@@ -1,0 +1,658 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package translation
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	inferencev1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
+)
+
+func TestGenerateTranslatedModelServerName(t *testing.T) {
+	tests := []struct {
+		name      string
+		namespace string
+		ipName    string
+		expected  string
+	}{
+		{
+			name:      "simple name",
+			namespace: "default",
+			ipName:    "my-pool",
+			expected:  "translated-default-my-pool",
+		},
+		{
+			name:      "complex namespace",
+			namespace: "my-namespace",
+			ipName:    "inference-pool-1",
+			expected:  "translated-my-namespace-inference-pool-1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GenerateTranslatedModelServerName(tt.namespace, tt.ipName)
+			if result != tt.expected {
+				t.Errorf("GenerateTranslatedModelServerName(%s, %s) = %s, expected %s",
+					tt.namespace, tt.ipName, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGenerateTranslatedModelRouteName(t *testing.T) {
+	tests := []struct {
+		name      string
+		namespace string
+		hrName    string
+		expected  string
+	}{
+		{
+			name:      "simple name",
+			namespace: "default",
+			hrName:    "my-route",
+			expected:  "translated-default-my-route",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GenerateTranslatedModelRouteName(tt.namespace, tt.hrName)
+			if result != tt.expected {
+				t.Errorf("GenerateTranslatedModelRouteName(%s, %s) = %s, expected %s",
+					tt.namespace, tt.hrName, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestTranslateInferencePoolToModelServer(t *testing.T) {
+	tests := []struct {
+		name           string
+		inferencePool  *inferencev1.InferencePool
+		expectedNil    bool
+		expectedPort   int32
+		expectedLabels map[string]string
+	}{
+		{
+			name:          "nil inference pool",
+			inferencePool: nil,
+			expectedNil:   true,
+		},
+		{
+			name: "basic inference pool",
+			inferencePool: &inferencev1.InferencePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pool",
+					Namespace: "default",
+				},
+				Spec: inferencev1.InferencePoolSpec{
+					Selector: inferencev1.LabelSelector{
+						MatchLabels: map[inferencev1.LabelKey]inferencev1.LabelValue{
+							"app": "vllm",
+						},
+					},
+					TargetPorts: []inferencev1.Port{
+						{Number: 8080},
+					},
+				},
+			},
+			expectedNil:  false,
+			expectedPort: 8080,
+			expectedLabels: map[string]string{
+				"app": "vllm",
+			},
+		},
+		{
+			name: "inference pool with multiple ports uses first",
+			inferencePool: &inferencev1.InferencePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "multi-port-pool",
+					Namespace: "test-ns",
+				},
+				Spec: inferencev1.InferencePoolSpec{
+					Selector: inferencev1.LabelSelector{
+						MatchLabels: map[inferencev1.LabelKey]inferencev1.LabelValue{
+							"app": "llm",
+						},
+					},
+					TargetPorts: []inferencev1.Port{
+						{Number: 8000},
+						{Number: 9000},
+					},
+				},
+			},
+			expectedNil:  false,
+			expectedPort: 8000,
+			expectedLabels: map[string]string{
+				"app": "llm",
+			},
+		},
+		{
+			name: "inference pool without ports defaults to 8000",
+			inferencePool: &inferencev1.InferencePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "no-port-pool",
+					Namespace: "default",
+				},
+				Spec: inferencev1.InferencePoolSpec{
+					Selector: inferencev1.LabelSelector{
+						MatchLabels: map[inferencev1.LabelKey]inferencev1.LabelValue{
+							"app": "model",
+						},
+					},
+					TargetPorts: []inferencev1.Port{},
+				},
+			},
+			expectedNil:  false,
+			expectedPort: 8000,
+			expectedLabels: map[string]string{
+				"app": "model",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := TranslateInferencePoolToModelServer(tt.inferencePool)
+
+			if tt.expectedNil {
+				if result != nil {
+					t.Errorf("Expected nil result, got %+v", result)
+				}
+				return
+			}
+
+			if result == nil {
+				t.Fatal("Expected non-nil result, got nil")
+			}
+
+			// Check name
+			expectedName := GenerateTranslatedModelServerName(tt.inferencePool.Namespace, tt.inferencePool.Name)
+			if result.Name != expectedName {
+				t.Errorf("Expected name %s, got %s", expectedName, result.Name)
+			}
+
+			// Check namespace
+			if result.Namespace != tt.inferencePool.Namespace {
+				t.Errorf("Expected namespace %s, got %s", tt.inferencePool.Namespace, result.Namespace)
+			}
+
+			// Check port
+			if result.Spec.WorkloadPort.Port != tt.expectedPort {
+				t.Errorf("Expected port %d, got %d", tt.expectedPort, result.Spec.WorkloadPort.Port)
+			}
+
+			// Check labels
+			if result.Spec.WorkloadSelector == nil {
+				t.Fatal("Expected WorkloadSelector to be non-nil")
+			}
+			for k, v := range tt.expectedLabels {
+				if result.Spec.WorkloadSelector.MatchLabels[k] != v {
+					t.Errorf("Expected label %s=%s, got %s=%s",
+						k, v, k, result.Spec.WorkloadSelector.MatchLabels[k])
+				}
+			}
+
+			// Check annotations
+			if result.Annotations[AnnotationOriginKind] != OriginKindInferencePool {
+				t.Errorf("Expected annotation %s=%s, got %s",
+					AnnotationOriginKind, OriginKindInferencePool, result.Annotations[AnnotationOriginKind])
+			}
+			if result.Annotations[AnnotationOriginName] != tt.inferencePool.Name {
+				t.Errorf("Expected annotation %s=%s, got %s",
+					AnnotationOriginName, tt.inferencePool.Name, result.Annotations[AnnotationOriginName])
+			}
+		})
+	}
+}
+
+// mockPoolLookup implements InferencePoolLookup for testing
+type mockPoolLookup struct {
+	pools map[string]*inferencev1.InferencePool
+}
+
+func (m *mockPoolLookup) GetInferencePool(key string) *inferencev1.InferencePool {
+	return m.pools[key]
+}
+
+func TestTranslateHTTPRouteToModelRoute(t *testing.T) {
+	pathPrefixType := gatewayv1.PathMatchPathPrefix
+	exactType := gatewayv1.PathMatchExact
+	gatewayKind := gatewayv1.Kind("Gateway")
+	inferenceGroup := gatewayv1.Group("inference.networking.k8s.io")
+	inferenceKind := gatewayv1.Kind("InferencePool")
+
+	tests := []struct {
+		name             string
+		httpRoute        *gatewayv1.HTTPRoute
+		poolLookup       InferencePoolLookup
+		expectedNil      bool
+		expectedRules    int
+		expectedModelNme string
+	}{
+		{
+			name:        "nil http route",
+			httpRoute:   nil,
+			poolLookup:  &mockPoolLookup{},
+			expectedNil: true,
+		},
+		{
+			name: "http route without inference pool backend",
+			httpRoute: &gatewayv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "no-pool-route",
+					Namespace: "default",
+				},
+				Spec: gatewayv1.HTTPRouteSpec{
+					Rules: []gatewayv1.HTTPRouteRule{
+						{
+							// No backendRefs
+						},
+					},
+				},
+			},
+			poolLookup:  &mockPoolLookup{},
+			expectedNil: true,
+		},
+		{
+			name: "http route with inference pool backend",
+			httpRoute: &gatewayv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "default",
+				},
+				Spec: gatewayv1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{
+						ParentRefs: []gatewayv1.ParentReference{
+							{
+								Kind: &gatewayKind,
+								Name: "my-gateway",
+							},
+						},
+					},
+					Rules: []gatewayv1.HTTPRouteRule{
+						{
+							Matches: []gatewayv1.HTTPRouteMatch{
+								{
+									Path: &gatewayv1.HTTPPathMatch{
+										Type:  &pathPrefixType,
+										Value: ptrString("/v1/"),
+									},
+								},
+							},
+							BackendRefs: []gatewayv1.HTTPBackendRef{
+								{
+									BackendRef: gatewayv1.BackendRef{
+										BackendObjectReference: gatewayv1.BackendObjectReference{
+											Group: &inferenceGroup,
+											Kind:  &inferenceKind,
+											Name:  "test-pool",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			poolLookup:       &mockPoolLookup{},
+			expectedNil:      false,
+			expectedRules:    1,
+			expectedModelNme: "*",
+		},
+		{
+			name: "http route with exact path match",
+			httpRoute: &gatewayv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "exact-route",
+					Namespace: "test-ns",
+				},
+				Spec: gatewayv1.HTTPRouteSpec{
+					Rules: []gatewayv1.HTTPRouteRule{
+						{
+							Matches: []gatewayv1.HTTPRouteMatch{
+								{
+									Path: &gatewayv1.HTTPPathMatch{
+										Type:  &exactType,
+										Value: ptrString("/api/chat"),
+									},
+								},
+							},
+							BackendRefs: []gatewayv1.HTTPBackendRef{
+								{
+									BackendRef: gatewayv1.BackendRef{
+										BackendObjectReference: gatewayv1.BackendObjectReference{
+											Group: &inferenceGroup,
+											Kind:  &inferenceKind,
+											Name:  "chat-pool",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			poolLookup:       &mockPoolLookup{},
+			expectedNil:      false,
+			expectedRules:    1,
+			expectedModelNme: "*",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := TranslateHTTPRouteToModelRoute(tt.httpRoute, tt.poolLookup)
+
+			if tt.expectedNil {
+				if result != nil {
+					t.Errorf("Expected nil result, got %+v", result)
+				}
+				return
+			}
+
+			if result == nil {
+				t.Fatal("Expected non-nil result, got nil")
+			}
+
+			// Check name
+			expectedName := GenerateTranslatedModelRouteName(tt.httpRoute.Namespace, tt.httpRoute.Name)
+			if result.Name != expectedName {
+				t.Errorf("Expected name %s, got %s", expectedName, result.Name)
+			}
+
+			// Check model name (should be wildcard for path-based routing)
+			if result.Spec.ModelName != tt.expectedModelNme {
+				t.Errorf("Expected model name %s, got %s", tt.expectedModelNme, result.Spec.ModelName)
+			}
+
+			// Check rules count
+			if len(result.Spec.Rules) != tt.expectedRules {
+				t.Errorf("Expected %d rules, got %d", tt.expectedRules, len(result.Spec.Rules))
+			}
+
+			// Check annotations
+			if result.Annotations[AnnotationOriginKind] != OriginKindHTTPRoute {
+				t.Errorf("Expected annotation %s=%s, got %s",
+					AnnotationOriginKind, OriginKindHTTPRoute, result.Annotations[AnnotationOriginKind])
+			}
+		})
+	}
+}
+
+func TestConvertPathMatch(t *testing.T) {
+	pathPrefixType := gatewayv1.PathMatchPathPrefix
+	exactType := gatewayv1.PathMatchExact
+	regexType := gatewayv1.PathMatchRegularExpression
+
+	tests := []struct {
+		name            string
+		pathMatch       *gatewayv1.HTTPPathMatch
+		expectedNil     bool
+		expectedPrefix  string
+		expectedExact   string
+		expectedRegex   string
+	}{
+		{
+			name:        "nil path match",
+			pathMatch:   nil,
+			expectedNil: true,
+		},
+		{
+			name: "path match without value",
+			pathMatch: &gatewayv1.HTTPPathMatch{
+				Type:  &pathPrefixType,
+				Value: nil,
+			},
+			expectedNil: true,
+		},
+		{
+			name: "prefix path match",
+			pathMatch: &gatewayv1.HTTPPathMatch{
+				Type:  &pathPrefixType,
+				Value: ptrString("/api/"),
+			},
+			expectedNil:    false,
+			expectedPrefix: "/api/",
+		},
+		{
+			name: "exact path match",
+			pathMatch: &gatewayv1.HTTPPathMatch{
+				Type:  &exactType,
+				Value: ptrString("/health"),
+			},
+			expectedNil:   false,
+			expectedExact: "/health",
+		},
+		{
+			name: "regex path match",
+			pathMatch: &gatewayv1.HTTPPathMatch{
+				Type:  &regexType,
+				Value: ptrString("/v[0-9]+/.*"),
+			},
+			expectedNil:   false,
+			expectedRegex: "/v[0-9]+/.*",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := convertPathMatch(tt.pathMatch)
+
+			if tt.expectedNil {
+				if result != nil {
+					t.Errorf("Expected nil result, got %+v", result)
+				}
+				return
+			}
+
+			if result == nil {
+				t.Fatal("Expected non-nil result, got nil")
+			}
+
+			if tt.expectedPrefix != "" {
+				if result.Prefix == nil || *result.Prefix != tt.expectedPrefix {
+					t.Errorf("Expected prefix %s, got %v", tt.expectedPrefix, result.Prefix)
+				}
+			}
+			if tt.expectedExact != "" {
+				if result.Exact == nil || *result.Exact != tt.expectedExact {
+					t.Errorf("Expected exact %s, got %v", tt.expectedExact, result.Exact)
+				}
+			}
+			if tt.expectedRegex != "" {
+				if result.Regex == nil || *result.Regex != tt.expectedRegex {
+					t.Errorf("Expected regex %s, got %v", tt.expectedRegex, result.Regex)
+				}
+			}
+		})
+	}
+}
+
+func TestIsTranslatedResource(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		expected    bool
+	}{
+		{
+			name:        "nil annotations",
+			annotations: nil,
+			expected:    false,
+		},
+		{
+			name:        "empty annotations",
+			annotations: map[string]string{},
+			expected:    false,
+		},
+		{
+			name: "without translated annotation",
+			annotations: map[string]string{
+				"some-other": "value",
+			},
+			expected: false,
+		},
+		{
+			name: "with translated annotation",
+			annotations: map[string]string{
+				AnnotationTranslatedFrom: "default/test-pool",
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsTranslatedResource(tt.annotations)
+			if result != tt.expected {
+				t.Errorf("IsTranslatedResource(%v) = %v, expected %v",
+					tt.annotations, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetTranslationMetadata(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		expectedNil bool
+		expected    *TranslationMetadata
+	}{
+		{
+			name:        "nil annotations",
+			annotations: nil,
+			expectedNil: true,
+		},
+		{
+			name: "without translated annotation",
+			annotations: map[string]string{
+				"some-other": "value",
+			},
+			expectedNil: true,
+		},
+		{
+			name: "with all metadata",
+			annotations: map[string]string{
+				AnnotationTranslatedFrom:  "default/test-pool",
+				AnnotationOriginKind:      OriginKindInferencePool,
+				AnnotationOriginName:      "test-pool",
+				AnnotationOriginNamespace: "default",
+			},
+			expectedNil: false,
+			expected: &TranslationMetadata{
+				OriginKind:      OriginKindInferencePool,
+				OriginName:      "test-pool",
+				OriginNamespace: "default",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetTranslationMetadata(tt.annotations)
+
+			if tt.expectedNil {
+				if result != nil {
+					t.Errorf("Expected nil result, got %+v", result)
+				}
+				return
+			}
+
+			if result == nil {
+				t.Fatal("Expected non-nil result, got nil")
+			}
+
+			if result.OriginKind != tt.expected.OriginKind {
+				t.Errorf("Expected OriginKind %s, got %s", tt.expected.OriginKind, result.OriginKind)
+			}
+			if result.OriginName != tt.expected.OriginName {
+				t.Errorf("Expected OriginName %s, got %s", tt.expected.OriginName, result.OriginName)
+			}
+			if result.OriginNamespace != tt.expected.OriginNamespace {
+				t.Errorf("Expected OriginNamespace %s, got %s", tt.expected.OriginNamespace, result.OriginNamespace)
+			}
+		})
+	}
+}
+
+func TestGetURLRewriteConfigs(t *testing.T) {
+	tests := []struct {
+		name           string
+		annotations    map[string]string
+		expectedNil    bool
+		expectedLength int
+	}{
+		{
+			name:        "nil annotations",
+			annotations: nil,
+			expectedNil: true,
+		},
+		{
+			name: "without url rewrite annotation",
+			annotations: map[string]string{
+				"other": "value",
+			},
+			expectedNil: true,
+		},
+		{
+			name: "with valid url rewrite config",
+			annotations: map[string]string{
+				AnnotationURLRewrite: `[{"type":"ReplacePrefixMatch","replacePrefixMatch":"/v1/","matchedPrefix":"/api/"}]`,
+			},
+			expectedNil:    false,
+			expectedLength: 1,
+		},
+		{
+			name: "with invalid json",
+			annotations: map[string]string{
+				AnnotationURLRewrite: `invalid json`,
+			},
+			expectedNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetURLRewriteConfigs(tt.annotations)
+
+			if tt.expectedNil {
+				if result != nil {
+					t.Errorf("Expected nil result, got %+v", result)
+				}
+				return
+			}
+
+			if result == nil {
+				t.Fatal("Expected non-nil result, got nil")
+			}
+
+			if len(result) != tt.expectedLength {
+				t.Errorf("Expected length %d, got %d", tt.expectedLength, len(result))
+			}
+		})
+	}
+}
+
+// Helper function to create string pointer
+func ptrString(s string) *string {
+	return &s
+}

--- a/pkg/kthena-router/translation/types.go
+++ b/pkg/kthena-router/translation/types.go
@@ -1,0 +1,62 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package translation
+
+const (
+	// AnnotationTranslatedFrom indicates the original resource that this resource was translated from
+	AnnotationTranslatedFrom = "kthena.volcano.sh/translated-from"
+	// AnnotationOriginKind indicates the kind of the original resource
+	AnnotationOriginKind = "kthena.volcano.sh/origin-kind"
+	// AnnotationOriginName indicates the name of the original resource
+	AnnotationOriginName = "kthena.volcano.sh/origin-name"
+	// AnnotationOriginNamespace indicates the namespace of the original resource
+	AnnotationOriginNamespace = "kthena.volcano.sh/origin-namespace"
+	// AnnotationURLRewrite stores URL rewrite configuration for translated ModelRoutes
+	AnnotationURLRewrite = "kthena.volcano.sh/url-rewrite"
+
+	// OriginKindInferencePool is the kind for InferencePool
+	OriginKindInferencePool = "InferencePool"
+	// OriginKindHTTPRoute is the kind for HTTPRoute
+	OriginKindHTTPRoute = "HTTPRoute"
+
+	// TranslatedPrefix is the prefix used for translated resource names
+	TranslatedPrefix = "translated"
+)
+
+// TranslationMetadata contains metadata about the original resource that was translated
+type TranslationMetadata struct {
+	// OriginKind is the kind of the original resource ("InferencePool" or "HTTPRoute")
+	OriginKind string
+	// OriginName is the name of the original resource
+	OriginName string
+	// OriginNamespace is the namespace of the original resource
+	OriginNamespace string
+}
+
+// URLRewriteConfig stores URL rewrite configuration extracted from HTTPRoute filters
+type URLRewriteConfig struct {
+	// Type is the type of path modification
+	Type string `json:"type,omitempty"`
+	// ReplaceFullPath is the replacement for the full path
+	ReplaceFullPath string `json:"replaceFullPath,omitempty"`
+	// ReplacePrefixMatch is the replacement for the prefix match
+	ReplacePrefixMatch string `json:"replacePrefixMatch,omitempty"`
+	// MatchedPrefix is the prefix that was matched (for prefix replacement)
+	MatchedPrefix string `json:"matchedPrefix,omitempty"`
+	// Hostname is the replacement hostname
+	Hostname string `json:"hostname,omitempty"`
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind enhancement

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:
build a general abstraction layer for both ModelRoute/ModelServer and Gateway API/Inference Extension
**Which issue(s) this PR fixes**:
Fixes #
https://github.com/volcano-sh/kthena/issues/546
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```
