### PR TITLE
change AutoscalingPolicyBinding minReplicas minimum from 0 to 1

### DIFF
--- a/charts/kthena/charts/workload/crds/workload.serving.volcano.sh_autoscalingpolicybindings.yaml
+++ b/charts/kthena/charts/workload/crds/workload.serving.volcano.sh_autoscalingpolicybindings.yaml
@@ -235,7 +235,7 @@ spec:
                       to maintain.
                     format: int32
                     maximum: 1000000
-                    minimum: 0
+                    minimum: 1
                     type: integer
                   target:
                     description: Target defines the object to be monitored and scaled.

--- a/docs/kthena/docs/reference/crd/workload.serving.volcano.sh.md
+++ b/docs/kthena/docs/reference/crd/workload.serving.volcano.sh.md
@@ -311,7 +311,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `target` _[Target](#target)_ | Target defines the object to be monitored and scaled. |  |  |
-| `minReplicas` _integer_ | MinReplicas defines the minimum number of replicas to maintain. |  | Maximum: 1e+06 <br />Minimum: 0 <br /> |
+| `minReplicas` _integer_ | MinReplicas defines the minimum number of replicas to maintain. |  | Maximum: 1e+06 <br />Minimum: 1 <br /> |
 | `maxReplicas` _integer_ | MaxReplicas defines the maximum number of replicas allowed. |  | Maximum: 1e+06 <br />Minimum: 1 <br /> |
 
 

--- a/pkg/apis/workload/v1alpha1/autoscalingpolicybinding_types.go
+++ b/pkg/apis/workload/v1alpha1/autoscalingpolicybinding_types.go
@@ -63,7 +63,7 @@ type HomogeneousTarget struct {
 	// Target defines the object to be monitored and scaled.
 	Target Target `json:"target,omitempty"`
 	// MinReplicas defines the minimum number of replicas to maintain.
-	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Maximum=1000000
 	MinReplicas int32 `json:"minReplicas"`
 	// MaxReplicas defines the maximum number of replicas allowed.


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:
1. [User Guide: Kthena Autoscaler](https://kthena.volcano.sh/docs/next/user-guide/autoscaler)
show: 
https://github.com/volcano-sh/kthena/blob/26678dab939a64479dc044cf9e3a32a40a1674d8/docs/kthena/docs/user-guide/autoscaler.md?plain=1#L82-L83

2. When `minReplicas=0`, workloads scale down to 0 and cannot auto-scale back up - no running pods mean no metrics collection, so autoscaler always skips recommendation calculation, requires manual intervention to restore. controller logs always show `pod list is null` and `skip recommended instances`
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
change AutoscalingPolicyBinding minReplicas minimum from 0 to 1
```
