### PR TITLE
Fix fork CI failures for GHCR owner casing and Python liccheck

### DIFF
--- a/.github/workflows/build-push-release.yml
+++ b/.github/workflows/build-push-release.yml
@@ -30,6 +30,7 @@ jobs:
       version: ${{ steps.version.outputs.version }}
       is_tag: ${{ steps.version.outputs.is_tag }}
       prerelease: ${{ steps.is_prerelease.outputs.prerelease }}
+      owner_lc: ${{ steps.owner.outputs.owner_lc }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -57,6 +58,11 @@ jobs:
           else
             echo "prerelease=false" >> $GITHUB_OUTPUT
           fi
+
+      - name: Normalize Repository Owner
+        id: owner
+        run: |
+          echo "owner_lc=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_OUTPUT
 
   build_images:
     needs: setup
@@ -128,7 +134,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ github.repository_owner }}/${{ matrix.service }}
+          images: ghcr.io/${{ needs.setup.outputs.owner_lc }}/${{ matrix.service }}
           tags: |
             type=raw,value=${{ needs.setup.outputs.version }}
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
@@ -145,7 +151,7 @@ jobs:
           target: ${{ matrix.target }}
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=ghcr.io/${{ github.repository_owner }}/${{ matrix.service }},push-by-digest=${{ github.event_name != 'pull_request' }},name-canonical=true,push=${{ github.event_name != 'pull_request' }}
+          outputs: type=image,name=ghcr.io/${{ needs.setup.outputs.owner_lc }}/${{ matrix.service }},push-by-digest=${{ github.event_name != 'pull_request' }},name-canonical=true,push=${{ github.event_name != 'pull_request' }}
 
       - name: Export digest
         if: ${{ github.event_name != 'pull_request' }}
@@ -197,7 +203,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ github.repository_owner }}/${{ matrix.service }}
+          images: ghcr.io/${{ needs.setup.outputs.owner_lc }}/${{ matrix.service }}
           tags: |
             type=raw,value=${{ needs.setup.outputs.version }}
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
@@ -208,11 +214,11 @@ jobs:
           DOCKER_METADATA_OUTPUT_JSON: ${{ steps.meta.outputs.json }}
         run: |
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-          $(printf 'ghcr.io/${{ github.repository_owner }}/${{ matrix.service }}@sha256:%s ' *)
+          $(printf 'ghcr.io/${{ needs.setup.outputs.owner_lc }}/${{ matrix.service }}@sha256:%s ' *)
 
       - name: Inspect image
         run: |
-          docker buildx imagetools inspect ghcr.io/${{ github.repository_owner }}/${{ matrix.service }}:${{ needs.setup.outputs.version }}
+          docker buildx imagetools inspect ghcr.io/${{ needs.setup.outputs.owner_lc }}/${{ matrix.service }}:${{ needs.setup.outputs.version }}
 
   build_cli:
     needs: setup
@@ -327,10 +333,9 @@ jobs:
         if: github.event_name != 'pull_request'
         env:
           VERSION: ${{ needs.setup.outputs.version }}
-          REPO_OWNER: ${{ github.repository_owner }}
+          REPO_OWNER: ${{ needs.setup.outputs.owner_lc }}
         run: |
-          LOWER_REPO_OWNER=$(echo "$REPO_OWNER" | tr '[:upper:]' '[:lower:]')
-          helm push kthena.tgz oci://ghcr.io/$LOWER_REPO_OWNER/charts
+          helm push kthena.tgz oci://ghcr.io/$REPO_OWNER/charts
 
       - name: Prepare Helm Release Artifacts
         if: needs.setup.outputs.is_tag == 'true'

--- a/config/python-licenses-lint.ini
+++ b/config/python-licenses-lint.ini
@@ -2,6 +2,7 @@
 [Licenses]
 authorized_licenses:
         bsd
+        bsd-2-clause
         new bsd
         bsd license
         bsd-3-clause
@@ -9,6 +10,7 @@ authorized_licenses:
         simplified bsd
         apache
         apache 2.0
+        apache-2.0
         apache software license
         apache software
         gnu lgpl
@@ -16,6 +18,8 @@ authorized_licenses:
         isc license
         isc license (iscl)
         mpl 2.0
+        mpl-2.0
+        mpl-2.0 and mit
         mozilla public license 2.0 (mpl 2.0)
         mit
         mit license

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,5 +1,4 @@
 FROM python:3.12-slim AS downloader
-
 RUN apt-get update && \
     apt-get install -y curl unzip rsync && \
     apt-get clean && \
@@ -52,4 +51,4 @@ COPY kthena/runtime/ ./kthena/runtime/
 RUN pip install --no-cache-dir -r kthena/runtime/requirements.txt
 ENV PYTHONPATH="/app"
 # Default to runtime, but can override with command
-ENTRYPOINT ["python","kthena/runtime/app.py"]
+ENTRYPOINT ["python", "kthena/runtime/app.py"]


### PR DESCRIPTION
## Summary
- normalize the GHCR repository owner to lowercase in the release workflow before constructing image references
- extend the Python liccheck allowlist for SPDX identifiers/expressions reported by `huggingface-hub` transitive dependencies
- keep a no-op Python Dockerfile formatting change so the PR can trigger the relevant release workflow checks

## Problem
This PR addresses two CI failures discussed in #834:
- GHCR image references fail when the repository owner contains uppercase characters
- Python license lint fails for SPDX expressions from `packaging` and `tqdm`

## Validation
- PRs that touch `python/Dockerfile` should trigger `Build, Push, and Release`
- GHCR image names should use lowercase owner names in workflow logs
- `Python Licenses Check` should stop flagging the `packaging` and `tqdm` dependencies as unknown
