### PR TITLE
fix: hide navigation on docs lightboxImage

### DIFF
--- a/docs/kthena/src/components/LightboxImage/index.tsx
+++ b/docs/kthena/src/components/LightboxImage/index.tsx
@@ -83,9 +83,14 @@ const LightboxImage: React.FC<LightboxImageProps> = ({
           }}
           carousel={{
             padding: '0px',
+            finite: true,
           }}
           controller={{
             closeOnBackdropClick: true,
+          }}
+          render={{
+            buttonPrev: () => null,
+            buttonNext: () => null,
           }}
         />
       )}


### PR DESCRIPTION
/kind bug

This PR fixes a UX issue in the documentation where diagrams open in a lightbox that shows next/previous navigation controls. Clicking those controls loops back to the same image, which can be confusing.

The navigation controls are now disabled.

Docs: Removed non-functional next/previous navigation controls when viewing image diagrams in the documentation.

Before:
https://github.com/user-attachments/assets/8f2bc27d-1ca6-4dfa-bb97-2f9faf4e3aa3

After:
<img width="1439" height="755" alt="Screenshot 2026-02-05 at 5 02 57 PM" src="https://github.com/user-attachments/assets/11c2d5a0-0a4b-42fa-b9cd-d7344a39a0db" />
