### PR TITLE
test: add unit tests for scheduler plugins cache package

### DIFF
--- a/pkg/kthena-router/scheduler/plugins/cache/lru_test.go
+++ b/pkg/kthena-router/scheduler/plugins/cache/lru_test.go
@@ -57,7 +57,7 @@ func TestNewLRUCache(t *testing.T) {
 	t.Run("implements Cache interface", func(t *testing.T) {
 		c, err := NewLRUCache[string, int](10, nil)
 		require.NoError(t, err)
-		// Assign to interface — compile-time check enforced at runtime.
+		// Compile-time check that LRUCache implements Cache.
 		var _ Cache[string, int] = c
 	})
 }
@@ -65,13 +65,15 @@ func TestNewLRUCache(t *testing.T) {
 // TestLRUCache_Add tests the Add method.
 func TestLRUCache_Add(t *testing.T) {
 	t.Run("add single entry", func(t *testing.T) {
-		c, _ := NewLRUCache[string, int](10, nil)
+		c, err := NewLRUCache[string, int](10, nil)
+		require.NoError(t, err)
 		c.Add("k", 1)
 		assert.Equal(t, 1, c.Len())
 	})
 
 	t.Run("add multiple distinct entries", func(t *testing.T) {
-		c, _ := NewLRUCache[string, int](10, nil)
+		c, err := NewLRUCache[string, int](10, nil)
+		require.NoError(t, err)
 		c.Add("a", 1)
 		c.Add("b", 2)
 		c.Add("c", 3)
@@ -79,7 +81,8 @@ func TestLRUCache_Add(t *testing.T) {
 	})
 
 	t.Run("add duplicate key overwrites value", func(t *testing.T) {
-		c, _ := NewLRUCache[string, int](10, nil)
+		c, err := NewLRUCache[string, int](10, nil)
+		require.NoError(t, err)
 		c.Add("k", 1)
 		c.Add("k", 99)
 		assert.Equal(t, 1, c.Len())
@@ -111,7 +114,8 @@ func TestLRUCache_Get(t *testing.T) {
 	})
 
 	t.Run("get nonexistent key returns zero value and false", func(t *testing.T) {
-		c, _ := NewLRUCache[string, int](10, nil)
+		c, err := NewLRUCache[string, int](10, nil)
+		require.NoError(t, err)
 		v, ok := c.Get("missing")
 		assert.False(t, ok)
 		assert.Equal(t, 0, v)
@@ -326,7 +330,7 @@ func TestLRUCache_Keys(t *testing.T) {
 		// Access "a" — it should move to the end (newest)
 		_, _ = c.Get("a")
 		keys := c.Keys()
-		assert.Equal(t, "a", keys[len(keys)-1])
+		assert.Equal(t, []string{"b", "c", "a"}, keys)
 	})
 
 	t.Run("keys after clear returns empty slice", func(t *testing.T) {
@@ -399,14 +403,14 @@ func TestLRUCache_EvictionCallback(t *testing.T) {
 
 // TestLRUCache_InterfaceCompliance verifies LRUCache satisfies Cache via table-driven interface calls.
 func TestLRUCache_InterfaceCompliance(t *testing.T) {
-	newCache := func() Cache[string, int] {
+	newCache := func(t *testing.T) Cache[string, int] {
 		c, err := NewLRUCache[string, int](10, nil)
 		require.NoError(t, err)
 		return c
 	}
 
 	t.Run("interface Add and Get", func(t *testing.T) {
-		c := newCache()
+		c := newCache(t)
 		c.Add("k", 7)
 		v, ok := c.Get("k")
 		assert.True(t, ok)
@@ -414,14 +418,14 @@ func TestLRUCache_InterfaceCompliance(t *testing.T) {
 	})
 
 	t.Run("interface Remove and Contains", func(t *testing.T) {
-		c := newCache()
+		c := newCache(t)
 		c.Add("k", 7)
 		c.Remove("k")
 		assert.False(t, c.Contains("k"))
 	})
 
 	t.Run("interface Len and Clear", func(t *testing.T) {
-		c := newCache()
+		c := newCache(t)
 		c.Add("a", 1)
 		c.Add("b", 2)
 		assert.Equal(t, 2, c.Len())
@@ -430,10 +434,10 @@ func TestLRUCache_InterfaceCompliance(t *testing.T) {
 	})
 
 	t.Run("interface Keys", func(t *testing.T) {
-		c := newCache()
+		c := newCache(t)
 		c.Add("x", 1)
 		c.Add("y", 2)
 		keys := c.Keys()
-		assert.ElementsMatch(t, []string{"x", "y"}, keys)
+		assert.Equal(t, []string{"x", "y"}, keys)
 	})
 }


### PR DESCRIPTION
## What this PR does

Add unit tests for `pkg/kthena-router/scheduler/plugins/cache/lru.go`
which previously had no test coverage.

## Test coverage

| File | Before | After |
|------|--------|-------|
| lru.go | 0% | 100% |

## Test cases covered

**LRUCache (`lru_test.go`):**

- `NewLRUCache`: valid size, zero/negative size returns error, eviction callback on creation, interface compliance
- `Add`: single entry, multiple distinct entries, duplicate key overwrites value, eviction of oldest entry when capacity exceeded
- `Get`: existing key returns value, nonexistent key returns zero value, get promotes entry to most-recently-used position
- `Remove`: existing key, nonexistent key does not panic, removing one entry leaves others intact
- `Contains`: existing key, missing key, after remove, after clear
- `Len`: empty cache, increases on add, unchanged on duplicate key, decreases on remove, zero after clear, capped at capacity
- `Clear`: empty cache does not panic, removes all entries, cache is usable after clear
- `Keys`: empty cache, returns all keys, ordered oldest to newest, get promotes key to newest position, after clear, evicted entries not present
- `EvictionCallback`: called with correct key/value, called multiple times as capacity exceeded, nil callback does not panic
- `InterfaceCompliance`: verifies LRUCache satisfies Cache interface via all methods

## How to verify
```bash
go test ./pkg/kthena-router/scheduler/plugins/cache/... -v
go test ./pkg/kthena-router/scheduler/plugins/cache/... -cover
```

## Related issue

Closes #825