### PR TITLE
model-serving: enable rolling updates for networkTopology and gangPol…

### DIFF
--- a/docs/kthena/docs/assets/examples/model-serving/network-topology-rolling-update.yaml
+++ b/docs/kthena/docs/assets/examples/model-serving/network-topology-rolling-update.yaml
@@ -1,0 +1,146 @@
+# This example demonstrates how to trigger a rolling update by modifying
+# the networkTopology policy in a ModelServing resource.
+#
+# Usage:
+# 1. Apply this YAML to create the initial deployment with tier-1 constraint
+# 2. Modify spec.template.networkTopology.groupPolicy.highestTierAllowed from 1 to 2
+# 3. Apply again - this will trigger a rolling update
+# 4. Use partition field to control canary deployments (update only a subset of replicas)
+#
+# The controller will:
+# - Detect the template change via revision hash
+# - Create a new ControllerRevision
+# - Perform rolling update respecting rolloutStrategy settings
+# - Reschedule pods with the new topology constraints
+
+apiVersion: workload.serving.volcano.sh/v1alpha1
+kind: ModelServing
+metadata:
+  name: topology-rolling-update-demo
+  namespace: default
+spec:
+  schedulerName: volcano
+  replicas: 3  # Create 3 servingGroup instances
+
+  # Rolling update strategy with partition support
+  rolloutStrategy:
+    type: ServingGroupRollingUpdate
+    rollingUpdateConfiguration:
+      maxUnavailable: 1  # Update one replica at a time
+      # partition: 1     # Uncomment to protect replica-0 from updates (canary deployment)
+
+  template:
+    restartGracePeriodSeconds: 60
+
+    # Network topology configuration - changing this will trigger rolling update
+    networkTopology:
+      groupPolicy:
+        mode: hard
+        highestTierAllowed: 1  # Start with tier-1 constraint
+        # To trigger rolling update, change this to:
+        # highestTierAllowed: 2
+      rolePolicy:
+        mode: hard
+        highestTierAllowed: 1
+
+    # Prefill-Decode disaggregation pattern
+    roles:
+      - name: prefill
+        replicas: 1
+        entryTemplate:
+          metadata:
+            labels:
+              role: prefill-entry
+          spec:
+            containers:
+              - name: vllm-prefill
+                image: nginx  # Replace with actual vLLM image
+                ports:
+                  - containerPort: 8000
+                    name: http
+                resources:
+                  limits:
+                    cpu: "2"
+                    memory: "4Gi"
+                  requests:
+                    cpu: "2"
+                    memory: "4Gi"
+        workerReplicas: 2
+        workerTemplate:
+          metadata:
+            labels:
+              role: prefill-worker
+          spec:
+            containers:
+              - name: vllm-prefill-worker
+                image: nginx  # Replace with actual vLLM image
+                resources:
+                  limits:
+                    cpu: "1"
+                    memory: "2Gi"
+                  requests:
+                    cpu: "1"
+                    memory: "2Gi"
+
+      - name: decode
+        replicas: 1
+        entryTemplate:
+          metadata:
+            labels:
+              role: decode-entry
+          spec:
+            containers:
+              - name: vllm-decode
+                image: nginx  # Replace with actual vLLM image
+                ports:
+                  - containerPort: 8001
+                    name: http
+                resources:
+                  limits:
+                    cpu: "2"
+                    memory: "4Gi"
+                  requests:
+                    cpu: "2"
+                    memory: "4Gi"
+        workerReplicas: 2
+        workerTemplate:
+          metadata:
+            labels:
+              role: decode-worker
+          spec:
+            containers:
+              - name: vllm-decode-worker
+                image: nginx  # Replace with actual vLLM image
+                resources:
+                  limits:
+                    cpu: "1"
+                    memory: "2Gi"
+                  requests:
+                    cpu: "1"
+                    memory: "2Gi"
+
+---
+# Example: Canary deployment with partition
+#
+# Step 1: Deploy with partition=2 (protects replicas 0-1 from updates)
+# apiVersion: workload.serving.volcano.sh/v1alpha1
+# kind: ModelServing
+# metadata:
+#   name: topology-rolling-update-demo
+#   namespace: default
+# spec:
+#   replicas: 3
+#   rolloutStrategy:
+#     type: ServingGroupRollingUpdate
+#     rollingUpdateConfiguration:
+#       maxUnavailable: 1
+#       partition: 2  # Only replica-2 will be updated
+#   template:
+#     networkTopology:
+#       groupPolicy:
+#         mode: hard
+#         highestTierAllowed: 2  # Changed from 1 to 2
+#     # ... rest of template
+#
+# This will update only replica-2, keeping replicas 0-1 on the old topology.
+# Once validated, set partition: 0 to roll out to all replicas.

--- a/docs/kthena/docs/developer-guide/model-serving-rolling-update.md
+++ b/docs/kthena/docs/developer-guide/model-serving-rolling-update.md
@@ -6,6 +6,56 @@ Currently, `ModelServing` supports rolling upgrades at the `ServingGroup` level,
 
 - Partition: Indicates the ordinal at which the `ModelServing` should be partitioned for updates. During a rolling update, replicas with an ordinal greater than or equal to `Partition` will be updated. Replicas with an ordinal less than `Partition` will not be updated.
 
+## What Triggers a Rolling Update
+
+ModelServing automatically triggers a rolling update when you modify certain fields in `spec.template`. The controller uses a revision hash to detect template changes and initiate the rolling update process.
+
+**Rolling updates are triggered by changes to:**
+
+1. **Role configurations** - Container specs, environment variables, resource requests/limits, volumes, etc.
+2. **Network topology policies** - `spec.template.networkTopology.groupPolicy` or `spec.template.networkTopology.rolePolicy`
+3. **Gang scheduling policies** - `spec.template.gangPolicy` (primarily when adding gang scheduling for the first time)
+
+**Scaling operations (NOT rolling updates):**
+
+- **Role replicas** - Changing `spec.template.roles[*].replicas` is treated as a scaling operation, not a rolling update
+
+### Example: Updating Network Topology
+
+```yaml
+# Initial deployment with tier-1 constraint
+spec:
+  template:
+    networkTopology:
+      groupPolicy:
+        mode: hard
+        highestTierAllowed: 1
+    roles:
+      - name: prefill
+        replicas: 1
+
+# Update to tier-2 - triggers rolling update
+spec:
+  template:
+    networkTopology:
+      groupPolicy:
+        mode: hard
+        highestTierAllowed: 2  # Changed!
+    roles:
+      - name: prefill
+        replicas: 1
+```
+
+When you apply this change, the controller will:
+1. Detect the template change via revision hash comparison
+2. Create a new ControllerRevision to track the update
+3. Perform a rolling update respecting the `rolloutStrategy` configuration
+4. Reschedule pods according to the new topology constraints
+
+For a complete example, see [network-topology-rolling-update.yaml](../assets/examples/model-serving/network-topology-rolling-update.yaml).
+
+## Rollout Strategy Configuration
+
 Here's a ModelServing configured with rollout strategy:
 
 ```yaml

--- a/examples/model-serving/network-topology-rolling-update.yaml
+++ b/examples/model-serving/network-topology-rolling-update.yaml
@@ -1,0 +1,146 @@
+# This example demonstrates how to trigger a rolling update by modifying
+# the networkTopology policy in a ModelServing resource.
+#
+# Usage:
+# 1. Apply this YAML to create the initial deployment with tier-1 constraint
+# 2. Modify spec.template.networkTopology.groupPolicy.highestTierAllowed from 1 to 2
+# 3. Apply again - this will trigger a rolling update
+# 4. Use partition field to control canary deployments (update only a subset of replicas)
+#
+# The controller will:
+# - Detect the template change via revision hash
+# - Create a new ControllerRevision
+# - Perform rolling update respecting rolloutStrategy settings
+# - Reschedule pods with the new topology constraints
+
+apiVersion: workload.serving.volcano.sh/v1alpha1
+kind: ModelServing
+metadata:
+  name: topology-rolling-update-demo
+  namespace: default
+spec:
+  schedulerName: volcano
+  replicas: 3  # Create 3 servingGroup instances
+
+  # Rolling update strategy with partition support
+  rolloutStrategy:
+    type: ServingGroupRollingUpdate
+    rollingUpdateConfiguration:
+      maxUnavailable: 1  # Update one replica at a time
+      # partition: 1     # Uncomment to protect replica-0 from updates (canary deployment)
+
+  template:
+    restartGracePeriodSeconds: 60
+
+    # Network topology configuration - changing this will trigger rolling update
+    networkTopology:
+      groupPolicy:
+        mode: hard
+        highestTierAllowed: 1  # Start with tier-1 constraint
+        # To trigger rolling update, change this to:
+        # highestTierAllowed: 2
+      rolePolicy:
+        mode: hard
+        highestTierAllowed: 1
+
+    # Prefill-Decode disaggregation pattern
+    roles:
+      - name: prefill
+        replicas: 1
+        entryTemplate:
+          metadata:
+            labels:
+              role: prefill-entry
+          spec:
+            containers:
+              - name: vllm-prefill
+                image: nginx  # Replace with actual vLLM image
+                ports:
+                  - containerPort: 8000
+                    name: http
+                resources:
+                  limits:
+                    cpu: "2"
+                    memory: "4Gi"
+                  requests:
+                    cpu: "2"
+                    memory: "4Gi"
+        workerReplicas: 2
+        workerTemplate:
+          metadata:
+            labels:
+              role: prefill-worker
+          spec:
+            containers:
+              - name: vllm-prefill-worker
+                image: nginx  # Replace with actual vLLM image
+                resources:
+                  limits:
+                    cpu: "1"
+                    memory: "2Gi"
+                  requests:
+                    cpu: "1"
+                    memory: "2Gi"
+
+      - name: decode
+        replicas: 1
+        entryTemplate:
+          metadata:
+            labels:
+              role: decode-entry
+          spec:
+            containers:
+              - name: vllm-decode
+                image: nginx  # Replace with actual vLLM image
+                ports:
+                  - containerPort: 8001
+                    name: http
+                resources:
+                  limits:
+                    cpu: "2"
+                    memory: "4Gi"
+                  requests:
+                    cpu: "2"
+                    memory: "4Gi"
+        workerReplicas: 2
+        workerTemplate:
+          metadata:
+            labels:
+              role: decode-worker
+          spec:
+            containers:
+              - name: vllm-decode-worker
+                image: nginx  # Replace with actual vLLM image
+                resources:
+                  limits:
+                    cpu: "1"
+                    memory: "2Gi"
+                  requests:
+                    cpu: "1"
+                    memory: "2Gi"
+
+---
+# Example: Canary deployment with partition
+#
+# Step 1: Deploy with partition=2 (protects replicas 0-1 from updates)
+# apiVersion: workload.serving.volcano.sh/v1alpha1
+# kind: ModelServing
+# metadata:
+#   name: topology-rolling-update-demo
+#   namespace: default
+# spec:
+#   replicas: 3
+#   rolloutStrategy:
+#     type: ServingGroupRollingUpdate
+#     rollingUpdateConfiguration:
+#       maxUnavailable: 1
+#       partition: 2  # Only replica-2 will be updated
+#   template:
+#     networkTopology:
+#       groupPolicy:
+#         mode: hard
+#         highestTierAllowed: 2  # Changed from 1 to 2
+#     # ... rest of template
+#
+# This will update only replica-2, keeping replicas 0-1 on the old topology.
+# Once validated, set partition: 0 to roll out to all replicas.

--- a/pkg/model-serving-controller/controller/model_serving_controller_test.go
+++ b/pkg/model-serving-controller/controller/model_serving_controller_test.go
@@ -2840,7 +2840,7 @@ func TestModelServingVersionControl(t *testing.T) {
 			// Create ControllerRevision for historical revision if partition is set
 			// This simulates the scenario where a partition-protected group was deleted and its revision was recorded
 			if tt.partition != nil {
-				_, err := utils.CreateControllerRevision(context.Background(), kubeClient, ms, tt.initialRevision, ms.Spec.Template.Roles)
+				_, err := utils.CreateControllerRevision(context.Background(), kubeClient, ms, tt.initialRevision, ms.Spec.Template)
 				assert.NoError(t, err, "Failed to create ControllerRevision for initial revision")
 			}
 
@@ -3001,7 +3001,11 @@ func TestScaleUpServingGroups_TemplateRecovery(t *testing.T) {
 
 			// Create ControllerRevision with recovery template if needed
 			if tt.hasControllerRevision {
-				_, err := utils.CreateControllerRevision(ctx, kubeClient, ms, tt.currentRevision, tt.recoveryTemplateRoles)
+				// Wrap roles in ServingGroup template for storage
+				recoveryTemplate := workloadv1alpha1.ServingGroup{
+					Roles: tt.recoveryTemplateRoles,
+				}
+				_, err := utils.CreateControllerRevision(ctx, kubeClient, ms, tt.currentRevision, recoveryTemplate)
 				assert.NoError(t, err, "Failed to create ControllerRevision")
 			}
 

--- a/pkg/model-serving-controller/controller/revision_test.go
+++ b/pkg/model-serving-controller/controller/revision_test.go
@@ -1,0 +1,289 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	volcanoV1Beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
+
+	workloadv1alpha1 "github.com/volcano-sh/kthena/pkg/apis/workload/v1alpha1"
+	"github.com/volcano-sh/kthena/pkg/model-serving-controller/utils"
+)
+
+// TestNetworkTopologyChangeTriggersRevision verifies that modifying networkTopology
+// policy triggers a revision change, which should initiate a rolling update.
+func TestNetworkTopologyChangeTriggersRevision(t *testing.T) {
+	tests := []struct {
+		name                 string
+		baseMS               *workloadv1alpha1.ModelServing
+		modifyFunc           func(*workloadv1alpha1.ModelServing)
+		expectRevisionChange bool
+		description          string
+	}{
+		{
+			name: "networkTopology_groupPolicy_mode_change",
+			baseMS: &workloadv1alpha1.ModelServing{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-ms",
+					Namespace: "default",
+				},
+				Spec: workloadv1alpha1.ModelServingSpec{
+					Template: workloadv1alpha1.ServingGroup{
+						Roles: []workloadv1alpha1.Role{
+							{Name: "prefill", Replicas: ptr.To[int32](1)},
+						},
+						NetworkTopology: &workloadv1alpha1.NetworkTopology{
+							GroupPolicy: &volcanoV1Beta1.NetworkTopologySpec{
+								Mode:               "hard",
+								HighestTierAllowed: ptr.To[int](1),
+							},
+						},
+					},
+				},
+			},
+			modifyFunc: func(ms *workloadv1alpha1.ModelServing) {
+				ms.Spec.Template.NetworkTopology.GroupPolicy.Mode = "soft"
+			},
+			expectRevisionChange: true,
+			description:          "Changing networkTopology.groupPolicy.mode should trigger revision change",
+		},
+		{
+			name: "networkTopology_groupPolicy_tier_change",
+			baseMS: &workloadv1alpha1.ModelServing{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-ms",
+					Namespace: "default",
+				},
+				Spec: workloadv1alpha1.ModelServingSpec{
+					Template: workloadv1alpha1.ServingGroup{
+						Roles: []workloadv1alpha1.Role{
+							{Name: "prefill", Replicas: ptr.To[int32](1)},
+						},
+						NetworkTopology: &workloadv1alpha1.NetworkTopology{
+							GroupPolicy: &volcanoV1Beta1.NetworkTopologySpec{
+								Mode:               "hard",
+								HighestTierAllowed: ptr.To[int](1),
+							},
+						},
+					},
+				},
+			},
+			modifyFunc: func(ms *workloadv1alpha1.ModelServing) {
+				ms.Spec.Template.NetworkTopology.GroupPolicy.HighestTierAllowed = ptr.To[int](2)
+			},
+			expectRevisionChange: true,
+			description:          "Changing networkTopology.groupPolicy.highestTierAllowed should trigger revision change",
+		},
+		{
+			name: "networkTopology_rolePolicy_change",
+			baseMS: &workloadv1alpha1.ModelServing{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-ms",
+					Namespace: "default",
+				},
+				Spec: workloadv1alpha1.ModelServingSpec{
+					Template: workloadv1alpha1.ServingGroup{
+						Roles: []workloadv1alpha1.Role{
+							{Name: "prefill", Replicas: ptr.To[int32](1)},
+						},
+						NetworkTopology: &workloadv1alpha1.NetworkTopology{
+							RolePolicy: &volcanoV1Beta1.NetworkTopologySpec{
+								Mode:               "hard",
+								HighestTierAllowed: ptr.To[int](1),
+							},
+						},
+					},
+				},
+			},
+			modifyFunc: func(ms *workloadv1alpha1.ModelServing) {
+				ms.Spec.Template.NetworkTopology.RolePolicy.HighestTierAllowed = ptr.To[int](3)
+			},
+			expectRevisionChange: true,
+			description:          "Changing networkTopology.rolePolicy should trigger revision change",
+		},
+		{
+			name: "adding_networkTopology",
+			baseMS: &workloadv1alpha1.ModelServing{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-ms",
+					Namespace: "default",
+				},
+				Spec: workloadv1alpha1.ModelServingSpec{
+					Template: workloadv1alpha1.ServingGroup{
+						Roles: []workloadv1alpha1.Role{
+							{Name: "prefill", Replicas: ptr.To[int32](1)},
+						},
+					},
+				},
+			},
+			modifyFunc: func(ms *workloadv1alpha1.ModelServing) {
+				ms.Spec.Template.NetworkTopology = &workloadv1alpha1.NetworkTopology{
+					GroupPolicy: &volcanoV1Beta1.NetworkTopologySpec{
+						Mode:               "hard",
+						HighestTierAllowed: ptr.To[int](1),
+					},
+				}
+			},
+			expectRevisionChange: true,
+			description:          "Adding networkTopology should trigger revision change",
+		},
+		{
+			name: "gangPolicy_addition",
+			baseMS: &workloadv1alpha1.ModelServing{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-ms",
+					Namespace: "default",
+				},
+				Spec: workloadv1alpha1.ModelServingSpec{
+					Template: workloadv1alpha1.ServingGroup{
+						Roles: []workloadv1alpha1.Role{
+							{Name: "prefill", Replicas: ptr.To[int32](1)},
+						},
+					},
+				},
+			},
+			modifyFunc: func(ms *workloadv1alpha1.ModelServing) {
+				ms.Spec.Template.GangPolicy = &workloadv1alpha1.GangPolicy{
+					MinRoleReplicas: map[string]int32{
+						"prefill": 1,
+					},
+				}
+			},
+			expectRevisionChange: true,
+			description:          "Adding gangPolicy should trigger revision change",
+		},
+		{
+			name: "role_replicas_only_change",
+			baseMS: &workloadv1alpha1.ModelServing{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-ms",
+					Namespace: "default",
+				},
+				Spec: workloadv1alpha1.ModelServingSpec{
+					Template: workloadv1alpha1.ServingGroup{
+						Roles: []workloadv1alpha1.Role{
+							{Name: "prefill", Replicas: ptr.To[int32](1)},
+						},
+					},
+				},
+			},
+			modifyFunc: func(ms *workloadv1alpha1.ModelServing) {
+				ms.Spec.Template.Roles[0].Replicas = ptr.To[int32](3)
+			},
+			expectRevisionChange: false,
+			description:          "Changing only role.replicas should NOT trigger revision change",
+		},
+		{
+			name: "role_container_spec_change",
+			baseMS: &workloadv1alpha1.ModelServing{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-ms",
+					Namespace: "default",
+				},
+				Spec: workloadv1alpha1.ModelServingSpec{
+					Template: workloadv1alpha1.ServingGroup{
+						Roles: []workloadv1alpha1.Role{
+							{
+								Name:     "prefill",
+								Replicas: ptr.To[int32](1),
+								EntryTemplate: workloadv1alpha1.PodTemplateSpec{
+									Metadata: &workloadv1alpha1.Metadata{
+										Labels: map[string]string{"app": "v1"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			modifyFunc: func(ms *workloadv1alpha1.ModelServing) {
+				ms.Spec.Template.Roles[0].EntryTemplate.Metadata.Labels["app"] = "v2"
+			},
+			expectRevisionChange: true,
+			description:          "Changing role container specs should trigger revision change",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Calculate initial revision
+			copy1 := utils.RemoveRoleReplicasForRevision(tt.baseMS)
+			revision1 := utils.Revision(copy1.Spec.Template)
+
+			// Modify the ModelServing
+			modifiedMS := tt.baseMS.DeepCopy()
+			tt.modifyFunc(modifiedMS)
+
+			// Calculate new revision
+			copy2 := utils.RemoveRoleReplicasForRevision(modifiedMS)
+			revision2 := utils.Revision(copy2.Spec.Template)
+
+			// Verify expectations
+			if tt.expectRevisionChange {
+				if revision1 == revision2 {
+					t.Errorf("%s: Expected revision to change, but got same revision: %s\nDescription: %s",
+						tt.name, revision1, tt.description)
+				}
+			} else {
+				if revision1 != revision2 {
+					t.Errorf("%s: Expected revision to remain same, but got different revisions: %s vs %s\nDescription: %s",
+						tt.name, revision1, revision2, tt.description)
+				}
+			}
+		})
+	}
+}
+
+// TestRevisionConsistency verifies that the same template produces the same revision hash
+func TestRevisionConsistency(t *testing.T) {
+	ms := &workloadv1alpha1.ModelServing{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-ms",
+			Namespace: "default",
+		},
+		Spec: workloadv1alpha1.ModelServingSpec{
+			Template: workloadv1alpha1.ServingGroup{
+				Roles: []workloadv1alpha1.Role{
+					{Name: "prefill", Replicas: ptr.To[int32](1)},
+				},
+				NetworkTopology: &workloadv1alpha1.NetworkTopology{
+					GroupPolicy: &volcanoV1Beta1.NetworkTopologySpec{
+						Mode:               "hard",
+						HighestTierAllowed: ptr.To[int](1),
+					},
+				},
+			},
+		},
+	}
+
+	// Calculate revision multiple times
+	copy1 := utils.RemoveRoleReplicasForRevision(ms)
+	revision1 := utils.Revision(copy1.Spec.Template)
+
+	copy2 := utils.RemoveRoleReplicasForRevision(ms)
+	revision2 := utils.Revision(copy2.Spec.Template)
+
+	copy3 := utils.RemoveRoleReplicasForRevision(ms)
+	revision3 := utils.Revision(copy3.Spec.Template)
+
+	if revision1 != revision2 || revision2 != revision3 {
+		t.Errorf("Expected consistent revision hashes, got: %s, %s, %s", revision1, revision2, revision3)
+	}
+}


### PR DESCRIPTION
Enable rolling updates for networkTopology and gangPolicy changes

- Modified revision calculation to hash entire Spec.Template instead of just Roles
- Added GetTemplateFromControllerRevision() for backward-compatible template extraction
- NetworkTopology and GangPolicy changes now trigger rolling updates as expected
- Added comprehensive unit tests for revision change detection
- Created example YAML demonstrating networkTopology rolling updates
- Updated documentation explaining rolling update triggers

Fixes #690

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This PR enables automatic rolling updates when `networkTopology` or `gangPolicy` fields are modified in a ModelServing resource, aligning with Kubernetes' declarative API philosophy.

**Current Problem:**
- Changing `spec.template.networkTopology` updates the PodGroup but does not reschedule existing pods
- Users must manually delete pods to apply new topology constraints
- This violates the declarative API principle where spec changes should reconcile cluster state

**Solution:**
- Changed revision hash calculation from `Spec.Template.Roles` to `Spec.Template` (entire template)
- NetworkTopology and GangPolicy changes now trigger rolling updates via revision detection
- Added backward-compatible `GetTemplateFromControllerRevision()` function
- Comprehensive test coverage ensures correctness

**Key Features:**
- NetworkTopology changes (groupPolicy, rolePolicy) trigger rolling updates
- GangPolicy changes trigger rolling updates (primarily when initially adding)
- Role.Replicas changes still treated as scaling operations (not rolling updates)
- Fully backward compatible with existing ControllerRevisions

**Which issue(s) this PR fixes**:

Fixes #690

**Special notes for your reviewer**:

1. **Backward Compatibility:** The new `GetTemplateFromControllerRevision()` function handles both old (roles-only) and new (full template) ControllerRevision formats. Existing deployments will continue to work without migration.

2. **GangPolicy Inclusion:** While GangPolicy is mostly immutable after being set, including it in the revision hash is correct because:
   - Adding gang scheduling for the first time requires pods to operate under the new scheduling paradigm
   - The immutability constraint prevents accidental rolling updates after initial setup

3. **No Breaking Changes:** 
   - `GetRolesFromControllerRevision()` is deprecated but still functional (calls new function internally)
   - Revision calculation change is transparent to existing logic
   - All existing tests pass

4. **Test Coverage:**
   - 7 new unit tests covering all networkTopology change scenarios
   - Tests verify role.replicas don't trigger revisions (maintains existing behavior)
   - Revision consistency test ensures deterministic hashing

5. **Files to Review:**
   - `controller_revision.go`: New template extraction function (backward compatible)
   - `revision_test.go`: Comprehensive test coverage
   - `model-serving-rolling-update.md`: User-facing documentation
   - `network-topology-rolling-update.yaml`: Practical example with detailed comments

**Does this PR introduce a user-facing change?**:

```release-note
ModelServing now automatically triggers rolling updates when `spec.template.networkTopology` or `spec.template.gangPolicy` are modified, enabling declarative network topology management with partition-based canary deployments.
