### PR TITLE
[BUG] fix bug about servingGroup partition in role scale up

### DIFF
--- a/pkg/model-serving-controller/controller/model_serving_controller.go
+++ b/pkg/model-serving-controller/controller/model_serving_controller.go
@@ -783,14 +783,42 @@ func (c *ModelServingController) manageRole(ctx context.Context, ms *workloadv1a
 	if err != nil && !errors.Is(err, datastore.ErrServingGroupNotFound) {
 		return fmt.Errorf("cannot get ServingGroup of modelServing: %s from map: %v", ms.GetName(), err)
 	}
-	for _, servingGroup := range servingGroupList {
+	partition := c.getPartition(ms)
+	for index, servingGroup := range servingGroupList {
 		if c.store.GetServingGroupStatus(utils.GetNamespaceName(ms), servingGroup.Name) == datastore.ServingGroupDeleting {
 			// Deleting ServingGroup will be recreated after the deletion is complete, so there is no need to scale the roles
 			continue
 		}
 		_, servingGroupOrdinal := utils.GetParentNameAndOrdinal(servingGroup.Name)
-		for _, targetRole := range ms.Spec.Template.Roles {
-			c.manageRoleReplicas(ctx, ms, servingGroup.Name, targetRole, servingGroupOrdinal, newRevision)
+		isPartitionProtected := partition > 0 && index < partition
+
+		rolesToManage := ms.Spec.Template.Roles
+		revisionToUse := newRevision
+		if isPartitionProtected {
+			if revision, ok := c.store.GetServingGroupRevision(utils.GetNamespaceName(ms), servingGroup.Name); ok && revision != "" {
+				revisionToUse = revision
+			} else if ms.Status.CurrentRevision != "" {
+				revisionToUse = ms.Status.CurrentRevision
+			}
+
+			if revisionToUse != "" {
+				cr, err := utils.GetControllerRevision(ctx, c.kubeClientSet, ms, revisionToUse)
+				if err != nil {
+					klog.Warningf("manageRole: failed to get ControllerRevision %s for protected ServingGroup %s: %v", revisionToUse, servingGroup.Name, err)
+				} else if cr != nil {
+					if oldRoles, err := utils.GetRolesFromControllerRevision(cr); err != nil {
+						klog.Warningf("manageRole: failed to get roles from ControllerRevision %s for protected ServingGroup %s: %v", revisionToUse, servingGroup.Name, err)
+					} else {
+						rolesToManage = oldRoles
+					}
+				} else {
+					klog.Warningf("manageRole: ControllerRevision %s not found for protected ServingGroup %s, fallback to latest roles", revisionToUse, servingGroup.Name)
+				}
+			}
+		}
+
+		for _, targetRole := range rolesToManage {
+			c.manageRoleReplicas(ctx, ms, servingGroup.Name, targetRole, servingGroupOrdinal, revisionToUse)
 		}
 	}
 	return nil

--- a/pkg/model-serving-controller/controller/model_serving_controller_test.go
+++ b/pkg/model-serving-controller/controller/model_serving_controller_test.go
@@ -2302,6 +2302,107 @@ func TestScaleUpRoles(t *testing.T) {
 	}
 }
 
+func TestManageRoleReplicasWithPartitionProtectedServingGroupAlignsToControllerRevision(t *testing.T) {
+	kubeClient := kubefake.NewSimpleClientset()
+	kthenaClient := kthenafake.NewSimpleClientset()
+	volcanoClient := volcanofake.NewSimpleClientset()
+	apiextfake := apiextfake.NewSimpleClientset()
+
+	controller, err := NewModelServingController(kubeClient, kthenaClient, volcanoClient, apiextfake)
+	assert.NoError(t, err)
+
+	msName := "test-partition-scaleup-roles"
+	roleName := "prefill"
+	groupOrdinal := 0
+	groupName := utils.GenerateServingGroupName(msName, groupOrdinal)
+
+	oldRevision := "revision-old"
+	newRevision := "revision-new"
+
+	partition := intstr.FromInt32(1)
+	ms := &workloadv1alpha1.ModelServing{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      msName,
+		},
+		Spec: workloadv1alpha1.ModelServingSpec{
+			Replicas:      ptr.To[int32](1),
+			SchedulerName: "volcano",
+			RolloutStrategy: &workloadv1alpha1.RolloutStrategy{
+				RollingUpdateConfiguration: &workloadv1alpha1.RollingUpdateConfiguration{
+					Partition: &partition,
+				},
+			},
+			Template: workloadv1alpha1.ServingGroup{
+				Roles: []workloadv1alpha1.Role{
+					{
+						Name:     roleName,
+						Replicas: ptr.To[int32](2),
+						EntryTemplate: workloadv1alpha1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{
+									Name:  "prefill-container",
+									Image: "new-image:latest",
+								}},
+							},
+						},
+					},
+				},
+			},
+		},
+		Status: workloadv1alpha1.ModelServingStatus{
+			CurrentRevision: oldRevision,
+		},
+	}
+
+	oldRoles := []workloadv1alpha1.Role{
+		{
+			Name:     roleName,
+			Replicas: ptr.To[int32](1),
+			EntryTemplate: workloadv1alpha1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "prefill-container",
+						Image: "old-image:latest",
+					}},
+				},
+			},
+		},
+	}
+
+	_, err = utils.CreateControllerRevision(context.Background(), kubeClient, ms, oldRevision, oldRoles)
+	assert.NoError(t, err)
+
+	controller.store.AddServingGroup(utils.GetNamespaceName(ms), groupOrdinal, oldRevision)
+	controller.store.AddRole(utils.GetNamespaceName(ms), groupName, roleName, utils.GenerateRoleID(roleName, 0), oldRevision)
+
+	err = controller.manageRole(context.Background(), ms, newRevision)
+	assert.NoError(t, err)
+
+	roles, err := controller.store.GetRoleList(utils.GetNamespaceName(ms), groupName, roleName)
+	assert.NoError(t, err)
+	// Partition-protected ServingGroup should align to ControllerRevision replicas (1), not new spec replicas (2)
+	assert.Equal(t, 1, len(roles))
+
+	pods, err := kubeClient.CoreV1().Pods(ms.Namespace).List(context.Background(), metav1.ListOptions{})
+	assert.NoError(t, err)
+
+	var createdPod *corev1.Pod
+	for i := range pods.Items {
+		p := &pods.Items[i]
+		if p.Labels[workloadv1alpha1.RoleIDKey] == utils.GenerateRoleID(roleName, 0) && p.Labels[workloadv1alpha1.EntryLabelKey] == utils.Entry {
+			createdPod = p
+			break
+		}
+	}
+	if assert.NotNil(t, createdPod) {
+		assert.Equal(t, oldRevision, createdPod.Labels[workloadv1alpha1.RevisionLabelKey])
+		if assert.NotEmpty(t, createdPod.Spec.Containers) {
+			assert.Equal(t, "old-image:latest", createdPod.Spec.Containers[0].Image)
+		}
+	}
+}
+
 func TestManageRoleReplicas(t *testing.T) {
 	tests := []struct {
 		name             string


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:

At present, changing the number of replicas for a Role results in the creation of newly configured pods within the servingGroup protected by the Partition. This does not align with the intended semantics of the Partition.

**Which issue(s) this PR fixes**:
a part of #841 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
