### PR TITLE
fix: add a initialSync check in updatePod

### DIFF
--- a/pkg/model-serving-controller/controller/model_serving_controller.go
+++ b/pkg/model-serving-controller/controller/model_serving_controller.go
@@ -291,12 +291,12 @@ func (c *ModelServingController) updatePod(_, newObj interface{}) {
 			klog.Errorf("handle error pod failed: %v", err)
 		}
 	default:
-		// Add the group and role to the global storage, otherwise after restart,
-		// it may create unexpected group and role because of missing group or role info.
-		c.store.AddServingGroupAndRole(types.NamespacedName{
-			Namespace: ms.Namespace,
-			Name:      ms.Name,
-		}, servingGroupName, utils.PodRevision(newPod), utils.GetRoleName(newPod), utils.GetRoleID(newPod))
+		if !c.initialSync {
+			c.store.AddServingGroupAndRole(types.NamespacedName{
+				Namespace: ms.Namespace,
+				Name:      ms.Name,
+			}, servingGroupName, utils.PodRevision(newPod), utils.GetRoleName(newPod), utils.GetRoleID(newPod))
+		}
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind enhancement

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**Which issue(s) this PR fixes**:
Fixes https://github.com/volcano-sh/kthena/issues/712

Before fix
```
(base) zhoujinyu@zhoujinyudeMacBook-Air kthena % go test -v -count=5 -run 'TestModelServingControllerModelServingLifecycle' ./pkg/model-serving-controller/controller/ -timeout 30s
=== RUN   TestModelServingControllerModelServingLifecycle
I0130 14:56:28.857874    9460 manager.go:441] [CRD Added] PodGroup CRD detected
I0130 14:56:28.858021    9460 manager.go:447] [CRD Added] PodGroup CRD does not have subGroupPolicy feature
I0130 14:56:28.858102    9460 model_serving_controller.go:132] Set the ModelServing event handler
I0130 14:56:28.858631    9460 manager.go:441] [CRD Added] PodGroup CRD detected
I0130 14:56:28.858639    9460 manager.go:447] [CRD Added] PodGroup CRD does not have subGroupPolicy feature
I0130 14:56:28.959212    9460 model_serving_controller.go:489] initial sync has been done
I0130 14:56:28.959235    9460 model_serving_controller.go:491] start modelServing controller
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingCreate
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingScaleUp
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingUpdateScaleDown
    model_serving_controller_test.go:1468: Object not found in cache after 2s timeout
    model_serving_controller_test.go:890: 
                Error Trace:    /Users/zhoujinyu/CursorProject/kthena/pkg/model-serving-controller/controller/model_serving_controller_test.go:890
                Error:          Should be true
                Test:           TestModelServingControllerModelServingLifecycle/ModelServingUpdateScaleDown
                Messages:       Pods should be created and synced to cache
    model_serving_controller_test.go:1552: 
                Error Trace:    /Users/zhoujinyu/CursorProject/kthena/pkg/model-serving-controller/controller/model_serving_controller_test.go:1552
                                                        /Users/zhoujinyu/CursorProject/kthena/pkg/model-serving-controller/controller/model_serving_controller_test.go:894
                Error:          Not equal: 
                                expected: 2
                                actual  : 3
                Test:           TestModelServingControllerModelServingLifecycle/ModelServingUpdateScaleDown
                Messages:       ServingGroup test-ms-scale-down-2 should have 2 pods
    model_serving_controller_test.go:1588: 
                Error Trace:    /Users/zhoujinyu/CursorProject/kthena/pkg/model-serving-controller/controller/model_serving_controller_test.go:1588
                                                        /Users/zhoujinyu/CursorProject/kthena/pkg/model-serving-controller/controller/model_serving_controller_test.go:895
                Error:          elements differ
                            
                                extra elements in list A:
                                ([]interface {}) (len=1) {
                                 (string) (len=9) "prefill-0"
                                }
                            
                            
                                extra elements in list B:
                                ([]interface {}) (len=1) {
                                 (string) (len=9) "prefill-2"
                                }
                            
                            
                                listA:
                                ([]string) (len=2) {
                                 (string) (len=9) "prefill-0",
                                 (string) (len=9) "prefill-1"
                                }
                            
                            
                                listB:
                                ([]string) (len=2) {
                                 (string) (len=9) "prefill-1",
                                 (string) (len=9) "prefill-2"
                                }
                Test:           TestModelServingControllerModelServingLifecycle/ModelServingUpdateScaleDown
                Messages:       Role IDs in group test-ms-scale-down-2 for role prefill should follow expected pattern
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingRoleReplicasScaleUp
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingRoleReplicasScaleDown
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingBinPackScaleDown
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingGangPolicyPodGroups
    model_serving_controller_test.go:1368: Scaling up ModelServing replicas to trigger PodGroup updates
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingGangPolicyCleanupPodGroups
--- FAIL: TestModelServingControllerModelServingLifecycle (2.46s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingCreate (0.02s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingScaleUp (0.03s)
    --- FAIL: TestModelServingControllerModelServingLifecycle/ModelServingUpdateScaleDown (2.03s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingRoleReplicasScaleUp (0.03s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingRoleReplicasScaleDown (0.04s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingBinPackScaleDown (0.13s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingGangPolicyPodGroups (0.04s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingGangPolicyCleanupPodGroups (0.02s)
=== RUN   TestModelServingControllerModelServingLifecycle
I0130 14:56:31.319309    9460 manager.go:441] [CRD Added] PodGroup CRD detected
I0130 14:56:31.319332    9460 manager.go:447] [CRD Added] PodGroup CRD does not have subGroupPolicy feature
I0130 14:56:31.319415    9460 model_serving_controller.go:132] Set the ModelServing event handler
I0130 14:56:31.320808    9460 manager.go:441] [CRD Added] PodGroup CRD detected
I0130 14:56:31.320828    9460 manager.go:447] [CRD Added] PodGroup CRD does not have subGroupPolicy feature
I0130 14:56:31.420558    9460 model_serving_controller.go:489] initial sync has been done
I0130 14:56:31.420596    9460 model_serving_controller.go:491] start modelServing controller
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingCreate
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingScaleUp
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingUpdateScaleDown
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingRoleReplicasScaleUp
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingRoleReplicasScaleDown
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingBinPackScaleDown
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingGangPolicyPodGroups
    model_serving_controller_test.go:1368: Scaling up ModelServing replicas to trigger PodGroup updates
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingGangPolicyCleanupPodGroups
--- PASS: TestModelServingControllerModelServingLifecycle (0.47s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingCreate (0.02s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingScaleUp (0.03s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingUpdateScaleDown (0.04s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingRoleReplicasScaleUp (0.03s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingRoleReplicasScaleDown (0.04s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingBinPackScaleDown (0.13s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingGangPolicyPodGroups (0.04s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingGangPolicyCleanupPodGroups (0.02s)
=== RUN   TestModelServingControllerModelServingLifecycle
I0130 14:56:31.790025    9460 manager.go:441] [CRD Added] PodGroup CRD detected
I0130 14:56:31.790040    9460 manager.go:447] [CRD Added] PodGroup CRD does not have subGroupPolicy feature
I0130 14:56:31.790078    9460 model_serving_controller.go:132] Set the ModelServing event handler
I0130 14:56:31.790418    9460 manager.go:441] [CRD Added] PodGroup CRD detected
I0130 14:56:31.790432    9460 manager.go:447] [CRD Added] PodGroup CRD does not have subGroupPolicy feature
I0130 14:56:31.891188    9460 model_serving_controller.go:489] initial sync has been done
I0130 14:56:31.891209    9460 model_serving_controller.go:491] start modelServing controller
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingCreate
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingScaleUp
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingUpdateScaleDown
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingRoleReplicasScaleUp
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingRoleReplicasScaleDown
    model_serving_controller_test.go:1468: Object not found in cache after 2s timeout
    model_serving_controller_test.go:1070: 
                Error Trace:    /Users/zhoujinyu/CursorProject/kthena/pkg/model-serving-controller/controller/model_serving_controller_test.go:1070
                Error:          Should be true
                Test:           TestModelServingControllerModelServingLifecycle/ModelServingRoleReplicasScaleDown
                Messages:       Pods should be created and synced to cache
    model_serving_controller_test.go:1552: 
                Error Trace:    /Users/zhoujinyu/CursorProject/kthena/pkg/model-serving-controller/controller/model_serving_controller_test.go:1552
                                                        /Users/zhoujinyu/CursorProject/kthena/pkg/model-serving-controller/controller/model_serving_controller_test.go:1074
                Error:          Not equal: 
                                expected: 3
                                actual  : 4
                Test:           TestModelServingControllerModelServingLifecycle/ModelServingRoleReplicasScaleDown
                Messages:       ServingGroup test-role-scale-down-1 should have 3 pods
    model_serving_controller_test.go:1588: 
                Error Trace:    /Users/zhoujinyu/CursorProject/kthena/pkg/model-serving-controller/controller/model_serving_controller_test.go:1588
                                                        /Users/zhoujinyu/CursorProject/kthena/pkg/model-serving-controller/controller/model_serving_controller_test.go:1075
                Error:          elements differ
                            
                                extra elements in list A:
                                ([]interface {}) (len=1) {
                                 (string) (len=9) "prefill-0"
                                }
                            
                            
                                extra elements in list B:
                                ([]interface {}) (len=1) {
                                 (string) (len=9) "prefill-3"
                                }
                            
                            
                                listA:
                                ([]string) (len=3) {
                                 (string) (len=9) "prefill-0",
                                 (string) (len=9) "prefill-1",
                                 (string) (len=9) "prefill-2"
                                }
                            
                            
                                listB:
                                ([]string) (len=3) {
                                 (string) (len=9) "prefill-1",
                                 (string) (len=9) "prefill-2",
                                 (string) (len=9) "prefill-3"
                                }
                Test:           TestModelServingControllerModelServingLifecycle/ModelServingRoleReplicasScaleDown
                Messages:       Role IDs in group test-role-scale-down-1 for role prefill should follow expected pattern
    model_serving_controller_test.go:1468: Object not found in cache after 2s timeout
    model_serving_controller_test.go:1139: 
                Error Trace:    /Users/zhoujinyu/CursorProject/kthena/pkg/model-serving-controller/controller/model_serving_controller_test.go:1139
                Error:          Should be true
                Test:           TestModelServingControllerModelServingLifecycle/ModelServingRoleReplicasScaleDown
                Messages:       Pods should be created and synced to cache
    model_serving_controller_test.go:1162: 
                Error Trace:    /Users/zhoujinyu/CursorProject/kthena/pkg/model-serving-controller/controller/model_serving_controller_test.go:1162
                Error:          Not equal: 
                                expected: 2
                                actual  : 3
                Test:           TestModelServingControllerModelServingLifecycle/ModelServingRoleReplicasScaleDown
                Messages:       total pods across all groups should match expected count after scale down
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingBinPackScaleDown
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingGangPolicyPodGroups
    model_serving_controller_test.go:1368: Scaling up ModelServing replicas to trigger PodGroup updates
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingGangPolicyCleanupPodGroups
--- FAIL: TestModelServingControllerModelServingLifecycle (4.45s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingCreate (0.02s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingScaleUp (0.03s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingUpdateScaleDown (0.04s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingRoleReplicasScaleUp (0.03s)
    --- FAIL: TestModelServingControllerModelServingLifecycle/ModelServingRoleReplicasScaleDown (4.02s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingBinPackScaleDown (0.13s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingGangPolicyPodGroups (0.04s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingGangPolicyCleanupPodGroups (0.02s)
=== RUN   TestModelServingControllerModelServingLifecycle
I0130 14:56:36.240243    9460 manager.go:441] [CRD Added] PodGroup CRD detected
I0130 14:56:36.240261    9460 manager.go:447] [CRD Added] PodGroup CRD does not have subGroupPolicy feature
I0130 14:56:36.240309    9460 model_serving_controller.go:132] Set the ModelServing event handler
I0130 14:56:36.240576    9460 manager.go:441] [CRD Added] PodGroup CRD detected
I0130 14:56:36.241730    9460 manager.go:447] [CRD Added] PodGroup CRD does not have subGroupPolicy feature
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingCreate
I0130 14:56:36.341430    9460 model_serving_controller.go:489] initial sync has been done
I0130 14:56:36.341466    9460 model_serving_controller.go:491] start modelServing controller
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingScaleUp
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingUpdateScaleDown
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingRoleReplicasScaleUp
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingRoleReplicasScaleDown
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingBinPackScaleDown
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingGangPolicyPodGroups
    model_serving_controller_test.go:1368: Scaling up ModelServing replicas to trigger PodGroup updates
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingGangPolicyCleanupPodGroups
--- PASS: TestModelServingControllerModelServingLifecycle (0.46s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingCreate (0.02s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingScaleUp (0.03s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingUpdateScaleDown (0.04s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingRoleReplicasScaleUp (0.03s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingRoleReplicasScaleDown (0.04s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingBinPackScaleDown (0.13s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingGangPolicyPodGroups (0.04s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingGangPolicyCleanupPodGroups (0.02s)
=== RUN   TestModelServingControllerModelServingLifecycle
I0130 14:56:36.704841    9460 manager.go:441] [CRD Added] PodGroup CRD detected
I0130 14:56:36.704850    9460 manager.go:447] [CRD Added] PodGroup CRD does not have subGroupPolicy feature
I0130 14:56:36.704880    9460 model_serving_controller.go:132] Set the ModelServing event handler
I0130 14:56:36.705134    9460 manager.go:441] [CRD Added] PodGroup CRD detected
I0130 14:56:36.705143    9460 manager.go:447] [CRD Added] PodGroup CRD does not have subGroupPolicy feature
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingCreate
I0130 14:56:36.805320    9460 model_serving_controller.go:489] initial sync has been done
I0130 14:56:36.805430    9460 model_serving_controller.go:491] start modelServing controller
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingScaleUp
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingUpdateScaleDown
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingRoleReplicasScaleUp
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingRoleReplicasScaleDown
    model_serving_controller_test.go:1468: Object not found in cache after 2s timeout
    model_serving_controller_test.go:1070: 
                Error Trace:    /Users/zhoujinyu/CursorProject/kthena/pkg/model-serving-controller/controller/model_serving_controller_test.go:1070
                Error:          Should be true
                Test:           TestModelServingControllerModelServingLifecycle/ModelServingRoleReplicasScaleDown
                Messages:       Pods should be created and synced to cache
    model_serving_controller_test.go:1552: 
                Error Trace:    /Users/zhoujinyu/CursorProject/kthena/pkg/model-serving-controller/controller/model_serving_controller_test.go:1552
                                                        /Users/zhoujinyu/CursorProject/kthena/pkg/model-serving-controller/controller/model_serving_controller_test.go:1074
                Error:          Not equal: 
                                expected: 3
                                actual  : 4
                Test:           TestModelServingControllerModelServingLifecycle/ModelServingRoleReplicasScaleDown
                Messages:       ServingGroup test-role-scale-down-1 should have 3 pods
    model_serving_controller_test.go:1588: 
                Error Trace:    /Users/zhoujinyu/CursorProject/kthena/pkg/model-serving-controller/controller/model_serving_controller_test.go:1588
                                                        /Users/zhoujinyu/CursorProject/kthena/pkg/model-serving-controller/controller/model_serving_controller_test.go:1075
                Error:          elements differ
                            
                                extra elements in list A:
                                ([]interface {}) (len=1) {
                                 (string) (len=9) "prefill-0"
                                }
                            
                            
                                extra elements in list B:
                                ([]interface {}) (len=1) {
                                 (string) (len=9) "prefill-3"
                                }
                            
                            
                                listA:
                                ([]string) (len=3) {
                                 (string) (len=9) "prefill-0",
                                 (string) (len=9) "prefill-1",
                                 (string) (len=9) "prefill-2"
                                }
                            
                            
                                listB:
                                ([]string) (len=3) {
                                 (string) (len=9) "prefill-1",
                                 (string) (len=9) "prefill-2",
                                 (string) (len=9) "prefill-3"
                                }
                Test:           TestModelServingControllerModelServingLifecycle/ModelServingRoleReplicasScaleDown
                Messages:       Role IDs in group test-role-scale-down-1 for role prefill should follow expected pattern
    model_serving_controller_test.go:1468: Object not found in cache after 2s timeout
    model_serving_controller_test.go:1139: 
                Error Trace:    /Users/zhoujinyu/CursorProject/kthena/pkg/model-serving-controller/controller/model_serving_controller_test.go:1139
                Error:          Should be true
                Test:           TestModelServingControllerModelServingLifecycle/ModelServingRoleReplicasScaleDown
                Messages:       Pods should be created and synced to cache
    model_serving_controller_test.go:1162: 
                Error Trace:    /Users/zhoujinyu/CursorProject/kthena/pkg/model-serving-controller/controller/model_serving_controller_test.go:1162
                Error:          Not equal: 
                                expected: 2
                                actual  : 3
                Test:           TestModelServingControllerModelServingLifecycle/ModelServingRoleReplicasScaleDown
                Messages:       total pods across all groups should match expected count after scale down
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingBinPackScaleDown
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingGangPolicyPodGroups
    model_serving_controller_test.go:1368: Scaling up ModelServing replicas to trigger PodGroup updates
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingGangPolicyCleanupPodGroups
--- FAIL: TestModelServingControllerModelServingLifecycle (4.45s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingCreate (0.02s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingScaleUp (0.03s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingUpdateScaleDown (0.04s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingRoleReplicasScaleUp (0.03s)
    --- FAIL: TestModelServingControllerModelServingLifecycle/ModelServingRoleReplicasScaleDown (4.03s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingBinPackScaleDown (0.13s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingGangPolicyPodGroups (0.04s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingGangPolicyCleanupPodGroups (0.02s)
FAIL
FAIL    github.com/volcano-sh/kthena/pkg/model-serving-controller/controller    12.606s
FAIL
```

After fix
```
(base) zhoujinyu@zhoujinyudeMacBook-Air kthena % go test -v -count=5 -run 'TestModelServingControllerModelServingLifecycle' ./pkg/model-serving-controller/controller/ -timeout 30s
=== RUN   TestModelServingControllerModelServingLifecycle
I0130 14:56:56.696534   10015 manager.go:441] [CRD Added] PodGroup CRD detected
I0130 14:56:56.696694   10015 manager.go:447] [CRD Added] PodGroup CRD does not have subGroupPolicy feature
I0130 14:56:56.696782   10015 model_serving_controller.go:132] Set the ModelServing event handler
I0130 14:56:56.697220   10015 manager.go:441] [CRD Added] PodGroup CRD detected
I0130 14:56:56.697233   10015 manager.go:447] [CRD Added] PodGroup CRD does not have subGroupPolicy feature
I0130 14:56:56.797911   10015 model_serving_controller.go:489] initial sync has been done
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingCreate
I0130 14:56:56.797951   10015 model_serving_controller.go:491] start modelServing controller
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingScaleUp
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingUpdateScaleDown
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingRoleReplicasScaleUp
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingRoleReplicasScaleDown
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingBinPackScaleDown
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingGangPolicyPodGroups
    model_serving_controller_test.go:1368: Scaling up ModelServing replicas to trigger PodGroup updates
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingGangPolicyCleanupPodGroups
--- PASS: TestModelServingControllerModelServingLifecycle (0.47s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingCreate (0.02s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingScaleUp (0.03s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingUpdateScaleDown (0.04s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingRoleReplicasScaleUp (0.03s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingRoleReplicasScaleDown (0.04s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingBinPackScaleDown (0.13s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingGangPolicyPodGroups (0.04s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingGangPolicyCleanupPodGroups (0.02s)
=== RUN   TestModelServingControllerModelServingLifecycle
I0130 14:56:57.170736   10015 manager.go:441] [CRD Added] PodGroup CRD detected
I0130 14:56:57.170747   10015 manager.go:447] [CRD Added] PodGroup CRD does not have subGroupPolicy feature
I0130 14:56:57.170786   10015 model_serving_controller.go:132] Set the ModelServing event handler
I0130 14:56:57.170967   10015 manager.go:441] [CRD Added] PodGroup CRD detected
I0130 14:56:57.170977   10015 manager.go:447] [CRD Added] PodGroup CRD does not have subGroupPolicy feature
I0130 14:56:57.271892   10015 model_serving_controller.go:489] initial sync has been done
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingCreate
I0130 14:56:57.271922   10015 model_serving_controller.go:491] start modelServing controller
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingScaleUp
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingUpdateScaleDown
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingRoleReplicasScaleUp
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingRoleReplicasScaleDown
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingBinPackScaleDown
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingGangPolicyPodGroups
    model_serving_controller_test.go:1368: Scaling up ModelServing replicas to trigger PodGroup updates
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingGangPolicyCleanupPodGroups
--- PASS: TestModelServingControllerModelServingLifecycle (0.47s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingCreate (0.02s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingScaleUp (0.03s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingUpdateScaleDown (0.04s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingRoleReplicasScaleUp (0.03s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingRoleReplicasScaleDown (0.04s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingBinPackScaleDown (0.13s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingGangPolicyPodGroups (0.04s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingGangPolicyCleanupPodGroups (0.02s)
=== RUN   TestModelServingControllerModelServingLifecycle
I0130 14:56:57.643084   10015 manager.go:441] [CRD Added] PodGroup CRD detected
I0130 14:56:57.643099   10015 manager.go:447] [CRD Added] PodGroup CRD does not have subGroupPolicy feature
I0130 14:56:57.643138   10015 model_serving_controller.go:132] Set the ModelServing event handler
I0130 14:56:57.643341   10015 manager.go:441] [CRD Added] PodGroup CRD detected
I0130 14:56:57.643399   10015 manager.go:447] [CRD Added] PodGroup CRD does not have subGroupPolicy feature
I0130 14:56:57.743620   10015 model_serving_controller.go:489] initial sync has been done
I0130 14:56:57.743647   10015 model_serving_controller.go:491] start modelServing controller
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingCreate
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingScaleUp
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingUpdateScaleDown
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingRoleReplicasScaleUp
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingRoleReplicasScaleDown
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingBinPackScaleDown
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingGangPolicyPodGroups
    model_serving_controller_test.go:1368: Scaling up ModelServing replicas to trigger PodGroup updates
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingGangPolicyCleanupPodGroups
--- PASS: TestModelServingControllerModelServingLifecycle (0.47s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingCreate (0.02s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingScaleUp (0.03s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingUpdateScaleDown (0.04s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingRoleReplicasScaleUp (0.03s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingRoleReplicasScaleDown (0.04s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingBinPackScaleDown (0.13s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingGangPolicyPodGroups (0.04s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingGangPolicyCleanupPodGroups (0.02s)
=== RUN   TestModelServingControllerModelServingLifecycle
I0130 14:56:58.110896   10015 manager.go:441] [CRD Added] PodGroup CRD detected
I0130 14:56:58.110910   10015 manager.go:447] [CRD Added] PodGroup CRD does not have subGroupPolicy feature
I0130 14:56:58.110944   10015 model_serving_controller.go:132] Set the ModelServing event handler
I0130 14:56:58.111061   10015 manager.go:441] [CRD Added] PodGroup CRD detected
I0130 14:56:58.111066   10015 manager.go:447] [CRD Added] PodGroup CRD does not have subGroupPolicy feature
I0130 14:56:58.211524   10015 model_serving_controller.go:489] initial sync has been done
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingCreate
I0130 14:56:58.211543   10015 model_serving_controller.go:491] start modelServing controller
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingScaleUp
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingUpdateScaleDown
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingRoleReplicasScaleUp
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingRoleReplicasScaleDown
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingBinPackScaleDown
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingGangPolicyPodGroups
    model_serving_controller_test.go:1368: Scaling up ModelServing replicas to trigger PodGroup updates
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingGangPolicyCleanupPodGroups
--- PASS: TestModelServingControllerModelServingLifecycle (0.47s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingCreate (0.02s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingScaleUp (0.03s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingUpdateScaleDown (0.04s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingRoleReplicasScaleUp (0.03s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingRoleReplicasScaleDown (0.04s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingBinPackScaleDown (0.13s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingGangPolicyPodGroups (0.04s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingGangPolicyCleanupPodGroups (0.02s)
=== RUN   TestModelServingControllerModelServingLifecycle
I0130 14:56:58.582396   10015 manager.go:441] [CRD Added] PodGroup CRD detected
I0130 14:56:58.582406   10015 manager.go:447] [CRD Added] PodGroup CRD does not have subGroupPolicy feature
I0130 14:56:58.582470   10015 model_serving_controller.go:132] Set the ModelServing event handler
I0130 14:56:58.582703   10015 manager.go:441] [CRD Added] PodGroup CRD detected
I0130 14:56:58.582714   10015 manager.go:447] [CRD Added] PodGroup CRD does not have subGroupPolicy feature
I0130 14:56:58.683625   10015 model_serving_controller.go:489] initial sync has been done
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingCreate
I0130 14:56:58.683642   10015 model_serving_controller.go:491] start modelServing controller
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingScaleUp
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingUpdateScaleDown
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingRoleReplicasScaleUp
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingRoleReplicasScaleDown
E0130 14:56:58.843254   10015 model_serving_controller.go:853] failed to set role test-role-scale-down-1/prefill-2 status: role prefill-2 not found in roleName prefill of group test-role-scale-down-1
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingBinPackScaleDown
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingGangPolicyPodGroups
    model_serving_controller_test.go:1368: Scaling up ModelServing replicas to trigger PodGroup updates
=== RUN   TestModelServingControllerModelServingLifecycle/ModelServingGangPolicyCleanupPodGroups
--- PASS: TestModelServingControllerModelServingLifecycle (0.47s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingCreate (0.02s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingScaleUp (0.03s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingUpdateScaleDown (0.04s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingRoleReplicasScaleUp (0.03s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingRoleReplicasScaleDown (0.04s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingBinPackScaleDown (0.13s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingGangPolicyPodGroups (0.04s)
    --- PASS: TestModelServingControllerModelServingLifecycle/ModelServingGangPolicyCleanupPodGroups (0.02s)
PASS
ok      github.com/volcano-sh/kthena/pkg/model-serving-controller/controller    2.648s
```

