### PR TITLE
feat(router): support scale-from-zero for zero-replica model serving

### DIFF
--- a/charts/kthena/charts/networking/templates/kthena-router/rbac/cluster-role.yaml
+++ b/charts/kthena/charts/networking/templates/kthena-router/rbac/cluster-role.yaml
@@ -95,6 +95,22 @@ rules:
       - update
   {{- end }}
   - apiGroups:
+      - workload.serving.volcano.sh
+    resources:
+      - modelservings
+    verbs:
+      - get
+      - list
+      - patch
+  - apiGroups:
+      - workload.serving.volcano.sh
+    resources:
+      - autoscalingpolicybindings
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - ""
     resources:
       - services

--- a/cmd/kthena-router/app/controller.go
+++ b/cmd/kthena-router/app/controller.go
@@ -40,6 +40,7 @@ import (
 	kthenaInformers "github.com/volcano-sh/kthena/client-go/informers/externalversions"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/controller"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/datastore"
+	"github.com/volcano-sh/kthena/pkg/kthena-router/scalefromzero"
 )
 
 type Controller interface {
@@ -52,7 +53,7 @@ type aggregatedController struct {
 
 var _ Controller = &aggregatedController{}
 
-func startControllers(store datastore.Store, stop <-chan struct{}, enableGatewayAPI bool, defaultPort string, enableGatewayAPIInferenceExtension bool, kubeAPIQPS float32, kubeAPIBurst int) Controller {
+func startControllers(store datastore.Store, stop <-chan struct{}, enableGatewayAPI bool, defaultPort string, enableGatewayAPIInferenceExtension bool, kubeAPIQPS float32, kubeAPIBurst int) (Controller, *scalefromzero.Manager) {
 	cfg, err := clientcmd.BuildConfigFromFlags("", "")
 	if err != nil {
 		klog.Fatalf("Error building kubeconfig: %s", err.Error())
@@ -78,13 +79,17 @@ func startControllers(store datastore.Store, stop <-chan struct{}, enableGateway
 	kubeInformerFactory := informers.NewSharedInformerFactory(kubeClient, 0)
 	kthenaInformerFactory := kthenaInformers.NewSharedInformerFactory(kthenaClient, 0)
 
+	bindingInformer := kthenaInformerFactory.Workload().V1alpha1().AutoscalingPolicyBindings()
+	sfzManager := scalefromzero.NewManager(kthenaClient, bindingInformer.Lister())
+
 	modelRouteController := controller.NewModelRouteController(kthenaInformerFactory, store)
-	modelServerController := controller.NewModelServerController(kthenaInformerFactory, kubeInformerFactory, store)
+	modelServerController := controller.NewModelServerController(kthenaInformerFactory, kubeInformerFactory, store, sfzManager)
 
 	cacheSyncs := []cache.InformerSynced{
 		kthenaInformerFactory.Networking().V1alpha1().ModelRoutes().Informer().HasSynced,
 		kthenaInformerFactory.Networking().V1alpha1().ModelServers().Informer().HasSynced,
 		kubeInformerFactory.Core().V1().Pods().Informer().HasSynced,
+		bindingInformer.Informer().HasSynced,
 	}
 
 	var gatewayInformerFactory gatewayinformers.SharedInformerFactory
@@ -138,6 +143,8 @@ func startControllers(store datastore.Store, stop <-chan struct{}, enableGateway
 		klog.Fatalf("Failed to sync informer caches")
 	}
 
+	sfzManager.RefreshBindingCache()
+
 	controllers := []Controller{modelRouteController, modelServerController}
 
 	go func() {
@@ -180,7 +187,7 @@ func startControllers(store datastore.Store, stop <-chan struct{}, enableGateway
 
 	return &aggregatedController{
 		controllers: controllers,
-	}
+	}, sfzManager
 }
 
 func (c *aggregatedController) HasSynced() bool {

--- a/cmd/kthena-router/app/server.go
+++ b/cmd/kthena-router/app/server.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/volcano-sh/kthena/pkg/kthena-router/datastore"
+	"github.com/volcano-sh/kthena/pkg/kthena-router/scalefromzero"
 )
 
 type Server struct {
@@ -63,7 +64,12 @@ func (s *Server) Run(ctx context.Context) {
 	// must be run before the controller, because it will register callbacks
 	r := NewRouter(store)
 	// start controller
-	s.controllers = startControllers(store, ctx.Done(), s.EnableGatewayAPI, s.Port, s.EnableGatewayAPIInferenceExtension, s.KubeAPIQPS, s.KubeAPIBurst)
+	var sfzManager *scalefromzero.Manager
+	s.controllers, sfzManager = startControllers(store, ctx.Done(), s.EnableGatewayAPI, s.Port, s.EnableGatewayAPIInferenceExtension, s.KubeAPIQPS, s.KubeAPIBurst)
+
+	if sfzManager != nil {
+		r.SetScaleFromZeroManager(sfzManager)
+	}
 
 	// Start store's periodic update loop after controllers have synced
 	if !cache.WaitForCacheSync(ctx.Done(), s.controllers.HasSynced) {

--- a/pkg/kthena-router/controller/modelserver_controller.go
+++ b/pkg/kthena-router/controller/modelserver_controller.go
@@ -39,6 +39,7 @@ import (
 	listerv1alpha1 "github.com/volcano-sh/kthena/client-go/listers/networking/v1alpha1"
 	aiv1alpha1 "github.com/volcano-sh/kthena/pkg/apis/networking/v1alpha1"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/datastore"
+	"github.com/volcano-sh/kthena/pkg/kthena-router/scalefromzero"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/utils"
 )
 
@@ -70,12 +71,14 @@ type ModelServerController struct {
 	workqueue   workqueue.TypedRateLimitingInterface[QueueItem]
 	initialSync *atomic.Bool
 	store       datastore.Store
+	sfzManager  *scalefromzero.Manager
 }
 
 func NewModelServerController(
 	kthenaInformerFactory informersv1alpha1.SharedInformerFactory,
 	kubeInformerFactory informers.SharedInformerFactory,
 	store datastore.Store,
+	sfzManager *scalefromzero.Manager,
 ) *ModelServerController {
 	modelServerInformer := kthenaInformerFactory.Networking().V1alpha1().ModelServers()
 	podInformer := kubeInformerFactory.Core().V1().Pods()
@@ -88,6 +91,7 @@ func NewModelServerController(
 		workqueue:         workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[QueueItem]()),
 		initialSync:       &atomic.Bool{},
 		store:             store,
+		sfzManager:        sfzManager,
 	}
 
 	// Register ModelServer event handlers
@@ -185,6 +189,9 @@ func (c *ModelServerController) syncModelServerHandler(key string) error {
 	ms, err := c.modelServerLister.ModelServers(namespace).Get(name)
 	if errors.IsNotFound(err) {
 		_ = c.store.DeleteModelServer(types.NamespacedName{Namespace: namespace, Name: name})
+		if c.sfzManager != nil {
+			c.sfzManager.DeleteModelServerMapping(namespace, name)
+		}
 		return nil
 	}
 	if err != nil {
@@ -243,6 +250,42 @@ func (c *ModelServerController) syncModelServerHandler(key string) error {
 
 		if err := c.store.AddOrUpdatePod(pod, []*aiv1alpha1.ModelServer{ms}); err != nil {
 			klog.Warningf("failed to add new pod %s/%s to data store: %v", pod.Namespace, pod.Name, err)
+		}
+	}
+
+	if c.sfzManager != nil {
+		modelServingName := ""
+		if ms.Spec.WorkloadSelector != nil && ms.Spec.WorkloadSelector.MatchLabels != nil {
+			modelServingName = ms.Spec.WorkloadSelector.MatchLabels["modelserving.volcano.sh/name"]
+		}
+
+		for _, pod := range podList {
+			if !isPodReady(pod) {
+				continue
+			}
+			if name, ok := pod.Labels["modelserving.volcano.sh/name"]; ok {
+				modelServingName = name
+				break
+			}
+		}
+
+		if modelServingName != "" {
+			c.sfzManager.SetModelServerMapping(namespace, name, modelServingName)
+		}
+
+		if len(podList) > 0 {
+			readyPods := make([]*datastore.PodInfo, 0, len(podList))
+			for _, pod := range podList {
+				if isPodReady(pod) {
+					podInfo := c.store.GetPodInfo(utils.GetNamespaceName(pod))
+					if podInfo != nil {
+						readyPods = append(readyPods, podInfo)
+					}
+				}
+			}
+			if len(readyPods) > 0 {
+				c.sfzManager.OnPodsAvailable(namespace, name, readyPods, ms)
+			}
 		}
 	}
 

--- a/pkg/kthena-router/controller/modelserver_controller_test.go
+++ b/pkg/kthena-router/controller/modelserver_controller_test.go
@@ -74,6 +74,7 @@ func TestModelServerController_ModelServerLifecycle(t *testing.T) {
 		kthenaInformerFactory,
 		kubeInformerFactory,
 		store,
+		nil,
 	)
 	modelServerIndexer := kthenaInformerFactory.Networking().V1alpha1().ModelServers().Informer().GetIndexer()
 
@@ -275,6 +276,7 @@ func TestModelServerController_PodLifecycle(t *testing.T) {
 		kthenaInformerFactory,
 		kubeInformerFactory,
 		store,
+		nil,
 	)
 
 	stop := make(chan struct{})
@@ -491,6 +493,7 @@ func TestModelServerController_ErrorHandling(t *testing.T) {
 		kthenaInformerFactory,
 		kubeInformerFactory,
 		store,
+		nil,
 	)
 
 	// Test Case 1: Invalid ModelServer Key
@@ -535,6 +538,7 @@ func TestModelServerController_WorkQueueProcessing(t *testing.T) {
 		kthenaInformerFactory,
 		kubeInformerFactory,
 		store,
+		nil,
 	)
 
 	// Test Case 1: Initial Sync Signal
@@ -610,6 +614,7 @@ func TestModelServerController_PodSelectionLogic(t *testing.T) {
 		kthenaInformerFactory,
 		kubeInformerFactory,
 		store,
+		nil,
 	)
 
 	stop := make(chan struct{})
@@ -798,6 +803,7 @@ func TestModelServerController_ComprehensiveLifecycleTest(t *testing.T) {
 		kthenaInformerFactory,
 		kubeInformerFactory,
 		store,
+		nil,
 	)
 
 	kthenaInformerFactory.Start(stopCh)
@@ -974,6 +980,7 @@ func TestModelServerController_SharedPods(t *testing.T) {
 		kthenaInformerFactory,
 		kubeInformerFactory,
 		store,
+		nil,
 	)
 
 	stop := make(chan struct{})

--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -48,6 +48,7 @@ import (
 	"github.com/volcano-sh/kthena/pkg/kthena-router/filters/tokenizer"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/handlers"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/metrics"
+	"github.com/volcano-sh/kthena/pkg/kthena-router/scalefromzero"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/scheduler"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/scheduler/framework"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/scheduler/plugins/conf"
@@ -86,6 +87,8 @@ type Router struct {
 	fairnessTimeout  time.Duration
 	tokenWeight      float64 // Weight for token-based priority (default 1.0)
 	requestNumWeight float64 // Weight for request-count-based priority (default 0.0)
+
+	sfzManager *scalefromzero.Manager
 }
 
 func NewRouter(store datastore.Store, routerConfigPath string) *Router {
@@ -169,6 +172,11 @@ func NewRouter(store datastore.Store, routerConfigPath string) *Router {
 }
 
 const defaultFairnessTimeout = 60 * time.Second
+
+// SetScaleFromZeroManager sets the scale-from-zero manager for the router.
+func (r *Router) SetScaleFromZeroManager(m *scalefromzero.Manager) {
+	r.sfzManager = m
+}
 
 func parseFairnessTimeout() time.Duration {
 	if s, ok := os.LookupEnv("FAIRNESS_QUEUE_TIMEOUT"); ok {
@@ -350,10 +358,29 @@ func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest) {
 
 		pods, modelServer, err = r.getPodsAndServer(modelServerName)
 		if err != nil || len(pods) == 0 {
-			klog.Errorf("failed to get pods and model server: %v, %v", modelServerName, err)
-			accesslog.SetError(c, "pod_discovery", fmt.Sprintf("can't find model server: %v", modelServerName))
-			c.AbortWithStatusJSON(http.StatusNotFound, fmt.Sprintf("can't find model server: %v", modelServerName))
-			return
+			if r.sfzManager != nil && r.sfzManager.Enabled() {
+				pods, modelServer, err = r.sfzManager.Handle(c.Request.Context(), modelServerName.Namespace, modelServerName.Name)
+				if err != nil {
+					if errors.Is(err, scalefromzero.ErrNotConfigured) {
+						msg := fmt.Sprintf("can't find model server: %v", modelServerName)
+						klog.Error(msg)
+						accesslog.SetError(c, "pod_discovery", msg)
+						c.AbortWithStatusJSON(http.StatusNotFound, msg)
+						return
+					}
+					msg := fmt.Sprintf("scale from zero timeout: %v", modelServerName)
+					klog.Errorf("scale-from-zero timeout: %v", err)
+					accesslog.SetError(c, "scale_from_zero", msg)
+					c.AbortWithStatusJSON(http.StatusGatewayTimeout, msg)
+					return
+				}
+			} else {
+				msg := fmt.Sprintf("can't find model server: %v", modelServerName)
+				klog.Error(msg)
+				accesslog.SetError(c, "pod_discovery", msg)
+				c.AbortWithStatusJSON(http.StatusNotFound, msg)
+				return
+			}
 		}
 
 		model := modelServer.Spec.Model

--- a/pkg/kthena-router/scalefromzero/manager.go
+++ b/pkg/kthena-router/scalefromzero/manager.go
@@ -1,0 +1,373 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scalefromzero
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+
+	clientset "github.com/volcano-sh/kthena/client-go/clientset/versioned"
+	listerv1alpha1 "github.com/volcano-sh/kthena/client-go/listers/workload/v1alpha1"
+	networkingv1alpha1 "github.com/volcano-sh/kthena/pkg/apis/networking/v1alpha1"
+	"github.com/volcano-sh/kthena/pkg/kthena-router/datastore"
+)
+
+var (
+	ErrNotConfigured = errors.New("scale from zero not configured for this model server")
+	ErrNotEnabled    = errors.New("scale from zero is disabled")
+	ErrTimeout       = errors.New("scale from zero timeout")
+	ErrTriggerFailed = errors.New("failed to trigger scale from zero")
+)
+
+const (
+	defaultScaleFromZeroTimeout = 5 * time.Minute
+	defaultBindingCacheTTL      = 2 * time.Minute
+)
+
+// Manager handles scale-from-zero for ModelServers that have zero pods.
+type Manager struct {
+	enabled bool
+
+	kubeClient    clientset.Interface
+	bindingLister listerv1alpha1.AutoscalingPolicyBindingLister
+
+	// Runtime mapping: ModelServer key ("namespace/name") -> ModelServing key ("namespace/name")
+	mu           sync.RWMutex
+	servingForMS map[string]string
+
+	// Binding existence cache: ModelServing key ("namespace/name") -> has binding
+	bindingMu       sync.RWMutex
+	bindingCache    map[string]bool
+	bindingCacheTTL time.Duration
+	bindingRefresh  time.Time
+
+	// Pending waits for scale-from-zero
+	pendingMu sync.Mutex
+	pending   map[string]*pendingWait
+
+	timeout time.Duration
+	stopCh  chan struct{}
+}
+
+type pendingWait struct {
+	triggered  bool
+	resultChan chan *waitResult
+}
+
+type waitResult struct {
+	pods        []*datastore.PodInfo
+	modelServer *networkingv1alpha1.ModelServer
+	err         error
+}
+
+// NewManager creates a new scale-from-zero manager.
+func NewManager(
+	kubeClient clientset.Interface,
+	bindingLister listerv1alpha1.AutoscalingPolicyBindingLister,
+) *Manager {
+	enabled := getEnvBool("ENABLE_SCALE_FROM_ZERO", false)
+	timeout := parseDurationEnv("SCALE_FROM_ZERO_TIMEOUT", defaultScaleFromZeroTimeout)
+
+	m := &Manager{
+		enabled:         enabled,
+		kubeClient:      kubeClient,
+		bindingLister:   bindingLister,
+		servingForMS:    make(map[string]string),
+		bindingCache:    make(map[string]bool),
+		bindingCacheTTL: defaultBindingCacheTTL,
+		pending:         make(map[string]*pendingWait),
+		timeout:         timeout,
+		stopCh:          make(chan struct{}),
+	}
+
+	if enabled && bindingLister != nil {
+		// Initial cache load
+		_ = m.refreshBindingCache()
+		// Start periodic refresher
+		go m.bindingCacheRefresher()
+	}
+
+	return m
+}
+
+// Enabled returns whether scale-from-zero is enabled.
+func (m *Manager) Enabled() bool {
+	return m.enabled
+}
+
+// Handle triggers scale-from-zero for the given ModelServer and waits for pods to become available.
+func (m *Manager) Handle(ctx context.Context, namespace, modelServerName string) ([]*datastore.PodInfo, *networkingv1alpha1.ModelServer, error) {
+	if !m.enabled {
+		return nil, nil, ErrNotEnabled
+	}
+
+	msKey := fmt.Sprintf("%s/%s", namespace, modelServerName)
+
+	m.mu.RLock()
+	servingKey, exists := m.servingForMS[msKey]
+	m.mu.RUnlock()
+	if !exists {
+		return nil, nil, ErrNotConfigured
+	}
+
+	if !m.hasAutoscalingPolicy(servingKey) {
+		return nil, nil, ErrNotConfigured
+	}
+
+	m.pendingMu.Lock()
+	pw, exists := m.pending[msKey]
+	if !exists {
+		pw = &pendingWait{resultChan: make(chan *waitResult, 1)}
+		m.pending[msKey] = pw
+	}
+	if !pw.triggered {
+		pw.triggered = true
+		go m.triggerScaleUp(servingKey, msKey)
+	}
+	m.pendingMu.Unlock()
+
+	waitCtx, cancel := context.WithTimeout(ctx, m.timeout)
+	defer cancel()
+
+	select {
+	case result := <-pw.resultChan:
+		if result.err != nil {
+			return nil, nil, result.err
+		}
+		return result.pods, result.modelServer, nil
+	case <-waitCtx.Done():
+		m.pendingMu.Lock()
+		delete(m.pending, msKey)
+		m.pendingMu.Unlock()
+		return nil, nil, ErrTimeout
+	}
+}
+
+// SetModelServerMapping maps a ModelServer to its parent ModelServing.
+func (m *Manager) SetModelServerMapping(namespace, modelServerName, modelServingName string) {
+	if !m.enabled {
+		return
+	}
+	msKey := fmt.Sprintf("%s/%s", namespace, modelServerName)
+	servingKey := fmt.Sprintf("%s/%s", namespace, modelServingName)
+
+	m.mu.Lock()
+	m.servingForMS[msKey] = servingKey
+	m.mu.Unlock()
+}
+
+// DeleteModelServerMapping removes the mapping for a deleted ModelServer.
+func (m *Manager) DeleteModelServerMapping(namespace, modelServerName string) {
+	if !m.enabled {
+		return
+	}
+	msKey := fmt.Sprintf("%s/%s", namespace, modelServerName)
+
+	m.mu.Lock()
+	delete(m.servingForMS, msKey)
+	m.mu.Unlock()
+
+	m.pendingMu.Lock()
+	delete(m.pending, msKey)
+	m.pendingMu.Unlock()
+}
+
+// OnPodsAvailable wakes pending waiters when pods become available.
+func (m *Manager) OnPodsAvailable(namespace, modelServerName string, pods []*datastore.PodInfo, modelServer *networkingv1alpha1.ModelServer) {
+	if !m.enabled {
+		return
+	}
+	msKey := fmt.Sprintf("%s/%s", namespace, modelServerName)
+
+	m.pendingMu.Lock()
+	pw, exists := m.pending[msKey]
+	if exists {
+		delete(m.pending, msKey)
+	}
+	m.pendingMu.Unlock()
+
+	if exists && pw != nil {
+		select {
+		case pw.resultChan <- &waitResult{pods: pods, modelServer: modelServer}:
+		default:
+		}
+	}
+}
+
+// RefreshBindingCache forces a refresh of the binding cache.
+func (m *Manager) RefreshBindingCache() {
+	_ = m.refreshBindingCache()
+}
+
+// Stop stops the manager's background goroutines.
+func (m *Manager) Stop() {
+	close(m.stopCh)
+}
+
+func (m *Manager) triggerScaleUp(servingKey, msKey string) {
+	servingNamespace, servingName, ok := strings.Cut(servingKey, "/")
+	if !ok {
+		klog.Errorf("invalid serving key: %s", servingKey)
+		m.notifyError(msKey, ErrTriggerFailed)
+		return
+	}
+
+	patch := map[string]any{
+		"spec": map[string]any{
+			"replicas": 1,
+		},
+	}
+	patchBytes, err := json.Marshal(patch)
+	if err != nil {
+		klog.Errorf("failed to marshal scale-up patch for %s: %v", servingKey, err)
+		m.notifyError(msKey, ErrTriggerFailed)
+		return
+	}
+
+	klog.Infof("scale-from-zero: patching %s/%s to replicas=1 (triggered by %s)", servingNamespace, servingName, msKey)
+
+	_, err = m.kubeClient.WorkloadV1alpha1().ModelServings(servingNamespace).Patch(
+		context.Background(), servingName, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+	if err != nil {
+		klog.Errorf("scale-from-zero: patch failed %s/%s: %v", servingNamespace, servingName, err)
+		m.notifyError(msKey, ErrTriggerFailed)
+		return
+	}
+
+	klog.Infof("scale-from-zero: patched %s/%s to replicas=1", servingNamespace, servingName)
+}
+
+func (m *Manager) notifyError(msKey string, err error) {
+	m.pendingMu.Lock()
+	pw, exists := m.pending[msKey]
+	if exists {
+		delete(m.pending, msKey)
+	}
+	m.pendingMu.Unlock()
+
+	if exists && pw != nil {
+		select {
+		case pw.resultChan <- &waitResult{err: err}:
+		default:
+		}
+	}
+}
+
+func (m *Manager) hasAutoscalingPolicy(servingKey string) bool {
+	m.bindingMu.RLock()
+	cached, exists := m.bindingCache[servingKey]
+	cacheValid := exists && time.Since(m.bindingRefresh) < m.bindingCacheTTL
+	m.bindingMu.RUnlock()
+
+	if cacheValid {
+		return cached
+	}
+
+	_ = m.refreshBindingCache()
+
+	m.bindingMu.RLock()
+	cached, exists = m.bindingCache[servingKey]
+	m.bindingMu.RUnlock()
+
+	return exists && cached
+}
+
+func (m *Manager) refreshBindingCache() error {
+	if m.bindingLister == nil {
+		return nil
+	}
+
+	bindings, err := m.bindingLister.List(labels.Everything())
+	if err != nil {
+		klog.Warningf("failed to list AutoscalingPolicyBindings: %v", err)
+		return err
+	}
+
+	newCache := make(map[string]bool)
+	for _, binding := range bindings {
+		if binding.Spec.HomogeneousTarget != nil {
+			ref := binding.Spec.HomogeneousTarget.Target.TargetRef
+			ns := ref.Namespace
+			if ns == "" {
+				ns = binding.Namespace
+			}
+			key := fmt.Sprintf("%s/%s", ns, ref.Name)
+			newCache[key] = true
+		}
+		if binding.Spec.HeterogeneousTarget != nil {
+			for _, param := range binding.Spec.HeterogeneousTarget.Params {
+				ref := param.Target.TargetRef
+				ns := ref.Namespace
+				if ns == "" {
+					ns = binding.Namespace
+				}
+				key := fmt.Sprintf("%s/%s", ns, ref.Name)
+				newCache[key] = true
+			}
+		}
+	}
+
+	m.bindingMu.Lock()
+	m.bindingCache = newCache
+	m.bindingRefresh = time.Now()
+	m.bindingMu.Unlock()
+
+	return nil
+}
+
+func (m *Manager) bindingCacheRefresher() {
+	ticker := time.NewTicker(m.bindingCacheTTL)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			_ = m.refreshBindingCache()
+		case <-m.stopCh:
+			return
+		}
+	}
+}
+
+func getEnvBool(key string, fallback bool) bool {
+	if value, ok := os.LookupEnv(key); ok {
+		if boolValue, err := strconv.ParseBool(value); err == nil {
+			return boolValue
+		}
+	}
+	return fallback
+}
+
+func parseDurationEnv(key string, fallback time.Duration) time.Duration {
+	if s, ok := os.LookupEnv(key); ok {
+		if d, err := time.ParseDuration(s); err == nil && d > 0 {
+			return d
+		}
+	}
+	return fallback
+}

--- a/pkg/kthena-router/scalefromzero/manager_test.go
+++ b/pkg/kthena-router/scalefromzero/manager_test.go
@@ -1,0 +1,408 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scalefromzero
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
+	kthenafake "github.com/volcano-sh/kthena/client-go/clientset/versioned/fake"
+	listerv1alpha1 "github.com/volcano-sh/kthena/client-go/listers/workload/v1alpha1"
+	networkingv1alpha1 "github.com/volcano-sh/kthena/pkg/apis/networking/v1alpha1"
+	workloadv1alpha1 "github.com/volcano-sh/kthena/pkg/apis/workload/v1alpha1"
+	"github.com/volcano-sh/kthena/pkg/kthena-router/datastore"
+)
+
+type fakeBindingLister struct {
+	bindings []*workloadv1alpha1.AutoscalingPolicyBinding
+	err      error
+}
+
+func (f *fakeBindingLister) List(selector labels.Selector) ([]*workloadv1alpha1.AutoscalingPolicyBinding, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.bindings, nil
+}
+
+func (f *fakeBindingLister) AutoscalingPolicyBindings(namespace string) listerv1alpha1.AutoscalingPolicyBindingNamespaceLister {
+	return &fakeBindingNamespaceLister{}
+}
+
+type fakeBindingNamespaceLister struct{}
+
+func (f *fakeBindingNamespaceLister) List(selector labels.Selector) ([]*workloadv1alpha1.AutoscalingPolicyBinding, error) {
+	return nil, nil
+}
+
+func (f *fakeBindingNamespaceLister) Get(name string) (*workloadv1alpha1.AutoscalingPolicyBinding, error) {
+	return nil, nil
+}
+
+func newTestSetup(t *testing.T, servingName, msName string) (*Manager, *kthenafake.Clientset) {
+	t.Helper()
+	t.Setenv("ENABLE_SCALE_FROM_ZERO", "true")
+
+	ms := &workloadv1alpha1.ModelServing{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: servingName},
+	}
+	client := kthenafake.NewSimpleClientset(ms)
+
+	binding := &workloadv1alpha1.AutoscalingPolicyBinding{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "test-binding"},
+		Spec: workloadv1alpha1.AutoscalingPolicyBindingSpec{
+			PolicyRef: corev1.LocalObjectReference{Name: "test-policy"},
+			HomogeneousTarget: &workloadv1alpha1.HomogeneousTarget{
+				Target: workloadv1alpha1.Target{
+					TargetRef: corev1.ObjectReference{Kind: "ModelServing", Name: servingName, Namespace: "default"},
+				},
+				MinReplicas: 0, MaxReplicas: 10,
+			},
+		},
+	}
+	lister := &fakeBindingLister{bindings: []*workloadv1alpha1.AutoscalingPolicyBinding{binding}}
+
+	m := NewManager(client, lister)
+	t.Cleanup(m.Stop)
+
+	m.SetModelServerMapping("default", msName, servingName)
+	return m, client
+}
+
+func TestNewManager(t *testing.T) {
+	t.Run("disabled by default", func(t *testing.T) {
+		m := NewManager(nil, nil)
+		assert.False(t, m.Enabled())
+	})
+
+	t.Run("enabled via env", func(t *testing.T) {
+		t.Setenv("ENABLE_SCALE_FROM_ZERO", "true")
+		m := NewManager(nil, &fakeBindingLister{})
+		assert.True(t, m.Enabled())
+		m.Stop()
+	})
+
+	t.Run("custom timeout via env", func(t *testing.T) {
+		t.Setenv("ENABLE_SCALE_FROM_ZERO", "true")
+		t.Setenv("SCALE_FROM_ZERO_TIMEOUT", "30s")
+		m := NewManager(nil, &fakeBindingLister{})
+		assert.Equal(t, 30*time.Second, m.timeout)
+		m.Stop()
+	})
+}
+
+func TestHandle_NotEnabled(t *testing.T) {
+	m := NewManager(nil, nil)
+	_, _, err := m.Handle(context.Background(), "default", "test-ms")
+	assert.ErrorIs(t, err, ErrNotEnabled)
+}
+
+func TestHandle_NoMapping(t *testing.T) {
+	t.Setenv("ENABLE_SCALE_FROM_ZERO", "true")
+	m := NewManager(nil, &fakeBindingLister{})
+	defer m.Stop()
+
+	_, _, err := m.Handle(context.Background(), "default", "test-ms")
+	assert.ErrorIs(t, err, ErrNotConfigured)
+}
+
+func TestHandle_NoBinding(t *testing.T) {
+	t.Setenv("ENABLE_SCALE_FROM_ZERO", "true")
+	lister := &fakeBindingLister{bindings: []*workloadv1alpha1.AutoscalingPolicyBinding{}}
+	m := NewManager(nil, lister)
+	defer m.Stop()
+
+	m.SetModelServerMapping("default", "test-ms", "test-serving")
+
+	_, _, err := m.Handle(context.Background(), "default", "test-ms")
+	assert.ErrorIs(t, err, ErrNotConfigured)
+}
+
+func TestHandle_HasBinding_TriggersScaleUp(t *testing.T) {
+	m, client := newTestSetup(t, "test-serving", "test-ms")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	_, _, err := m.Handle(ctx, "default", "test-ms")
+	assert.ErrorIs(t, err, ErrTimeout)
+
+	patched, err := client.WorkloadV1alpha1().ModelServings("default").Get(context.Background(), "test-serving", metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, int32(1), *patched.Spec.Replicas)
+}
+
+func TestHandle_HasBinding_WaitForPods(t *testing.T) {
+	m, _ := newTestSetup(t, "test-serving", "test-ms")
+
+	handleDone := make(chan struct{})
+	var resultPods []*datastore.PodInfo
+	var resultMS *networkingv1alpha1.ModelServer
+	var handleErr error
+	go func() {
+		defer close(handleDone)
+		resultPods, resultMS, handleErr = m.Handle(context.Background(), "default", "test-ms")
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	modelServer := &networkingv1alpha1.ModelServer{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "test-ms"},
+	}
+	m.OnPodsAvailable("default", "test-ms", []*datastore.PodInfo{{Pod: &corev1.Pod{}}}, modelServer)
+
+	select {
+	case <-handleDone:
+		assert.NoError(t, handleErr)
+		assert.Len(t, resultPods, 1)
+		assert.Equal(t, "test-ms", resultMS.Name)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Handle did not complete after pods became available")
+	}
+}
+
+func TestHandle_HasBinding_Timeout(t *testing.T) {
+	t.Setenv("SCALE_FROM_ZERO_TIMEOUT", "50ms")
+	m, _ := newTestSetup(t, "test-serving", "test-ms")
+
+	_, _, err := m.Handle(context.Background(), "default", "test-ms")
+	assert.ErrorIs(t, err, ErrTimeout)
+}
+
+func TestHandle_ConcurrentRequestsShareTrigger(t *testing.T) {
+	m, _ := newTestSetup(t, "test-serving", "test-ms")
+
+	var wg sync.WaitGroup
+	for range 3 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+			defer cancel()
+			m.Handle(ctx, "default", "test-ms")
+		}()
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	m.pendingMu.Lock()
+	assert.Len(t, m.pending, 1)
+	m.pendingMu.Unlock()
+
+	modelServer := &networkingv1alpha1.ModelServer{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "test-ms"},
+	}
+	m.OnPodsAvailable("default", "test-ms", []*datastore.PodInfo{{Pod: &corev1.Pod{}}}, modelServer)
+
+	wg.Wait()
+}
+
+func TestOnPodsAvailable_NoPending(t *testing.T) {
+	t.Setenv("ENABLE_SCALE_FROM_ZERO", "true")
+	m := NewManager(nil, &fakeBindingLister{})
+	defer m.Stop()
+
+	modelServer := &networkingv1alpha1.ModelServer{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "test-ms"},
+	}
+	m.OnPodsAvailable("default", "test-ms", []*datastore.PodInfo{{Pod: &corev1.Pod{}}}, modelServer)
+}
+
+func TestSetDeleteModelServerMapping(t *testing.T) {
+	t.Setenv("ENABLE_SCALE_FROM_ZERO", "true")
+	m := NewManager(nil, &fakeBindingLister{})
+	defer m.Stop()
+
+	m.SetModelServerMapping("default", "ms1", "serving1")
+
+	m.mu.RLock()
+	val, ok := m.servingForMS["default/ms1"]
+	m.mu.RUnlock()
+	assert.True(t, ok)
+	assert.Equal(t, "default/serving1", val)
+
+	m.DeleteModelServerMapping("default", "ms1")
+
+	m.mu.RLock()
+	_, ok = m.servingForMS["default/ms1"]
+	m.mu.RUnlock()
+	assert.False(t, ok)
+}
+
+func TestDeleteModelServerMapping_ClearsPending(t *testing.T) {
+	t.Setenv("ENABLE_SCALE_FROM_ZERO", "true")
+	m := NewManager(nil, &fakeBindingLister{})
+	defer m.Stop()
+
+	m.pendingMu.Lock()
+	m.pending["default/ms1"] = &pendingWait{
+		resultChan: make(chan *waitResult, 1),
+	}
+	m.pendingMu.Unlock()
+
+	m.DeleteModelServerMapping("default", "ms1")
+
+	m.pendingMu.Lock()
+	_, ok := m.pending["default/ms1"]
+	m.pendingMu.Unlock()
+	assert.False(t, ok)
+}
+
+func TestBindingCacheRefresh(t *testing.T) {
+	binding := &workloadv1alpha1.AutoscalingPolicyBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "test-binding",
+		},
+		Spec: workloadv1alpha1.AutoscalingPolicyBindingSpec{
+			PolicyRef: corev1.LocalObjectReference{Name: "test-policy"},
+			HomogeneousTarget: &workloadv1alpha1.HomogeneousTarget{
+				Target: workloadv1alpha1.Target{
+					TargetRef: corev1.ObjectReference{
+						Kind: "ModelServing",
+						Name: "test-serving",
+					},
+				},
+				MinReplicas: 0,
+				MaxReplicas: 10,
+			},
+		},
+	}
+	lister := &fakeBindingLister{bindings: []*workloadv1alpha1.AutoscalingPolicyBinding{binding}}
+
+	t.Setenv("ENABLE_SCALE_FROM_ZERO", "true")
+	m := NewManager(nil, lister)
+	defer m.Stop()
+
+	time.Sleep(50 * time.Millisecond)
+
+	assert.True(t, m.hasAutoscalingPolicy("default/test-serving"))
+	assert.False(t, m.hasAutoscalingPolicy("default/other-serving"))
+}
+
+func TestBindingCacheRefresh_HeterogeneousTarget(t *testing.T) {
+	binding := &workloadv1alpha1.AutoscalingPolicyBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "test-binding",
+		},
+		Spec: workloadv1alpha1.AutoscalingPolicyBindingSpec{
+			PolicyRef: corev1.LocalObjectReference{Name: "test-policy"},
+			HeterogeneousTarget: &workloadv1alpha1.HeterogeneousTarget{
+				Params: []workloadv1alpha1.HeterogeneousTargetParam{
+					{
+						Target: workloadv1alpha1.Target{
+							TargetRef: corev1.ObjectReference{
+								Kind: "ModelServing",
+								Name: "hetero-serving",
+							},
+						},
+						MinReplicas: 0,
+						MaxReplicas: 10,
+					},
+				},
+			},
+		},
+	}
+	lister := &fakeBindingLister{bindings: []*workloadv1alpha1.AutoscalingPolicyBinding{binding}}
+
+	t.Setenv("ENABLE_SCALE_FROM_ZERO", "true")
+	m := NewManager(nil, lister)
+	defer m.Stop()
+
+	time.Sleep(50 * time.Millisecond)
+
+	assert.True(t, m.hasAutoscalingPolicy("default/hetero-serving"))
+}
+
+func TestBindingCache_WithNilLister(t *testing.T) {
+	t.Setenv("ENABLE_SCALE_FROM_ZERO", "true")
+	m := NewManager(nil, nil)
+	defer m.Stop()
+
+	assert.False(t, m.hasAutoscalingPolicy("default/test-serving"))
+}
+
+func TestBindingCache_ListError(t *testing.T) {
+	lister := &fakeBindingLister{err: errors.New("list error")}
+
+	t.Setenv("ENABLE_SCALE_FROM_ZERO", "true")
+	m := NewManager(nil, lister)
+	defer m.Stop()
+
+	assert.False(t, m.hasAutoscalingPolicy("default/test-serving"))
+}
+
+func TestTriggerScaleUp_InvalidKey(t *testing.T) {
+	t.Setenv("ENABLE_SCALE_FROM_ZERO", "true")
+	m := NewManager(nil, &fakeBindingLister{})
+	defer m.Stop()
+
+	resultChan := make(chan *waitResult, 1)
+	m.pendingMu.Lock()
+	m.pending["default/ms1"] = &pendingWait{
+		resultChan: resultChan,
+	}
+	m.pendingMu.Unlock()
+
+	m.triggerScaleUp("invalid-key", "default/ms1")
+
+	select {
+	case result := <-resultChan:
+		assert.ErrorIs(t, result.err, ErrTriggerFailed)
+	case <-time.After(time.Second):
+		t.Fatal("expected error notification")
+	}
+}
+
+func TestGetEnvBool(t *testing.T) {
+	assert.False(t, getEnvBool("NONEXISTENT_VAR", false))
+	assert.True(t, getEnvBool("NONEXISTENT_VAR", true))
+
+	t.Run("true", func(t *testing.T) {
+		t.Setenv("TEST_BOOL", "true")
+		assert.True(t, getEnvBool("TEST_BOOL", false))
+	})
+	t.Run("false", func(t *testing.T) {
+		t.Setenv("TEST_BOOL", "false")
+		assert.False(t, getEnvBool("TEST_BOOL", true))
+	})
+	t.Run("invalid", func(t *testing.T) {
+		t.Setenv("TEST_BOOL", "invalid")
+		assert.False(t, getEnvBool("TEST_BOOL", false))
+	})
+}
+
+func TestParseDurationEnv(t *testing.T) {
+	assert.Equal(t, 5*time.Minute, parseDurationEnv("NONEXISTENT", 5*time.Minute))
+
+	t.Run("valid", func(t *testing.T) {
+		t.Setenv("TEST_DURATION", "30s")
+		assert.Equal(t, 30*time.Second, parseDurationEnv("TEST_DURATION", time.Hour))
+	})
+	t.Run("invalid", func(t *testing.T) {
+		t.Setenv("TEST_DURATION", "invalid")
+		assert.Equal(t, time.Hour, parseDurationEnv("TEST_DURATION", time.Hour))
+	})
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:
When a ModelServing scales to 0 replicas, incoming requests to the
router are held and the ModelServing is automatically scaled up to 1
replica. Once pods become available, the request is forwarded.

The ModelServer-to-ModelServing mapping is derived from pod labels at
runtime, avoiding CRD coupling between routing and autoscaling domains.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
