### PR TITLE
fix rolling update e2e error

### DIFF
--- a/test/e2e/controller-manager/model_serving_test.go
+++ b/test/e2e/controller-manager/model_serving_test.go
@@ -446,7 +446,7 @@ func TestModelServingRollingUpdateMaxUnavailable(t *testing.T) {
 	// Update the ModelServing to trigger a rolling update (change image)
 	updatedMS := initialMS.DeepCopy()
 	// Modify the container image to trigger a rolling update
-	updatedMS.Spec.Template.Roles[0].EntryTemplate.Spec.Containers[0].Image = "nginx:alpine"
+	updatedMS.Spec.Template.Roles[0].EntryTemplate.Spec.Containers[0].Image = "nginx:1.29" // Change to a different image to ensure update is triggered
 
 	t.Log("Updating ModelServing to trigger rolling update with maxUnavailable=2")
 	_, err = kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Update(ctx, updatedMS, metav1.UpdateOptions{})


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:

The original end-to-end test employed a bad image(nginx: alpine), causing `utils.WaitForModelServingReady(t, ctx, kthenaClient, testNamespace, updatedMS.Name)` to time out.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
