### PR TITLE
test: wait for router webhook readiness

### DIFF
--- a/test/e2e/router/context/context.go
+++ b/test/e2e/router/context/context.go
@@ -209,12 +209,14 @@ func (c *RouterTestContext) SetupCommonComponents() error {
 func (c *RouterTestContext) waitForRouterValidatingWebhook(ctx stdcontext.Context) error {
 	fmt.Println("Waiting for kthena-router validating webhook to accept requests...")
 
+	probeTemplate := utils.LoadYAMLFromFile[networkingv1alpha1.ModelServer](filepath.Join(testDataDir, "ModelServer-ds1.5b.yaml"))
+	probeTemplate.Namespace = c.Namespace
+
 	waitCtx, cancel := stdcontext.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 
 	err := wait.PollUntilContextCancel(waitCtx, 2*time.Second, true, func(ctx stdcontext.Context) (bool, error) {
-		probe := utils.LoadYAMLFromFile[networkingv1alpha1.ModelServer](filepath.Join(testDataDir, "ModelServer-ds1.5b.yaml"))
-		probe.Namespace = c.Namespace
+		probe := probeTemplate.DeepCopy()
 		probe.Name = "webhook-ready-probe-" + utils.RandomString(5)
 
 		_, err := c.KthenaClient.NetworkingV1alpha1().ModelServers(c.Namespace).Create(ctx, probe, metav1.CreateOptions{DryRun: []string{"All"}})

--- a/test/e2e/router/context/context.go
+++ b/test/e2e/router/context/context.go
@@ -20,6 +20,7 @@ import (
 	stdcontext "context"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"time"
 
 	clientset "github.com/volcano-sh/kthena/client-go/clientset/versioned"
@@ -170,6 +171,10 @@ func (c *RouterTestContext) SetupCommonComponents() error {
 		return fmt.Errorf("deployments did not become ready: %w", err)
 	}
 
+	if err := c.waitForRouterValidatingWebhook(ctx); err != nil {
+		return err
+	}
+
 	// Deploy ModelServer DS1.5B
 	fmt.Println("Deploying ModelServer DS1.5B...")
 	modelServer1_5b := utils.LoadYAMLFromFile[networkingv1alpha1.ModelServer](filepath.Join(testDataDir, "ModelServer-ds1.5b.yaml"))
@@ -198,6 +203,39 @@ func (c *RouterTestContext) SetupCommonComponents() error {
 	}
 
 	fmt.Println("Common components deployed successfully")
+	return nil
+}
+
+func (c *RouterTestContext) waitForRouterValidatingWebhook(ctx stdcontext.Context) error {
+	fmt.Println("Waiting for kthena-router validating webhook to accept requests...")
+
+	waitCtx, cancel := stdcontext.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+
+	err := wait.PollUntilContextCancel(waitCtx, 2*time.Second, true, func(ctx stdcontext.Context) (bool, error) {
+		probe := utils.LoadYAMLFromFile[networkingv1alpha1.ModelServer](filepath.Join(testDataDir, "ModelServer-ds1.5b.yaml"))
+		probe.Namespace = c.Namespace
+		probe.Name = "webhook-ready-probe-" + utils.RandomString(5)
+
+		_, err := c.KthenaClient.NetworkingV1alpha1().ModelServers(c.Namespace).Create(ctx, probe, metav1.CreateOptions{DryRun: []string{"All"}})
+		if err != nil {
+			errStr := err.Error()
+			if strings.Contains(errStr, "failed calling webhook") ||
+				strings.Contains(errStr, "connect: connection refused") ||
+				strings.Contains(errStr, "i/o timeout") ||
+				strings.Contains(errStr, "context deadline exceeded") {
+				fmt.Printf("Router validating webhook not ready yet, retrying: %v\n", err)
+				return false, nil
+			}
+			return false, err
+		}
+
+		fmt.Println("Router validating webhook is ready")
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("kthena-router validating webhook did not become ready in time: %w", err)
+	}
 	return nil
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind cleanup

**What this PR does / why we need it**:
Wait for the kthena-router validating webhook to accept dry-run `ModelServer` requests before creating shared router E2E `ModelServer` fixtures.

This avoids a setup race where the router pod is Ready, but the admission webhook endpoint is not accepting requests yet, causing errors such as `connect: connection refused`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This addresses the webhook readiness race observed in `E2E (gateway-inference-extension)`.

Tested with:
```console
go test ./test/e2e/router/context
go test -c -o /tmp/kthena-gateway-inference-extension.test ./test/e2e/router/gateway-inference-extension
go test -c -o /tmp/kthena-gateway-api.test ./test/e2e/router/gateway-api
```

Full local E2E was not run because the local Kubernetes API server in the current kubeconfig was unreachable.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
