### PR TITLE
fix: set OutputTokensPerUnit to nil in InputLimitRateTest

### DIFF
--- a/test/e2e/router/shared.go
+++ b/test/e2e/router/shared.go
@@ -539,6 +539,10 @@ func TestModelRouteWithRateLimitShared(t *testing.T, testCtx *routercontext.Rout
 
 		modelRoute := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute]("examples/kthena-router/ModelRouteWithRateLimit.yaml")
 		modelRoute.Namespace = testNamespace
+		// Only test input rate limit; remove output limit to avoid 429 "output token rate limit exceeded"
+		if modelRoute.Spec.RateLimit != nil {
+			modelRoute.Spec.RateLimit.OutputTokensPerUnit = nil
+		}
 		setupModelRouteWithGatewayAPI(modelRoute, useGatewayApi, kthenaNamespace)
 
 		createdModelRoute, err := testCtx.KthenaClient.NetworkingV1alpha1().ModelRoutes(testNamespace).Create(ctx, modelRoute, metav1.CreateOptions{})
@@ -604,6 +608,10 @@ func TestModelRouteWithRateLimitShared(t *testing.T, testCtx *routercontext.Rout
 
 		modelRoute := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute]("examples/kthena-router/ModelRouteWithRateLimit.yaml")
 		modelRoute.Namespace = testNamespace
+		// Only test input rate limit; remove output limit to avoid 429 "output token rate limit exceeded"
+		if modelRoute.Spec.RateLimit != nil {
+			modelRoute.Spec.RateLimit.OutputTokensPerUnit = nil
+		}
 		setupModelRouteWithGatewayAPI(modelRoute, useGatewayApi, kthenaNamespace)
 
 		createdModelRoute, err := testCtx.KthenaClient.NetworkingV1alpha1().ModelRoutes(testNamespace).Create(ctx, modelRoute, metav1.CreateOptions{})


### PR DESCRIPTION


**Which issue(s) this PR fixes**:
Fixes https://github.com/volcano-sh/kthena/issues/710

We dont need output token limit in InputLimitRateTest
