### PR TITLE
feat: Introducing Dynamo Mocker instead of Flask Mocker

### DIFF
--- a/docs/kthena/docs/assets/examples/kthena-router/LLM-Mock-ds1.5b-Canary.yaml
+++ b/docs/kthena/docs/assets/examples/kthena-router/LLM-Mock-ds1.5b-Canary.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: llm-engine
-          image: ghcr.io/yaozengzeng/vllm-mock:latest
+          image: ghcr.io/faust-benchou/dynamo-mocker-vllm:latest
           imagePullPolicy: IfNotPresent
           env:
             # specify the model name to mock
@@ -49,7 +49,7 @@ spec:
     spec:
       containers:
         - name: llm-engine
-          image: ghcr.io/yaozengzeng/vllm-mock:latest
+          image: ghcr.io/faust-benchou/dynamo-mocker-vllm:latest
           imagePullPolicy: IfNotPresent
           env:
             # specify the model name to mock

--- a/docs/kthena/docs/assets/examples/kthena-router/LLM-Mock-ds1.5b.yaml
+++ b/docs/kthena/docs/assets/examples/kthena-router/LLM-Mock-ds1.5b.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: llm-engine
-          image: ghcr.io/yaozengzeng/vllm-mock:latest
+          image: ghcr.io/faust-benchou/dynamo-mocker-vllm:latest
           imagePullPolicy: IfNotPresent
           env:
             # specify the model name to mock

--- a/docs/kthena/docs/assets/examples/kthena-router/LLM-Mock-ds7b.yaml
+++ b/docs/kthena/docs/assets/examples/kthena-router/LLM-Mock-ds7b.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: llm-engine
-          image: ghcr.io/yaozengzeng/vllm-mock:latest
+          image: ghcr.io/faust-benchou/dynamo-mocker-vllm:latest
           imagePullPolicy: IfNotPresent
           env:
             # specify the model name to mock

--- a/docs/kthena/docs/assets/examples/kthena-router/LLM-Mock.yaml
+++ b/docs/kthena/docs/assets/examples/kthena-router/LLM-Mock.yaml
@@ -2,7 +2,7 @@
 # The mock server will return a fixed response for any input.
 # You can use this mock server to test the inference router without deploying a real LLM server.
 #
-# NOTE: `ghcr.io/yaozengzeng/vllm-mock:latest` is built based on `https://github.com/YaoZengzeng/aibrix/tree/vllm-mock`.
+# NOTE: `ghcr.io/faust-benchou/dynamo-mocker-vllm:latest` is built based on `https://github.com/YaoZengzeng/aibrix/tree/vllm-mock`.
 # Move the image to kthena registry once it's public.
 
 apiVersion: apps/v1
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: llm-engine
-          image: ghcr.io/yaozengzeng/vllm-mock:latest
+          image: ghcr.io/faust-benchou/dynamo-mocker-vllm:latest
           imagePullPolicy: IfNotPresent
           env:
             # specify the model name to mock

--- a/docs/kthena/versioned_docs/version-v0.1.0/assets/examples/kthena-router/LLM-Mock-ds1.5b-Canary.yaml
+++ b/docs/kthena/versioned_docs/version-v0.1.0/assets/examples/kthena-router/LLM-Mock-ds1.5b-Canary.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: llm-engine
-          image: ghcr.io/yaozengzeng/vllm-mock:latest
+          image: ghcr.io/faust-benchou/dynamo-mocker-vllm:latest
           imagePullPolicy: IfNotPresent
           env:
             # specify the model name to mock
@@ -49,7 +49,7 @@ spec:
     spec:
       containers:
         - name: llm-engine
-          image: ghcr.io/yaozengzeng/vllm-mock:latest
+          image: ghcr.io/faust-benchou/dynamo-mocker-vllm:latest
           imagePullPolicy: IfNotPresent
           env:
             # specify the model name to mock

--- a/docs/kthena/versioned_docs/version-v0.1.0/assets/examples/kthena-router/LLM-Mock-ds1.5b.yaml
+++ b/docs/kthena/versioned_docs/version-v0.1.0/assets/examples/kthena-router/LLM-Mock-ds1.5b.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: llm-engine
-          image: ghcr.io/yaozengzeng/vllm-mock:latest
+          image: ghcr.io/faust-benchou/dynamo-mocker-vllm:latest
           imagePullPolicy: IfNotPresent
           env:
             # specify the model name to mock

--- a/docs/kthena/versioned_docs/version-v0.1.0/assets/examples/kthena-router/LLM-Mock-ds7b.yaml
+++ b/docs/kthena/versioned_docs/version-v0.1.0/assets/examples/kthena-router/LLM-Mock-ds7b.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: llm-engine
-          image: ghcr.io/yaozengzeng/vllm-mock:latest
+          image: ghcr.io/faust-benchou/dynamo-mocker-vllm:latest
           imagePullPolicy: IfNotPresent
           env:
             # specify the model name to mock

--- a/docs/kthena/versioned_docs/version-v0.1.0/assets/examples/kthena-router/LLM-Mock.yaml
+++ b/docs/kthena/versioned_docs/version-v0.1.0/assets/examples/kthena-router/LLM-Mock.yaml
@@ -2,7 +2,7 @@
 # The mock server will return a fixed response for any input.
 # You can use this mock server to test the inference router without deploying a real LLM server.
 #
-# NOTE: `ghcr.io/yaozengzeng/vllm-mock:latest` is built based on `https://github.com/YaoZengzeng/aibrix/tree/vllm-mock`.
+# NOTE: `ghcr.io/faust-benchou/dynamo-mocker-vllm:latest` is built based on `https://github.com/YaoZengzeng/aibrix/tree/vllm-mock`.
 # Move the image to kthena registry once it's public.
 
 apiVersion: apps/v1
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: llm-engine
-          image: ghcr.io/yaozengzeng/vllm-mock:latest
+          image: ghcr.io/faust-benchou/dynamo-mocker-vllm:latest
           imagePullPolicy: IfNotPresent
           env:
             # specify the model name to mock

--- a/docs/kthena/versioned_docs/version-v0.2.0/assets/examples/kthena-router/LLM-Mock-ds1.5b-Canary.yaml
+++ b/docs/kthena/versioned_docs/version-v0.2.0/assets/examples/kthena-router/LLM-Mock-ds1.5b-Canary.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: llm-engine
-          image: ghcr.io/yaozengzeng/vllm-mock:latest
+          image: ghcr.io/faust-benchou/dynamo-mocker-vllm:latest
           imagePullPolicy: IfNotPresent
           env:
             # specify the model name to mock
@@ -49,7 +49,7 @@ spec:
     spec:
       containers:
         - name: llm-engine
-          image: ghcr.io/yaozengzeng/vllm-mock:latest
+          image: ghcr.io/faust-benchou/dynamo-mocker-vllm:latest
           imagePullPolicy: IfNotPresent
           env:
             # specify the model name to mock

--- a/docs/kthena/versioned_docs/version-v0.2.0/assets/examples/kthena-router/LLM-Mock-ds1.5b.yaml
+++ b/docs/kthena/versioned_docs/version-v0.2.0/assets/examples/kthena-router/LLM-Mock-ds1.5b.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: llm-engine
-          image: ghcr.io/yaozengzeng/vllm-mock:latest
+          image: ghcr.io/faust-benchou/dynamo-mocker-vllm:latest
           imagePullPolicy: IfNotPresent
           env:
             # specify the model name to mock

--- a/docs/kthena/versioned_docs/version-v0.2.0/assets/examples/kthena-router/LLM-Mock-ds7b.yaml
+++ b/docs/kthena/versioned_docs/version-v0.2.0/assets/examples/kthena-router/LLM-Mock-ds7b.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: llm-engine
-          image: ghcr.io/yaozengzeng/vllm-mock:latest
+          image: ghcr.io/faust-benchou/dynamo-mocker-vllm:latest
           imagePullPolicy: IfNotPresent
           env:
             # specify the model name to mock

--- a/docs/kthena/versioned_docs/version-v0.2.0/assets/examples/kthena-router/LLM-Mock.yaml
+++ b/docs/kthena/versioned_docs/version-v0.2.0/assets/examples/kthena-router/LLM-Mock.yaml
@@ -2,7 +2,7 @@
 # The mock server will return a fixed response for any input.
 # You can use this mock server to test the inference router without deploying a real LLM server.
 #
-# NOTE: `ghcr.io/yaozengzeng/vllm-mock:latest` is built based on `https://github.com/YaoZengzeng/aibrix/tree/vllm-mock`.
+# NOTE: `ghcr.io/faust-benchou/dynamo-mocker-vllm:latest` is built based on `https://github.com/YaoZengzeng/aibrix/tree/vllm-mock`.
 # Move the image to kthena registry once it's public.
 
 apiVersion: apps/v1
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: llm-engine
-          image: ghcr.io/yaozengzeng/vllm-mock:latest
+          image: ghcr.io/faust-benchou/dynamo-mocker-vllm:latest
           imagePullPolicy: IfNotPresent
           env:
             # specify the model name to mock

--- a/docs/kthena/versioned_docs/version-v0.3.0/assets/examples/kthena-router/LLM-Mock-ds1.5b-Canary.yaml
+++ b/docs/kthena/versioned_docs/version-v0.3.0/assets/examples/kthena-router/LLM-Mock-ds1.5b-Canary.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: llm-engine
-          image: ghcr.io/yaozengzeng/vllm-mock:latest
+          image: ghcr.io/faust-benchou/dynamo-mocker-vllm:latest
           imagePullPolicy: IfNotPresent
           env:
             # specify the model name to mock
@@ -49,7 +49,7 @@ spec:
     spec:
       containers:
         - name: llm-engine
-          image: ghcr.io/yaozengzeng/vllm-mock:latest
+          image: ghcr.io/faust-benchou/dynamo-mocker-vllm:latest
           imagePullPolicy: IfNotPresent
           env:
             # specify the model name to mock

--- a/docs/kthena/versioned_docs/version-v0.3.0/assets/examples/kthena-router/LLM-Mock-ds1.5b.yaml
+++ b/docs/kthena/versioned_docs/version-v0.3.0/assets/examples/kthena-router/LLM-Mock-ds1.5b.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: llm-engine
-          image: ghcr.io/yaozengzeng/vllm-mock:latest
+          image: ghcr.io/faust-benchou/dynamo-mocker-vllm:latest
           imagePullPolicy: IfNotPresent
           env:
             # specify the model name to mock

--- a/docs/kthena/versioned_docs/version-v0.3.0/assets/examples/kthena-router/LLM-Mock-ds7b.yaml
+++ b/docs/kthena/versioned_docs/version-v0.3.0/assets/examples/kthena-router/LLM-Mock-ds7b.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: llm-engine
-          image: ghcr.io/yaozengzeng/vllm-mock:latest
+          image: ghcr.io/faust-benchou/dynamo-mocker-vllm:latest
           imagePullPolicy: IfNotPresent
           env:
             # specify the model name to mock

--- a/docs/kthena/versioned_docs/version-v0.3.0/assets/examples/kthena-router/LLM-Mock.yaml
+++ b/docs/kthena/versioned_docs/version-v0.3.0/assets/examples/kthena-router/LLM-Mock.yaml
@@ -2,7 +2,7 @@
 # The mock server will return a fixed response for any input.
 # You can use this mock server to test the inference router without deploying a real LLM server.
 #
-# NOTE: `ghcr.io/yaozengzeng/vllm-mock:latest` is built based on `https://github.com/YaoZengzeng/aibrix/tree/vllm-mock`.
+# NOTE: `ghcr.io/faust-benchou/dynamo-mocker-vllm:latest` is built based on `https://github.com/YaoZengzeng/aibrix/tree/vllm-mock`.
 # Move the image to kthena registry once it's public.
 
 apiVersion: apps/v1
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: llm-engine
-          image: ghcr.io/yaozengzeng/vllm-mock:latest
+          image: ghcr.io/faust-benchou/dynamo-mocker-vllm:latest
           imagePullPolicy: IfNotPresent
           env:
             # specify the model name to mock

--- a/examples/kthena-router/LLM-Mock-ds1.5b-Canary.yaml
+++ b/examples/kthena-router/LLM-Mock-ds1.5b-Canary.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: llm-engine
-          image: ghcr.io/yaozengzeng/vllm-mock:latest
+          image: ghcr.io/faust-benchou/dynamo-mocker-vllm:latest
           imagePullPolicy: IfNotPresent
           env:
             # specify the model name to mock
@@ -49,7 +49,7 @@ spec:
     spec:
       containers:
         - name: llm-engine
-          image: ghcr.io/yaozengzeng/vllm-mock:latest
+          image: ghcr.io/faust-benchou/dynamo-mocker-vllm:latest
           imagePullPolicy: IfNotPresent
           env:
             # specify the model name to mock

--- a/examples/kthena-router/LLM-Mock-ds1.5b.yaml
+++ b/examples/kthena-router/LLM-Mock-ds1.5b.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: llm-engine
-          image: ghcr.io/yaozengzeng/vllm-mock:latest
+          image: ghcr.io/faust-benchou/dynamo-mocker-vllm:latest
           imagePullPolicy: IfNotPresent
           env:
             # specify the model name to mock

--- a/examples/kthena-router/LLM-Mock-ds7b.yaml
+++ b/examples/kthena-router/LLM-Mock-ds7b.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: llm-engine
-          image: ghcr.io/yaozengzeng/vllm-mock:latest
+          image: ghcr.io/faust-benchou/dynamo-mocker-vllm:latest
           imagePullPolicy: IfNotPresent
           env:
             # specify the model name to mock

--- a/examples/kthena-router/LLM-Mock.yaml
+++ b/examples/kthena-router/LLM-Mock.yaml
@@ -2,7 +2,7 @@
 # The mock server will return a fixed response for any input.
 # You can use this mock server to test the inference router without deploying a real LLM server.
 #
-# NOTE: `ghcr.io/yaozengzeng/vllm-mock:latest` is built based on `https://github.com/YaoZengzeng/aibrix/tree/vllm-mock`.
+# NOTE: `ghcr.io/faust-benchou/dynamo-mocker-vllm:latest` is built based on `https://github.com/YaoZengzeng/aibrix/tree/vllm-mock`.
 # Move the image to kthena registry once it's public.
 
 apiVersion: apps/v1
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: llm-engine
-          image: ghcr.io/yaozengzeng/vllm-mock:latest
+          image: ghcr.io/faust-benchou/dynamo-mocker-vllm:latest
           imagePullPolicy: IfNotPresent
           env:
             # specify the model name to mock

--- a/examples/kthena-router/ModelServing-ds1.5b-pd-disaggregation.yaml
+++ b/examples/kthena-router/ModelServing-ds1.5b-pd-disaggregation.yaml
@@ -19,7 +19,7 @@ spec:
           spec:
             containers:
               - name: leader
-                image: ghcr.io/yaozengzeng/vllm-mock:latest
+                image: ghcr.io/faust-benchou/dynamo-mocker-vllm:latest
                 imagePullPolicy: IfNotPresent
                 env:
                   # specify the model name to mock
@@ -39,7 +39,7 @@ spec:
           spec:
             containers:
               - name: leader
-                image: ghcr.io/yaozengzeng/vllm-mock:latest
+                image: ghcr.io/faust-benchou/dynamo-mocker-vllm:latest
                 imagePullPolicy: IfNotPresent
                 env:
                   # specify the model name to mock

--- a/test/e2e/router/e2e_test.go
+++ b/test/e2e/router/e2e_test.go
@@ -119,7 +119,7 @@ func TestModelRoutePrefillDecodeDisaggregation(t *testing.T) {
 // TestModelRouteSubset tests ModelRoute with subset routing.
 // This test runs the shared test function without Gateway API (no ParentRefs).
 func TestModelRouteSubset(t *testing.T) {
-	TestModelRouteSubsetShared(t, testCtx, testNamespace, false, "")
+	TestModelRouteSubsetShared(t, testCtx, testNamespace, false, kthenaNamespace)
 }
 
 // TestModelRouteWithRateLimit tests local rate limiting enforced by the Kthena Router.

--- a/test/e2e/router/shared.go
+++ b/test/e2e/router/shared.go
@@ -482,6 +482,24 @@ func TestModelRoutePrefillDecodeDisaggregationShared(t *testing.T, testCtx *rout
 	utils.CheckChatCompletions(t, modelRoute.Spec.ModelName, messages)
 }
 
+// subsetCanaryBackendCountsFromRouterLogs counts canary traffic to each mock pool using
+// router access logs (selected_pod). Chat response bodies no longer differ when both
+// backends use the same HuggingFace model id without -v1/-v2 suffixes.
+func subsetCanaryBackendCountsFromRouterLogs(t *testing.T, kube kubernetes.Interface, kthenaNamespace string, since *metav1.Time) (v1, v2 int) {
+	t.Helper()
+	routerPod := utils.GetRouterPod(t, kube, kthenaNamespace)
+	opts := &corev1.PodLogOptions{}
+	if since != nil {
+		opts.SinceTime = since
+	}
+	logs, err := kube.CoreV1().Pods(kthenaNamespace).GetLogs(routerPod.Name, opts).Do(context.Background()).Raw()
+	require.NoError(t, err)
+	s := string(logs)
+	// Pod names are deployment-prefixed: deepseek-r1-1-5b-v1-<rs>-<suffix>
+	return strings.Count(s, "selected_pod=deepseek-r1-1-5b-v1-"),
+		strings.Count(s, "selected_pod=deepseek-r1-1-5b-v2-")
+}
+
 // TestModelRouteSubsetShared is a shared test function that can be used by both
 // router and gateway-api test suites. When useGatewayAPI is true, it configures ModelRoute
 // with ParentRefs to the default Gateway.
@@ -573,29 +591,25 @@ func TestModelRouteSubsetShared(t *testing.T, testCtx *routercontext.RouterTestC
 		// Use more requests to reduce randomness impact
 		const totalRequests = 500
 		const sumTolerance = 0.01 // Allow ±1% deviation for floating-point rounding errors
-		v1Count := 0
-		v2Count := 0
+		sinceTime := metav1.NewTime(time.Now().Add(-2 * time.Second))
 
 		for i := 0; i < totalRequests; i++ {
 			resp := utils.CheckChatCompletionsQuiet(t, modelRoute.Spec.ModelName, messages)
 			assert.Equal(t, 200, resp.StatusCode)
 			assert.NotEmpty(t, resp.Body)
-
-			if strings.Contains(resp.Body, "DeepSeek-R1-Distill-Qwen-1.5B-v1") {
-				v1Count++
-			} else if strings.Contains(resp.Body, "DeepSeek-R1-Distill-Qwen-1.5B-v2") {
-				v2Count++
-			}
 		}
 
-		// Verify weight distribution statistics across multiple requests
-		// 1. Verify statistics completeness: all requests are accounted for
-		totalCounted := v1Count + v2Count
-		assert.Equal(t, totalRequests, totalCounted, "All requests should be accounted for in statistics")
+		v1Count, v2Count := subsetCanaryBackendCountsFromRouterLogs(t, testCtx.KubeClient, kthenaNamespace, &sinceTime)
+		totalFromLogs := v1Count + v2Count
+		require.GreaterOrEqual(t, totalFromLogs, int(0.85*float64(totalRequests)),
+			"expected router access logs to cover most requests (got %d lines, v1=%d v2=%d)", totalFromLogs, v1Count, v2Count)
+		require.Greater(t, v1Count, 0, "canary v1 should receive some traffic")
+		require.Greater(t, v2Count, 0, "canary v2 should receive some traffic")
 
-		// 2. Calculate and verify distribution ratios
-		v1Ratio := float64(v1Count) / float64(totalRequests)
-		v2Ratio := float64(v2Count) / float64(totalRequests)
+		// Verify weight distribution statistics across multiple requests
+		// 1. Ratios from access logs (retries may add extra lines; use log totals for proportions)
+		v1Ratio := float64(v1Count) / float64(totalFromLogs)
+		v2Ratio := float64(v2Count) / float64(totalFromLogs)
 		expectedV1Ratio := 0.70
 		expectedV2Ratio := 0.30
 		maxDeviation := 0.05 // Allow ±5% deviation for randomness
@@ -606,16 +620,16 @@ func TestModelRouteSubsetShared(t *testing.T, testCtx *routercontext.RouterTestC
 		assert.LessOrEqual(t, v1Ratio, expectedV1Ratio+maxDeviation,
 			"deepseek-r1-1-5b ratio should be at most %.1f%% (expected %.1f%%)", (expectedV1Ratio+maxDeviation)*100, expectedV1Ratio*100)
 		assert.GreaterOrEqual(t, v2Ratio, expectedV2Ratio-maxDeviation,
-			"deepseek-r1-7b ratio should be at least %.1f%% (expected %.1f%%)", (expectedV2Ratio-maxDeviation)*100, expectedV2Ratio*100)
+			"deepseek-r1-1-5b-v2 ratio should be at least %.1f%% (expected %.1f%%)", (expectedV2Ratio-maxDeviation)*100, expectedV2Ratio*100)
 		assert.LessOrEqual(t, v2Ratio, expectedV2Ratio+maxDeviation,
-			"deepseek-r1-7b ratio should be at most %.1f%% (expected %.1f%%)", (expectedV2Ratio+maxDeviation)*100, expectedV2Ratio*100)
+			"deepseek-r1-1-5b-v2 ratio should be at most %.1f%% (expected %.1f%%)", (expectedV2Ratio+maxDeviation)*100, expectedV2Ratio*100)
 
 		// 4. Verify statistics sum to 100% (with tolerance for floating-point rounding)
 		assert.InDelta(t, 1.0, v1Ratio+v2Ratio, sumTolerance, "Distribution ratios should sum to approximately 100%")
 
 		// Log statistics for debugging
 		t.Logf("Weight distribution statistics verified:")
-		t.Logf("  Total requests: %d, Counted: %d", totalRequests, totalCounted)
+		t.Logf("  Total requests: %d, log lines (v1+v2): %d", totalRequests, totalFromLogs)
 		t.Logf("  deepseek-r1-1-5b-v1: %d requests (%.1f%%, expected %.1f%%)", v1Count, v1Ratio*100, expectedV1Ratio*100)
 		t.Logf("  deepseek-r1-1-5b-v2: %d requests (%.1f%%, expected %.1f%%)", v2Count, v2Ratio*100, expectedV2Ratio*100)
 	})
@@ -640,34 +654,31 @@ func TestModelRouteSubsetShared(t *testing.T, testCtx *routercontext.RouterTestC
 		require.Eventually(t, func() bool {
 			resp := utils.CheckChatCompletions(t, modelRoute.Spec.ModelName, messages)
 			return resp.StatusCode == 200 && resp.Body != "" &&
-				(strings.Contains(resp.Body, "DeepSeek-R1-Distill-Qwen-1.5B-v1") || strings.Contains(resp.Body, "DeepSeek-R1-Distill-Qwen-1.5B-v2"))
+				strings.Contains(resp.Body, `"choices"`) &&
+				strings.Contains(resp.Body, "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B")
 		}, 1*time.Minute, 2*time.Second, "ModelRoute update should propagate and requests should route successfully")
 
 		// Verify requests still work and verify the normalized weight distribution (50:30 = 5/8:3/8)
 		// Send multiple requests to verify weight distribution statistics
 		const totalRequests = 500
-		v1Count := 0
-		v2Count := 0
+		sinceTime := metav1.NewTime(time.Now().Add(-2 * time.Second))
 
 		for i := 0; i < totalRequests; i++ {
 			resp := utils.CheckChatCompletionsQuiet(t, modelRoute.Spec.ModelName, messages)
 			assert.Equal(t, 200, resp.StatusCode)
 			assert.NotEmpty(t, resp.Body)
-
-			if strings.Contains(resp.Body, "DeepSeek-R1-Distill-Qwen-1.5B-v1") {
-				v1Count++
-			} else if strings.Contains(resp.Body, "DeepSeek-R1-Distill-Qwen-1.5B-v2") {
-				v2Count++
-			}
 		}
 
-		// Verify weight distribution statistics
-		totalCounted := v1Count + v2Count
-		assert.Equal(t, totalRequests, totalCounted, "All requests should be accounted for in statistics")
+		v1Count, v2Count := subsetCanaryBackendCountsFromRouterLogs(t, testCtx.KubeClient, kthenaNamespace, &sinceTime)
+		totalFromLogs := v1Count + v2Count
+		require.GreaterOrEqual(t, totalFromLogs, int(0.85*float64(totalRequests)),
+			"expected router access logs to cover most requests (got %d lines, v1=%d v2=%d)", totalFromLogs, v1Count, v2Count)
+		require.Greater(t, v1Count, 0, "canary v1 should receive some traffic")
+		require.Greater(t, v2Count, 0, "canary v2 should receive some traffic")
 
 		// Calculate and verify distribution ratios (50:30 should normalize to 5/8:3/8 = 62.5%:37.5%)
-		v1Ratio := float64(v1Count) / float64(totalRequests)
-		v2Ratio := float64(v2Count) / float64(totalRequests)
+		v1Ratio := float64(v1Count) / float64(totalFromLogs)
+		v2Ratio := float64(v2Count) / float64(totalFromLogs)
 		expectedV1Ratio := 0.625 // 5/8 = 62.5%
 		expectedV2Ratio := 0.375 // 3/8 = 37.5%
 		maxDeviation := 0.05     // Allow ±5% deviation for randomness
@@ -687,7 +698,7 @@ func TestModelRouteSubsetShared(t *testing.T, testCtx *routercontext.RouterTestC
 
 		// Log statistics for debugging
 		t.Logf("Normalized weight distribution verified (50:30 -> 5/8:3/8):")
-		t.Logf("  Total requests: %d, Counted: %d", totalRequests, totalCounted)
+		t.Logf("  Total requests: %d, log lines (v1+v2): %d", totalRequests, totalFromLogs)
 		t.Logf("  deepseek-r1-1-5b-v1: %d requests (%.1f%%, expected %.1f%%)", v1Count, v1Ratio*100, expectedV1Ratio*100)
 		t.Logf("  deepseek-r1-1-5b-v2: %d requests (%.1f%%, expected %.1f%%)", v2Count, v2Ratio*100, expectedV2Ratio*100)
 

--- a/test/e2e/router/shared.go
+++ b/test/e2e/router/shared.go
@@ -1246,13 +1246,13 @@ func TestModelRouteLoraShared(t *testing.T, testCtx *routercontext.RouterTestCon
 	podName := podList.Items[0].Name
 	t.Logf("Using pod %s for LoRA adapter loading", podName)
 
-	pf, err := utils.SetupPortForwardToPod(testNamespace, podName, "9002", "8002")
+	pf, err := utils.SetupPortForwardToPod(testNamespace, podName, "9000", "8000")
 	require.NoError(t, err, "Failed to setup port-forward to LLM-Mock pod")
 	defer pf.Close()
 
 	t.Log("Loading LoRA adapters on backend...")
-	utils.LoadLoRAAdapter(t, "http://127.0.0.1:9002", "lora-A", "/models/lora-A")
-	utils.LoadLoRAAdapter(t, "http://127.0.0.1:9002", "lora-B", "/models/lora-B")
+	utils.LoadLoRAAdapter(t, "http://127.0.0.1:9000", "lora-A", "/models/lora-A")
+	utils.LoadLoRAAdapter(t, "http://127.0.0.1:9000", "lora-B", "/models/lora-B")
 	t.Log("LoRA adapters loaded successfully")
 
 	messages := []utils.ChatMessage{
@@ -1310,8 +1310,8 @@ func TestModelRouteLoraShared(t *testing.T, testCtx *routercontext.RouterTestCon
 
 	// Unload LoRA adapters after test is complete
 	t.Log("Unloading LoRA adapters after test...")
-	utils.UnloadLoRAAdapter(t, "http://127.0.0.1:9002", "lora-A")
-	utils.UnloadLoRAAdapter(t, "http://127.0.0.1:9002", "lora-B")
+	utils.UnloadLoRAAdapter(t, "http://127.0.0.1:9000", "lora-A")
+	utils.UnloadLoRAAdapter(t, "http://127.0.0.1:9000", "lora-B")
 	t.Log("LoRA adapters unloaded successfully")
 }
 

--- a/test/e2e/router/shared.go
+++ b/test/e2e/router/shared.go
@@ -1235,13 +1235,13 @@ func TestModelRouteLoraShared(t *testing.T, testCtx *routercontext.RouterTestCon
 	podName := podList.Items[0].Name
 	t.Logf("Using pod %s for LoRA adapter loading", podName)
 
-	pf, err := utils.SetupPortForwardToPod(testNamespace, podName, "9000", "8000")
+	pf, err := utils.SetupPortForwardToPod(testNamespace, podName, "9002", "8002")
 	require.NoError(t, err, "Failed to setup port-forward to LLM-Mock pod")
 	defer pf.Close()
 
 	t.Log("Loading LoRA adapters on backend...")
-	utils.LoadLoRAAdapter(t, "http://127.0.0.1:9000", "lora-A", "/models/lora-A")
-	utils.LoadLoRAAdapter(t, "http://127.0.0.1:9000", "lora-B", "/models/lora-B")
+	utils.LoadLoRAAdapter(t, "http://127.0.0.1:9002", "lora-A", "/models/lora-A")
+	utils.LoadLoRAAdapter(t, "http://127.0.0.1:9002", "lora-B", "/models/lora-B")
 	t.Log("LoRA adapters loaded successfully")
 
 	messages := []utils.ChatMessage{
@@ -1299,8 +1299,8 @@ func TestModelRouteLoraShared(t *testing.T, testCtx *routercontext.RouterTestCon
 
 	// Unload LoRA adapters after test is complete
 	t.Log("Unloading LoRA adapters after test...")
-	utils.UnloadLoRAAdapter(t, "http://127.0.0.1:9000", "lora-A")
-	utils.UnloadLoRAAdapter(t, "http://127.0.0.1:9000", "lora-B")
+	utils.UnloadLoRAAdapter(t, "http://127.0.0.1:9002", "lora-A")
+	utils.UnloadLoRAAdapter(t, "http://127.0.0.1:9002", "lora-B")
 	t.Log("LoRA adapters unloaded successfully")
 }
 

--- a/test/e2e/router/testdata/LLM-Mock-ds1.5b-Canary.yaml
+++ b/test/e2e/router/testdata/LLM-Mock-ds1.5b-Canary.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: llm-engine
-          image: ghcr.io/yaozengzeng/vllm-mock:latest
+          image: ghcr.io/faust-benchou/dynamo-mocker-vllm:latest
           imagePullPolicy: IfNotPresent
           env:
             # specify the model name to mock
@@ -49,7 +49,7 @@ spec:
     spec:
       containers:
         - name: llm-engine
-          image: ghcr.io/yaozengzeng/vllm-mock:latest
+          image: ghcr.io/faust-benchou/dynamo-mocker-vllm:latest
           imagePullPolicy: IfNotPresent
           env:
             # specify the model name to mock

--- a/test/e2e/router/testdata/LLM-Mock-ds1.5b-Canary.yaml
+++ b/test/e2e/router/testdata/LLM-Mock-ds1.5b-Canary.yaml
@@ -27,9 +27,6 @@ spec:
             # specify the model name to mock
             - name: MODEL_NAME
               value: "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B-v1"
-          command:
-            - python3
-            - app.py
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -55,6 +52,3 @@ spec:
             # specify the model name to mock
             - name: MODEL_NAME
               value: "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B-v2"
-          command:
-            - python3
-            - app.py

--- a/test/e2e/router/testdata/LLM-Mock-ds1.5b-Canary.yaml
+++ b/test/e2e/router/testdata/LLM-Mock-ds1.5b-Canary.yaml
@@ -26,7 +26,7 @@ spec:
           env:
             # specify the model name to mock
             - name: MODEL_NAME
-              value: "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B-v1"
+              value: "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -51,4 +51,4 @@ spec:
           env:
             # specify the model name to mock
             - name: MODEL_NAME
-              value: "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B-v2"
+              value: "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"

--- a/test/e2e/router/testdata/LLM-Mock-ds1.5b.yaml
+++ b/test/e2e/router/testdata/LLM-Mock-ds1.5b.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: llm-engine
-          image: ghcr.io/yaozengzeng/vllm-mock:latest
+          image: ghcr.io/faust-benchou/dynamo-mocker-vllm:latest
           imagePullPolicy: IfNotPresent
           env:
             # specify the model name to mock

--- a/test/e2e/router/testdata/LLM-Mock-ds1.5b.yaml
+++ b/test/e2e/router/testdata/LLM-Mock-ds1.5b.yaml
@@ -25,7 +25,4 @@ spec:
             # specify the model name to mock
             - name: MODEL_NAME
               value: "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
-          command:
-            - python3
-            - app.py
 

--- a/test/e2e/router/testdata/LLM-Mock-ds7b.yaml
+++ b/test/e2e/router/testdata/LLM-Mock-ds7b.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: llm-engine
-          image: ghcr.io/yaozengzeng/vllm-mock:latest
+          image: ghcr.io/faust-benchou/dynamo-mocker-vllm:latest
           imagePullPolicy: IfNotPresent
           env:
             # specify the model name to mock

--- a/test/e2e/router/testdata/LLM-Mock-ds7b.yaml
+++ b/test/e2e/router/testdata/LLM-Mock-ds7b.yaml
@@ -25,6 +25,3 @@ spec:
             # specify the model name to mock
             - name: MODEL_NAME
               value: "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B"
-          command:
-            - python3
-            - app.py

--- a/test/e2e/router/testdata/ModelServer-ds1.5b-Canary.yaml
+++ b/test/e2e/router/testdata/ModelServer-ds1.5b-Canary.yaml
@@ -10,7 +10,7 @@ spec:
       version: v1
   workloadPort:
     port: 8000
-  model: "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B-v1"
+  model: "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
   inferenceEngine: "vLLM"
   trafficPolicy:
     timeout: 10s
@@ -29,7 +29,7 @@ spec:
       version: v2
   workloadPort:
     port: 8000
-  model: "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B-v2"
+  model: "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
   inferenceEngine: "vLLM"
   trafficPolicy:
     timeout: 10s

--- a/test/e2e/router/testdata/ModelServing-ds1.5b-pd-disaggregation.yaml
+++ b/test/e2e/router/testdata/ModelServing-ds1.5b-pd-disaggregation.yaml
@@ -19,7 +19,7 @@ spec:
           spec:
             containers:
               - name: leader
-                image: ghcr.io/yaozengzeng/vllm-mock:latest
+                image: ghcr.io/faust-benchou/dynamo-mocker-vllm:latest
                 imagePullPolicy: IfNotPresent
                 env:
                   # specify the model name to mock
@@ -39,7 +39,7 @@ spec:
           spec:
             containers:
               - name: leader
-                image: ghcr.io/yaozengzeng/vllm-mock:latest
+                image: ghcr.io/faust-benchou/dynamo-mocker-vllm:latest
                 imagePullPolicy: IfNotPresent
                 env:
                   # specify the model name to mock

--- a/test/e2e/utils/chat.go
+++ b/test/e2e/utils/chat.go
@@ -35,6 +35,8 @@ const (
 	// DefaultRouterURL is the default URL for the router service via port-forward
 	// Use 127.0.0.1 instead of localhost to avoid IPv6 resolution issues in CI environments
 	DefaultRouterURL = "http://127.0.0.1:8080/v1/chat/completions"
+	// DefaultChatMaxTokens matches OpenAI-style e2e backends (e.g. Dynamo mocker) that require max_tokens.
+	DefaultChatMaxTokens = 16
 )
 
 // ChatMessage represents a chat message in the request
@@ -45,9 +47,10 @@ type ChatMessage struct {
 
 // ChatCompletionsRequest represents a chat completions API request
 type ChatCompletionsRequest struct {
-	Model    string        `json:"model"`
-	Messages []ChatMessage `json:"messages"`
-	Stream   bool          `json:"stream"`
+	Model     string        `json:"model"`
+	Messages  []ChatMessage `json:"messages"`
+	Stream    bool          `json:"stream"`
+	MaxTokens int           `json:"max_tokens"`
 }
 
 // ChatCompletionsResponse represents the response from chat completions API
@@ -88,9 +91,10 @@ func SendChatRequestWithRetryQuiet(t *testing.T, url string, modelName string, m
 
 func sendChatRequestWithRetry(t *testing.T, url string, modelName string, messages []ChatMessage, headers map[string]string, quiet bool) *ChatCompletionsResponse {
 	requestBody := ChatCompletionsRequest{
-		Model:    modelName,
-		Messages: messages,
-		Stream:   false,
+		Model:     modelName,
+		Messages:  messages,
+		Stream:    false,
+		MaxTokens: DefaultChatMaxTokens,
 	}
 
 	jsonData, err := json.Marshal(requestBody)
@@ -201,7 +205,12 @@ func CheckChatCompletionsQuiet(t *testing.T, modelName string, messages []ChatMe
 // Use before assertions when the router may need time to discover new models.
 func WaitForChatModelReady(t *testing.T, url, modelName string, messages []ChatMessage, timeout time.Duration) {
 	t.Helper()
-	requestBody := ChatCompletionsRequest{Model: modelName, Messages: messages, Stream: false}
+	requestBody := ChatCompletionsRequest{
+		Model:     modelName,
+		Messages:  messages,
+		Stream:    false,
+		MaxTokens: DefaultChatMaxTokens,
+	}
 	jsonData, err := json.Marshal(requestBody)
 	require.NoError(t, err)
 	client := &http.Client{Timeout: 30 * time.Second}
@@ -256,9 +265,10 @@ func SendChatRequest(t *testing.T, modelName string, messages []ChatMessage) *ht
 
 func SendChatRequestWithURL(t *testing.T, url string, modelName string, messages []ChatMessage) *http.Response {
 	requestBody := ChatCompletionsRequest{
-		Model:    modelName,
-		Messages: messages,
-		Stream:   false,
+		Model:     modelName,
+		Messages:  messages,
+		Stream:    false,
+		MaxTokens: DefaultChatMaxTokens,
 	}
 
 	jsonData, err := json.Marshal(requestBody)


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
part of https://github.com/volcano-sh/kthena/issues/849



**Special notes for your reviewer**:

https://github.com/FAUST-BENCHOU/dynamo/pull/1/changes#diff-cb5563796ecb666824d46b8e560bd843987cab634a0639296270de37a10dc018

mocker is here

use dynamo can better mock vllm's behavior.mocker is built based on `nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.0.1`


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
