### PR TITLE
Fix router panic when all target model weights are zero

### DIFF
--- a/pkg/kthena-router/datastore/store.go
+++ b/pkg/kthena-router/datastore/store.go
@@ -981,6 +981,11 @@ func selectFromWeightedSlice(weights []uint32) int {
 		totalWeight += int(weight)
 	}
 
+	// Guard against divide-by-zero when all weights are zero
+	if totalWeight == 0 {
+		return 0
+	}
+
 	randomNum := rng.Intn(totalWeight)
 
 	for i, weight := range weights {

--- a/pkg/kthena-router/datastore/store_test.go
+++ b/pkg/kthena-router/datastore/store_test.go
@@ -1217,3 +1217,69 @@ func TestStoreMatchModelServer(t *testing.T) {
 		})
 	}
 }
+
+func TestSelectFromWeightedSlice(t *testing.T) {
+	tests := []struct {
+		name           string
+		weights        []uint32
+		expectPanic    bool
+		expectedResult int // only checked when not expecting panic and result is deterministic
+		checkRange     bool
+		minResult      int
+		maxResult      int
+	}{
+		{
+			name:           "all weights zero does not panic",
+			weights:        []uint32{0, 0, 0},
+			expectPanic:    false,
+			expectedResult: 0,
+		},
+		{
+			name:           "single zero weight does not panic",
+			weights:        []uint32{0},
+			expectPanic:    false,
+			expectedResult: 0,
+		},
+		{
+			name:        "normal weighted selection returns valid index",
+			weights:     []uint32{1, 2, 3},
+			expectPanic: false,
+			checkRange:  true,
+			minResult:   0,
+			maxResult:   2,
+		},
+		{
+			name:           "single non-zero weight returns index 0",
+			weights:        []uint32{5},
+			expectPanic:    false,
+			expectedResult: 0,
+		},
+		{
+			name:           "empty weights returns 0",
+			weights:        []uint32{},
+			expectPanic:    false,
+			expectedResult: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.expectPanic {
+				assert.Panics(t, func() {
+					selectFromWeightedSlice(tt.weights)
+				})
+				return
+			}
+
+			assert.NotPanics(t, func() {
+				result := selectFromWeightedSlice(tt.weights)
+				if tt.checkRange {
+					assert.GreaterOrEqual(t, result, tt.minResult)
+					assert.LessOrEqual(t, result, tt.maxResult)
+				} else {
+					assert.Equal(t, tt.expectedResult, result)
+				}
+			})
+		})
+	}
+}


### PR DESCRIPTION
## Summary

This PR fixes a critical router panic caused by a divide-by-zero error when selecting a target model from a weighted list where all weights are set to zero
A minimal defensive guard has been added to prevent `rand.Intn(0)` from panicking, along with focused unit tests to cover the affected edge cases.

---

## Issue Description

When a `ModelRoute` is configured with `TargetModel` entries whose weights all evaluate to `0`, the router crashes at runtime.

This happens because `selectFromWeightedSlice` computes a total weight of `0` and passes it directly to `rand.Intn`, which panics immediately.  
Such configurations are valid and realistic during canary rollbacks, maintenance windows, or temporary target disablement.

Since this code runs on the request hot path, the panic causes a full router crash and impacts all traffic.

---

## What Was Fixed

- Added a defensive guard in `selectFromWeightedSlice` to safely handle the case where the total weight is zero
- Ensured existing behavior remains unchanged for all valid non-zero weight scenarios
- Added table-driven unit tests covering both edge cases and normal behavior

The fix is intentionally minimal and localized.

---

## Impact of the Fix

- Prevents a hard router crash caused by valid but edge-case configurations
- Eliminates a denial-of-service scenario triggered by zero-weight routes
- Improves router stability during deployments, rollbacks, and partial updates
- No behavior change for existing valid configurations

---

## Code Changes

**Files modified:**
- `pkg/kthena-router/datastore/store.go`
  - Added a guard in `selectFromWeightedSlice` to handle `totalWeight == 0`
- `pkg/kthena-router/datastore/store_test.go`
  - Added table-driven unit tests for weighted selection logic

---

## Test Verification

Unit tests were added using Go’s table-driven testing pattern, covering:

- all weights set to zero (no panic)
- single zero weight
- normal weighted selection
- single non-zero weight
- empty weight slice
- all the test cases are passed locally 
<img width="1009" height="356" alt="image" src="https://github.com/user-attachments/assets/a3697835-9875-4900-9d32-898e3e8e6595" />
