### PR TITLE
Remove workflow path filters for required checks

### DIFF
--- a/.github/workflows/build-push-release.yml
+++ b/.github/workflows/build-push-release.yml
@@ -7,21 +7,9 @@ on:
     tags:
       - "v*.*.*"
       - "v*.*.*-*" # Support for pre-release tags like v1.2.3-alpha
-    paths:
-      - 'charts/kthena/**'
-      - 'python/**'
-      - 'docker/**'
-      - '**.go'
-      - 'pkg/**'
-      - 'cmd/**'
-      - 'go.mod'
-      - 'go.sum'
   pull_request:
     branches:
       - main
-    paths:
-      - "docker/**"
-      - 'python/Dockerfile'
 
 jobs:
   setup:
@@ -165,7 +153,7 @@ jobs:
 
   # merge images: Create Multi-Arch Manifests
   merge_images:
-    needs: [ setup, build_images ]
+    needs: [setup, build_images]
     runs-on: ubuntu-latest
     if: ${{ github.event_name != 'pull_request' }}
     strategy:
@@ -252,7 +240,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: "1.24"
 
       - name: Build binary
         env:
@@ -286,7 +274,7 @@ jobs:
           retention-days: 1
 
   push_helm_chart:
-    needs: [ setup, merge_images ]
+    needs: [setup, merge_images]
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -347,7 +335,7 @@ jobs:
             ./kthena-install.yaml
 
   create_github_release:
-    needs: [ setup, push_helm_chart, build_cli ]
+    needs: [setup, push_helm_chart, build_cli]
     if: needs.setup.outputs.is_tag == 'true'
     permissions:
       contents: write
@@ -377,7 +365,7 @@ jobs:
             - **CLI Binaries**: Pre-built binaries for Linux (amd64/arm64), macOS (amd64/arm64), and Windows (amd64)
 
             ### Documentation
-            
+
             - [Installation](https://kthena.volcano.sh/docs/getting-started/installation)
             - [Quick Start](https://kthena.volcano.sh/docs/getting-started/quick-start)
             - [Helm Chart Values](https://kthena.volcano.sh/docs/reference/helm-chart-values)

--- a/.github/workflows/docs-tests.yml
+++ b/.github/workflows/docs-tests.yml
@@ -4,13 +4,9 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - 'docs/kthena/**'
   push:
     branches:
       - main
-    paths:
-      - 'docs/kthena/**'
 
 jobs:
   docs_test:
@@ -21,9 +17,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '24.5.0'
-          cache: 'npm'
-          cache-dependency-path: './docs/kthena/package-lock.json'
+          node-version: "24.5.0"
+          cache: "npm"
+          cache-dependency-path: "./docs/kthena/package-lock.json"
       - name: Install dependencies
         working-directory: ./docs/kthena
         run: npm ci

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -5,18 +5,6 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - "pkg/**"
-      - "cmd/**"
-      - "test/**"
-      - "config/**"
-      - "charts/**"
-      - "docker/**"
-      - "hack/**"
-      - "go.mod"
-      - "go.sum"
-      - "Makefile"
-      - ".github/workflows/e2e-tests.yml"
 
 jobs:
   e2e-tests:
@@ -39,7 +27,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version-file: 'go.mod'
+          go-version-file: "go.mod"
       - name: Install helm
         shell: bash
         run: |

--- a/.github/workflows/go-check.yml
+++ b/.github/workflows/go-check.yml
@@ -4,18 +4,9 @@ on:
   pull_request:
     branches:
       - main
-    paths-ignore:
-      - "**.md"
-      - "**.svg"
-      - "**.png"
-      - "docs/**"
-      - ".github/**"
   push:
     branches:
       - main
-    paths-ignore:
-      - "docs/**"
-      - ".github/**"
 
 jobs:
   build:

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -3,22 +3,10 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - '**.go'
-      - "pkg/**"
-      - "cmd/**"
-      - "go.mod"
-      - "go.sum"
 
   push:
     branches:
       - main
-    paths:
-      - '**.go'
-      - "pkg/**"
-      - "cmd/**"
-      - "go.mod"
-      - "go.sum"
 
 jobs:
   go_unit_test:
@@ -29,7 +17,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: 'go.mod' # Automatically set Go version from go.mod
+          go-version-file: "go.mod" # Automatically set Go version from go.mod
       - name: Run Unit Tests
         run: make test
       - name: Calculate coverage percentage

--- a/.github/workflows/licenses-lint.yaml
+++ b/.github/workflows/licenses-lint.yaml
@@ -5,13 +5,6 @@ on:
     branches:
       - main
       - release-*
-    paths-ignore:
-      - "docs/**"
-      - "LICENSE"
-      - "OWNERS"
-      - "*.md"
-      - "python/**"
-
 
 jobs:
   licenses-lint:

--- a/.github/workflows/python-licenses-lint.yml
+++ b/.github/workflows/python-licenses-lint.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
       - release-*
-    paths:
-      - "python/**"
 
 jobs:
   python-licenses-lint:
@@ -19,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11' 
+          python-version: "3.11"
       - name: Install liccheck
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -5,16 +5,9 @@ on:
     branches:
       - main
       - release
-    paths:
-      - "python/**"
-      - "**.py"
-      - "python/kthena/pyproject.toml"
   push:
     branches:
       - main
-    paths:
-      - "python/**"
-      - "python/kthena/pyproject.toml"
 
 jobs:
   python_lint:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -4,14 +4,9 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - "python/**"
-      - "**.py"
   push:
     branches:
       - main
-    paths:
-      - "python/**"
 
 jobs:
   python_unit_test:


### PR DESCRIPTION
## Summary
- remove all `paths` and `paths-ignore` filters from CI workflows
- keep existing branch and tag triggers unchanged
- allow these workflows to run consistently so they can be configured as required checks

## Testing
- validated the edited workflow YAML files have no reported errors in VS Code
- verified no remaining `paths` or `paths-ignore` filters exist under .github/workflows