### PR TITLE
fix: add mutex protection for PodInfo metrics fields

### DIFF
--- a/pkg/kthena-router/scheduler/plugins/gpu.go
+++ b/pkg/kthena-router/scheduler/plugins/gpu.go
@@ -41,7 +41,7 @@ func (g *GPUCacheUsage) Name() string {
 func (g *GPUCacheUsage) Score(ctx *framework.Context, pods []*datastore.PodInfo) map[*datastore.PodInfo]int {
 	scoreResults := make(map[*datastore.PodInfo]int)
 	for _, info := range pods {
-		score := int((1.0 - info.GPUCacheUsage) * 100)
+		score := int((1.0 - info.GetGPUCacheUsage()) * 100)
 		scoreResults[info] = score
 	}
 

--- a/pkg/kthena-router/scheduler/plugins/least_latency.go
+++ b/pkg/kthena-router/scheduler/plugins/least_latency.go
@@ -80,12 +80,14 @@ func (l *LeastLatency) Score(ctx *framework.Context, pods []*datastore.PodInfo) 
 	for _, info := range pods {
 		scoreTTFT := MaxScore
 		scoreTPOT := MaxScore
+		ttft := info.GetTTFT()
+		tpot := info.GetTPOT()
 		// Only compute normalized score if there's variance in latency values
 		if maxTTFT > minTTFT {
-			scoreTTFT = MaxScore * (maxTTFT - info.TTFT) / (maxTTFT - minTTFT)
+			scoreTTFT = MaxScore * (maxTTFT - ttft) / (maxTTFT - minTTFT)
 		}
 		if maxTPOT > minTPOT {
-			scoreTPOT = MaxScore * (maxTPOT - info.TPOT) / (maxTPOT - minTPOT)
+			scoreTPOT = MaxScore * (maxTPOT - tpot) / (maxTPOT - minTPOT)
 		}
 		scoreResults[info] = int(scoreTTFT*l.TTFTTPOTWeightFactor + scoreTPOT*(1-l.TTFTTPOTWeightFactor))
 	}
@@ -100,25 +102,27 @@ func calculateMinMaxMetrics(pods []*datastore.PodInfo) (minTTFT, maxTTFT, minTPO
 	maxTPOT = 0.0
 
 	for _, info := range pods {
+		ttft := info.GetTTFT()
+		tpot := info.GetTPOT()
 		// Skip pods with invalid values
-		if info.TTFT < 0 || info.TPOT < 0 {
+		if ttft < 0 || tpot < 0 {
 			continue
 		}
 
 		// Update TTFT min/max
-		if info.TTFT < minTTFT {
-			minTTFT = info.TTFT
+		if ttft < minTTFT {
+			minTTFT = ttft
 		}
-		if info.TTFT > maxTTFT {
-			maxTTFT = info.TTFT
+		if ttft > maxTTFT {
+			maxTTFT = ttft
 		}
 
 		// Update TPOT min/max
-		if info.TPOT < minTPOT {
-			minTPOT = info.TPOT
+		if tpot < minTPOT {
+			minTPOT = tpot
 		}
-		if info.TPOT > maxTPOT {
-			maxTPOT = info.TPOT
+		if tpot > maxTPOT {
+			maxTPOT = tpot
 		}
 	}
 

--- a/pkg/kthena-router/scheduler/plugins/least_request.go
+++ b/pkg/kthena-router/scheduler/plugins/least_request.go
@@ -61,7 +61,7 @@ func (l *LeastRequest) Name() string {
 
 func (l *LeastRequest) Filter(ctx *framework.Context, pods []*datastore.PodInfo) []*datastore.PodInfo {
 	return slices.FilterInPlace(pods, func(info *datastore.PodInfo) bool {
-		return info.RequestWaitingNum < float64(l.maxWaitingRequest)
+		return info.GetRequestWaitingNum() < float64(l.maxWaitingRequest)
 	})
 }
 
@@ -76,7 +76,7 @@ func (l *LeastRequest) Score(ctx *framework.Context, pods []*datastore.PodInfo) 
 	maxScore := 0.0
 	for _, info := range pods {
 		// The weight of waiting requests is 100. It's a magic number just to sinificantly lower the score of the pod when there are waiting reqs.
-		base := info.RequestRunningNum + 100*info.RequestWaitingNum
+		base := info.GetRequestRunningNum() + 100*info.GetRequestWaitingNum()
 		baseScores[info] = base
 		if base > maxScore {
 			maxScore = base


### PR DESCRIPTION
## Fix data race on PodInfo metrics accessed by scheduler plugins

### Summary
This PR fixes a real data race in the kthena router where `PodInfo` metric fields were updated by a background metrics goroutine while being read concurrently by scheduler plugins without synchronization.

The race could lead to inconsistent scheduling decisions and is detectable with the Go race detector.

---

### What was fixed
- Added mutex protection around metric updates in the datastore:
  - `updateGaugeMetricsInfo`
  - `updateHistogramMetrics`
- Extended the existing `PodInfo` mutex usage to cover metric fields.
- Added lightweight getter methods for metric fields, following existing access patterns.
- Updated scheduler plugins to use getters instead of direct field access:
  - `least_request`
  - `gpu`
  - `least_latency`

No scheduling logic or behavior was changed; only synchronization was added.

---

### Why this matters
- Eliminates a real Go data race between the metrics collector and scheduler plugins.
- Prevents scheduler decisions based on stale or inconsistent metric values.
- Avoids silent mis-routing of requests to overloaded pods.
- Improves stability and correctness under concurrent load in production clusters.

---

### Areas of the codebase affected
- `pkg/kthena-router/datastore`
  - Metrics update paths
  - `PodInfo` accessors
- `pkg/kthena-router/scheduler/plugins`
  - LeastRequest
  - GPU
  - LeastLatency

---

### Test verification
No new unit tests were added.

This change is a mechanical synchronization fix; the Go race detector is the appropriate validation tool.  
Existing tests already exercise the affected code paths.
