### PR TITLE
test: pin nginx image to fix flaky ModelServing E2E test

### DIFF
--- a/test/e2e/controller-manager/model_serving_test.go
+++ b/test/e2e/controller-manager/model_serving_test.go
@@ -408,7 +408,7 @@ func TestModelServingRollingUpdateMaxUnavailable(t *testing.T) {
 								Containers: []corev1.Container{
 									{
 										Name:  "test-container",
-										Image: "nginx:latest", // Initial image
+										Image: "nginx:1.28.2", // Initial image
 										Ports: []corev1.ContainerPort{
 											{
 												Name:          "http",
@@ -708,7 +708,7 @@ func createRole(name string, roleReplicas, workerReplicas int32) workload.Role {
 				Containers: []corev1.Container{
 					{
 						Name:  "test-container",
-						Image: "nginx:latest",
+						Image: "nginx:1.28.2",
 						Ports: []corev1.ContainerPort{
 							{
 								Name:          "http",
@@ -725,7 +725,7 @@ func createRole(name string, roleReplicas, workerReplicas int32) workload.Role {
 				Containers: []corev1.Container{
 					{
 						Name:  "worker-container",
-						Image: "nginx:latest",
+						Image: "nginx:1.28.2",
 						Ports: []corev1.ContainerPort{
 							{
 								Name:          "http",
@@ -752,7 +752,7 @@ func createBasicModelServing(name string, servingGroupReplicas int32, roles ...w
 						Containers: []corev1.Container{
 							{
 								Name:  "test-container",
-								Image: "nginx:latest",
+								Image: "nginx:1.28.2",
 								Ports: []corev1.ContainerPort{
 									{
 										Name:          "http",
@@ -801,7 +801,7 @@ func createInvalidModelServing() *workload.ModelServing {
 								Containers: []corev1.Container{
 									{
 										Name:  "test",
-										Image: "nginx:latest",
+										Image: "nginx:1.28.2",
 									},
 								},
 							},
@@ -845,7 +845,7 @@ func TestModelServingRollingUpdateMaxUnavailableWithBadImage(t *testing.T) {
 								Containers: []corev1.Container{
 									{
 										Name:  "test-container",
-										Image: "nginx:latest",
+										Image: "nginx:1.28.2",
 										Ports: []corev1.ContainerPort{
 											{
 												Name:          "http",
@@ -992,7 +992,7 @@ func TestLWSAPIBasic(t *testing.T) {
 						Containers: []corev1.Container{
 							{
 								Name:            "worker",
-								Image:           "nginx:latest",
+								Image:           "nginx:1.28.2",
 								ImagePullPolicy: corev1.PullIfNotPresent,
 								Ports: []corev1.ContainerPort{
 									{


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:

This PR fixes the flaky `TestModelServingRollingUpdateMaxUnavailable` E2E test. 
The test previously used `nginx:latest`, which forces kubernetes into  `imagePullPolicy: Always` state. During rolling updates it repeatedly pulls this image from dockerhub over the CI network caused rate-limiting and  leaving pods stuck in `ImagePullBackOff` 

**Which issue(s) this PR fixes**:
Fixes #777 

**Special notes for your reviewer**:
Thanks to @hzxuzhonghu for the pointer on the default pull policy behavior

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
