### PR TITLE
allow partition to be greater than or equal to replicas

### DIFF
--- a/pkg/model-serving-controller/webhook/validator.go
+++ b/pkg/model-serving-controller/webhook/validator.go
@@ -155,12 +155,6 @@ func validateRollingUpdateConfiguration(ms *workloadv1alpha1.ModelServing) field
 		if partitionValue < 0 {
 			allErrs = append(allErrs, field.Invalid(partitionPath, partitionValue, "partition must be greater than or equal to 0"))
 		}
-
-		// Check if partition is less than replicas
-		if ms.Spec.Replicas != nil && partitionValue >= *ms.Spec.Replicas {
-			allErrs = append(allErrs, field.Invalid(partitionPath, partitionValue,
-				fmt.Sprintf("partition must be less than replicas (%d)", *ms.Spec.Replicas)))
-		}
 	}
 
 	maxUnavailableValue, err := intstr.GetScaledValueFromIntOrPercent(maxUnavailable, int(*ms.Spec.Replicas), false)

--- a/pkg/model-serving-controller/webhook/validator_test.go
+++ b/pkg/model-serving-controller/webhook/validator_test.go
@@ -24,6 +24,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/ptr"
 )
 
 func TestValidPodNameLength(t *testing.T) {
@@ -229,7 +230,7 @@ func TestValidateRollingUpdateConfiguration(t *testing.T) {
 			},
 		},
 		{
-			name: "invalid partition - equal to replicas",
+			name: "valid partition - equal to replicas",
 			args: args{
 				ms: &workloadv1alpha1.ModelServing{
 					Spec: workloadv1alpha1.ModelServingSpec{
@@ -243,19 +244,25 @@ func TestValidateRollingUpdateConfiguration(t *testing.T) {
 								Partition: int32Ptr(3),
 							},
 						},
+						Template: workloadv1alpha1.ServingGroup{
+							Roles: []workloadv1alpha1.Role{
+								{
+									Name:     "predictor",
+									Replicas: ptr.To[int32](1),
+									EntryTemplate: workloadv1alpha1.PodTemplateSpec{
+										Metadata: &workloadv1alpha1.Metadata{},
+									},
+									WorkerReplicas: 0,
+								},
+							},
+						},
 					},
 				},
 			},
-			want: field.ErrorList{
-				field.Invalid(
-					field.NewPath("spec").Child("rolloutStrategy").Child("rollingUpdateConfiguration").Child("partition"),
-					int32(3),
-					"partition must be less than replicas (3)",
-				),
-			},
+			want: nil,
 		},
 		{
-			name: "invalid partition - greater than replicas",
+			name: "valid partition - greater than replicas",
 			args: args{
 				ms: &workloadv1alpha1.ModelServing{
 					Spec: workloadv1alpha1.ModelServingSpec{
@@ -269,16 +276,22 @@ func TestValidateRollingUpdateConfiguration(t *testing.T) {
 								Partition: int32Ptr(5),
 							},
 						},
+						Template: workloadv1alpha1.ServingGroup{
+							Roles: []workloadv1alpha1.Role{
+								{
+									Name:     "predictor",
+									Replicas: ptr.To[int32](1),
+									EntryTemplate: workloadv1alpha1.PodTemplateSpec{
+										Metadata: &workloadv1alpha1.Metadata{},
+									},
+									WorkerReplicas: 0,
+								},
+							},
+						},
 					},
 				},
 			},
-			want: field.ErrorList{
-				field.Invalid(
-					field.NewPath("spec").Child("rolloutStrategy").Child("rollingUpdateConfiguration").Child("partition"),
-					int32(5),
-					"partition must be less than replicas (3)",
-				),
-			},
+			want: nil,
 		},
 		{
 			name: "valid partition - zero value",


### PR DESCRIPTION
This change allows initializing ModelServing with replicas: 0 and partition: 0, and enables pausing rollouts by setting partition >= replicas.

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #809 

**Special notes for your reviewer**:
The `ModelServing` admission webhook currently rejects resources where `spec.rolloutStrategy.rollingUpdateConfiguration.partition` is greater than or equal to `spec.replicas`.
Specifically, creating a `ModelServing` with `replicas: 0` and `partition: 0` fails with:
`partition must be less than replicas (0)`

This prevents users from initializing a `ModelServing` with zero replicas while maintaining a default `partition: 0` configuration. It also deviates from standard Kubernetes `StatefulSet` behavior, where `partition` can be equal to or greater than `replicas` to effectively pause or prevent updates to any pods.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
