### PR TITLE
  Fix router panic on empty TargetModels in ModelRoute

### DIFF
--- a/charts/kthena/charts/networking/crds/networking.serving.volcano.sh_modelroutes.yaml
+++ b/charts/kthena/charts/networking/crds/networking.serving.volcano.sh_modelroutes.yaml
@@ -340,6 +340,7 @@ spec:
                         - modelServerName
                         type: object
                       maxItems: 16
+                      minItems: 1
                       type: array
                   required:
                   - targetModels

--- a/docs/kthena/docs/reference/crd/networking.serving.volcano.sh.md
+++ b/docs/kthena/docs/reference/crd/networking.serving.volcano.sh.md
@@ -366,7 +366,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `name` _string_ | Name is the name of the rule. |  |  |
 | `modelMatch` _[ModelMatch](#modelmatch)_ | Match conditions to be satisfied for the rule to be activated.<br />Empty `modelMatch` means matching all requests. |  |  |
-| `targetModels` _[TargetModel](#targetmodel) array_ |  |  | MaxItems: 16 <br /> |
+| `targetModels` _[TargetModel](#targetmodel) array_ |  |  | MaxItems: 16 <br />MinItems: 1 <br /> |
 
 
 #### StringMatch

--- a/pkg/apis/networking/v1alpha1/modelroute_types.go
+++ b/pkg/apis/networking/v1alpha1/modelroute_types.go
@@ -63,6 +63,7 @@ type Rule struct {
 	// Empty `modelMatch` means matching all requests.
 	// +optional
 	ModelMatch *ModelMatch `json:"modelMatch,omitempty"`
+	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=16
 	TargetModels []*TargetModel `json:"targetModels"`
 }

--- a/pkg/kthena-router/datastore/store.go
+++ b/pkg/kthena-router/datastore/store.go
@@ -1055,12 +1055,19 @@ func matchString(sm *aiv1alpha1.StringMatch, value string) bool {
 }
 
 func (s *store) selectDestination(targets []*aiv1alpha1.TargetModel) (*aiv1alpha1.TargetModel, error) {
+	if len(targets) == 0 {
+		return nil, fmt.Errorf("no target models specified in rule")
+	}
+
 	weightedSlice, err := toWeightedSlice(targets)
 	if err != nil {
 		return nil, err
 	}
 
-	index := selectFromWeightedSlice(weightedSlice)
+	index, err := selectFromWeightedSlice(weightedSlice)
+	if err != nil {
+		return nil, err
+	}
 
 	return targets[index], nil
 }
@@ -1089,22 +1096,32 @@ func toWeightedSlice(targets []*aiv1alpha1.TargetModel) ([]uint32, error) {
 	return res, nil
 }
 
-func selectFromWeightedSlice(weights []uint32) int {
+func selectFromWeightedSlice(weights []uint32) (int, error) {
+	if len(weights) == 0 {
+		return 0, fmt.Errorf("no weights provided")
+	}
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
 	totalWeight := 0
 	for _, weight := range weights {
 		totalWeight += int(weight)
 	}
 
-	randomNum := rand.Intn(totalWeight)
+	if totalWeight == 0 {
+		return 0, fmt.Errorf("total weight is zero")
+	}
+
+	randomNum := rng.Intn(totalWeight)
 
 	for i, weight := range weights {
 		randomNum -= int(weight)
 		if randomNum < 0 {
-			return i
+			return i, nil
 		}
 	}
 
-	return 0
+	return 0, nil
 }
 
 func (s *store) updatePodMetrics(pod *PodInfo) {

--- a/pkg/kthena-router/datastore/store_test.go
+++ b/pkg/kthena-router/datastore/store_test.go
@@ -1745,3 +1745,158 @@ func TestAddOrUpdatePod_ModelServerChangePreservesMetrics(t *testing.T) {
 	models := podInfo.GetModels()
 	assert.True(t, models.Contains("model-a"), "model lost during model server reassignment")
 }
+
+func TestSelectDestination_EmptyTargets(t *testing.T) {
+	// This test verifies the fix for the panic when TargetModels is empty.
+	// Before the fix, toWeightedSlice would panic with index out of range [0] with length 0.
+	targets := []*aiv1alpha1.TargetModel{}
+	s := &store{}
+	_, err := s.selectDestination(targets)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no target models specified in rule")
+}
+
+func TestToWeightedSlice_SingleTarget(t *testing.T) {
+	weight := uint32(100)
+	targets := []*aiv1alpha1.TargetModel{
+		{ModelServerName: "server-a", Weight: &weight},
+	}
+	result, err := toWeightedSlice(targets)
+	assert.NoError(t, err)
+	assert.Equal(t, []uint32{100}, result)
+}
+
+func TestToWeightedSlice_MultipleTargets(t *testing.T) {
+	w1 := uint32(70)
+	w2 := uint32(30)
+	targets := []*aiv1alpha1.TargetModel{
+		{ModelServerName: "server-a", Weight: &w1},
+		{ModelServerName: "server-b", Weight: &w2},
+	}
+	result, err := toWeightedSlice(targets)
+	assert.NoError(t, err)
+	assert.Equal(t, []uint32{70, 30}, result)
+}
+
+func TestToWeightedSlice_NoWeights(t *testing.T) {
+	targets := []*aiv1alpha1.TargetModel{
+		{ModelServerName: "server-a"},
+		{ModelServerName: "server-b"},
+	}
+	result, err := toWeightedSlice(targets)
+	assert.NoError(t, err)
+	assert.Equal(t, []uint32{1, 1}, result)
+}
+
+func TestToWeightedSlice_MixedWeights(t *testing.T) {
+	w1 := uint32(50)
+	targets := []*aiv1alpha1.TargetModel{
+		{ModelServerName: "server-a", Weight: &w1},
+		{ModelServerName: "server-b"}, // no weight
+	}
+	_, err := toWeightedSlice(targets)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "weight field in targetModel must be either fully specified or not specified")
+}
+
+func TestSelectFromWeightedSlice_EmptyWeights(t *testing.T) {
+	_, err := selectFromWeightedSlice([]uint32{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no weights provided")
+}
+
+func TestSelectFromWeightedSlice_ZeroTotalWeight(t *testing.T) {
+	// This test verifies the fix for the panic when all weights are zero.
+	// Before the fix, rng.Intn(0) would panic.
+	_, err := selectFromWeightedSlice([]uint32{0, 0, 0})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "total weight is zero")
+}
+
+func TestSelectFromWeightedSlice_ValidWeights(t *testing.T) {
+	// Run multiple times to verify no panics and results are within range
+	for i := 0; i < 100; i++ {
+		idx, err := selectFromWeightedSlice([]uint32{50, 30, 20})
+		assert.NoError(t, err)
+		assert.True(t, idx >= 0 && idx < 3, "index should be in range [0, 3)")
+	}
+}
+
+func TestMatchModelServer_EmptyTargetModels_NoPanic(t *testing.T) {
+	// This is the end-to-end test for the bug: a ModelRoute with a rule
+	// that has empty TargetModels should return an error, not panic.
+	s := &store{
+		routeInfo:          make(map[string]*modelRouteInfo),
+		routes:             make(map[string][]*aiv1alpha1.ModelRoute),
+		loraRoutes:         make(map[string][]*aiv1alpha1.ModelRoute),
+		gatewayModelRoutes: make(map[string]sets.Set[string]),
+	}
+
+	mr := &aiv1alpha1.ModelRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "broken-route",
+		},
+		Spec: aiv1alpha1.ModelRouteSpec{
+			ModelName: "my-model",
+			Rules: []*aiv1alpha1.Rule{
+				{
+					Name:         "catch-all",
+					TargetModels: []*aiv1alpha1.TargetModel{}, // empty — the bug trigger
+				},
+			},
+		},
+	}
+	s.AddOrUpdateModelRoute(mr)
+
+	req := &http.Request{URL: &url.URL{Path: "/v1/chat/completions"}}
+
+	// Before the fix this would panic. After the fix it returns an error.
+	assert.NotPanics(t, func() {
+		_, _, _, err := s.MatchModelServer("my-model", req, "")
+		assert.Error(t, err)
+	})
+}
+
+func TestMatchModelServer_EmptyTargetModels_FallsThrough(t *testing.T) {
+	// When the first rule has empty TargetModels but a second rule is valid,
+	// the request should fall through to the second rule.
+	s := &store{
+		routeInfo:          make(map[string]*modelRouteInfo),
+		routes:             make(map[string][]*aiv1alpha1.ModelRoute),
+		loraRoutes:         make(map[string][]*aiv1alpha1.ModelRoute),
+		gatewayModelRoutes: make(map[string]sets.Set[string]),
+	}
+
+	w := uint32(100)
+	mr := &aiv1alpha1.ModelRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "route-with-fallback",
+		},
+		Spec: aiv1alpha1.ModelRouteSpec{
+			ModelName: "my-model",
+			Rules: []*aiv1alpha1.Rule{
+				{
+					Name: "broken-rule",
+					ModelMatch: &aiv1alpha1.ModelMatch{
+						Uri: &aiv1alpha1.StringMatch{Exact: ptr("/v1/broken")},
+					},
+					TargetModels: []*aiv1alpha1.TargetModel{}, // empty
+				},
+				{
+					Name: "valid-rule",
+					TargetModels: []*aiv1alpha1.TargetModel{
+						{ModelServerName: "good-server", Weight: &w},
+					},
+				},
+			},
+		},
+	}
+	s.AddOrUpdateModelRoute(mr)
+
+	req := &http.Request{URL: &url.URL{Path: "/v1/chat/completions"}}
+	server, _, _, err := s.MatchModelServer("my-model", req, "")
+	assert.NoError(t, err)
+	assert.Equal(t, types.NamespacedName{Namespace: "default", Name: "good-server"}, server)
+}

--- a/pkg/kthena-router/webhook/validator.go
+++ b/pkg/kthena-router/webhook/validator.go
@@ -170,6 +170,18 @@ func (v *KthenaRouterValidator) validateModelRoute(modelRoute *networkingv1alpha
 		}
 	}
 
+	rulesField := specField.Child("rules")
+	for i, rule := range modelRoute.Spec.Rules {
+		if rule == nil {
+			allErrs = append(allErrs, field.Invalid(rulesField.Index(i), rule, "rule must not be nil"))
+			continue
+		}
+		ruleField := rulesField.Index(i)
+		if len(rule.TargetModels) == 0 {
+			allErrs = append(allErrs, field.Required(ruleField.Child("targetModels"), "each rule must have at least one target model"))
+		}
+	}
+
 	if len(allErrs) > 0 {
 		var messages []string
 		for _, err := range allErrs {

--- a/pkg/kthena-router/webhook/validator_test.go
+++ b/pkg/kthena-router/webhook/validator_test.go
@@ -255,6 +255,104 @@ func TestValidateModelRoute(t *testing.T) {
 			expectValid:    false,
 			expectedReason: "validation failed:   - spec: Required value: either modelName or loraAdapters must be specified",
 		},
+		{
+			name: "invalid model route - rule with empty targetModels",
+			modelRoute: &networkingv1alpha1.ModelRoute{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "networking.serving.volcano.sh/v1alpha1",
+					Kind:       "ModelRoute",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "default",
+				},
+				Spec: networkingv1alpha1.ModelRouteSpec{
+					ModelName: "test-model",
+					Rules: []*networkingv1alpha1.Rule{
+						{
+							Name:         "empty-targets-rule",
+							TargetModels: []*networkingv1alpha1.TargetModel{},
+						},
+					},
+				},
+			},
+			expectValid:    false,
+			expectedReason: "validation failed:   - spec.rules[0].targetModels: Required value: each rule must have at least one target model",
+		},
+		{
+			name: "invalid model route - multiple rules with empty targetModels",
+			modelRoute: &networkingv1alpha1.ModelRoute{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "networking.serving.volcano.sh/v1alpha1",
+					Kind:       "ModelRoute",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "default",
+				},
+				Spec: networkingv1alpha1.ModelRouteSpec{
+					ModelName: "test-model",
+					Rules: []*networkingv1alpha1.Rule{
+						{
+							Name: "valid-rule",
+							TargetModels: []*networkingv1alpha1.TargetModel{
+								{ModelServerName: "test-server"},
+							},
+						},
+						{
+							Name:         "empty-rule",
+							TargetModels: []*networkingv1alpha1.TargetModel{},
+						},
+					},
+				},
+			},
+			expectValid:    false,
+			expectedReason: "validation failed:   - spec.rules[1].targetModels: Required value: each rule must have at least one target model",
+		},
+		{
+			name: "invalid model route - nil rule",
+			modelRoute: &networkingv1alpha1.ModelRoute{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "networking.serving.volcano.sh/v1alpha1",
+					Kind:       "ModelRoute",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "default",
+				},
+				Spec: networkingv1alpha1.ModelRouteSpec{
+					ModelName: "test-model",
+					Rules: []*networkingv1alpha1.Rule{
+						nil,
+					},
+				},
+			},
+			expectValid:    false,
+			expectedReason: "validation failed:   - spec.rules[0]: Invalid value: null: rule must not be nil",
+		},
+		{
+			name: "invalid model route - combined errors: missing model name and empty targetModels",
+			modelRoute: &networkingv1alpha1.ModelRoute{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "networking.serving.volcano.sh/v1alpha1",
+					Kind:       "ModelRoute",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "default",
+				},
+				Spec: networkingv1alpha1.ModelRouteSpec{
+					Rules: []*networkingv1alpha1.Rule{
+						{
+							Name:         "empty-rule",
+							TargetModels: []*networkingv1alpha1.TargetModel{},
+						},
+					},
+				},
+			},
+			expectValid:    false,
+			expectedReason: "validation failed:   - spec: Required value: either modelName or loraAdapters must be specified  - spec.rules[0].targetModels: Required value: each rule must have at least one target model",
+		},
 	}
 
 	// Create a validator instance


### PR DESCRIPTION
  Problem

Router crashes with index out of range [0] panic when a ModelRoute rule contains an empty targetModels array. This passes CRD validation but crashes the gateway on the first matching inference
request, affecting all users.

  Root Cause

  toWeightedSlice() unconditionally accesses targets[0] without checking if the slice is empty. No validation exists at the CRD schema or webhook level.

  Solution

  Three-layer defense:
  1. Runtime guard - Return error instead of panic in selectDestination()
  2. CRD schema - Add +kubebuilder:validation:MinItems=1 to TargetModels
  3. Webhook - Validate each rule has at least one target model

  Testing

  - 14 new tests covering empty targets, zero weights, and edge cases
  - All existing tests pass (regression check)
  - Verified panic prevention with TestMatchModelServer_EmptyTargetModels_NoPanic
  - all the tests are passed locally 
   
<img width="1857" height="917" alt="image" src="https://github.com/user-attachments/assets/6737dab1-5ae0-47cf-90b5-f668e5ae069b" />
<img width="1224" height="226" alt="image" src="https://github.com/user-attachments/assets/90bcb15a-4a02-49b8-925f-f979a74875db" />



  Impact

  -  Eliminates router crash
  -  Rejects invalid configs at admission time
  -  No behavior change for valid ModelRoutes

  Fixes: Router panic DoS vector for all cluster users