### PR TITLE
Fix divide-by-zero in LeastRequest scoring

### DIFF
--- a/pkg/kthena-router/scheduler/plugins/least_request.go
+++ b/pkg/kthena-router/scheduler/plugins/least_request.go
@@ -85,7 +85,10 @@ func (l *LeastRequest) Score(ctx *framework.Context, pods []*datastore.PodInfo) 
 
 	// 2. Calculate the score for each pod as a percentage of the max base score
 	for _, info := range pods {
-		score := ((maxScore - baseScores[info]) / maxScore) * 100
+		score := 100.0
+		if maxScore > 0 {
+			score = ((maxScore - baseScores[info]) / maxScore) * 100
+		}
 		scoreResults[info] = int(score)
 	}
 

--- a/pkg/kthena-router/scheduler/plugins/least_request_test.go
+++ b/pkg/kthena-router/scheduler/plugins/least_request_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugins
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/volcano-sh/kthena/pkg/kthena-router/datastore"
+)
+
+func TestLeastRequestScore(t *testing.T) {
+	tests := []struct {
+		name           string
+		pods           []*datastore.PodInfo
+		expectedScores map[string]int
+	}{
+		{
+			name: "all pods idle",
+			pods: []*datastore.PodInfo{
+				{Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-1"}}, RequestRunningNum: 0, RequestWaitingNum: 0},
+				{Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-2"}}, RequestRunningNum: 0, RequestWaitingNum: 0},
+				{Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-3"}}, RequestRunningNum: 0, RequestWaitingNum: 0},
+			},
+			expectedScores: map[string]int{"pod-1": 100, "pod-2": 100, "pod-3": 100},
+		},
+		{
+			name: "single pod idle",
+			pods: []*datastore.PodInfo{
+				{Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-1"}}, RequestRunningNum: 0, RequestWaitingNum: 0},
+			},
+			expectedScores: map[string]int{"pod-1": 100},
+		},
+		{
+			name: "mixed load pods",
+			pods: []*datastore.PodInfo{
+				{Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-1"}}, RequestRunningNum: 0, RequestWaitingNum: 0},
+				{Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-2"}}, RequestRunningNum: 10, RequestWaitingNum: 0},
+				{Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-3"}}, RequestRunningNum: 5, RequestWaitingNum: 0},
+			},
+			expectedScores: map[string]int{"pod-1": 100, "pod-2": 0, "pod-3": 50},
+		},
+		{
+			name: "normal non-zero case",
+			pods: []*datastore.PodInfo{
+				{Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-1"}}, RequestRunningNum: 1, RequestWaitingNum: 0},
+				{Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-2"}}, RequestRunningNum: 2, RequestWaitingNum: 0},
+				{Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-3"}}, RequestRunningNum: 3, RequestWaitingNum: 0},
+			},
+			expectedScores: map[string]int{"pod-1": 66, "pod-2": 33, "pod-3": 0},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plugin := NewLeastRequest(runtime.RawExtension{Raw: []byte(`{}`)})
+			scores := plugin.Score(nil, tt.pods)
+
+			for _, pod := range tt.pods {
+				podName := pod.Pod.Name
+				expected := tt.expectedScores[podName]
+				actual := scores[pod]
+				if actual != expected {
+					t.Errorf("pod %s: expected score %d, got %d", podName, expected, actual)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Fix divide-by-zero in LeastRequest scoring

### Summary
`LeastRequest.Score` was dividing by zero when all pods were idle which resulted in `NaN` scores and inconsistent scheduling behavior this can happen during cold starts after restarts or in low-traffic periods

### What changed
- Added a small guard in `LeastRequest.Score` to handle the `maxScore == 0` case
- When all pods have equal (zero) load they now receive the same maximum score
- Behavior for normal non-zero load remains unchanged

### Why this matters
Without this check invalid scores can silently propagate through the scheduler and lead to arbitrary pod selection the issue is easy to miss since scheduling continues without errors

### Code changes
- `pkg/kthena-router/scheduler/plugins/least_request.go`
- `pkg/kthena-router/scheduler/plugins/least_request_test.go`

### Tests
Added table-driven unit tests covering:
- all pods idle
- single idle pod
- mixed load pods
- normal non-zero load case

The tests fail on the previous implementation and pass with this fix applied
<img width="1077" height="245" alt="image" src="https://github.com/user-attachments/assets/c469aa0a-b425-4193-847a-2bcdb07893d8" />


### Notes
This follows the same guard pattern already used in the `LeastLatency` plugin and keeps the change minimal and localized.
