### PR TITLE
fix validate gangpolicy minRoleReplicas

### DIFF
--- a/pkg/model-serving-controller/webhook/validator.go
+++ b/pkg/model-serving-controller/webhook/validator.go
@@ -237,19 +237,19 @@ func validateGangPolicy(ms *workloadv1alpha1.ModelServing) field.ErrorList {
 		// Find the role to check its actual replicas
 		for _, role := range ms.Spec.Template.Roles {
 			if role.Name == roleName {
-				// Calculate total replicas for this role (entry + workers)
-				totalReplicas := int32(1) // Entry pod
+				/// Calculate total replicas for this role
+				// minRoleReplicas is compared against the number of Role replicas
+				replicas := int32(1)
 				if role.Replicas != nil {
-					totalReplicas *= *role.Replicas
+					replicas = *role.Replicas
 				}
-				totalReplicas += role.WorkerReplicas
 
 				// Validate minReplicas doesn't exceed total replicas
-				if minReplicas > totalReplicas {
+				if minReplicas > replicas {
 					allErrs = append(allErrs, field.Invalid(
 						minRoleReplicasPath.Key(roleName),
 						minReplicas,
-						fmt.Sprintf("minRoleReplicas (%d) for role %s cannot exceed total replicas (%d)", minReplicas, roleName, totalReplicas),
+						fmt.Sprintf("minRoleReplicas (%d) for role %s cannot exceed replicas (%d)", minReplicas, roleName, replicas),
 					))
 				}
 

--- a/pkg/model-serving-controller/webhook/validator_test.go
+++ b/pkg/model-serving-controller/webhook/validator_test.go
@@ -491,7 +491,7 @@ func TestValidateGangPolicy(t *testing.T) {
 							},
 							GangPolicy: &workloadv1alpha1.GangPolicy{
 								MinRoleReplicas: map[string]int32{
-									"worker": 3, // 2*1 (entry) + 3 (workers) = 5 total, min=3 is valid
+									"worker": 2, // 2 (role replicas) >= 2 (min), valid
 								},
 							},
 						},
@@ -532,7 +532,7 @@ func TestValidateGangPolicy(t *testing.T) {
 			},
 		},
 		{
-			name: "invalid minRoleReplicas - exceeds total replicas",
+			name: "invalid minRoleReplicas - exceeds role replicas",
 			args: args{
 				ms: &workloadv1alpha1.ModelServing{
 					Spec: workloadv1alpha1.ModelServingSpec{
@@ -547,7 +547,7 @@ func TestValidateGangPolicy(t *testing.T) {
 							},
 							GangPolicy: &workloadv1alpha1.GangPolicy{
 								MinRoleReplicas: map[string]int32{
-									"worker": 10, // 2*1 (entry) + 3 (workers) = 5 total, min=10 is invalid
+									"worker": 10, // exceeds replicas 2
 								},
 							},
 						},
@@ -558,7 +558,7 @@ func TestValidateGangPolicy(t *testing.T) {
 				field.Invalid(
 					field.NewPath("spec").Child("template").Child("gangPolicy").Child("minRoleReplicas").Key("worker"),
 					int32(10),
-					"minRoleReplicas (10) for role worker cannot exceed total replicas (5)",
+					"minRoleReplicas (10) for role worker cannot exceed replicas (2)",
 				),
 			},
 		},


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:

Fixes the validation logic for minRoleReplicas within the GangPolicy of a ModelServing resource.

  Previously, the validation incorrectly calculated the available replicas by mixing role.Replicas with role.WorkerReplicas and assuming an "entry pod" structure (calculating 1 * role.Replicas + role.WorkerReplicas). This could lead to incorrect
  validation results where minRoleReplicas was compared against an inflated total.

  This PR simplifies the check to correctly compare minRoleReplicas directly against the specific Role's Replicas count.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
