### PR TITLE
Fix: The ServingGroup will fail to rebuild when recoverPolicy is ServingGroupRecreate.

### DIFF
--- a/pkg/model-serving-controller/controller/model_serving_controller.go
+++ b/pkg/model-serving-controller/controller/model_serving_controller.go
@@ -769,6 +769,13 @@ func (c *ModelServingController) manageRoleReplicas(ctx context.Context, ms *wor
 		return
 	}
 
+	// Check if the entire ServingGroup is being deleted - if so, don't recreate pods
+	sgStatus := c.store.GetServingGroupStatus(utils.GetNamespaceName(ms), groupName)
+	if sgStatus == datastore.ServingGroupDeleting {
+		klog.V(4).Infof("ServingGroup %s is being deleted, skipping role %s management", groupName, targetRole.Name)
+		return
+	}
+
 	// TODO: need to check the pod spec match the modelserving spec, if not, recreate the pod
 
 	expectedCount := int(*targetRole.Replicas)


### PR DESCRIPTION

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:

When `recoverPolicy` is set to `ServingGroupRecreate`, the deletion of pods is blocked because `manageRoleReplicas` does not check the ServingGroup status. This prevents the ServingGroup from being recreated.

A check for the servingGroup status has now been added to manageRoleReplicas.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
