### PR TITLE
change kthena installation command

### DIFF
--- a/docs/kthena/docs/getting-started/installation.md
+++ b/docs/kthena/docs/getting-started/installation.md
@@ -40,13 +40,13 @@ Kthena provides all necessary components in a single manifest file for easy inst
 1. **Apply the Kthena manifest:**
 
    ```bash
-   kubectl apply -f https://github.com/volcano-sh/kthena/releases/latest/download/kthena-install.yaml
+   kubectl apply --server-side -f https://github.com/volcano-sh/kthena/releases/latest/download/kthena-install.yaml
    ```
 
    To install a specific version, replace `latest` with the desired release tag (e.g., `v1.2.3`):
 
    ```bash
-   kubectl apply -f https://github.com/volcano-sh/kthena/releases/download/vX.Y.Z/kthena-install.yaml
+   kubectl apply --server-side -f https://github.com/volcano-sh/kthena/releases/download/vX.Y.Z/kthena-install.yaml
    ```
 
 ### Method 3: Helm Installation from GitHub Release Package


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation
<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:

During validation of release v0.4.0-rc.0, running 

```sh
kubectl apply -f https://github.com/volcano-sh/kthena/releases/v0.4.0-rc.0/download/kthena-install.yaml
```
results in an `The CustomResourceDefinition "modelservings.workload.serving.volcano.sh" is invalid: metadata.annotations: Too long: must have at most 262144 bytes` error. Switching to `kubectl create` resolves this issue.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
