### PR TITLE
Add Prometheus monitoring and KEDA autoscaling support

### DIFF
--- a/charts/kthena/charts/networking/templates/kthena-router/component/podmonitor.yaml
+++ b/charts/kthena/charts/networking/templates/kthena-router/component/podmonitor.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.kthenaRouter.metrics.podMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: kthena-inference
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: kthena-inference
+    release: prometheus
+    {{- include "kthena.labels" . | nindent 4 }}
+spec:
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchExpressions:
+      - key: modelserving.volcano.sh/name
+        operator: Exists
+      - key: modelserving.volcano.sh/group-name
+        operator: Exists
+      - key: modelserving.volcano.sh/role
+        operator: Exists
+      - key: modelserving.volcano.sh/entry
+        operator: In
+        values:
+          - "true"
+  podMetricsEndpoints:
+    - targetPort: 8000
+      path: /metrics
+      interval: {{ .Values.kthenaRouter.metrics.podMonitor.interval }}
+    - targetPort: 30000
+      path: /metrics
+      interval: {{ .Values.kthenaRouter.metrics.podMonitor.interval }}
+{{- end }}

--- a/charts/kthena/charts/networking/templates/kthena-router/component/scaledobject.yaml
+++ b/charts/kthena/charts/networking/templates/kthena-router/component/scaledobject.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.kthenaRouter.autoscaling.enabled }}
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: kthena-inference-scaler
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: kthena-inference
+    {{- include "kthena.labels" . | nindent 4 }}
+spec:
+  cooldownPeriod: {{ .Values.kthenaRouter.autoscaling.cooldownPeriod }}
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .Values.kthenaRouter.autoscaling.scaleTargetName }}
+  minReplicaCount: {{ .Values.kthenaRouter.autoscaling.minReplicas }}
+  maxReplicaCount: {{ .Values.kthenaRouter.autoscaling.maxReplicas }}
+  triggers:
+    - type: prometheus
+      metadata:
+        serverAddress: {{ .Values.kthenaRouter.autoscaling.prometheusAddress }}
+        query: {{ .Values.kthenaRouter.autoscaling.query }}
+        threshold: {{ .Values.kthenaRouter.autoscaling.threshold | quote }}
+{{- end }}

--- a/charts/kthena/charts/networking/templates/kthena-router/component/servicemonitor.yaml
+++ b/charts/kthena/charts/networking/templates/kthena-router/component/servicemonitor.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.kthenaRouter.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: kthena-router
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: kthena-router
+    release: prometheus
+    {{- include "kthena.labels" . | nindent 4 }}
+spec:
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: kthena-router
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: {{ .Values.kthenaRouter.metrics.serviceMonitor.interval }}
+{{- end }}

--- a/charts/kthena/charts/networking/values.yaml
+++ b/charts/kthena/charts/networking/values.yaml
@@ -66,6 +66,36 @@ kthenaRouter:
   # kubeAPIBurst is the burst to use while talking with kubernetes apiserver
   # If 0 or not specified, uses default value (10)
   kubeAPIBurst: 0
+  # metrics configuration for Prometheus monitoring
+  metrics:
+    serviceMonitor:
+      # enabled creates a ServiceMonitor for kthena-router (requires Prometheus Operator)
+      enabled: false
+      # interval is the scrape interval for the ServiceMonitor
+      interval: 15s
+    podMonitor:
+      # enabled creates a PodMonitor for inference pods (requires Prometheus Operator)
+      enabled: false
+      # interval is the scrape interval for the PodMonitor
+      interval: 15s
+  # autoscaling configuration for KEDA-based inference scaling
+  autoscaling:
+    # enabled creates a KEDA ScaledObject (requires KEDA)
+    enabled: false
+    # scaleTargetName is the name of the Deployment to scale
+    scaleTargetName: ""
+    # prometheusAddress is the Prometheus server URL
+    prometheusAddress: http://prometheus-kube-prometheus-prometheus.monitoring.svc:9090
+    # query is the PromQL query used for scaling decisions
+    query: sum(kthena_router_active_downstream_requests)
+    # threshold is the per-pod metric value that triggers scaling
+    threshold: 5
+    # cooldownPeriod is seconds to wait before scaling down after last trigger
+    cooldownPeriod: 30
+    # minReplicas is the minimum number of inference replicas
+    minReplicas: 1
+    # maxReplicas is the maximum number of inference replicas
+    maxReplicas: 10
 
 webhook:
   enabled: true

--- a/charts/kthena/values.yaml
+++ b/charts/kthena/values.yaml
@@ -81,6 +81,34 @@ networking:
       # -- Enable Gateway API Inference Extension features.<br/>
       # Requires `gatewayAPI.enabled` to be true.
       inferenceExtension: false
+    metrics:
+      serviceMonitor:
+        # -- Enable ServiceMonitor for kthena-router (requires Prometheus Operator).
+        enabled: false
+        # -- Scrape interval for the ServiceMonitor.
+        interval: 15s
+      podMonitor:
+        # -- Enable PodMonitor for inference pods (requires Prometheus Operator).
+        enabled: false
+        # -- Scrape interval for the PodMonitor.
+        interval: 15s
+    autoscaling:
+      # -- Enable KEDA ScaledObject for inference autoscaling (requires KEDA).
+      enabled: false
+      # -- Name of the Deployment to scale.
+      scaleTargetName: ""
+      # -- Prometheus server URL for KEDA to query.
+      prometheusAddress: http://prometheus-kube-prometheus-prometheus.monitoring.svc:9090
+      # -- PromQL query for scaling decisions.
+      query: sum(kthena_router_active_downstream_requests)
+      # -- Per-pod metric threshold that triggers scaling.
+      threshold: 5
+      # -- Seconds to wait before scaling down.
+      cooldownPeriod: 30
+      # -- Minimum inference replicas.
+      minReplicas: 1
+      # -- Maximum inference replicas.
+      maxReplicas: 10
 
 global:
   # -- Certificate Management Mode.<br/>

--- a/monitoring.yaml
+++ b/monitoring.yaml
@@ -1,0 +1,61 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: kthena-router
+  labels:
+    app.kubernetes.io/component: kthena-router
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: kthena-router
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: 15s
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: kthena-inference
+  labels:
+    app.kubernetes.io/part-of: kthena
+spec:
+  selector:
+    matchExpressions:
+      - key: modelserving.volcano.sh/name
+        operator: Exists
+      - key: modelserving.volcano.sh/group-name
+        operator: Exists
+      - key: modelserving.volcano.sh/role
+        operator: Exists
+      - key: modelserving.volcano.sh/entry
+        operator: In
+        values:
+          - "true"
+  podMetricsEndpoints:
+    - port: ""
+      targetPort: 8000
+      path: /metrics
+      interval: 15s
+    - port: ""
+      targetPort: 30000
+      path: /metrics
+      interval: 15s
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: kthena-inference-scaler
+  labels:
+    app.kubernetes.io/part-of: kthena
+spec:
+  minReplicaCount: 1
+  maxReplicaCount: 10
+  scaleTargetRef:
+    name: kthena-inference
+  triggers:
+    - type: prometheus
+      metadata:
+        serverAddress: http://prometheus-kube-prometheus-prometheus.monitoring:9090
+        query: sum(kthena_router_active_downstream_requests)
+        threshold: "5"


### PR DESCRIPTION
## Add Prometheus monitoring + KEDA autoscaling prototype for Kthena

### Summary

This PR introduces a **prototype** for Prometheus-based monitoring and KEDA-driven autoscaling in Kthena.

It enables scraping router and inference metrics and demonstrates scaling of workloads based on real-time request load.

This is an initial step toward integrating Prometheus + KEDA with ModelServing.

---

### Changes

- **ServiceMonitor (kthena-router)**
  - Scrapes `/metrics` from the router service (`port: http`)
  - Supports cross-namespace scraping

- **PodMonitor (inference pods)**
  - Targets entry pods using `modelserving.volcano.sh/entry: "true"`
  - Supports vLLM (8000) and SGLang (30000) metrics ports

- **KEDA ScaledObject**
  - Uses Prometheus trigger:
    ```
    sum(kthena_router_active_downstream_requests)
    ```
  - Demonstrates scaling based on active request load
  - Configurable threshold, min/max replicas, and cooldown

- **values.yaml updates**
  - Adds `metrics` and `autoscaling` sections
  - Features are disabled by default (no impact on existing deployments)

---

### Testing

Tested locally on a KIND cluster:

- Prometheus successfully scrapes kthena-router metrics via ServiceMonitor
- Verified metrics via PromQL queries
- KEDA consumes metrics from Prometheus
- HPA is created automatically by KEDA
- Observed:
  - Scale-up when metric exceeds threshold
  - Scale-down when metric falls below threshold

This validates the end-to-end flow:

Router → Prometheus → KEDA → HPA → workload scaling

<img width="1919" height="919" alt="Screenshot 2026-03-25 023732" src="https://github.com/user-attachments/assets/c5806eeb-4640-4404-98f4-048667144193" />
<img width="811" height="265" alt="Screenshot 2026-03-25 023759" src="https://github.com/user-attachments/assets/4781c384-ce84-498d-88c7-231cd16be8de" />
<img width="1119" height="227" alt="Screenshot 2026-03-25 023819" src="https://github.com/user-attachments/assets/d4175686-4d57-4cb2-b3f1-abb21dda4007" />


---

### Notes / Limitations

- This is a prototype and does not yet fully integrate with ModelServing resources
- Label mapping between metrics and ModelServing may require refinement
- Inference pod metrics ports are backend-specific (vLLM/SGLang)

---

### Next Steps

- Integrate scaling directly with ModelServing CRD
- Improve metric-to-resource mapping
- Add Helm-level configurability for monitoring components

ref #799 