### PR TITLE
test: avoid retrying counted metrics requests

### DIFF
--- a/test/e2e/router/shared.go
+++ b/test/e2e/router/shared.go
@@ -1460,10 +1460,10 @@ func TestMetricsShared(t *testing.T, testCtx *routercontext.RouterTestContext, t
 		// Send requests
 		for range 3 {
 			resp := utils.SendChatRequest(t, modelName, messages)
-			assert.Equal(t, 200, resp.StatusCode)
-			_, err := io.Copy(io.Discard, resp.Body)
-			require.NoError(t, err, "Failed to read response body")
+			body, err := io.ReadAll(resp.Body)
 			require.NoError(t, resp.Body.Close(), "Failed to close response body")
+			require.NoError(t, err, "Failed to read response body")
+			require.Equal(t, 200, resp.StatusCode, "Request failed with body: %s", string(body))
 		}
 
 		// Verify metrics incremented by exactly numRequests

--- a/test/e2e/router/shared.go
+++ b/test/e2e/router/shared.go
@@ -1448,6 +1448,8 @@ func TestMetricsShared(t *testing.T, testCtx *routercontext.RouterTestContext, t
 			"status_code": "200",
 		}
 
+		utils.WaitForChatModelReady(t, utils.DefaultRouterURL, modelName, messages, 60*time.Second)
+
 		// Capture baseline metrics
 		baselineMetrics, err := backendmetrics.ParseMetricsURL(defaultMetricsURL)
 		require.NoError(t, err, "Failed to fetch baseline metrics")
@@ -1457,8 +1459,11 @@ func TestMetricsShared(t *testing.T, testCtx *routercontext.RouterTestContext, t
 
 		// Send requests
 		for range 3 {
-			resp := utils.CheckChatCompletions(t, modelName, messages)
+			resp := utils.SendChatRequest(t, modelName, messages)
 			assert.Equal(t, 200, resp.StatusCode)
+			_, err := io.Copy(io.Discard, resp.Body)
+			require.NoError(t, err, "Failed to read response body")
+			require.NoError(t, resp.Body.Close(), "Failed to close response body")
 		}
 
 		// Verify metrics incremented by exactly numRequests


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
Avoid retrying requests that are counted by the router metrics E2E assertion, so the test still verifies the exact expected metric delta.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
The readiness check runs before capturing the metrics baseline; the counted requests still require an exact delta of 3.

Tested with:
```console
go test -c -o /tmp/kthena-gateway-api.test ./test/e2e/router/gateway-api
go test -c -o /tmp/kthena-router.test ./test/e2e/router
```

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
