### PR TITLE
test/e2e: fix flake in WaitForModelServingReady

### DIFF
--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -31,13 +31,11 @@ import (
 // if all expected replicas are available.
 func WaitForModelServingReady(t *testing.T, ctx context.Context, kthenaClient *clientset.Clientset, namespace, name string) {
 	t.Log("Waiting for ModelServing to be ready...")
-	timeoutCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
-	defer cancel()
-	err := wait.PollUntilContextTimeout(timeoutCtx, 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
 		ms, err := kthenaClient.WorkloadV1alpha1().ModelServings(namespace).Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			t.Logf("Error getting ModelServing %s, retrying: %v", name, err)
-			return false, err
+			return false, nil
 		}
 		// Check if all replicas are available
 		expectedReplicas := int32(1)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixes a flake in TestModelRoutePrefillDecodeDisaggregation by improving the reliability of the WaitForModelServingReady e2e utility.

The flake was caused by two interacting issues in test/e2e/utils/utils.go:

1. Redundant timeout: a context.WithTimeout wrapper was used around PollUntilContextTimeout , which already manages its own timeout. This creates a race condition where the context could expire during a condition call.
2. immediate Abort on Error: condition function returned (false, err). In k8s.io/apimachinery, returning a non nil error from a polling condition immediately terminates the loop. when the context expired during a client go call, the resulting "context deadline exceeded" error killed the poll prematurely instead of allowing a clean timeout.

**Which issue(s) this PR fixes**:
Fixes #870 

**Special notes for your reviewer**:
- analysis verified against k8s.io/apimachinery@v0.34.2 source code
- other polling utilities in test/e2e/router/context/context.go and test/e2e/utils/chat.go were inspected. they correctly use return false, nil for transient errors