### PR TITLE
Bug fix: When deleting a Pod associated with a single Pod role, the role is not recreated

### DIFF
--- a/pkg/model-serving-controller/controller/model_serving_controller.go
+++ b/pkg/model-serving-controller/controller/model_serving_controller.go
@@ -1063,12 +1063,14 @@ func (c *ModelServingController) DeleteRole(ctx context.Context, ms *workloadv1a
 		}
 	}
 
-	// We need to ensure that a pod’s role can enqueue after it has been deleted.
+	// Once the role's pods and services are fully deleted, remove the role from the store.
+	// Note: This measure is taken to prevent the Role’s resources from being deleted before the current function execution has completed,
+	// which would prevent them from being queued for re-coordination.
 	if c.isRoleDeleted(ms, groupName, roleName, roleID) {
 		klog.V(2).Infof("Role %s of ServingGroup %s has been deleted", roleID, groupName)
 		c.store.DeleteRole(utils.GetNamespaceName(ms), groupName, roleName, roleID)
-		// this is needed when a pod is deleted accidentally, and the Role is deleted completely
-		// and the controller has no chance to supplement it.
+		// Re-enqueue the ModelServing for reconciliation after the role has been deleted
+		// so the controller can recreate any missing resources if needed.
 		c.enqueueModelServing(ms)
 	}
 }

--- a/pkg/model-serving-controller/controller/model_serving_controller.go
+++ b/pkg/model-serving-controller/controller/model_serving_controller.go
@@ -1003,6 +1003,7 @@ func (c *ModelServingController) DeleteRole(ctx context.Context, ms *workloadv1a
 		workloadv1alpha1.RoleLabelKey:      roleName,
 		workloadv1alpha1.RoleIDKey:         roleID,
 	})
+
 	// If the role is already in the deletion process, no further processing will be done.
 	roleStatus := c.store.GetRoleStatus(utils.GetNamespaceName(ms), groupName, roleName, roleID)
 	if roleStatus == datastore.RoleDeleting {
@@ -1014,6 +1015,7 @@ func (c *ModelServingController) DeleteRole(ctx context.Context, ms *workloadv1a
 		klog.Errorf("failed to set role %s/%s status: %v", groupName, roleID, err)
 		return
 	}
+
 	// Emit event for role entering Deleting state.
 	message := fmt.Sprintf("Role %s/%s in ServingGroup %s is now Deleting", roleName, roleID, groupName)
 	c.emitRoleStatusEvent(ms, corev1.EventTypeNormal, "RoleDeleting", message)
@@ -1059,6 +1061,15 @@ func (c *ModelServingController) DeleteRole(ctx context.Context, ms *workloadv1a
 				return
 			}
 		}
+	}
+
+	// We need to ensure that a pod’s role can enqueue after it has been deleted.
+	if c.isRoleDeleted(ms, groupName, roleName, roleID) {
+		klog.V(2).Infof("Role %s of ServingGroup %s has been deleted", roleID, groupName)
+		c.store.DeleteRole(utils.GetNamespaceName(ms), groupName, roleName, roleID)
+		// this is needed when a pod is deleted accidentally, and the Role is deleted completely
+		// and the controller has no chance to supplement it.
+		c.enqueueModelServing(ms)
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:

When a role has only one pod, deleting that pod does not cause the role to be recreated. 
This PR adds an operation to enqueue the pod to the role’s deletion function. This issue has been resolved.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
