### PR TITLE
fix: flaky TestHTTPRouteNotSkippedAfterRouterRestart

### DIFF
--- a/test/e2e/router/gateway-inference-extension/e2e_test.go
+++ b/test/e2e/router/gateway-inference-extension/e2e_test.go
@@ -313,7 +313,7 @@ func TestHTTPRouteNotSkippedAfterRouterRestart(t *testing.T) {
 
 	// Wait for all terminating pods to be fully gone before setting up port-forward.
 	// A pod in "Terminating" state still has Phase=Running, so findPodForService
-	// can connect to a dying container whose ports are already closed.	
+	// can connect to a dying container whose ports are already closed.
 	routerDeploy, err := testCtx.KubeClient.AppsV1().Deployments(kthenaNamespace).Get(ctx, "kthena-router", metav1.GetOptions{})
 	require.NoError(t, err, "Failed to get router deployment")
 	routerPodSelector := metav1.FormatLabelSelector(routerDeploy.Spec.Selector)

--- a/test/e2e/router/gateway-inference-extension/e2e_test.go
+++ b/test/e2e/router/gateway-inference-extension/e2e_test.go
@@ -321,7 +321,13 @@ func TestHTTPRouteNotSkippedAfterRouterRestart(t *testing.T) {
 		pods, err := testCtx.KubeClient.CoreV1().Pods(kthenaNamespace).List(ctx, metav1.ListOptions{
 			LabelSelector: routerPodSelector,
 		})
-		if err != nil || len(pods.Items) == 0 {
+		if err != nil {
+		
+			return false
+		}
+		// Defensive: rollout status already confirmed new pods are Ready,
+		// so empty list indicates a transient API hiccup, not expected state.
+		if len(pods.Items) == 0 {
 			return false
 		}
 		for _, pod := range pods.Items {

--- a/test/e2e/router/gateway-inference-extension/e2e_test.go
+++ b/test/e2e/router/gateway-inference-extension/e2e_test.go
@@ -311,8 +311,26 @@ func TestHTTPRouteNotSkippedAfterRouterRestart(t *testing.T) {
 	require.NoError(t, exec.Command("kubectl", "rollout", "restart", "deployment/kthena-router", "-n", kthenaNamespace).Run())
 	require.NoError(t, exec.Command("kubectl", "rollout", "status", "deployment/kthena-router", "-n", kthenaNamespace, "--timeout=120s").Run())
 
-	// Wait for old pod to fully terminate before port-forward
-	time.Sleep(5 * time.Second)
+	// Wait for all terminating pods to be fully gone before setting up port-forward.
+	// A pod in "Terminating" state still has Phase=Running, so findPodForService
+	// can connect to a dying container whose ports are already closed.	
+	routerDeploy, err := testCtx.KubeClient.AppsV1().Deployments(kthenaNamespace).Get(ctx, "kthena-router", metav1.GetOptions{})
+	require.NoError(t, err, "Failed to get router deployment")
+	routerPodSelector := metav1.FormatLabelSelector(routerDeploy.Spec.Selector)
+	require.Eventually(t, func() bool {
+		pods, err := testCtx.KubeClient.CoreV1().Pods(kthenaNamespace).List(ctx, metav1.ListOptions{
+			LabelSelector: routerPodSelector,
+		})
+		if err != nil || len(pods.Items) == 0 {
+			return false
+		}
+		for _, pod := range pods.Items {
+			if pod.DeletionTimestamp != nil {
+				return false
+			}
+		}
+		return true
+	}, 2*time.Minute, 2*time.Second, "Terminating router pods should be fully removed")
 
 	// 4. Re-establish port-forward (original breaks when pod restarts)
 	pf, err := utils.SetupPortForward(kthenaNamespace, "kthena-router", "9080", "80")

--- a/test/e2e/router/gateway-inference-extension/e2e_test.go
+++ b/test/e2e/router/gateway-inference-extension/e2e_test.go
@@ -322,7 +322,6 @@ func TestHTTPRouteNotSkippedAfterRouterRestart(t *testing.T) {
 			LabelSelector: routerPodSelector,
 		})
 		if err != nil {
-		
 			return false
 		}
 		// Defensive: rollout status already confirmed new pods are Ready,

--- a/test/e2e/utils/portforward.go
+++ b/test/e2e/utils/portforward.go
@@ -262,7 +262,7 @@ func findPodForService(clientset *kubernetes.Clientset, namespace, serviceName s
 
 	// Find the first running pod and resolve the targetPort
 	for _, pod := range pods.Items {
-		if pod.Status.Phase == v1.PodRunning {
+		if pod.Status.Phase == v1.PodRunning && pod.DeletionTimestamp == nil {
 			// Resolve the container port from targetPort
 			containerPort, err := resolveContainerPort(&pod, targetPort)
 			if err != nil {

--- a/test/e2e/utils/portforward.go
+++ b/test/e2e/utils/portforward.go
@@ -349,6 +349,9 @@ func (f *forwarder) buildK8sPortForwarder(readyCh chan struct{}) (*portforward.P
 	if pod.Status.Phase != v1.PodRunning {
 		return nil, fmt.Errorf("pod is not running. Status=%v", pod.Status.Phase)
 	}
+	if pod.DeletionTimestamp != nil {
+		return nil, fmt.Errorf("pod %s/%s is terminating", pod.Namespace, pod.Name)
+	}
 
 	return fw, nil
 }


### PR DESCRIPTION
Description:

What type of PR is this?

/kind bug

What this PR does / why we need it:
Fixes a flaky E2E test TestHTTPRouteNotSkippedAfterRouterRestart that intermittently fails after a router restart.

After kubectl rollout restart, the test used time.Sleep(5s) before setting up a port-forward. A pod in "Terminating" state still has Phase=Running, so findPodForService can pick the dying pod whose ports are already closed — causing connection refused errors.

Replaced the sleep with a proper poll that waits until all terminating pods (those with DeletionTimestamp set) are fully removed. This matches the existing pattern used in controller-manager/model_serving_test.go.

Which issue(s) this PR fixes:
#923

Fixes flaky CI failure in E2E (gateway-inference-extension).

/cc @FAUST-BENCHOU @YaoZengzeng 
