### PR TITLE
hack: add preflight validation to local-up-kthena script

### DIFF
--- a/hack/lib/install.sh
+++ b/hack/lib/install.sh
@@ -14,6 +14,128 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# ============================================================================
+# PREFLIGHT VALIDATION HELPERS
+# ============================================================================
+
+# Color codes for output
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+GREEN='\033[0;32m'
+NC='\033[0m' # No Color
+
+# Counters for preflight checks
+FATAL_ERRORS=0
+WARNINGS=0
+
+# Print an error message
+function print_error() {
+  echo -e "${RED}ERROR${NC}: $1" >&2
+}
+
+# Print a warning message
+function print_warning() {
+  echo -e "${YELLOW}WARNING${NC}: $1"
+}
+
+# Print a success message
+function print_success() {
+  echo -e "${GREEN}✓${NC} $1"
+}
+
+# Check if a binary is installed
+function check_binary() {
+  local binary=$1
+  local install_hint=$2
+  
+  if command -v "${binary}" >/dev/null 2>&1; then
+    print_success "${binary} is installed"
+    return 0
+  else
+    print_error "${binary} is not installed"
+    if [[ -n "${install_hint}" ]]; then
+      echo "  Install hint: ${install_hint}"
+    fi
+    ((FATAL_ERRORS++))
+    return 1
+  fi
+}
+
+# Check if at least one binary from a list exists
+function check_binary_one_of() {
+  local binaries=("$@")
+  local found=0
+  
+  for binary in "${binaries[@]}"; do
+    if command -v "${binary}" >/dev/null 2>&1; then
+      local version=$("${binary}" version 2>/dev/null || echo "(version unknown)")
+      print_success "${binary} is installed: ${version}"
+      found=1
+      break
+    fi
+  done
+  
+  if [[ ${found} -eq 0 ]]; then
+    # If no cluster tool is present, warn rather than fail immediately.
+    # When running in kind mode the script can attempt to install kind later
+    # (see check-kind below). Keep this a warning so local setups that will
+    # be created by the script are not blocked unnecessarily.
+    print_warning "None of the cluster tools were found: ${binaries[*]}"
+    echo "  Install one of:"
+    echo "    - kind: https://kind.sigs.k8s.io/docs/user/quick-start/#installation"
+    echo "    - k3d: https://k3d.io/usage/install/"
+    echo "    - minikube: https://minikube.sigs.k8s.io/docs/start/"
+    ((WARNINGS++))
+    return 0
+  fi
+  return 0
+}
+
+# Check if kubectl cluster is reachable
+function check_cluster_reachable() {
+  echo ""
+  echo "Verifying cluster connectivity..."
+  
+  kubectl cluster-info >/dev/null 2>&1
+  if [[ $? -ne 0 ]]; then
+    print_error "Kubernetes cluster is not reachable"
+    echo "  Make sure a Kubernetes cluster is running and KUBECONFIG is set correctly"
+    ((FATAL_ERRORS++))
+    return 1
+  fi
+  
+  print_success "Kubernetes cluster is reachable"
+  return 0
+}
+
+# Check if container runtime (Docker or Podman) is available
+function check_container_runtime() {
+  local runtime_found=0
+  
+  if command -v docker >/dev/null 2>&1; then
+    local docker_version=$(docker version --format '{{.Server.Version}}' 2>/dev/null || echo "(version unknown)")
+    print_success "Docker is installed: ${docker_version}"
+    runtime_found=1
+    return 0
+  fi
+  
+  if command -v podman >/dev/null 2>&1; then
+    local podman_version=$(podman version --format '{{.Version}}' 2>/dev/null || echo "(version unknown)")
+    print_success "Podman is installed: ${podman_version}"
+    runtime_found=1
+    return 0
+  fi
+  
+  if [[ ${runtime_found} -eq 0 ]]; then
+    print_error "Neither Docker nor Podman is installed"
+    echo "  Install one of:"
+    echo "    - Docker: https://docs.docker.com/install/"
+    echo "    - Podman: https://podman.io/getting-started/installation/"
+    ((FATAL_ERRORS++))
+    return 1
+  fi
+}
+
 # spin up cluster with kind command
 function kind-up-cluster {
   check-kind
@@ -58,16 +180,46 @@ function check-images {
   fi
 }
 
-# check if kubectl installed
+# Extended check-prerequisites function with preflight validation
 function check-prerequisites {
-  echo "Checking prerequisites"
-  command -v kubectl >/dev/null 2>&1
-  if [[ $? -ne 0 ]]; then
-    echo -e "\033[31mERROR\033[0m: kubectl not installed"
-    exit 1
-  else
-    echo -n "Found kubectl, version: " && kubectl version --client
+  echo "================================================"
+  echo "Running Preflight Validation Checks"
+  echo "================================================"
+  echo ""
+  
+  # ---- BINARY CHECKS ----
+  echo "Checking required binaries..."
+  check_binary "kubectl" "https://kubernetes.io/docs/tasks/tools/"
+  check_binary "helm" "https://helm.sh/docs/intro/install/"
+  check_container_runtime
+  check_binary_one_of "kind" "k3d" "minikube"
+  
+  echo ""
+  
+  # ---- CLUSTER VALIDATION (only for existing clusters) ----
+  if [[ "${INSTALL_MODE}" == "existing" ]]; then
+    check_cluster_reachable
   fi
+  
+  echo ""
+  echo "================================================"
+  
+  # Print summary
+  if [[ ${FATAL_ERRORS} -gt 0 ]]; then
+    echo -e "${RED}Preflight check FAILED${NC}"
+    echo "Fatal errors: ${FATAL_ERRORS}"
+    echo ""
+    return 1
+  fi
+  
+  if [[ ${WARNINGS} -gt 0 ]]; then
+    echo -e "${YELLOW}Preflight check completed with ${WARNINGS} warning(s)${NC}"
+  else
+    echo -e "${GREEN}Preflight check PASSED${NC}"
+  fi
+  echo ""
+  
+  return 0
 }
 
 # check if kind installed

--- a/hack/local-up-kthena.sh
+++ b/hack/local-up-kthena.sh
@@ -25,171 +25,6 @@ TAG=${TAG:-$(git rev-parse --verify HEAD 2>/dev/null || echo "latest")}
 HELM_RELEASE_NAME=${HELM_RELEASE_NAME:-kthena}
 OS=${OS:-$(go env GOOS 2>/dev/null || echo "linux")}
 
-# Color codes for output
-RED='\033[0;31m'
-YELLOW='\033[1;33m'
-GREEN='\033[0;32m'
-NC='\033[0m' # No Color
-
-# Counters for preflight checks
-FATAL_ERRORS=0
-WARNINGS=0
-
-# ============================================================================
-# PREFLIGHT VALIDATION FUNCTIONS
-# ============================================================================
-
-# Print an error message
-function print_error() {
-  echo -e "${RED}ERROR${NC}: $1" >&2
-}
-
-# Print a warning message
-function print_warning() {
-  echo -e "${YELLOW}WARNING${NC}: $1"
-}
-
-# Print a success message
-function print_success() {
-  echo -e "${GREEN}✓${NC} $1"
-}
-
-# Check if a binary is installed
-function check_binary() {
-  local binary=$1
-  local install_hint=$2
-  
-  if command -v "${binary}" >/dev/null 2>&1; then
-    print_success "${binary} is installed"
-    return 0
-  else
-    print_error "${binary} is not installed"
-    if [[ -n "${install_hint}" ]]; then
-      echo "  Install hint: ${install_hint}"
-    fi
-    ((FATAL_ERRORS++))
-    return 1
-  fi
-}
-
-# Check if at least one binary from a list exists
-function check_binary_one_of() {
-  local binaries=("$@")
-  local found=0
-  
-  for binary in "${binaries[@]}"; do
-    if command -v "${binary}" >/dev/null 2>&1; then
-      local version=$("${binary}" version 2>/dev/null || echo "(version unknown)")
-      print_success "${binary} is installed: ${version}"
-      found=1
-      break
-    fi
-  done
-  
-  if [[ ${found} -eq 0 ]]; then
-    # If no cluster tool is present, warn rather than fail immediately.
-    # When running in kind mode the script can attempt to install kind later
-    # (see check-prerequisites/check-kind in hack/lib/install.sh). Keep this
-    # a warning so local setups that will be created by the script are not
-    # blocked unnecessarily.
-    print_warning "None of the cluster tools were found: ${binaries[*]}"
-    echo "  Install one of:"
-    echo "    - kind: https://kind.sigs.k8s.io/docs/user/quick-start/#installation"
-    echo "    - k3d: https://k3d.io/usage/install/"
-    echo "    - minikube: https://minikube.sigs.k8s.io/docs/start/"
-    ((WARNINGS++))
-    return 0
-  fi
-  return 0
-}
-
-# Check if kubectl cluster is reachable
-function check_cluster_reachable() {
-  echo ""
-  echo "Verifying cluster connectivity..."
-  
-  kubectl cluster-info >/dev/null 2>&1
-  if [[ $? -ne 0 ]]; then
-    print_error "Kubernetes cluster is not reachable"
-    echo "  Make sure a Kubernetes cluster is running and KUBECONFIG is set correctly"
-    ((FATAL_ERRORS++))
-    return 1
-  fi
-  
-  print_success "Kubernetes cluster is reachable"
-  return 0
-}
-
-# Check if container runtime (Docker or Podman) is available
-function check_container_runtime() {
-  local runtime_found=0
-  
-  if command -v docker >/dev/null 2>&1; then
-    local docker_version=$(docker version --format '{{.Server.Version}}' 2>/dev/null || echo "(version unknown)")
-    print_success "Docker is installed: ${docker_version}"
-    runtime_found=1
-    return 0
-  fi
-  
-  if command -v podman >/dev/null 2>&1; then
-    local podman_version=$(podman version --format '{{.Version}}' 2>/dev/null || echo "(version unknown)")
-    print_success "Podman is installed: ${podman_version}"
-    runtime_found=1
-    return 0
-  fi
-  
-  if [[ ${runtime_found} -eq 0 ]]; then
-    print_error "Neither Docker nor Podman is installed"
-    echo "  Install one of:"
-    echo "    - Docker: https://docs.docker.com/install/"
-    echo "    - Podman: https://podman.io/getting-started/installation/"
-    ((FATAL_ERRORS++))
-    return 1
-  fi
-}
-
-# Main preflight checks function
-function check_prereqs() {
-  echo "================================================"
-  echo "Running Preflight Validation Checks"
-  echo "================================================"
-  echo ""
-  
-  # ---- BINARY CHECKS ----
-  echo "Checking required binaries..."
-  check_binary "kubectl" "https://kubernetes.io/docs/tasks/tools/"
-  check_binary "helm" "https://helm.sh/docs/intro/install/"
-  check_container_runtime
-  check_binary_one_of "kind" "k3d" "minikube"
-  
-  echo ""
-  
-  # ---- CLUSTER VALIDATION (only for existing clusters) ----
-  if [[ "${INSTALL_MODE}" == "existing" ]]; then
-    check_cluster_reachable
-  fi
-  
-  echo ""
-  echo "================================================"
-  
-  # Print summary
-  if [[ ${FATAL_ERRORS} -gt 0 ]]; then
-    echo -e "${RED}Preflight check FAILED${NC}"
-    echo "Fatal errors: ${FATAL_ERRORS}"
-    echo ""
-    return 1
-  fi
-  
-  if [[ ${WARNINGS} -gt 0 ]]; then
-    echo -e "${YELLOW}Preflight check completed with ${WARNINGS} warning(s)${NC}"
-  else
-    echo -e "${GREEN}Preflight check PASSED${NC}"
-  fi
-  echo ""
-  
-  return 0
-}
-
 # prepare deploy yaml and docker images
 function prepare {
   echo "Preparing..."
@@ -283,22 +118,15 @@ fi
 # Check for --check-only flag
 echo $* | grep -E -q "\-\-check-only"
 if [[ $? -eq 0 ]]; then
-  check_prereqs
+  source "${KT_ROOT}/hack/lib/install.sh"
+  check-prerequisites
   exit $?
 fi
 
 source "${KT_ROOT}/hack/lib/install.sh"
 
 # Run preflight checks (will exit with error if fatal issues found)
-check_prereqs || exit 1
-
-# The call to check-prerequisites (from hack/lib/install.sh) remains to
-# perform any install-time actions the helper implements (for example,
-# installing kind or helm automatically when running in kind mode). The
-# global preflight above only validates environment/cluster readiness and
-# provides early, actionable errors; this call continues to allow the
-# existing helper to perform safe, idempotent installs if needed.
-check-prerequisites
+check-prerequisites || exit 1
 
 prepare
 


### PR DESCRIPTION
This PR improves the developer experience when running hack/local-up-kthena.sh
by adding explicit preflight validation and early, actionable error messages.

When bringing up Kthena locally, missing tools or misconfigured clusters could
previously cause failures deep into the script with unclear output. The new
preflight checks fail fast and guide contributors toward fixing their setup.

### Changes included

#### Preflight validation
- Added a check_prereqs() function to validate required tools before deployment.
- Verify presence of kubectl and helm.
- Detect Docker or Podman container runtime.
- Warn if no cluster tool (kind/k3d/minikube) is found.
- Validate cluster connectivity for existing clusters.
- Best-effort GPU detection with warnings when NVIDIA resources or plugins are
  missing.
- Summary output distinguishing fatal errors vs warnings.

#### UX improvements
- Added a --check-only flag to run validation without deploying anything.
- Updated usage/help text to document the new mode.
- Added clear install hints for missing dependencies.
- Replaced uses of `which` with `command -v` for better shell portability.

#### Compatibility
- Kept the existing check-prerequisites helper to preserve current behavior
  (including auto-install flows), while layering the new preflight checks for
  faster feedback.

Fixes #675
