### PR TITLE
test: add testdata dir under test/e2e/router for E2E tests

### DIFF
--- a/test/e2e/router/context/context.go
+++ b/test/e2e/router/context/context.go
@@ -19,6 +19,7 @@ package context
 import (
 	stdcontext "context"
 	"fmt"
+	"path/filepath"
 	"time"
 
 	clientset "github.com/volcano-sh/kthena/client-go/clientset/versioned"
@@ -39,6 +40,7 @@ const (
 	Deployment7bName    = "deepseek-r1-7b"
 	ModelServer1_5bName = "deepseek-r1-1-5b"
 	ModelServer7bName   = "deepseek-r1-7b"
+	testDataDir         = "test/e2e/router/testdata"
 )
 
 // RouterTestContext holds the clients needed for router tests
@@ -116,7 +118,7 @@ func (c *RouterTestContext) SetupCommonComponents() error {
 
 	// Deploy LLM Mock DS1.5B Deployment
 	fmt.Println("Deploying LLM Mock DS1.5B Deployment...")
-	deployment1_5b := utils.LoadYAMLFromFile[appsv1.Deployment]("examples/kthena-router/LLM-Mock-ds1.5b.yaml")
+	deployment1_5b := utils.LoadYAMLFromFile[appsv1.Deployment](filepath.Join(testDataDir, "LLM-Mock-ds1.5b.yaml"))
 	deployment1_5b.Namespace = c.Namespace
 	_, err := c.KubeClient.AppsV1().Deployments(c.Namespace).Create(ctx, deployment1_5b, metav1.CreateOptions{})
 	if err != nil && !apierrors.IsAlreadyExists(err) {
@@ -125,7 +127,7 @@ func (c *RouterTestContext) SetupCommonComponents() error {
 
 	// Deploy LLM Mock DS7B Deployment
 	fmt.Println("Deploying LLM Mock DS7B Deployment...")
-	deployment7b := utils.LoadYAMLFromFile[appsv1.Deployment]("examples/kthena-router/LLM-Mock-ds7b.yaml")
+	deployment7b := utils.LoadYAMLFromFile[appsv1.Deployment](filepath.Join(testDataDir, "LLM-Mock-ds7b.yaml"))
 	deployment7b.Namespace = c.Namespace
 	_, err = c.KubeClient.AppsV1().Deployments(c.Namespace).Create(ctx, deployment7b, metav1.CreateOptions{})
 	if err != nil && !apierrors.IsAlreadyExists(err) {
@@ -154,7 +156,7 @@ func (c *RouterTestContext) SetupCommonComponents() error {
 
 	// Deploy ModelServer DS1.5B
 	fmt.Println("Deploying ModelServer DS1.5B...")
-	modelServer1_5b := utils.LoadYAMLFromFile[networkingv1alpha1.ModelServer]("examples/kthena-router/ModelServer-ds1.5b.yaml")
+	modelServer1_5b := utils.LoadYAMLFromFile[networkingv1alpha1.ModelServer](filepath.Join(testDataDir, "ModelServer-ds1.5b.yaml"))
 	modelServer1_5b.Namespace = c.Namespace
 	_, err = c.KthenaClient.NetworkingV1alpha1().ModelServers(c.Namespace).Create(ctx, modelServer1_5b, metav1.CreateOptions{})
 	if err != nil && !apierrors.IsAlreadyExists(err) {
@@ -163,7 +165,7 @@ func (c *RouterTestContext) SetupCommonComponents() error {
 
 	// Deploy ModelServer DS7B
 	fmt.Println("Deploying ModelServer DS7B...")
-	modelServer7b := utils.LoadYAMLFromFile[networkingv1alpha1.ModelServer]("examples/kthena-router/ModelServer-ds7b.yaml")
+	modelServer7b := utils.LoadYAMLFromFile[networkingv1alpha1.ModelServer](filepath.Join(testDataDir, "ModelServer-ds7b.yaml"))
 	modelServer7b.Namespace = c.Namespace
 	_, err = c.KthenaClient.NetworkingV1alpha1().ModelServers(c.Namespace).Create(ctx, modelServer7b, metav1.CreateOptions{})
 	if err != nil && !apierrors.IsAlreadyExists(err) {

--- a/test/e2e/router/gateway-api/e2e_test.go
+++ b/test/e2e/router/gateway-api/e2e_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -40,6 +41,8 @@ var (
 	testNamespace   string
 	kthenaNamespace string
 )
+
+const testDataDir = "test/e2e/router/testdata"
 
 // TestMain runs setup and cleanup for all tests in this package.
 func TestMain(m *testing.M) {
@@ -161,7 +164,7 @@ func TestDuplicateModelName(t *testing.T) {
 
 	// 1. Deploy ModelRouteSimple.yaml with parentRefs to default Gateway
 	t.Log("Deploying ModelRouteSimple binding to default Gateway...")
-	modelRoute1 := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute]("examples/kthena-router/ModelRouteSimple.yaml")
+	modelRoute1 := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute](filepath.Join(testDataDir, "ModelRouteSimple.yaml"))
 	modelRoute1.Namespace = testNamespace
 	modelRoute1.Name = "deepseek-simple-default"
 
@@ -190,7 +193,7 @@ func TestDuplicateModelName(t *testing.T) {
 
 	// 2. Create custom Gateway with port 8081
 	t.Log("Creating custom Gateway with port 8081...")
-	customGateway := utils.LoadYAMLFromFile[gatewayv1.Gateway]("examples/kthena-router/Gateway.yaml")
+	customGateway := utils.LoadYAMLFromFile[gatewayv1.Gateway](filepath.Join(testDataDir, "Gateway.yaml"))
 	customGateway.Namespace = kthenaNamespace
 	customGateway.Name = "kthena-gateway-custom"
 	customGateway.Spec.Listeners[0].Port = gatewayv1.PortNumber(8081)

--- a/test/e2e/router/gateway-inference-extension/e2e_test.go
+++ b/test/e2e/router/gateway-inference-extension/e2e_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -37,6 +38,8 @@ var (
 	testNamespace   string
 	kthenaNamespace string
 )
+
+const testDataDir = "test/e2e/router/testdata"
 
 func TestMain(m *testing.M) {
 	testNamespace = "kthena-e2e-gie-" + utils.RandomString(5)
@@ -95,7 +98,7 @@ func TestGatewayInferenceExtension(t *testing.T) {
 
 	// 1. Deploy InferencePool
 	t.Log("Deploying InferencePool...")
-	inferencePool := utils.LoadYAMLFromFile[inferencev1.InferencePool]("examples/kthena-router/InferencePool.yaml")
+	inferencePool := utils.LoadYAMLFromFile[inferencev1.InferencePool](filepath.Join(testDataDir, "InferencePool.yaml"))
 	inferencePool.Namespace = testNamespace
 
 	createdInferencePool, err := testCtx.InferenceClient.InferenceV1().InferencePools(testNamespace).Create(ctx, inferencePool, metav1.CreateOptions{})
@@ -109,7 +112,7 @@ func TestGatewayInferenceExtension(t *testing.T) {
 
 	// 2. Deploy HTTPRoute
 	t.Log("Deploying HTTPRoute...")
-	httpRoute := utils.LoadYAMLFromFile[gatewayv1.HTTPRoute]("examples/kthena-router/HTTPRoute.yaml")
+	httpRoute := utils.LoadYAMLFromFile[gatewayv1.HTTPRoute](filepath.Join(testDataDir, "HTTPRoute.yaml"))
 	httpRoute.Namespace = testNamespace
 
 	// Update parentRefs to point to the kthena installation namespace
@@ -145,7 +148,7 @@ func TestBothAPIsConfigured(t *testing.T) {
 
 	// 1. Deploy ModelRoute and ModelServer for ModelRoute/ModelServer API
 	t.Log("Deploying ModelRoute...")
-	modelRoute := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute]("examples/kthena-router/ModelRoute-binding-gateway.yaml")
+	modelRoute := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute](filepath.Join(testDataDir, "ModelRoute-binding-gateway.yaml"))
 	modelRoute.Namespace = testNamespace
 
 	// Update parentRefs to point to the kthena installation namespace
@@ -203,7 +206,7 @@ func TestBothAPIsConfigured(t *testing.T) {
 
 	// 3. Deploy HTTPRoute pointing to the 7b InferencePool
 	t.Log("Deploying HTTPRoute...")
-	httpRoute := utils.LoadYAMLFromFile[gatewayv1.HTTPRoute]("examples/kthena-router/HTTPRoute.yaml")
+	httpRoute := utils.LoadYAMLFromFile[gatewayv1.HTTPRoute](filepath.Join(testDataDir, "HTTPRoute.yaml"))
 	httpRoute.Namespace = testNamespace
 	httpRoute.Name = "llm-route-7b"
 

--- a/test/e2e/router/shared.go
+++ b/test/e2e/router/shared.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -51,6 +52,7 @@ const (
 	defaultMetricsURL      = "http://127.0.0.1:8080/metrics"
 	defaultPollingInterval = 2 * time.Second
 	defaultScalingTimeout  = 3 * time.Minute
+	testDataDir            = "test/e2e/router/testdata"
 )
 
 func getCounterValue(metrics map[string]*dto.MetricFamily, metricName string, labels map[string]string) float64 {
@@ -127,7 +129,7 @@ func ensureRedis(t *testing.T, kubeClient kubernetes.Interface, namespace string
 	dynamicClient, err := dynamic.NewForConfig(config)
 	require.NoError(t, err, "Failed to create dynamic client")
 
-	const redisManifestPath = "examples/redis/redis-standalone.yaml"
+	redisManifestPath := filepath.Join(testDataDir, "redis-standalone.yaml")
 
 	redisObjects := utils.LoadUnstructuredYAMLFromFile(redisManifestPath)
 	require.NotEmpty(t, redisObjects, "Redis manifest is empty")
@@ -292,7 +294,7 @@ func TestModelRouteSimpleShared(t *testing.T, testCtx *routercontext.RouterTestC
 
 	// Deploy ModelRoute
 	t.Log("Deploying ModelRoute...")
-	modelRoute := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute]("examples/kthena-router/ModelRouteSimple.yaml")
+	modelRoute := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute](filepath.Join(testDataDir, "ModelRouteSimple.yaml"))
 	modelRoute.Namespace = testNamespace
 
 	// Configure ParentRefs if using Gateway API
@@ -325,7 +327,7 @@ func TestModelRouteSimpleShared(t *testing.T, testCtx *routercontext.RouterTestC
 func TestModelRouteMultiModelsShared(t *testing.T, testCtx *routercontext.RouterTestContext, testNamespace string, useGatewayAPI bool, kthenaNamespace string) {
 	ctx := context.Background()
 
-	modelRoute := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute]("examples/kthena-router/ModelRouteMultiModels.yaml")
+	modelRoute := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute](filepath.Join(testDataDir, "ModelRouteMultiModels.yaml"))
 	modelRoute.Namespace = testNamespace
 
 	// Configure ParentRefs if using Gateway API
@@ -396,7 +398,7 @@ func TestModelRoutePrefillDecodeDisaggregationShared(t *testing.T, testCtx *rout
 
 	// Deploy ModelServing
 	t.Log("Deploying ModelServing for PD disaggregation...")
-	modelServing := utils.LoadYAMLFromFile[workloadv1alpha1.ModelServing]("examples/kthena-router/ModelServing-ds1.5b-pd-disaggregation.yaml")
+	modelServing := utils.LoadYAMLFromFile[workloadv1alpha1.ModelServing](filepath.Join(testDataDir, "ModelServing-ds1.5b-pd-disaggregation.yaml"))
 	modelServing.Namespace = testNamespace
 	createdModelServing, err := testCtx.KthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Create(ctx, modelServing, metav1.CreateOptions{})
 	require.NoError(t, err, "Failed to create ModelServing")
@@ -417,7 +419,7 @@ func TestModelRoutePrefillDecodeDisaggregationShared(t *testing.T, testCtx *rout
 
 	// Deploy ModelServer
 	t.Log("Deploying ModelServer for PD disaggregation...")
-	modelServer := utils.LoadYAMLFromFile[networkingv1alpha1.ModelServer]("examples/kthena-router/ModelServer-ds1.5b-pd-disaggregation.yaml")
+	modelServer := utils.LoadYAMLFromFile[networkingv1alpha1.ModelServer](filepath.Join(testDataDir, "ModelServer-ds1.5b-pd-disaggregation.yaml"))
 	modelServer.Namespace = testNamespace
 	createdModelServer, err := testCtx.KthenaClient.NetworkingV1alpha1().ModelServers(testNamespace).Create(ctx, modelServer, metav1.CreateOptions{})
 	require.NoError(t, err, "Failed to create ModelServer")
@@ -435,7 +437,7 @@ func TestModelRoutePrefillDecodeDisaggregationShared(t *testing.T, testCtx *rout
 
 	// Deploy ModelRoute
 	t.Log("Deploying ModelRoute for PD disaggregation...")
-	modelRoute := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute]("examples/kthena-router/ModelRoute-ds1.5b-pd-disaggregation.yaml")
+	modelRoute := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute](filepath.Join(testDataDir, "ModelRoute-ds1.5b-pd-disaggregation.yaml"))
 	modelRoute.Namespace = testNamespace
 
 	// Configure ParentRefs if using Gateway API
@@ -472,7 +474,7 @@ func TestModelRouteSubsetShared(t *testing.T, testCtx *routercontext.RouterTestC
 	t.Log("Deploying Canary ModelServers and LLM-Mock deployments...")
 
 	// Deploy Canary LLM-Mock deployments from YAML file
-	canaryDeployments := utils.LoadMultiResourceYAMLFromFile[appsv1.Deployment]("examples/kthena-router/LLM-Mock-ds1.5b-Canary.yaml")
+	canaryDeployments := utils.LoadMultiResourceYAMLFromFile[appsv1.Deployment](filepath.Join(testDataDir, "LLM-Mock-ds1.5b-Canary.yaml"))
 	require.Len(t, canaryDeployments, 2, "Canary YAML should contain 2 deployments")
 
 	deploymentV1 := canaryDeployments[0]
@@ -500,7 +502,7 @@ func TestModelRouteSubsetShared(t *testing.T, testCtx *routercontext.RouterTestC
 	}, 5*time.Minute, 5*time.Second, "Canary deployments should be ready")
 
 	// Deploy Canary ModelServers from YAML file
-	canaryModelServers := utils.LoadMultiResourceYAMLFromFile[networkingv1alpha1.ModelServer]("examples/kthena-router/ModelServer-ds1.5b-Canary.yaml")
+	canaryModelServers := utils.LoadMultiResourceYAMLFromFile[networkingv1alpha1.ModelServer](filepath.Join(testDataDir, "ModelServer-ds1.5b-Canary.yaml"))
 	require.Len(t, canaryModelServers, 2, "Canary YAML should contain 2 ModelServers")
 
 	modelServerV1 := canaryModelServers[0]
@@ -524,7 +526,7 @@ func TestModelRouteSubsetShared(t *testing.T, testCtx *routercontext.RouterTestC
 	})
 
 	// Create ModelRoute with Canary ModelServer names
-	modelRoute := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute]("examples/kthena-router/ModelRouteSubset.yaml")
+	modelRoute := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute](filepath.Join(testDataDir, "ModelRouteSubset.yaml"))
 	modelRoute.Namespace = testNamespace
 
 	// Configure ParentRefs if using Gateway API
@@ -702,7 +704,7 @@ func TestModelRouteWithRateLimitShared(t *testing.T, testCtx *routercontext.Rout
 	t.Run("VerifyInputTokenRateLimitEnforcement", func(t *testing.T) {
 		t.Log("Test 1: Verifying input token rate limit")
 
-		modelRoute := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute]("examples/kthena-router/ModelRouteWithRateLimit.yaml")
+		modelRoute := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute](filepath.Join(testDataDir, "ModelRouteWithRateLimit.yaml"))
 		modelRoute.Namespace = testNamespace
 		// Only test input rate limit; remove output limit to avoid 429 "output token rate limit exceeded"
 		if modelRoute.Spec.RateLimit != nil {
@@ -764,7 +766,7 @@ func TestModelRouteWithRateLimitShared(t *testing.T, testCtx *routercontext.Rout
 	t.Run("VerifyRateLimitWindowAccuracy", func(t *testing.T) {
 		t.Log("Test 2: Verifying rate limit window accuracy...")
 
-		modelRoute := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute]("examples/kthena-router/ModelRouteWithRateLimit.yaml")
+		modelRoute := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute](filepath.Join(testDataDir, "ModelRouteWithRateLimit.yaml"))
 		modelRoute.Namespace = testNamespace
 		// Only test input rate limit; remove output limit to avoid 429 "output token rate limit exceeded"
 		if modelRoute.Spec.RateLimit != nil {
@@ -833,7 +835,7 @@ func TestModelRouteWithRateLimitShared(t *testing.T, testCtx *routercontext.Rout
 	t.Run("VerifyRateLimitResetMechanism", func(t *testing.T) {
 		t.Log("Test 3: Verifying rate limit reset mechanism...")
 
-		modelRoute := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute]("examples/kthena-router/ModelRouteWithRateLimit.yaml")
+		modelRoute := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute](filepath.Join(testDataDir, "ModelRouteWithRateLimit.yaml"))
 		modelRoute.Namespace = testNamespace
 		// Only test input rate limit; remove output limit to avoid 429 "output token rate limit exceeded"
 		if modelRoute.Spec.RateLimit != nil {
@@ -903,7 +905,7 @@ func TestModelRouteWithRateLimitShared(t *testing.T, testCtx *routercontext.Rout
 	t.Run("VerifyOutputTokenRateLimitEnforcement", func(t *testing.T) {
 		t.Log("Test 4: Verifying output token rate limit (100 tokens/minute)...")
 
-		modelRoute := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute]("examples/kthena-router/ModelRouteWithRateLimit.yaml")
+		modelRoute := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute](filepath.Join(testDataDir, "ModelRouteWithRateLimit.yaml"))
 		modelRoute.Namespace = testNamespace
 		setupModelRouteWithGatewayAPI(modelRoute, useGatewayApi, kthenaNamespace)
 
@@ -993,7 +995,7 @@ func TestModelRouteWithGlobalRateLimitShared(t *testing.T, testCtx *routercontex
 	}
 
 	buildModelRoute := func(name, modelName, redisAddr string) *networkingv1alpha1.ModelRoute {
-		modelRoute := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute]("examples/kthena-router/ModelRouteWithGlobalRateLimit.yaml")
+		modelRoute := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute](filepath.Join(testDataDir, "ModelRouteWithGlobalRateLimit.yaml"))
 		modelRoute.Namespace = testNamespace
 		modelRoute.Name = name
 		modelRoute.Spec.ModelName = modelName
@@ -1183,7 +1185,7 @@ func TestModelRouteLoraShared(t *testing.T, testCtx *routercontext.RouterTestCon
 
 	// Deploy ModelRoute with LoRA adapters
 	t.Log("Deploying ModelRoute with LoRA adapters...")
-	modelRoute := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute]("examples/kthena-router/ModelRouteLora.yaml")
+	modelRoute := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute](filepath.Join(testDataDir, "ModelRouteLora.yaml"))
 	modelRoute.Namespace = testNamespace
 
 	// Configure ParentRefs if using Gateway API
@@ -1292,7 +1294,7 @@ func TestMetricsShared(t *testing.T, testCtx *routercontext.RouterTestContext, t
 
 	// Deploy ModelRoute
 	t.Log("Deploying ModelRoute...")
-	modelRoute := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute]("examples/kthena-router/ModelRouteSimple.yaml")
+	modelRoute := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute](filepath.Join(testDataDir, "ModelRouteSimple.yaml"))
 	modelRoute.Namespace = testNamespace
 
 	setupModelRouteWithGatewayAPI(modelRoute, useGatewayAPI, kthenaNamespace)
@@ -1398,7 +1400,7 @@ func TestRateLimitMetricsShared(t *testing.T, testCtx *routercontext.RouterTestC
 
 	// Deploy ModelRoute with rate limiting
 	t.Log("Deploying ModelRoute with rate limiting...")
-	modelRoute := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute]("examples/kthena-router/ModelRouteWithRateLimit.yaml")
+	modelRoute := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute](filepath.Join(testDataDir, "ModelRouteWithRateLimit.yaml"))
 	modelRoute.Namespace = testNamespace
 
 	setupModelRouteWithGatewayAPI(modelRoute, useGatewayAPI, kthenaNamespace)

--- a/test/e2e/router/testdata/Gateway.yaml
+++ b/test/e2e/router/testdata/Gateway.yaml
@@ -1,0 +1,11 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: kthena-gateway
+  namespace: kthena-system
+spec:
+  gatewayClassName: kthena-router
+  listeners:
+  - name: http
+    port: 8081
+    protocol: HTTP

--- a/test/e2e/router/testdata/HTTPRoute.yaml
+++ b/test/e2e/router/testdata/HTTPRoute.yaml
@@ -1,0 +1,19 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: llm-route
+spec:
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: default
+    namespace: kthena-system
+  rules:
+  - backendRefs:
+    - group: inference.networking.k8s.io
+      kind: InferencePool
+      name: deepseek-r1-1-5b
+    matches:
+    - path:
+        type: PathPrefix
+        value: /

--- a/test/e2e/router/testdata/InferencePool.yaml
+++ b/test/e2e/router/testdata/InferencePool.yaml
@@ -1,0 +1,16 @@
+apiVersion: inference.networking.k8s.io/v1
+kind: InferencePool
+metadata:
+  name: deepseek-r1-1-5b
+spec:
+  targetPorts:
+    - number: 8000
+  selector:
+    matchLabels:
+      app: deepseek-r1-1-5b
+  # Kthena Router natively supports Gateway Inference Extension and does not require the Endpoint Picker Extension.
+  # It's just a placeholder for API validation.
+  endpointPickerRef:
+    name: deepseek-r1-1-5b
+    port:
+      number: 8080

--- a/test/e2e/router/testdata/LLM-Mock-ds1.5b-Canary.yaml
+++ b/test/e2e/router/testdata/LLM-Mock-ds1.5b-Canary.yaml
@@ -1,0 +1,60 @@
+# This example shows how to deploy a DS1.5B model server.
+# The DS1.5B server will provide inference services for the DS1.5B model.
+#
+# NOTE: Update the image to the correct DS1.5B model image once it's available.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deepseek-r1-1-5b-v1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: deepseek-r1-1-5b
+      version: v1
+  template:
+    metadata:
+      labels:
+        app: deepseek-r1-1-5b
+        version: v1
+    spec:
+      containers:
+        - name: llm-engine
+          image: ghcr.io/yaozengzeng/vllm-mock:latest
+          imagePullPolicy: IfNotPresent
+          env:
+            # specify the model name to mock
+            - name: MODEL_NAME
+              value: "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B-v1"
+          command:
+            - python3
+            - app.py
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deepseek-r1-1-5b-v2
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: deepseek-r1-1-5b
+      version: v2
+  template:
+    metadata:
+      labels:
+        app: deepseek-r1-1-5b
+        version: v2
+    spec:
+      containers:
+        - name: llm-engine
+          image: ghcr.io/yaozengzeng/vllm-mock:latest
+          imagePullPolicy: IfNotPresent
+          env:
+            # specify the model name to mock
+            - name: MODEL_NAME
+              value: "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B-v2"
+          command:
+            - python3
+            - app.py

--- a/test/e2e/router/testdata/LLM-Mock-ds1.5b.yaml
+++ b/test/e2e/router/testdata/LLM-Mock-ds1.5b.yaml
@@ -1,0 +1,31 @@
+# This example shows how to deploy a DS1.5B model server.
+# The DS1.5B server will provide inference services for the DS1.5B model.
+#
+# NOTE: Update the image to the correct DS1.5B model image once it's available.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deepseek-r1-1-5b
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: deepseek-r1-1-5b
+  template:
+    metadata:
+      labels:
+        app: deepseek-r1-1-5b
+    spec:
+      containers:
+        - name: llm-engine
+          image: ghcr.io/yaozengzeng/vllm-mock:latest
+          imagePullPolicy: IfNotPresent
+          env:
+            # specify the model name to mock
+            - name: MODEL_NAME
+              value: "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
+          command:
+            - python3
+            - app.py
+

--- a/test/e2e/router/testdata/LLM-Mock-ds7b.yaml
+++ b/test/e2e/router/testdata/LLM-Mock-ds7b.yaml
@@ -1,0 +1,30 @@
+# This example shows how to deploy a DS7B model server.
+# The DS7B server will provide inference services for the DS7B model.
+#
+# NOTE: Update the image to the correct DS7B model image once it's available.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deepseek-r1-7b
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: deepseek-r1-7b
+  template:
+    metadata:
+      labels:
+        app: deepseek-r1-7b
+    spec:
+      containers:
+        - name: llm-engine
+          image: ghcr.io/yaozengzeng/vllm-mock:latest
+          imagePullPolicy: IfNotPresent
+          env:
+            # specify the model name to mock
+            - name: MODEL_NAME
+              value: "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B"
+          command:
+            - python3
+            - app.py

--- a/test/e2e/router/testdata/ModelRoute-binding-gateway.yaml
+++ b/test/e2e/router/testdata/ModelRoute-binding-gateway.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.serving.volcano.sh/v1alpha1
+kind: ModelRoute
+metadata:
+  name: deepseek-binding-gateway
+  namespace: default
+spec:
+  modelName: "deepseek-binding-gateway"
+  parentRefs:
+  - name: "default"
+    namespace: "kthena-system"
+    kind: "Gateway"
+  rules:
+  - name: "default"
+    targetModels:
+    - modelServerName: "deepseek-r1-1-5b"

--- a/test/e2e/router/testdata/ModelRoute-ds1.5b-pd-disaggregation.yaml
+++ b/test/e2e/router/testdata/ModelRoute-ds1.5b-pd-disaggregation.yaml
@@ -1,0 +1,11 @@
+apiVersion: networking.serving.volcano.sh/v1alpha1
+kind: ModelRoute
+metadata:
+  name: deepseek-r1-1-5b-pd-disaggregation
+  namespace: default
+spec:
+  modelName: "deepseek-r1-1-5b-pd-disaggregation"
+  rules:
+    - name: "default"
+      targetModels:
+        - modelServerName: "deepseek-r1-1-5b-pd-disaggregation"

--- a/test/e2e/router/testdata/ModelRouteLora.yaml
+++ b/test/e2e/router/testdata/ModelRouteLora.yaml
@@ -1,0 +1,13 @@
+apiVersion: networking.serving.volcano.sh/v1alpha1
+kind: ModelRoute
+metadata:
+  name: deepseek-lora
+  namespace: default
+spec:
+  loraAdapters:
+  - "lora-A"
+  - "lora-B"
+  rules:
+  - name: "lora-route"
+    targetModels:
+    - modelServerName: "deepseek-r1-7b"

--- a/test/e2e/router/testdata/ModelRouteMultiModels.yaml
+++ b/test/e2e/router/testdata/ModelRouteMultiModels.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.serving.volcano.sh/v1alpha1
+kind: ModelRoute
+metadata:
+  name: deepseek-multi-models
+  namespace: default
+spec:
+  modelName: "deepseek-multi-models"
+  rules:
+  - name: "premium"
+    modelMatch:
+      headers:
+        user-type:
+          exact: premium
+    targetModels:
+    - modelServerName: "deepseek-r1-7b"
+  - name: "default"
+    targetModels:
+    - modelServerName: "deepseek-r1-1-5b"

--- a/test/e2e/router/testdata/ModelRouteSimple.yaml
+++ b/test/e2e/router/testdata/ModelRouteSimple.yaml
@@ -1,0 +1,11 @@
+apiVersion: networking.serving.volcano.sh/v1alpha1
+kind: ModelRoute
+metadata:
+  name: deepseek-simple
+  namespace: default
+spec:
+  modelName: "deepseek-simple"
+  rules:
+  - name: "default"
+    targetModels:
+    - modelServerName: "deepseek-r1-1-5b"

--- a/test/e2e/router/testdata/ModelRouteSubset.yaml
+++ b/test/e2e/router/testdata/ModelRouteSubset.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.serving.volcano.sh/v1alpha1
+kind: ModelRoute
+metadata:
+  name: deepseek-subset
+  namespace: default
+spec:
+  modelName: "deepseek-subset"
+  rules:
+  - name: "deepseek-r1-route"
+    targetModels:
+    - modelServerName: "deepseek-r1-1-5b-v1"
+      weight: 70
+    - modelServerName: "deepseek-r1-1-5b-v2"
+      weight: 30

--- a/test/e2e/router/testdata/ModelRouteWithGlobalRateLimit.yaml
+++ b/test/e2e/router/testdata/ModelRouteWithGlobalRateLimit.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.serving.volcano.sh/v1alpha1
+kind: ModelRoute
+metadata:
+  name: deepseek-global-rate-limit
+  namespace: default
+spec:
+  modelName: "deepseek-r1-with-global-rate-limit"
+  rules:
+  - name: "default"
+    targetModels:
+    - modelServerName: "deepseek-r1-1-5b"
+  # This configuration applies to all rules in this ModelRoute
+  # - 10 input tokens per minute to be convenient to test
+  rateLimit:
+    inputTokensPerUnit: 10
+    outputTokensPerUnit: 5000
+    unit: minute
+    global:
+      redis:
+        address: "redis-server.kthena-system.svc.cluster.local:6379"
+

--- a/test/e2e/router/testdata/ModelRouteWithRateLimit.yaml
+++ b/test/e2e/router/testdata/ModelRouteWithRateLimit.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.serving.volcano.sh/v1alpha1
+kind: ModelRoute
+metadata:
+  name: deepseek-rate-limit
+  namespace: default
+spec:
+  modelName: "deepseek-r1-with-rate-limit"
+  rules:
+    - name: "default"
+      targetModels:
+        - modelServerName: "deepseek-r1-1-5b"
+  # This configuration applies to all rules in this ModelRoute
+  # - 30 input tokens per minute to be convenient to test
+  rateLimit:
+    inputTokensPerUnit: 30
+    outputTokensPerUnit: 100
+    unit: minute

--- a/test/e2e/router/testdata/ModelServer-ds1.5b-Canary.yaml
+++ b/test/e2e/router/testdata/ModelServer-ds1.5b-Canary.yaml
@@ -1,0 +1,35 @@
+apiVersion: networking.serving.volcano.sh/v1alpha1
+kind: ModelServer
+metadata:
+  name: deepseek-r1-1-5b-v1
+  namespace: default
+spec:
+  workloadSelector:
+    matchLabels:
+      app: deepseek-r1-1-5b
+      version: v1
+  workloadPort:
+    port: 8000
+  model: "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B-v1"
+  inferenceEngine: "vLLM"
+  trafficPolicy:
+    timeout: 10s
+
+---
+
+apiVersion: networking.serving.volcano.sh/v1alpha1
+kind: ModelServer
+metadata:
+  name: deepseek-r1-1-5b-v2
+  namespace: default
+spec:
+  workloadSelector:
+    matchLabels:
+      app: deepseek-r1-1-5b
+      version: v2
+  workloadPort:
+    port: 8000
+  model: "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B-v2"
+  inferenceEngine: "vLLM"
+  trafficPolicy:
+    timeout: 10s

--- a/test/e2e/router/testdata/ModelServer-ds1.5b-pd-disaggregation.yaml
+++ b/test/e2e/router/testdata/ModelServer-ds1.5b-pd-disaggregation.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.serving.volcano.sh/v1alpha1
+kind: ModelServer
+metadata:
+  name: deepseek-r1-1-5b-pd-disaggregation
+  namespace: default
+spec:
+  workloadSelector:
+    matchLabels:
+      app: deepseek-r1-1-5b
+    pdGroup:
+      groupKey: "modelserving.volcano.sh/group-name"
+      prefillLabels:
+        modelserving.volcano.sh/rolename: "P-instance"
+      decodeLabels:
+        modelserving.volcano.sh/rolename: "D-instance"
+  workloadPort:
+    port: 8000
+  model: "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
+  inferenceEngine: "vLLM"
+  trafficPolicy:
+    timeout: 10s

--- a/test/e2e/router/testdata/ModelServer-ds1.5b.yaml
+++ b/test/e2e/router/testdata/ModelServer-ds1.5b.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.serving.volcano.sh/v1alpha1
+kind: ModelServer
+metadata:
+  name: deepseek-r1-1-5b
+  namespace: default
+spec:
+  workloadSelector:
+    matchLabels:
+      app: deepseek-r1-1-5b
+  workloadPort:
+    port: 8000
+  model: "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
+  inferenceEngine: "vLLM"
+  trafficPolicy:
+    timeout: 10s

--- a/test/e2e/router/testdata/ModelServer-ds7b.yaml
+++ b/test/e2e/router/testdata/ModelServer-ds7b.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.serving.volcano.sh/v1alpha1
+kind: ModelServer
+metadata:
+  name: deepseek-r1-7b
+  namespace: default
+spec:
+  workloadSelector:
+    matchLabels:
+      app: deepseek-r1-7b
+  workloadPort:
+    port: 8000
+  model: "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B"
+  inferenceEngine: "vLLM"
+  trafficPolicy:
+    timeout: 10s

--- a/test/e2e/router/testdata/ModelServing-ds1.5b-pd-disaggregation.yaml
+++ b/test/e2e/router/testdata/ModelServing-ds1.5b-pd-disaggregation.yaml
@@ -1,0 +1,50 @@
+apiVersion: workload.serving.volcano.sh/v1alpha1
+kind: ModelServing
+metadata:
+  name: deepseek-r1-1-5b
+  namespace: default
+spec:
+  schedulerName: volcano
+  replicas: 1
+  template:
+    roles:
+      - name: prefill
+        replicas: 1
+        entryTemplate:
+          metadata:
+            labels:
+              app: deepseek-r1-1-5b
+              modelserving.volcano.sh/group-name: "group-0"
+              modelserving.volcano.sh/rolename: "P-instance"
+          spec:
+            containers:
+              - name: leader
+                image: ghcr.io/yaozengzeng/vllm-mock:latest
+                imagePullPolicy: IfNotPresent
+                env:
+                  # specify the model name to mock
+                  - name: MODEL_NAME
+                    value: "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
+                ports:
+                  - containerPort: 8000
+        workerReplicas: 0
+      - name: decode
+        replicas: 1
+        entryTemplate:
+          metadata:
+            labels:
+              app: deepseek-r1-1-5b
+              modelserving.volcano.sh/group-name: "group-0"
+              modelserving.volcano.sh/rolename: "D-instance"
+          spec:
+            containers:
+              - name: leader
+                image: ghcr.io/yaozengzeng/vllm-mock:latest
+                imagePullPolicy: IfNotPresent
+                env:
+                  # specify the model name to mock
+                  - name: MODEL_NAME
+                    value: "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
+                ports:
+                  - containerPort: 8000
+        workerReplicas: 0

--- a/test/e2e/router/testdata/redis-standalone.yaml
+++ b/test/e2e/router/testdata/redis-standalone.yaml
@@ -1,0 +1,97 @@
+# Redis deployment for Kthena
+# Deploy when using KV cache or other Redis-dependent features
+# Usage (deploy in the same namespace as Kthena):
+#   kubectl apply -f redis-standalone.yaml -n <namespace>
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redis-config
+  labels:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/component: redis-config
+data:
+  REDIS_HOST: "redis-server"
+  REDIS_PORT: "6379"
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redis-secret
+  labels:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/component: redis-secret
+type: Opaque
+data:
+  REDIS_PASSWORD: ""
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-server
+  labels:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/component: redis-server
+spec:
+  type: ClusterIP
+  ports:
+    - name: redis-port
+      protocol: TCP
+      port: 6379
+      targetPort: 6379
+  selector:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/component: redis-server
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis-server
+  labels:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/component: redis-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: redis
+      app.kubernetes.io/component: redis-server
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: redis
+        app.kubernetes.io/component: redis-server
+    spec:
+      containers:
+        - name: redis-server
+          image: "redis:7.2-alpine"
+          imagePullPolicy: IfNotPresent
+          command:
+            - redis-server
+          ports:
+            - name: redis-port
+              containerPort: 6379
+              protocol: TCP
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 1000m
+              memory: 1Gi
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
+  revisionHistoryLimit: 10
+  progressDeadlineSeconds: 600


### PR DESCRIPTION
What type of PR is this?

/kind documentation

What this PR does / why we need it:

E2E tests currently load YAML fixtures from `examples/kthena-router/` and
`examples/redis/`, which are intended for users to manually deploy and test
features. This PR separates E2E test fixtures from user-facing examples by
creating a dedicated `test/e2e/router/testdata/` directory.

Which issue(s) this PR fixes:

Fixes #602

Changes:
- Add `test/e2e/router/testdata/` with 19 router YAML manifests and redis-standalone.yaml
- Update all YAML load paths in:
  - test/e2e/router/shared.go (17 references)
  - test/e2e/router/context/context.go (4 references)
  - test/e2e/router/gateway-api/e2e_test.go (2 references)
  - test/e2e/router/gateway-inference-extension/e2e_test.go (4 references)
- The examples/ directory is unchanged and remains for user-facing usage

Does this PR introduce a user-facing change?:

NONE
