### PR TITLE
examples(model-serving): add runnable autoscaling example with keda and prometheus

### DIFF
--- a/docs/model-serving/autoscaling.md
+++ b/docs/model-serving/autoscaling.md
@@ -1,0 +1,77 @@
+# Autoscaling ModelServing with KEDA
+
+Scale a `ModelServing` based on live traffic. KEDA reads a Prometheus metric
+from the kthena-router and updates `ModelServing.spec.replicas` through its
+scale subresource.
+
+```
+Prometheus  →  KEDA  →  HPA  →  ModelServing  →  Pods
+```
+
+## Prerequisites
+
+- A Kubernetes cluster with Kthena installed.
+- [KEDA](https://keda.sh/docs/latest/deploy/) installed in the cluster.
+- Prometheus scraping the kthena-router `/metrics` endpoint (port `8080`).
+- A reachable Prometheus URL, e.g. `http://prometheus.monitoring.svc:9090`.
+
+Check KEDA is ready:
+
+```bash
+kubectl get pods -n keda
+kubectl get crd scaledobjects.keda.sh
+```
+
+## Step 1 — Deploy a ModelServing
+
+Edit [`examples/model-serving/autoscaling-with-keda.yaml`](../../examples/model-serving/autoscaling-with-keda.yaml)
+and replace every `<...>` placeholder. Then apply it:
+
+```bash
+kubectl apply -f examples/model-serving/autoscaling-with-keda.yaml
+kubectl get modelserving <modelserving-name>
+```
+
+## Step 2 — Apply the ScaledObject
+
+The same file already contains a `ScaledObject`. After it is applied, KEDA
+creates an HPA pointing at the `ModelServing` scale subresource:
+
+```bash
+kubectl get scaledobject <modelserving-name>-scaler
+kubectl get hpa
+```
+
+## Step 3 — Verify scaling
+
+Send traffic through the kthena-router and watch the replicas change:
+
+```bash
+kubectl get modelserving <modelserving-name> -w
+kubectl describe scaledobject <modelserving-name>-scaler
+```
+
+Replicas should rise once the metric crosses the threshold and fall again
+after the cooldown.
+
+## How it works
+
+- The kthena-router exports `kthena_router_active_downstream_requests`,
+  labeled by the served `model` name.
+- KEDA polls Prometheus every `pollingInterval` seconds.
+- If the query value exceeds `threshold`, KEDA scales the `ModelServing`
+  through its scale subresource (the same path HPA uses).
+- After traffic drops, KEDA waits `cooldownPeriod` before scaling down to
+  `minReplicaCount`.
+
+## Notes
+
+- Pod labels in `entryTemplate` / `workerTemplate` are user-defined. The
+  example uses `model-name` only as a hint — the trigger is router-level
+  and does not depend on any pod label.
+- Any Prometheus query works. Swap the example for queue depth, latency,
+  GPU utilization, or anything else you scrape.
+- KEDA scales the number of `ServingGroups` (`spec.replicas`). Per-role
+  replicas inside a group are set in the template and stay fixed.
+- Use `minReplicaCount: 1` to keep the model warm. Set it to `0` only if
+  cold starts are acceptable.

--- a/examples/model-serving/autoscaling-with-keda.yaml
+++ b/examples/model-serving/autoscaling-with-keda.yaml
@@ -1,0 +1,88 @@
+# This example shows how to configure ModelServing for autoscaling with KEDA.
+#
+# How it works:
+#   1. KEDA polls a Prometheus metric (e.g. active request count per model).
+#   2. When the metric exceeds the threshold, KEDA scales up the ModelServing
+#      replicas (ServingGroups) via the scale subresource.
+#   3. When traffic drops, KEDA scales back down after the cooldown period.
+#
+# The Prometheus metric "kthena_router_active_downstream_requests" is emitted
+# by the kthena-router with a "model" label matching the served model name.
+# This is a router-level metric — it is NOT derived from pod labels.
+#
+# User-defined pod labels (set in entryTemplate/workerTemplate metadata) are
+# standard Kubernetes pod-template labels and appear on the resulting pods.
+# They are optional here — useful only if you write custom pod-level
+# Prometheus queries. The KEDA trigger below uses a router metric and does
+# not depend on pod labels.
+#
+# Prerequisites:
+#   - KEDA installed in the cluster (https://keda.sh)
+#   - Prometheus scraping the kthena-router metrics endpoint (:8080/metrics)
+#   - The metric "kthena_router_active_downstream_requests" available
+
+---
+apiVersion: workload.serving.volcano.sh/v1alpha1
+kind: ModelServing
+metadata:
+  name: <modelserving-name>       # e.g. "deepseek-r1"
+  namespace: default
+spec:
+  schedulerName: volcano
+  replicas: 1                     # number of ServingGroups (KEDA scales this field)
+  template:
+    restartGracePeriodSeconds: 60
+    roles:
+      - name: prefill
+        replicas: 2
+        entryTemplate:
+          metadata:
+            labels:
+              # Optional user-defined labels — choose any key/value for your needs.
+              # Not required by the KEDA trigger below; only useful if you write
+              # custom pod-level Prometheus queries.
+              model-name: "<model-name>"    # e.g. "deepseek-r1"
+          spec:
+            containers:
+              - name: leader
+                image: nginx      # replace with your model serving image
+                ports:
+                  - containerPort: 8080
+      - name: decode
+        replicas: 2
+        entryTemplate:
+          metadata:
+            labels:
+              model-name: "<model-name>"    # same label across roles
+          spec:
+            containers:
+              - name: leader
+                image: nginx      # replace with your model serving image
+                ports:
+                  - containerPort: 8080
+
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: <modelserving-name>-scaler
+  namespace: default
+spec:
+  scaleTargetRef:
+    apiVersion: workload.serving.volcano.sh/v1alpha1
+    kind: ModelServing
+    name: <modelserving-name>     # must match the ModelServing name above
+  pollingInterval: 15             # how often KEDA checks the metric (seconds)
+  cooldownPeriod: 120             # wait time before scaling down after metric drops
+  minReplicaCount: 1              # minimum ServingGroup replicas
+  maxReplicaCount: 10             # maximum ServingGroup replicas
+  triggers:
+    - type: prometheus
+      metadata:
+        serverAddress: <prometheus-url>   # e.g. "http://prometheus.monitoring.svc:9090"
+        metricName: kthena_router_active_downstream_requests
+        # The "model" label below is the router's metric label — it corresponds
+        # to the served model name in the kthena-router configuration, NOT a pod label.
+        query: |
+          sum(kthena_router_active_downstream_requests{model="<model-name>"})
+        threshold: "100"          # scale up when active requests exceed this value

--- a/examples/model-serving/autoscaling-with-keda.yaml
+++ b/examples/model-serving/autoscaling-with-keda.yaml
@@ -1,35 +1,20 @@
-# This example shows how to configure ModelServing for autoscaling with KEDA.
+# Autoscale a ModelServing with KEDA + Prometheus.
 #
-# How it works:
-#   1. KEDA polls a Prometheus metric (e.g. active request count per model).
-#   2. When the metric exceeds the threshold, KEDA scales up the ModelServing
-#      replicas (ServingGroups) via the scale subresource.
-#   3. When traffic drops, KEDA scales back down after the cooldown period.
+# Pipeline: Prometheus -> KEDA -> HPA -> ModelServing -> Pods
 #
-# The Prometheus metric "kthena_router_active_downstream_requests" is emitted
-# by the kthena-router with a "model" label matching the served model name.
-# This is a router-level metric — it is NOT derived from pod labels.
+# See docs/model-serving/autoscaling.md for the full guide.
 #
-# User-defined pod labels (set in entryTemplate/workerTemplate metadata) are
-# standard Kubernetes pod-template labels and appear on the resulting pods.
-# They are optional here — useful only if you write custom pod-level
-# Prometheus queries. The KEDA trigger below uses a router metric and does
-# not depend on pod labels.
-#
-# Prerequisites:
-#   - KEDA installed in the cluster (https://keda.sh)
-#   - Prometheus scraping the kthena-router metrics endpoint (:8080/metrics)
-#   - The metric "kthena_router_active_downstream_requests" available
+# Before applying, replace every "<...>" placeholder with a real value.
 
 ---
 apiVersion: workload.serving.volcano.sh/v1alpha1
 kind: ModelServing
 metadata:
-  name: <modelserving-name>       # e.g. "deepseek-r1"
+  name: <modelserving-name>            # e.g. "deepseek-r1"
   namespace: default
 spec:
   schedulerName: volcano
-  replicas: 1                     # number of ServingGroups (KEDA scales this field)
+  replicas: 1                          # KEDA will update this field
   template:
     restartGracePeriodSeconds: 60
     roles:
@@ -38,14 +23,14 @@ spec:
         entryTemplate:
           metadata:
             labels:
-              # Optional user-defined labels — choose any key/value for your needs.
-              # Not required by the KEDA trigger below; only useful if you write
-              # custom pod-level Prometheus queries.
-              model-name: "<model-name>"    # e.g. "deepseek-r1"
+              # Optional. Free-form pod labels — only useful if you write
+              # custom pod-level Prometheus queries. Not required by the
+              # router-level trigger below.
+              model-name: "<model-name>"
           spec:
             containers:
               - name: leader
-                image: nginx      # replace with your model serving image
+                image: <your-model-image>     # e.g. vllm/vllm-openai:latest
                 ports:
                   - containerPort: 8080
       - name: decode
@@ -53,11 +38,11 @@ spec:
         entryTemplate:
           metadata:
             labels:
-              model-name: "<model-name>"    # same label across roles
+              model-name: "<model-name>"
           spec:
             containers:
               - name: leader
-                image: nginx      # replace with your model serving image
+                image: <your-model-image>
                 ports:
                   - containerPort: 8080
 
@@ -71,18 +56,18 @@ spec:
   scaleTargetRef:
     apiVersion: workload.serving.volcano.sh/v1alpha1
     kind: ModelServing
-    name: <modelserving-name>     # must match the ModelServing name above
-  pollingInterval: 15             # how often KEDA checks the metric (seconds)
-  cooldownPeriod: 120             # wait time before scaling down after metric drops
-  minReplicaCount: 1              # minimum ServingGroup replicas
-  maxReplicaCount: 10             # maximum ServingGroup replicas
+    name: <modelserving-name>          # must match the ModelServing above
+  pollingInterval: 15                  # seconds between Prometheus polls
+  cooldownPeriod: 120                  # seconds to wait before scaling down
+  minReplicaCount: 1                   # keep at least 1 replica warm
+  maxReplicaCount: 10                  # upper bound on replicas
   triggers:
     - type: prometheus
       metadata:
-        serverAddress: <prometheus-url>   # e.g. "http://prometheus.monitoring.svc:9090"
+        serverAddress: <prometheus-url>            # e.g. http://prometheus.monitoring.svc:9090
         metricName: kthena_router_active_downstream_requests
-        # The "model" label below is the router's metric label — it corresponds
-        # to the served model name in the kthena-router configuration, NOT a pod label.
+        # Router-level metric, labeled by the served model name.
+        # The "model" label is set by the kthena-router config — NOT a pod label.
         query: |
           sum(kthena_router_active_downstream_requests{model="<model-name>"})
-        threshold: "100"          # scale up when active requests exceed this value
+        threshold: "100"               # scale up when active requests exceed this

--- a/examples/model-serving/autoscaling-with-keda.yaml
+++ b/examples/model-serving/autoscaling-with-keda.yaml
@@ -1,48 +1,39 @@
 # Autoscale a ModelServing with KEDA + Prometheus.
 #
-# Pipeline: Prometheus -> KEDA -> HPA -> ModelServing -> Pods
+#   Prometheus  ->  KEDA  ->  HPA  ->  ModelServing  ->  Pods
 #
-# See docs/model-serving/autoscaling.md for the full guide.
-#
-# Before applying, replace every "<...>" placeholder with a real value.
+# Assumes KEDA and a Prometheus that scrapes the kthena-router /metrics
+# endpoint are already installed in the cluster. KEDA auto-creates the HPA
+# from the ScaledObject below. See docs/model-serving/autoscaling.md.
 
 ---
 apiVersion: workload.serving.volcano.sh/v1alpha1
 kind: ModelServing
 metadata:
-  name: <modelserving-name>            # e.g. "deepseek-r1"
+  name: autoscaling-sample
   namespace: default
 spec:
   schedulerName: volcano
-  replicas: 1                          # KEDA will update this field
+  replicas: 1                       # ServingGroup replicas — KEDA updates this field
   template:
     restartGracePeriodSeconds: 60
     roles:
       - name: prefill
-        replicas: 2
+        replicas: 1                 # role replicas, stay fixed
         entryTemplate:
-          metadata:
-            labels:
-              # Optional. Free-form pod labels — only useful if you write
-              # custom pod-level Prometheus queries. Not required by the
-              # router-level trigger below.
-              model-name: "<model-name>"
           spec:
             containers:
               - name: leader
-                image: <your-model-image>     # e.g. vllm/vllm-openai:latest
+                image: nginx           # stub; swap for a real engine (e.g. vllm) + ModelRoute to drive the metric
                 ports:
                   - containerPort: 8080
       - name: decode
-        replicas: 2
+        replicas: 1
         entryTemplate:
-          metadata:
-            labels:
-              model-name: "<model-name>"
           spec:
             containers:
               - name: leader
-                image: <your-model-image>
+                image: nginx           # stub; swap for a real engine (e.g. vllm) + ModelRoute to drive the metric
                 ports:
                   - containerPort: 8080
 
@@ -50,24 +41,26 @@ spec:
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
-  name: <modelserving-name>-scaler
+  name: autoscaling-sample-scaler
   namespace: default
 spec:
   scaleTargetRef:
     apiVersion: workload.serving.volcano.sh/v1alpha1
     kind: ModelServing
-    name: <modelserving-name>          # must match the ModelServing above
-  pollingInterval: 15                  # seconds between Prometheus polls
-  cooldownPeriod: 120                  # seconds to wait before scaling down
-  minReplicaCount: 1                   # keep at least 1 replica warm
-  maxReplicaCount: 10                  # upper bound on replicas
+    name: autoscaling-sample
+  pollingInterval: 15               # seconds between Prometheus polls
+  cooldownPeriod: 120               # seconds to wait before scaling down
+  minReplicaCount: 1
+  maxReplicaCount: 10
   triggers:
     - type: prometheus
       metadata:
-        serverAddress: <prometheus-url>            # e.g. http://prometheus.monitoring.svc:9090
+        # Default Service for the `prometheus-community/prometheus` Helm chart.
+        # For kube-prometheus-stack use e.g.
+        #   http://<release>-kube-prometheus-prometheus.monitoring.svc.cluster.local:9090
+        serverAddress: http://prometheus-server.monitoring.svc.cluster.local:9090
         metricName: kthena_router_active_downstream_requests
         # Router-level metric, labeled by the served model name.
-        # The "model" label is set by the kthena-router config — NOT a pod label.
         query: |
-          sum(kthena_router_active_downstream_requests{model="<model-name>"})
-        threshold: "100"               # scale up when active requests exceed this
+          sum(kthena_router_active_downstream_requests{model="autoscaling-sample"})
+        threshold: "100"            # scale up when active requests exceed this


### PR DESCRIPTION
## Summary

This PR updates the autoscaling example for ModelServing based on the feedback.

The earlier approach of adding controller-side label propagation has been removed. 
Now the example just uses user-defined labels in the ModelServing templates.

---

## Changes

- removed the controller-side label propagation attempt
- removed the fixed annotation (`kthena.io/model-name`) and related code
- added a KEDA + Prometheus autoscaling example:
  `examples/model-serving/autoscaling-with-keda.yaml`

---

## Notes

- no controller changes in this PR
- no CRD changes
- labels are fully user-defined
- autoscaling is shown only via example

---

## Context

An earlier version of this PR tried to propagate labels from the controller, 
but that was dropped based on feedback to keep labeling user-controlled.

This version keeps things simple and focuses only on the example.

---

## Example

The example shows:

- how to define labels in ModelServing
- how to query Prometheus using router metrics
- how to configure KEDA to scale ModelServing