### PR TITLE
fix wait for webhook to be ready before running webhook tests

### DIFF
--- a/test/e2e/controller-manager/test_suite_test.go
+++ b/test/e2e/controller-manager/test_suite_test.go
@@ -124,14 +124,14 @@ func setupControllerManagerE2ETest(t *testing.T) (context.Context, *clientset.Cl
 	return ctx, kthenaClient, kubeClient
 }
 
-func waitForWebhookReady(t *testing.T, kthenaClient *clientset.Clientset, namespace string) {
+func waitForWebhookReady(t *testing.T, ctx context.Context, kthenaClient *clientset.Clientset, namespace string) {
 	t.Helper()
 	t.Log("Waiting for webhook server to accept requests")
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	waitCtx, cancel := context.WithTimeout(ctx, 1*time.Minute)
 	defer cancel()
 
-	err := wait.PollUntilContextCancel(ctx, 2*time.Second, true, func(ctx context.Context) (bool, error) {
+	err := wait.PollUntilContextCancel(waitCtx, 2*time.Second, true, func(ctx context.Context) (bool, error) {
 		probe := createValidModelBoosterForWebhookTest()
 		probe.Namespace = namespace
 		probe.Name = "webhook-ready-probe-" + utils.RandomString(5)

--- a/test/e2e/controller-manager/webhook_test.go
+++ b/test/e2e/controller-manager/webhook_test.go
@@ -31,7 +31,7 @@ func TestWebhook(t *testing.T) {
 	ctx, kthenaClient, _ := setupControllerManagerE2ETest(t)
 
 	// waiting for webhook to be ready before running tests
-	waitForWebhookReady(t, kthenaClient, testNamespace)
+	waitForWebhookReady(t, ctx, kthenaClient, testNamespace)
 
 	testCases := []struct {
 		name          string


### PR DESCRIPTION
**What type of PR is this?**

This PR fixes webhook tests that were failing with "connection refused" error in webhook_test.go e2e tests.
<img width="856" height="493" alt="Screenshot 2026-03-16 at 1 31 53 AM" src="https://github.com/user-attachments/assets/70ddeaf8-2cb1-4835-982c-ca1d2004328f" />


<!--bug — 
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:
  
we need this pr to make our e2e test more stable 

**Which issue(s) this PR fixes**:
Fixes #815 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
 NONE

```
