### PR TITLE
add a debug port which can dump configuration of servingGroup and role

### DIFF
--- a/cmd/kthena-controller-manager/main.go
+++ b/cmd/kthena-controller-manager/main.go
@@ -82,6 +82,7 @@ func main() {
 		"named 'foo', '-foo' disables the controller named 'foo'.\nIf both '+foo' and '-foo' are set simultaneously, then controller named 'foo' will be enabled.\nAll controllers: 'modelserving', 'modelbooster', 'autoscaler'")
 	pflag.Float32Var(&cc.KubeAPIQPS, "kube-api-qps", 0, "QPS to use while talking with kubernetes apiserver. If 0, use default value.")
 	pflag.IntVar(&cc.KubeAPIBurst, "kube-api-burst", 0, "Burst to use while talking with kubernetes apiserver. If 0, use default value.")
+	pflag.IntVar(&cc.DebugPort, "debug-port", 0, "Port for debug server to dump internal cache. If 0, debug server is disabled.")
 	pflag.Parse()
 
 	cc.Controllers = parseControllers(controllers)

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -26,4 +26,3 @@ type Config struct {
 	KubeAPIBurst         int
 	DebugPort            int
 }
-

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -24,4 +24,6 @@ type Config struct {
 	Controllers          map[string]bool
 	KubeAPIQPS           float32
 	KubeAPIBurst         int
+	DebugPort            int
 }
+

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -128,14 +128,23 @@ func SetupController(ctx context.Context, cc Config) {
 			go func() {
 				debugMux := http.ServeMux{}
 				if msc != nil {
-					msc.RegisterDebugHandlers(&debugMux)
+					msc.RegisterModelServingDebugEndpoints(&debugMux)
 				}
 				debugAddr := fmt.Sprintf(":%d", cc.DebugPort)
 				klog.Infof("Starting debug server on %s", debugAddr)
-				server := &http.Server{Addr: debugAddr, Handler: &debugMux}
+				server := &http.Server{
+					Addr:              debugAddr,
+					Handler:           &debugMux,
+					ReadHeaderTimeout: 5 * time.Second,
+					ReadTimeout:       10 * time.Second,
+					WriteTimeout:      10 * time.Second,
+					IdleTimeout:       30 * time.Second,
+				}
 				go func() {
 					<-ctx.Done()
-					_ = server.Close()
+					shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+					defer cancel()
+					_ = server.Shutdown(shutdownCtx)
 				}()
 				if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 					klog.Errorf("Debug server failed: %v", err)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -18,6 +18,8 @@ package controller
 
 import (
 	"context"
+	"fmt"
+	"net/http"
 	"os"
 	"time"
 
@@ -120,6 +122,25 @@ func SetupController(ctx context.Context, cc Config) {
 		if ac != nil {
 			go ac.Run(ctx)
 			klog.Info("Autoscaler controller started")
+		}
+
+		if cc.DebugPort > 0 {
+			go func() {
+				debugMux := http.ServeMux{}
+				if msc != nil {
+					msc.RegisterDebugHandlers(&debugMux)
+				}
+				debugAddr := fmt.Sprintf(":%d", cc.DebugPort)
+				klog.Infof("Starting debug server on %s", debugAddr)
+				server := &http.Server{Addr: debugAddr, Handler: &debugMux}
+				go func() {
+					<-ctx.Done()
+					_ = server.Close()
+				}()
+				if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+					klog.Errorf("Debug server failed: %v", err)
+				}
+			}()
 		}
 	}
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -130,7 +130,8 @@ func SetupController(ctx context.Context, cc Config) {
 				if msc != nil {
 					msc.RegisterModelServingDebugEndpoints(&debugMux)
 				}
-				debugAddr := fmt.Sprintf(":%d", cc.DebugPort)
+				// Ensure the debug server is only accessible locally for security reasons
+				debugAddr := fmt.Sprintf("localhost:%d", cc.DebugPort)
 				klog.Infof("Starting debug server on %s", debugAddr)
 				server := &http.Server{
 					Addr:              debugAddr,

--- a/pkg/model-serving-controller/controller/model_serving_controller.go
+++ b/pkg/model-serving-controller/controller/model_serving_controller.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"reflect"
 	"slices"
 	"sync"
@@ -2413,4 +2414,22 @@ func (c *ModelServingController) findOutdatedRolesInServingGroups(ms *workloadv1
 	}
 
 	return outdatedRolesMap
+}
+
+// dumpCacheHandler handles requests to dump the datastore cache.
+func (c *ModelServingController) dumpCacheHandler(w http.ResponseWriter, r *http.Request) {
+	data := c.store.DumpCache()
+	if data == nil {
+		http.Error(w, "Failed to dump cache", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if _, err := w.Write(data); err != nil {
+		klog.Errorf("failed to write cache dump response: %v", err)
+	}
+}
+
+// RegisterDebugHandlers registers debug endpoints for the ModelServingController
+func (c *ModelServingController) RegisterDebugHandlers(mux *http.ServeMux) {
+	mux.HandleFunc("/debug/modelserving/cache", c.dumpCacheHandler)
 }

--- a/pkg/model-serving-controller/controller/model_serving_controller.go
+++ b/pkg/model-serving-controller/controller/model_serving_controller.go
@@ -2416,11 +2416,17 @@ func (c *ModelServingController) findOutdatedRolesInServingGroups(ms *workloadv1
 	return outdatedRolesMap
 }
 
-// dumpCacheHandler handles requests to dump the datastore cache.
-func (c *ModelServingController) dumpCacheHandler(w http.ResponseWriter, r *http.Request) {
-	data := c.store.DumpCache()
-	if data == nil {
-		http.Error(w, "Failed to dump cache", http.StatusInternalServerError)
+// handleModelServingDatastoreCacheDump handles requests to dump the ServingGroup and role in dataStore cache.
+func (c *ModelServingController) handleModelServingDatastoreCacheDump(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	data, err := c.store.DumpCache()
+	if err != nil {
+		klog.Errorf("failed to dump model serving datastore cache: %v", err)
+		http.Error(w, "Failed to dump datastore cache", http.StatusInternalServerError)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -2429,7 +2435,7 @@ func (c *ModelServingController) dumpCacheHandler(w http.ResponseWriter, r *http
 	}
 }
 
-// RegisterDebugHandlers registers debug endpoints for the ModelServingController
-func (c *ModelServingController) RegisterDebugHandlers(mux *http.ServeMux) {
-	mux.HandleFunc("/debug/modelserving/cache", c.dumpCacheHandler)
+// RegisterModelServingDebugEndpoints registers debug endpoints for the ModelServingController
+func (c *ModelServingController) RegisterModelServingDebugEndpoints(mux *http.ServeMux) {
+	mux.HandleFunc("/debug/modelserving/cache", c.handleModelServingDatastoreCacheDump)
 }

--- a/pkg/model-serving-controller/datastore/dump.go
+++ b/pkg/model-serving-controller/datastore/dump.go
@@ -18,8 +18,6 @@ package datastore
 
 import (
 	"encoding/json"
-
-	"k8s.io/klog/v2"
 )
 
 // ExportedRole is a DTO used exclusively for JSON serialization of the cache state.
@@ -34,19 +32,19 @@ type ExportedRole struct {
 // ExportedServingGroup is a DTO used exclusively for JSON serialization of the cache state.
 // It maps the internal non-exported fields (like runningPods and roles) to JSON serializable formats.
 type ExportedServingGroup struct {
-	Name        string                             `json:"name"`
-	RunningPods []string                           `json:"runningPods"`
-	Revision    string                             `json:"revision"`
-	Status      ServingGroupStatus                 `json:"status"`
-	Roles       map[string]map[string]ExportedRole `json:"roles"`
+	Name        string             `json:"name"`
+	RunningPods []string           `json:"runningPods"`
+	Revision    string             `json:"revision"`
+	Status      ServingGroupStatus `json:"status"`
+	// Roles maps role name -> role ID -> ExportedRole
+	Roles map[string]map[string]ExportedRole `json:"roles"`
 }
 
 // DumpCache returns a JSON dump of the current store cache representation
-func (s *store) DumpCache() []byte {
-	s.mutex.RLock()
-	defer s.mutex.RUnlock()
-
+func (s *store) DumpCache() ([]byte, error) {
 	exportedCache := make(map[string]map[string]ExportedServingGroup)
+
+	s.mutex.RLock()
 	for msName, groups := range s.servingGroup {
 		msKey := msName.String()
 		exportedCache[msKey] = make(map[string]ExportedServingGroup)
@@ -75,11 +73,11 @@ func (s *store) DumpCache() []byte {
 			exportedCache[msKey][groupName] = expGroup
 		}
 	}
+	s.mutex.RUnlock()
 
 	data, err := json.Marshal(exportedCache)
 	if err != nil {
-		klog.Errorf("failed to marshal cache: %v", err)
-		return nil
+		return nil, err
 	}
-	return data
+	return data, nil
 }

--- a/pkg/model-serving-controller/datastore/dump.go
+++ b/pkg/model-serving-controller/datastore/dump.go
@@ -1,0 +1,85 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package datastore
+
+import (
+	"encoding/json"
+
+	"k8s.io/klog/v2"
+)
+
+// ExportedRole is a DTO used exclusively for JSON serialization of the cache state.
+// It allows us to safely export unexported inner structures without exposing internal lock mechanics.
+type ExportedRole struct {
+	Name             string     `json:"name"`
+	Revision         string     `json:"revision"`
+	RoleTemplateHash string     `json:"roleTemplateHash"`
+	Status           RoleStatus `json:"status"`
+}
+
+// ExportedServingGroup is a DTO used exclusively for JSON serialization of the cache state.
+// It maps the internal non-exported fields (like runningPods and roles) to JSON serializable formats.
+type ExportedServingGroup struct {
+	Name        string                             `json:"name"`
+	RunningPods []string                           `json:"runningPods"`
+	Revision    string                             `json:"revision"`
+	Status      ServingGroupStatus                 `json:"status"`
+	Roles       map[string]map[string]ExportedRole `json:"roles"`
+}
+
+// DumpCache returns a JSON dump of the current store cache representation
+func (s *store) DumpCache() []byte {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	exportedCache := make(map[string]map[string]ExportedServingGroup)
+	for msName, groups := range s.servingGroup {
+		msKey := msName.String()
+		exportedCache[msKey] = make(map[string]ExportedServingGroup)
+		for groupName, group := range groups {
+			expGroup := ExportedServingGroup{
+				Name:        group.Name,
+				Revision:    group.Revision,
+				Status:      group.Status,
+				RunningPods: make([]string, 0, len(group.runningPods)),
+				Roles:       make(map[string]map[string]ExportedRole),
+			}
+			for pod := range group.runningPods {
+				expGroup.RunningPods = append(expGroup.RunningPods, pod)
+			}
+			for roleName, roleMap := range group.roles {
+				expGroup.Roles[roleName] = make(map[string]ExportedRole)
+				for roleID, role := range roleMap {
+					expGroup.Roles[roleName][roleID] = ExportedRole{
+						Name:             role.Name,
+						Revision:         role.Revision,
+						RoleTemplateHash: role.RoleTemplateHash,
+						Status:           role.Status,
+					}
+				}
+			}
+			exportedCache[msKey][groupName] = expGroup
+		}
+	}
+
+	data, err := json.Marshal(exportedCache)
+	if err != nil {
+		klog.Errorf("failed to marshal cache: %v", err)
+		return nil
+	}
+	return data
+}

--- a/pkg/model-serving-controller/datastore/dump_test.go
+++ b/pkg/model-serving-controller/datastore/dump_test.go
@@ -1,0 +1,100 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package datastore
+
+import (
+	"encoding/json"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestStore_DumpCache(t *testing.T) {
+	s := New()
+
+	msName := types.NamespacedName{Namespace: "default", Name: "test-ms"}
+	groupName := "test-ms-0"
+	revision := "rev-1"
+	roleName := "worker"
+	roleID := "worker-0"
+	roleTemplateHash := "hash-1"
+	podName := "pod-1"
+
+	s.AddServingGroup(msName, 0, revision)
+	s.AddRole(msName, groupName, roleName, roleID, revision, roleTemplateHash)
+	s.AddRunningPodToServingGroup(msName, groupName, podName, revision, roleTemplateHash, roleName, roleID)
+
+	data := s.DumpCache()
+	if data == nil {
+		t.Fatalf("DumpCache returned nil")
+	}
+
+	var cache map[string]map[string]ExportedServingGroup
+	err := json.Unmarshal(data, &cache)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal cache data: %v", err)
+	}
+
+	msKey := msName.String()
+	groups, ok := cache[msKey]
+	if !ok {
+		t.Fatalf("Expected model serving %s in cache", msKey)
+	}
+
+	group, ok := groups[groupName]
+	if !ok {
+		t.Fatalf("Expected serving group %s in cache", groupName)
+	}
+
+	if group.Name != groupName {
+		t.Errorf("Expected group name %s, got %s", groupName, group.Name)
+	}
+	if group.Revision != revision {
+		t.Errorf("Expected group revision %s, got %s", revision, group.Revision)
+	}
+
+	foundPod := false
+	for _, p := range group.RunningPods {
+		if p == podName {
+			foundPod = true
+			break
+		}
+	}
+	if !foundPod {
+		t.Errorf("Expected running pod %s in group cache", podName)
+	}
+
+	rolesMap, ok := group.Roles[roleName]
+	if !ok {
+		t.Fatalf("Expected role %s in group roles", roleName)
+	}
+
+	role, ok := rolesMap[roleID]
+	if !ok {
+		t.Fatalf("Expected role ID %s in map", roleID)
+	}
+
+	if role.Name != roleID {
+		t.Errorf("Expected role name %s, got %s", roleID, role.Name)
+	}
+	if role.Revision != revision {
+		t.Errorf("Expected role revision %s, got %s", revision, role.Revision)
+	}
+	if role.RoleTemplateHash != roleTemplateHash {
+		t.Errorf("Expected role hash %s, got %s", roleTemplateHash, role.RoleTemplateHash)
+	}
+}

--- a/pkg/model-serving-controller/datastore/dump_test.go
+++ b/pkg/model-serving-controller/datastore/dump_test.go
@@ -38,13 +38,16 @@ func TestStore_DumpCache(t *testing.T) {
 	s.AddRole(msName, groupName, roleName, roleID, revision, roleTemplateHash)
 	s.AddRunningPodToServingGroup(msName, groupName, podName, revision, roleTemplateHash, roleName, roleID)
 
-	data := s.DumpCache()
+	data, err := s.DumpCache()
+	if err != nil {
+		t.Fatalf("DumpCache returned error: %v", err)
+	}
 	if data == nil {
 		t.Fatalf("DumpCache returned nil")
 	}
 
 	var cache map[string]map[string]ExportedServingGroup
-	err := json.Unmarshal(data, &cache)
+	err = json.Unmarshal(data, &cache)
 	if err != nil {
 		t.Fatalf("Failed to unmarshal cache data: %v", err)
 	}

--- a/pkg/model-serving-controller/datastore/store.go
+++ b/pkg/model-serving-controller/datastore/store.go
@@ -49,6 +49,8 @@ type Store interface {
 	DeleteRunningPodFromServingGroup(modelServingName types.NamespacedName, groupName string, pod string)
 	UpdateServingGroupStatus(modelServingName types.NamespacedName, groupName string, Status ServingGroupStatus) error
 	UpdateServingGroupRevision(modelServingName types.NamespacedName, groupName string, revision string) error
+	// DumpCache returns a JSON dump of the current store cache representation, which is useful for debugging and monitoring purposes. The structure of the JSON will be a map of modelServing names to their ServingGroups, and each ServingGroup will include its roles and running pods.
+	DumpCache() []byte
 }
 
 type store struct {
@@ -503,3 +505,4 @@ func (s *store) UpdateServingGroupRevision(modelServingName types.NamespacedName
 	}
 	return nil
 }
+

--- a/pkg/model-serving-controller/datastore/store.go
+++ b/pkg/model-serving-controller/datastore/store.go
@@ -50,7 +50,7 @@ type Store interface {
 	UpdateServingGroupStatus(modelServingName types.NamespacedName, groupName string, Status ServingGroupStatus) error
 	UpdateServingGroupRevision(modelServingName types.NamespacedName, groupName string, revision string) error
 	// DumpCache returns a JSON dump of the current store cache representation, which is useful for debugging and monitoring purposes. The structure of the JSON will be a map of modelServing names to their ServingGroups, and each ServingGroup will include its roles and running pods.
-	DumpCache() []byte
+	DumpCache() ([]byte, error)
 }
 
 type store struct {
@@ -505,4 +505,3 @@ func (s *store) UpdateServingGroupRevision(modelServingName types.NamespacedName
 	}
 	return nil
 }
-


### PR DESCRIPTION
**What type of PR is this?**
/kind enhancement
<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:

modelServing uses a cache to store the configurations of ServingGroups and Roles, thereby reducing the load on the kube-apiserver. However, this approach lacks observability regarding the status of ServingGroups and Roles.

Therefore, a debug port has been added in this PR to enable the dumping of configurations from the dataStore. This enhances Kthena’s observability.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
