### PR TITLE
fix modelserving controller panic

### DIFF
--- a/pkg/model-serving-controller/podgroupmanager/manager.go
+++ b/pkg/model-serving-controller/podgroupmanager/manager.go
@@ -82,7 +82,6 @@ func NewManager(kubeClient kubernetes.Interface, volcanoClient volcanoclient.Int
 			newManager.hasSubGroupPolicy.Store(false)
 		} else {
 			klog.Errorf("failed to get PodGroup CRD: %v", err)
-			return nil
 		}
 	} else {
 		newManager.handlePodGroupCRDChange(crd, false)


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:

Previously, a nil `podGroupManager` would be returned due to get `podGroup` CRD failed, causing the model serving controller to panic. 

Now a default `podGroupManager` is provided to prevent such panic conditions.

**Which issue(s) this PR fixes**:
Fixes #687

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
