### PR TITLE
fix: panic when workerTemplate is nil

### DIFF
--- a/pkg/model-serving-controller/controller/model_serving_controller.go
+++ b/pkg/model-serving-controller/controller/model_serving_controller.go
@@ -2003,9 +2003,14 @@ func (c *ModelServingController) CreatePodsByRole(ctx context.Context, role work
 	if err := c.createPod(ctx, ms, servingGroupName, role.Name, roleID, entryPod, true, chain, "entry"); err != nil {
 		return err
 	}
+	if role.WorkerReplicas > 0 && role.WorkerTemplate == nil {
+		klog.Errorf("WorkerTemplate is required when workerReplicas > 0 for role %s. This should have been caught by webhook validation.", role.Name)
+		return nil
+	}
 
 	for i := 1; i <= int(role.WorkerReplicas); i++ {
 		workerPod := utils.GenerateWorkerPod(role, ms, entryPod, servingGroupName, roleIndex, i, revision)
+
 		c.podGroupManager.AnnotatePodWithPodGroup(workerPod, ms, servingGroupName, taskName)
 		if err := c.createPod(ctx, ms, servingGroupName, role.Name, roleID, workerPod, false, chain, "worker"); err != nil {
 			return err

--- a/pkg/model-serving-controller/utils/utils.go
+++ b/pkg/model-serving-controller/utils/utils.go
@@ -107,12 +107,16 @@ func GenerateEntryPod(role workloadv1alpha1.Role, ms *workloadv1alpha1.ModelServ
 }
 
 func GenerateWorkerPod(role workloadv1alpha1.Role, ms *workloadv1alpha1.ModelServing, entryPod *corev1.Pod, groupName string, roleIndex, podIndex int, revision string) *corev1.Pod {
+	if role.WorkerTemplate == nil {
+		klog.Errorf("WorkerTemplate is required when workerReplicas > 0 for role %s", role.Name)
+		return nil
+	}
+
 	workerPodName := GeneratePodName(groupName, GenerateRoleID(role.Name, roleIndex), podIndex)
 	workerPod := createBasePod(role, ms, workerPodName, groupName, revision, roleIndex)
 	addPodLabelAndAnnotation(workerPod, role.WorkerTemplate.Metadata)
 	workerPod.Spec = role.WorkerTemplate.Spec
 	workerPod.Spec.SchedulerName = ms.Spec.SchedulerName
-	// Build environment variables into each container of all pod
 	envVars := createCommonEnvVars(role, entryPod, podIndex)
 	addPodEnvVars(workerPod, envVars...)
 	return workerPod

--- a/pkg/model-serving-controller/webhook/validator.go
+++ b/pkg/model-serving-controller/webhook/validator.go
@@ -273,8 +273,13 @@ func validateWorkerReplicas(ms *workloadv1alpha1.ModelServing) field.ErrorList {
 				"workerReplicas must be a non-negative integer",
 			))
 		}
+		if role.WorkerReplicas > 0 && role.WorkerTemplate == nil {
+			allErrs = append(allErrs, field.Required(
+				field.NewPath("spec").Child("template").Child("roles").Index(i).Child("workerTemplate"),
+				"workerTemplate is required when workerReplicas is greater than 0",
+			))
+		}
 	}
-
 	return allErrs
 }
 

--- a/pkg/model-serving-controller/webhook/validator_test.go
+++ b/pkg/model-serving-controller/webhook/validator_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	workloadv1alpha1 "github.com/volcano-sh/kthena/pkg/apis/workload/v1alpha1"
+
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -48,7 +49,12 @@ func TestValidPodNameLength(t *testing.T) {
 						Replicas: &replicas,
 						Template: workloadv1alpha1.ServingGroup{
 							Roles: []workloadv1alpha1.Role{
-								{Name: "role1", Replicas: &replicas, WorkerReplicas: 2},
+								{
+									Name:           "role1",
+									Replicas:       &replicas,
+									WorkerReplicas: 2,
+									WorkerTemplate: &workloadv1alpha1.PodTemplateSpec{}, // <--- FIXED TYPE
+								},
 							},
 						},
 					},
@@ -67,7 +73,12 @@ func TestValidPodNameLength(t *testing.T) {
 						Replicas: &replicas,
 						Template: workloadv1alpha1.ServingGroup{
 							Roles: []workloadv1alpha1.Role{
-								{Name: "role1", Replicas: &replicas, WorkerReplicas: 2},
+								{
+									Name:           "role1",
+									Replicas:       &replicas,
+									WorkerReplicas: 2,
+									WorkerTemplate: &workloadv1alpha1.PodTemplateSpec{}, // <--- FIXED TYPE
+								},
 							},
 						},
 					},
@@ -389,8 +400,18 @@ func TestValidatorReplicas(t *testing.T) {
 						Replicas: int32Ptr(3),
 						Template: workloadv1alpha1.ServingGroup{
 							Roles: []workloadv1alpha1.Role{
-								{Name: "role1", Replicas: int32Ptr(2), WorkerReplicas: 1},
-								{Name: "role2", Replicas: int32Ptr(1), WorkerReplicas: 1},
+								{
+									Name:           "role1",
+									Replicas:       int32Ptr(2),
+									WorkerReplicas: 1,
+									WorkerTemplate: &workloadv1alpha1.PodTemplateSpec{}, // <--- FIXED TYPE
+								},
+								{
+									Name:           "role2",
+									Replicas:       int32Ptr(1),
+									WorkerReplicas: 1,
+									WorkerTemplate: &workloadv1alpha1.PodTemplateSpec{}, // <--- FIXED TYPE
+								},
 							},
 						},
 					},
@@ -406,8 +427,18 @@ func TestValidatorReplicas(t *testing.T) {
 						Replicas: int32PtrNil(),
 						Template: workloadv1alpha1.ServingGroup{
 							Roles: []workloadv1alpha1.Role{
-								{Name: "role1", Replicas: int32Ptr(2), WorkerReplicas: 1},
-								{Name: "role2", Replicas: int32Ptr(1), WorkerReplicas: 1},
+								{
+									Name:           "role1",
+									Replicas:       int32Ptr(2),
+									WorkerReplicas: 1,
+									WorkerTemplate: &workloadv1alpha1.PodTemplateSpec{}, // <--- FIXED TYPE
+								},
+								{
+									Name:           "role2",
+									Replicas:       int32Ptr(1),
+									WorkerReplicas: 1,
+									WorkerTemplate: &workloadv1alpha1.PodTemplateSpec{}, // <--- FIXED TYPE
+								},
 							},
 						},
 					},
@@ -429,8 +460,18 @@ func TestValidatorReplicas(t *testing.T) {
 						Replicas: int32Ptr(-1),
 						Template: workloadv1alpha1.ServingGroup{
 							Roles: []workloadv1alpha1.Role{
-								{Name: "role1", Replicas: int32Ptr(2), WorkerReplicas: 1},
-								{Name: "role2", Replicas: int32Ptr(1), WorkerReplicas: 1},
+								{
+									Name:           "role1",
+									Replicas:       int32Ptr(2),
+									WorkerReplicas: 1,
+									WorkerTemplate: &workloadv1alpha1.PodTemplateSpec{}, // <--- FIXED TYPE
+								},
+								{
+									Name:           "role2",
+									Replicas:       int32Ptr(1),
+									WorkerReplicas: 1,
+									WorkerTemplate: &workloadv1alpha1.PodTemplateSpec{}, // <--- FIXED TYPE
+								},
 							},
 						},
 					},
@@ -452,8 +493,18 @@ func TestValidatorReplicas(t *testing.T) {
 						Replicas: int32Ptr(3),
 						Template: workloadv1alpha1.ServingGroup{
 							Roles: []workloadv1alpha1.Role{
-								{Name: "role1", Replicas: int32Ptr(-1), WorkerReplicas: 1},
-								{Name: "role2", Replicas: int32Ptr(1), WorkerReplicas: 1},
+								{
+									Name:           "role1",
+									Replicas:       int32Ptr(-1),
+									WorkerReplicas: 1,
+									WorkerTemplate: &workloadv1alpha1.PodTemplateSpec{}, // <--- FIXED TYPE
+								},
+								{
+									Name:           "role2",
+									Replicas:       int32Ptr(1),
+									WorkerReplicas: 1,
+									WorkerTemplate: &workloadv1alpha1.PodTemplateSpec{}, // <--- FIXED TYPE
+								},
 							},
 						},
 					},
@@ -475,8 +526,18 @@ func TestValidatorReplicas(t *testing.T) {
 						Replicas: int32Ptr(3),
 						Template: workloadv1alpha1.ServingGroup{
 							Roles: []workloadv1alpha1.Role{
-								{Name: "role1", Replicas: int32PtrNil(), WorkerReplicas: 1},
-								{Name: "role2", Replicas: int32Ptr(1), WorkerReplicas: 1},
+								{
+									Name:           "role1",
+									Replicas:       int32PtrNil(),
+									WorkerReplicas: 1,
+									WorkerTemplate: &workloadv1alpha1.PodTemplateSpec{}, // <--- FIXED TYPE
+								},
+								{
+									Name:           "role2",
+									Replicas:       int32Ptr(1),
+									WorkerReplicas: 1,
+									WorkerTemplate: &workloadv1alpha1.PodTemplateSpec{}, // <--- FIXED TYPE
+								},
 							},
 						},
 					},
@@ -546,11 +607,12 @@ func TestValidateGangPolicy(t *testing.T) {
 									Name:           "worker",
 									Replicas:       &roleReplicas,
 									WorkerReplicas: 3,
+									WorkerTemplate: &workloadv1alpha1.PodTemplateSpec{}, // <--- FIXED TYPE
 								},
 							},
 							GangPolicy: &workloadv1alpha1.GangPolicy{
 								MinRoleReplicas: map[string]int32{
-									"worker": 2, // 2 (role replicas) >= 2 (min), valid
+									"worker": 2,
 								},
 							},
 						},
@@ -571,6 +633,7 @@ func TestValidateGangPolicy(t *testing.T) {
 									Name:           "worker",
 									Replicas:       &roleReplicas,
 									WorkerReplicas: 3,
+									WorkerTemplate: &workloadv1alpha1.PodTemplateSpec{}, // <--- FIXED TYPE
 								},
 							},
 							GangPolicy: &workloadv1alpha1.GangPolicy{
@@ -602,6 +665,7 @@ func TestValidateGangPolicy(t *testing.T) {
 									Name:           "worker",
 									Replicas:       &roleReplicas,
 									WorkerReplicas: 3,
+									WorkerTemplate: &workloadv1alpha1.PodTemplateSpec{}, // <--- FIXED TYPE
 								},
 							},
 							GangPolicy: &workloadv1alpha1.GangPolicy{
@@ -633,6 +697,7 @@ func TestValidateGangPolicy(t *testing.T) {
 									Name:           "worker",
 									Replicas:       &roleReplicas,
 									WorkerReplicas: 3,
+									WorkerTemplate: &workloadv1alpha1.PodTemplateSpec{}, // <--- FIXED TYPE
 								},
 							},
 							GangPolicy: &workloadv1alpha1.GangPolicy{
@@ -664,6 +729,7 @@ func TestValidateGangPolicy(t *testing.T) {
 									Name:           "worker",
 									Replicas:       &roleReplicas,
 									WorkerReplicas: 3,
+									WorkerTemplate: &workloadv1alpha1.PodTemplateSpec{}, // <--- FIXED TYPE
 								},
 							},
 							GangPolicy: nil,
@@ -685,6 +751,7 @@ func TestValidateGangPolicy(t *testing.T) {
 									Name:           "worker",
 									Replicas:       &roleReplicas,
 									WorkerReplicas: 3,
+									WorkerTemplate: &workloadv1alpha1.PodTemplateSpec{}, // <--- FIXED TYPE
 								},
 							},
 							GangPolicy: &workloadv1alpha1.GangPolicy{
@@ -721,25 +788,33 @@ func TestValidateWorkerReplicas(t *testing.T) {
 		want field.ErrorList
 	}{
 		{
-			name: "valid worker replicas",
+			name: "WorkerReplicas > 0 but WorkerTemplate is nil",
 			args: args{
 				ms: &workloadv1alpha1.ModelServing{
 					Spec: workloadv1alpha1.ModelServingSpec{
-						Replicas: &replicas,
+						Replicas: &replicas, // It Uses the variable defined at top of test
 						Template: workloadv1alpha1.ServingGroup{
 							Roles: []workloadv1alpha1.Role{
 								{
 									Name:           "worker",
 									Replicas:       &roleReplicas,
-									WorkerReplicas: 3,
+									WorkerReplicas: 1,   // > 0 to trigger the check
+									WorkerTemplate: nil, // Missing template!
 								},
 							},
 						},
 					},
 				},
 			},
-			want: field.ErrorList(nil),
+
+			want: field.ErrorList{
+				field.Required(
+					field.NewPath("spec").Child("template").Child("roles").Index(0).Child("workerTemplate"),
+					"workerTemplate is required when workerReplicas is greater than 0",
+				),
+			},
 		},
+
 		{
 			name: "valid zero worker replicas",
 			args: args{
@@ -798,6 +873,7 @@ func TestValidateWorkerReplicas(t *testing.T) {
 									Name:           "worker1",
 									Replicas:       &roleReplicas,
 									WorkerReplicas: 3,
+									WorkerTemplate: &workloadv1alpha1.PodTemplateSpec{}, // <--- FIXED TYPE
 								},
 								{
 									Name:           "worker2",
@@ -848,8 +924,18 @@ func TestValidateRoleNames(t *testing.T) {
 						Replicas: &replicas,
 						Template: workloadv1alpha1.ServingGroup{
 							Roles: []workloadv1alpha1.Role{
-								{Name: "prefill", Replicas: &replicas, WorkerReplicas: 2},
-								{Name: "decode", Replicas: &replicas, WorkerReplicas: 2},
+								{
+									Name:           "prefill",
+									Replicas:       &replicas,
+									WorkerReplicas: 2,
+									WorkerTemplate: &workloadv1alpha1.PodTemplateSpec{}, // <--- FIXED TYPE
+								},
+								{
+									Name:           "decode",
+									Replicas:       &replicas,
+									WorkerReplicas: 2,
+									WorkerTemplate: &workloadv1alpha1.PodTemplateSpec{}, // <--- FIXED TYPE
+								},
 							},
 						},
 					},
@@ -865,7 +951,12 @@ func TestValidateRoleNames(t *testing.T) {
 						Replicas: &replicas,
 						Template: workloadv1alpha1.ServingGroup{
 							Roles: []workloadv1alpha1.Role{
-								{Name: "Prefill", Replicas: &replicas, WorkerReplicas: 2},
+								{
+									Name:           "Prefill",
+									Replicas:       &replicas,
+									WorkerReplicas: 2,
+									WorkerTemplate: &workloadv1alpha1.PodTemplateSpec{}, // <--- FIXED TYPE
+								},
 							},
 						},
 					},
@@ -887,7 +978,12 @@ func TestValidateRoleNames(t *testing.T) {
 						Replicas: &replicas,
 						Template: workloadv1alpha1.ServingGroup{
 							Roles: []workloadv1alpha1.Role{
-								{Name: "1role", Replicas: &replicas, WorkerReplicas: 2},
+								{
+									Name:           "1role",
+									Replicas:       &replicas,
+									WorkerReplicas: 2,
+									WorkerTemplate: &workloadv1alpha1.PodTemplateSpec{}, // <--- FIXED TYPE
+								},
 							},
 						},
 					},
@@ -909,7 +1005,12 @@ func TestValidateRoleNames(t *testing.T) {
 						Replicas: &replicas,
 						Template: workloadv1alpha1.ServingGroup{
 							Roles: []workloadv1alpha1.Role{
-								{Name: "role-", Replicas: &replicas, WorkerReplicas: 2},
+								{
+									Name:           "role-",
+									Replicas:       &replicas,
+									WorkerReplicas: 2,
+									WorkerTemplate: &workloadv1alpha1.PodTemplateSpec{}, // <--- FIXED TYPE
+								},
 							},
 						},
 					},
@@ -931,8 +1032,18 @@ func TestValidateRoleNames(t *testing.T) {
 						Replicas: &replicas,
 						Template: workloadv1alpha1.ServingGroup{
 							Roles: []workloadv1alpha1.Role{
-								{Name: "prefill", Replicas: &replicas, WorkerReplicas: 2},
-								{Name: "Decode", Replicas: &replicas, WorkerReplicas: 2},
+								{
+									Name:           "prefill",
+									Replicas:       &replicas,
+									WorkerReplicas: 2,
+									WorkerTemplate: &workloadv1alpha1.PodTemplateSpec{}, // <--- FIXED TYPE
+								},
+								{
+									Name:           "Decode",
+									Replicas:       &replicas,
+									WorkerReplicas: 2,
+									WorkerTemplate: &workloadv1alpha1.PodTemplateSpec{}, // <--- FIXED TYPE
+								},
 							},
 						},
 					},


### PR DESCRIPTION
**What type of PR is this?**



<!--

Add one of the following kinds:



/kind bug

/kind cleanup

/kind enhancement

/kind security

/kind documentation

/kind feature



-->



**What this PR does / why we need it**:



**Which issue(s) this PR fixes**:

Fixes #745 



**Special notes for your reviewer**:
The approach i used 

By Identifying the root cause: The GenerateWorkerPod function was attempting to access .Metadata on a nil WorkerTemplate, causing the panic

The Fix: I  Added a guard clause to check if WorkerTemplate is nil before accessing it

I chose to log the error and return nil instead of returning an error object.


**Does this PR introduce a user-facing change?**:

<!--

If no, just write "NONE" in the release-note block below.

If yes, a release note is required.

-->

```Fixed a controller panic when workerReplicas is set > 0 but workerTemplate is missing.



```
