### PR TITLE
[Bug] Error skip calculation of resources required for subGroupPolicy

### DIFF
--- a/pkg/model-serving-controller/podgroupmanager/manager.go
+++ b/pkg/model-serving-controller/podgroupmanager/manager.go
@@ -370,7 +370,7 @@ func (m *Manager) calculateRequirements(ms *workloadv1alpha1.ModelServing, podGr
 		// Under the binpack scaling strategy, it is unknown which role replicas will be deleted.
 		// However, if the PodGroup was deleted externally, we should still calculate requirements
 		// to recreate it with correct settings.
-		if len(roleList) > expectReplicas && podGroupExists {
+		if !m.hasSubGroupPolicy.Load() && len(roleList) > expectReplicas && podGroupExists {
 			// Only skip during active scaling if PodGroup exists.
 			// If PodGroup was deleted externally, we should proceed to recalculate and recreate it.
 			klog.V(4).Infof("Skipping PodGroup update for %s during scaling operation, roleList length: %d, expectReplicas: %d",
@@ -468,7 +468,6 @@ func (m *Manager) updatePodGroupIfNeeded(ctx context.Context, existing *scheduli
 
 		// Calculate current requirements
 		minMember, minRoleMember, minTaskMember, minResources := m.calculateRequirements(ms, currentPodGroup.GetName())
-
 		updated := currentPodGroup.DeepCopy()
 		updated.Spec.MinMember = int32(minMember)
 		updated.Spec.MinResources = &minResources


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:

When setting MinRoleReplicas to a value lower than Role Replicas, the computation required by the subGroupPolicy for data will be skipped.
```sh
minMember: 0, minRoleMember: map[], minTaskMember: map[], minResources: map[]
I0205 03:49:20.588826       1 manager.go:376] Skipping PodGroup update for sample-0 during scaling operation, roleList length: 2, expectReplicas: 1
I0205 03:49:20.588843       1 manager.go:376] Skipping PodGroup update for sample-0 during scaling operation, roleList length: 2, expectReplicas: 1
E0205 03:49:20.592761       1 model_serving_controller.go:483] "Unhandled Error" err="sync \"default/sample\" failed with cannot manage ServingGroup replicas: failed to update PodGroup for ServingGroup sample-0: failed to update PodGroup for ServingGroup sample-0: PodGroup.scheduling.volcano.sh \"sample-0\" is invalid: [spec.subGroupPolicy[0].subGroupSize: Invalid value: 0: spec.subGroupPolicy[0].subGroupSize in body should be greater than or equal to 1, spec.subGroupPolicy[1].subGroupSize: Invalid value: 0: spec.subGroupPolicy[1].subGroupSize in body should be greater than or equal to 1]" logger="UnhandledError"
```

**Which issue(s) this PR fixes**:
Fixes # 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
