### PR TITLE
enable modelserving webhook in helm charts

### DIFF
--- a/charts/kthena/charts/workload/templates/kthena-controller-manager/component/validating-webhook.yaml
+++ b/charts/kthena/charts/workload/templates/kthena-controller-manager/component/validating-webhook.yaml
@@ -77,4 +77,26 @@ webhooks:
         resources: [ "autoscalingpolicybindings" ]
         operations: [ "CREATE", "UPDATE" ]
         scope: "Namespaced"
+  - name: validate-workload-ai-v1alpha1-modelserving.volcano.sh
+    admissionReviewVersions: [ "v1" ]
+    sideEffects: None
+    failurePolicy: Fail
+    timeoutSeconds: 30
+    clientConfig:
+      service:
+        name: kthena-controller-manager-webhook
+        namespace: {{ .Release.Namespace }}
+        path: "/validate-workload-ai-v1alpha1-modelserving"
+        port: 443
+      {{- if or (eq .Values.global.certManagementMode "auto") (eq .Values.global.certManagementMode "cert-manager") }}
+      caBundle: ""
+      {{- else }}
+      caBundle: {{ required "A caBundle is required for the kthena-controller-manager validating webhook when certManagementMode is set to 'manual' (global.webhook.caBundle)" .Values.global.webhook.caBundle | quote }}
+      {{- end }}
+    rules:
+      - apiGroups: [ "workload.serving.volcano.sh" ]
+        apiVersions: [ "v1alpha1" ]
+        resources: [ "modelservings" ]
+        operations: [ "CREATE", "UPDATE" ]
+        scope: "Namespaced"
 {{- end }}

--- a/cmd/kthena-controller-manager/main.go
+++ b/cmd/kthena-controller-manager/main.go
@@ -179,7 +179,7 @@ func setupWebhook(ctx context.Context, wc webhookConfig) error {
 	mux := http.NewServeMux()
 
 	modelServingValidator := modelservingwebhook.NewModelServingValidator()
-	mux.HandleFunc("/validate-workload-ai-v1alpha1-modelServing", modelServingValidator.Handle)
+	mux.HandleFunc("/validate-workload-ai-v1alpha1-modelserving", modelServingValidator.Handle)
 
 	modelValidator := modelboosterwebhook.NewModelValidator()
 	modelMutator := modelboosterwebhook.NewModelMutator()


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Enable modelserving webhook in helm charts

**Which issue(s) this PR fixes**:
Fixes #678

**Special notes for your reviewer**:
<img width="1692" height="74" alt="image" src="https://github.com/user-attachments/assets/3c38323c-5831-4589-9f35-7354dd829452" />


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
