### PR TITLE
fix: autoscaler use target's namespace if specified

### DIFF
--- a/pkg/autoscaler/autoscaler/metric_collector.go
+++ b/pkg/autoscaler/autoscaler/metric_collector.go
@@ -49,11 +49,17 @@ type MetricCollector struct {
 }
 
 func NewMetricCollector(target *v1alpha1.Target, binding *v1alpha1.AutoscalingPolicyBinding, metricTargets map[string]float64) *MetricCollector {
+	// Use target's namespace if specified, otherwise fall back to binding's namespace
+	namespace := target.TargetRef.Namespace
+	if namespace == "" {
+		namespace = binding.Namespace
+	}
+
 	return &MetricCollector{
 		PastHistograms: datastructure.NewSnapshotSlidingWindow[map[string]HistogramInfo](util.SecondToTimestamp(util.SloQuantileSlidingWindowSeconds), util.SecondToTimestamp(util.SloQuantileDataKeepSeconds)),
 		Target:         target,
 		Scope: Scope{
-			Namespace:      binding.Namespace,
+			Namespace:      namespace,
 			OwnedBindingId: binding.UID,
 		},
 		MetricTargets:   metricTargets,


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**: When the namespace of the modelserving pod differs from that of the autoscaler, the namespace corresponding to the modelserving pod is used first to ensure the pod is correctly located.

**Which issue(s) this PR fixes**:
Fixes autoscaler, use target's namespace if specified

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:  NONE

```release-note

```
