### PR TITLE
router: fix output token usage not recorded when TokenUsageKey is set

### DIFF
--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -785,12 +785,14 @@ func proxyRequest(
 				if parsed.Usage.CompletionTokens > 0 {
 					klog.V(4).Infof("Parsed usage: %+v", parsed.Usage)
 
+					// Always call onUsage callback to record output tokens
+					if onUsage != nil {
+						onUsage(parsed)
+					}
+
 					// The token usage is set by router, so remove it before sending to downstream
 					if v, ok := c.Get(common.TokenUsageKey); ok && v.(bool) {
 						return true
-					}
-					if onUsage != nil {
-						onUsage(parsed)
 					}
 				}
 				// Forward to downstream


### PR DESCRIPTION
## Problem

In the streaming response handler of `proxyRequest`, when `TokenUsageKey` is set in the gin context, the code returns early (skipping the usage line from being forwarded to downstream). However, the `onUsage` callback was placed **after** this early return, which means output token usage statistics were never recorded in this code path.

This caused output usage metrics to be silently lost whenever the router was configured to manage token usage reporting.

## Summary of Changes

Moved the `onUsage(parsed)` callback invocation to execute **before** the early return triggered by `TokenUsageKey`. This ensures that output token usage is always recorded regardless of whether the router strips the usage line from the downstream response.

**Before (buggy order):**
1. Check `TokenUsageKey` → early return (skip forwarding usage line)
2. Call `onUsage(parsed)` ← **never reached**

**After (fixed order):**
1. Call `onUsage(parsed)` ← **always executed**
2. Check `TokenUsageKey` → early return (skip forwarding usage line)

## Testing

- Verified that output token usage is correctly recorded in streaming responses when `TokenUsageKey` is set.
- Verified that the usage line is still correctly stripped from downstream responses when `TokenUsageKey` is set.
- Verified that behavior is unchanged when `TokenUsageKey` is not set.

## Impact

- **File changed:** `pkg/kthena-router/router/router.go`
- No API changes, no new dependencies.
