### PR TITLE
docs: add mermaid diagram for modelserving plugin framework

### DIFF
--- a/docs/proposal/modelserving-plugin-framework.md
+++ b/docs/proposal/modelserving-plugin-framework.md
@@ -57,7 +57,7 @@ A plugin system enables:
 
 ### Proposal
 
-### Diagram
+#### Diagram
 
 ```mermaid
 flowchart LR
@@ -66,16 +66,16 @@ flowchart LR
     PG["Pod Generator<br/>GenerateEntry/Worker"]
     PM["Plugin Manager<br/>(run in order)"]
   end
-  PL["Plugins<br/>BuiltIn/Webhook<br/>config: JSON"]
+  PL["Plugins<br/>BuiltIn/Webhook"]
   POD["Pod<br/>(mutated spec)"]
   OBS["Events / Status<br/>Annotations"]
 
-  MS -->|reconcile| PG
-  PG -->|OnPodCreate| PM
-  PL -->|config + hooks| PM
-  PM -->|mutate Pod spec| POD
-  POD -.->|OnPodReady| PM
-  PM -.->|events/conditions| OBS
+  MS -->|reconcile| PG;
+  MS -->|spec.plugins config| PM;
+  PG -->|OnPodCreate| PM;
+  PM -->|mutate Pod spec| POD;
+  POD -.->|OnPodReady| PM;
+  PM -.->|events/conditions| OBS;
 ```
 
 #### API changes


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:
Adds a Mermaid diagram to the ModelServing plugin framework proposal and places it under the Proposal section for clarity.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
None.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
