### PR TITLE
feat: Introducing Sglang Dynamo Mocker instead of Flask Mocker

### DIFF
--- a/examples/kthena-router/LLM-Mock-sglang.yaml
+++ b/examples/kthena-router/LLM-Mock-sglang.yaml
@@ -1,6 +1,6 @@
 # SGLang metrics mock deployment for kthena runtime verification.
 # Exposes Prometheus metrics at :30000/metrics compatible with sglang metrics format.
-# Build from aibrix-1/development/app: docker build -t ghcr.io/faust-benchou/sglang-mock:latest -f Dockerfile.sglang .
+# Build from dynamo docker build -t ghcr.io/faust-benchou/dynamo-mocker-sglang:v2026-04-23 -f Dockerfile.sglang .
 
 apiVersion: apps/v1
 kind: Deployment
@@ -18,13 +18,13 @@ spec:
     spec:
       containers:
         - name: llm-engine
-          image: ghcr.io/faust-benchou/sglang-mock:latest
+          image: ghcr.io/faust-benchou/dynamo-mocker-sglang:v2026-04-23
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 30000
           env:
             - name: MODEL_NAME
-              value: "meta-llama/Llama-3.1-8B-Instruct"
+              value: "Qwen/Qwen3-8B"
           command:
             - python3
             - sglang_app.py

--- a/examples/kthena-router/LLM-Mock-sglang.yaml
+++ b/examples/kthena-router/LLM-Mock-sglang.yaml
@@ -25,6 +25,3 @@ spec:
           env:
             - name: MODEL_NAME
               value: "Qwen/Qwen3-8B"
-          command:
-            - python3
-            - sglang_app.py

--- a/examples/kthena-router/ModelServer-sglang.yaml
+++ b/examples/kthena-router/ModelServer-sglang.yaml
@@ -9,7 +9,7 @@ spec:
       app: sglang-mock
   workloadPort:
     port: 30000
-  model: "meta-llama/Llama-3.1-8B-Instruct"
+  model: "Qwen/Qwen3-8B"
   inferenceEngine: "SGLang"
   trafficPolicy:
     timeout: 10s

--- a/test/e2e/router/testdata/LLM-Mock-sglang.yaml
+++ b/test/e2e/router/testdata/LLM-Mock-sglang.yaml
@@ -17,13 +17,13 @@ spec:
     spec:
       containers:
         - name: llm-engine
-          image: ghcr.io/faust-benchou/sglang-mock:latest
+          image: ghcr.io/faust-benchou/dynamo-mocker-sglang:v2026-04-23
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 30000
           env:
             - name: MODEL_NAME
-              value: "meta-llama/Llama-3.1-8B-Instruct"
+              value: "Qwen/Qwen3-8B"
           command:
             - python3
             - sglang_app.py

--- a/test/e2e/router/testdata/LLM-Mock-sglang.yaml
+++ b/test/e2e/router/testdata/LLM-Mock-sglang.yaml
@@ -24,6 +24,3 @@ spec:
           env:
             - name: MODEL_NAME
               value: "Qwen/Qwen3-8B"
-          command:
-            - python3
-            - sglang_app.py

--- a/test/e2e/router/testdata/ModelServer-sglang.yaml
+++ b/test/e2e/router/testdata/ModelServer-sglang.yaml
@@ -9,7 +9,7 @@ spec:
       app: sglang-mock
   workloadPort:
     port: 30000
-  model: "meta-llama/Llama-3.1-8B-Instruct"
+  model: "Qwen/Qwen3-8B"
   inferenceEngine: "SGLang"
   trafficPolicy:
     timeout: 10s


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
close https://github.com/volcano-sh/kthena/issues/849
part of https://github.com/volcano-sh/kthena/issues/912
part of https://github.com/volcano-sh/kthena/issues/913

**Special notes for your reviewer**:

see https://github.com/FAUST-BENCHOU/dynamo/pull/4 for detail

`/metrics` endpoint still need to mock since the dynamo's metrics is not the standard sglang metrics.
FYI: https://github.com/volcano-sh/kthena/issues/913#issuecomment-4312792182

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
