### PR TITLE
fix(e2e): remove overly broad "error" string check in chat response assertions

### DIFF
--- a/test/e2e/utils/chat.go
+++ b/test/e2e/utils/chat.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 	"time"
 
@@ -186,7 +185,6 @@ func CheckChatCompletionsWithURLAndHeaders(t *testing.T, url string, modelName s
 	// Assert successful response
 	assert.Equal(t, http.StatusOK, resp.StatusCode, "Expected HTTP 200 status code")
 	assert.NotEmpty(t, resp.Body, "Chat response is empty")
-	assert.NotContains(t, resp.Body, "error", "Chat response contains error")
 
 	return resp
 }
@@ -197,7 +195,6 @@ func CheckChatCompletionsQuiet(t *testing.T, modelName string, messages []ChatMe
 	resp := SendChatRequestWithRetryQuiet(t, DefaultRouterURL, modelName, messages, nil)
 	assert.Equal(t, http.StatusOK, resp.StatusCode, "Expected HTTP 200 status code")
 	assert.NotEmpty(t, resp.Body, "Chat response is empty")
-	assert.NotContains(t, resp.Body, "error", "Chat response contains error")
 	return resp
 }
 
@@ -240,8 +237,11 @@ func WaitForChatModelReady(t *testing.T, url, modelName string, messages []ChatM
 
 // containsError checks if the response string contains error indicators
 func containsError(response string) bool {
-	responseLower := strings.ToLower(response)
-	return strings.Contains(responseLower, "error")
+	var r struct {
+		Error json.RawMessage `json:"error"`
+	}
+	_ = json.Unmarshal([]byte(response), &r)
+	return len(r.Error) > 0
 }
 
 // min returns the minimum of two time.Duration values


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:

fix test in ci:E2E Tests (gateway-api) like https://github.com/volcano-sh/kthena/actions/runs/24876825004/job/72835282280?pr=916#step:7:8123

The previous check `strings.Contains(response, "error")` caused false positives when chat messages naturally contained the word `"error"`. Now properly checks JSON error field instead.

Fixes flaky `TestMetrics` and similar tests.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```
