### PR TITLE
fix autoscaler, use target's namespace if specified

### DIFF
--- a/pkg/autoscaler/autoscaler/metric_collector.go
+++ b/pkg/autoscaler/autoscaler/metric_collector.go
@@ -67,7 +67,6 @@ func NewMetricCollector(target *v1alpha1.Target, binding *v1alpha1.AutoscalingPo
 	}
 }
 
-
 type HistogramInfo struct {
 	PodStartTime *metav1.Time
 	HistogramMap map[string]*histogram.Snapshot


### PR DESCRIPTION
When the namespace of the modelserving pod differs from that of the autoscaler, the namespace corresponding to the modelserving pod is used first to ensure the pod is correctly located.

**What type of PR is this?**

/kind bug


**What this PR does / why we need it**: When the namespace of the modelserving pod differs from that of the autoscaler, the namespace corresponding to the modelserving pod is used first to ensure the pod is correctly located.

**Which issue(s) this PR fixes**:
Fixes autoscaler, use target's namespace if specified

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: NONE

```release-note

```
