### PR TITLE
[bug] Fixed an error where the headless service was not pointing solely to the entry pod

### DIFF
--- a/pkg/model-serving-controller/controller/model_serving_controller.go
+++ b/pkg/model-serving-controller/controller/model_serving_controller.go
@@ -1884,6 +1884,7 @@ func (c *ModelServingController) manageHeadlessService(ctx context.Context, ms *
 					workloadv1alpha1.GroupNameLabelKey: sg.Name,
 					workloadv1alpha1.RoleLabelKey:      role.Name,
 					workloadv1alpha1.RoleIDKey:         roleObj.Name,
+					workloadv1alpha1.EntryLabelKey:     "true",
 				}
 
 				services, err := c.getServicesByIndex(RoleIDKey, fmt.Sprintf("%s/%s/%s/%s", ms.Namespace, sg.Name, role.Name, roleObj.Name))

--- a/pkg/model-serving-controller/controller/model_serving_controller_test.go
+++ b/pkg/model-serving-controller/controller/model_serving_controller_test.go
@@ -4866,6 +4866,7 @@ func TestManageHeadlessService(t *testing.T) {
 					assert.Contains(t, item.Labels, workloadv1alpha1.GroupNameLabelKey)
 					assert.Contains(t, item.Labels, workloadv1alpha1.RoleLabelKey)
 					assert.Contains(t, item.Labels, workloadv1alpha1.RoleIDKey)
+					assert.Contains(t, item.Labels, workloadv1alpha1.EntryLabelKey)
 				}
 			}
 		})


### PR DESCRIPTION

**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:

When introducing the headless service manager, the Selector in the headless service creation process was missing `workloadv1alpha1.EntryLabelKey: ‘true’`. 

This has been added in this PR.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
