### PR TITLE
Fix nil pointer panic when removing NetworkTopology without GangPolicy

### DIFF
--- a/pkg/model-serving-controller/controller/model_serving_controller.go
+++ b/pkg/model-serving-controller/controller/model_serving_controller.go
@@ -214,7 +214,7 @@ func (c *ModelServingController) updateModelServing(old, cur interface{}) {
 	// If network topology is removed, we need to clean up the PodGroups.
 	// Because minRoleReplicas is not allowed to be updated, so we do not need to check it here.
 	if oldms.Spec.Template.NetworkTopology != nil && curms.Spec.Template.NetworkTopology == nil {
-		if curms.Spec.Template.GangPolicy.MinRoleReplicas == nil {
+		if curms.Spec.Template.GangPolicy == nil || curms.Spec.Template.GangPolicy.MinRoleReplicas == nil {
 			if err := c.podGroupManager.CleanupPodGroups(context.TODO(), curms); err != nil {
 				klog.Errorf("failed to clean up PodGroups for ModelServing %s/%s: %v", curms.Namespace, curms.Name, err)
 			}


### PR DESCRIPTION
## Fix: Prevent controller panic when NetworkTopology is removed without GangPolicy

### Description

This PR fixes a **nil pointer dereference** in the `ModelServing` controller that could crash the controller when a user removes `networkTopology` from a `ModelServing` resource that does **not** define a `gangPolicy`.

Both `networkTopology` and `gangPolicy` are optional and independent features in the CRD. However, the update event handler previously assumed that `gangPolicy` would always be present when handling `networkTopology` removal, which is not guaranteed and leads to a panic.

---

### What Was Fixed

- Added a **defensive nil check** for `GangPolicy` before accessing `GangPolicy.MinRoleReplicas` in the `updateModelServing` update handler.
- Ensured the existing cleanup logic executes safely when:
  - `GangPolicy` is `nil`, or
  - `GangPolicy.MinRoleReplicas` is `nil`
- Added a **table-driven regression test** to ensure this update path never panics again.

This preserves the original behavior while preventing a controller crash.

---

### Why This Matters (Impact)

- Prevents a **controller panic** triggered by a normal user operation (removing `networkTopology`)
- Avoids **cluster-wide ModelServing reconciliation outages**
- Ensures all ModelServing resources continue to be processed normally
- Eliminates the need for manual controller restarts in this scenario

This fix protects production clusters where `networkTopology` is used without gang scheduling.

---

### Code Areas Touched

- **Controller logic**
  - `pkg/model-serving-controller/controller/model_serving_controller.go`
  - Function: `updateModelServing`

- **Tests**
  - `pkg/model-serving-controller/controller/model_serving_controller_test.go`
  - Added a new table-driven test covering NetworkTopology removal edge cases

---

### Test Verification

- Added **table-driven unit tests** covering:
  - NetworkTopology removal with `GangPolicy == nil` (regression case)
  - NetworkTopology removal with `GangPolicy.MinRoleReplicas == nil`
  - Valid gang scheduling configurations
  - No-op update scenarios
- Verified:
  - No panics occur in the update handler
  - Existing behavior remains unchanged
- All existing and new tests pass:
  - `go test ./pkg/model-serving-controller/controller/...`
  - `go vet`
  - `gofmt`
  
<img width="1404" height="674" alt="image" src="https://github.com/user-attachments/assets/90b8f1ac-e57c-413d-a8ec-1915ae93e766" />



-- Added a table-driven unit test using `t.Run` to validate the fix and prevent regressions.


---

### Summary

-  Fixes a real controller crash
-  Minimal and safe change
-  Maintainer-preferred **Go table-driven tests**
-  No behavior changes beyond crash prevention
