### PR TITLE
e2e: move shared test helpers to utils

### DIFF
--- a/test/e2e/controller-manager/model_serving_test.go
+++ b/test/e2e/controller-manager/model_serving_test.go
@@ -357,11 +357,8 @@ func TestModelServingServingGroupRecreate(t *testing.T) {
 
 			// Must be a new pod (not in original UIDs) and must be ready
 			if !isOriginal && isNonTerminating {
-				for _, condition := range pod.Status.Conditions {
-					if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionTrue {
-						readyNewPods++
-						break
-					}
+				if utils.IsPodReady(pod) {
+					readyNewPods++
 				}
 			}
 		}
@@ -504,11 +501,8 @@ func TestModelServingPodRecovery(t *testing.T) {
 	for _, pod := range pods.Items {
 		// Check if it's a new pod (different UID from original)
 		if pod.UID != originalPodUID {
-			// Check for PodReady condition with status True
-			for _, condition := range pod.Status.Conditions {
-				if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionTrue {
-					t.Logf("New pod created and ready: %s (UID: %s)", pod.Name, pod.UID)
-				}
+			if utils.IsPodReady(pod) {
+				t.Logf("New pod created and ready: %s (UID: %s)", pod.Name, pod.UID)
 			}
 		}
 	}
@@ -1200,11 +1194,8 @@ func TestLWSAPIBasic(t *testing.T) {
 	// Verify all pods are running and ready
 	readyPods := 0
 	for _, pod := range podList.Items {
-		for _, cond := range pod.Status.Conditions {
-			if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
-				readyPods++
-				break
-			}
+		if utils.IsPodReady(pod) {
+			readyPods++
 		}
 	}
 	assert.Equal(t, expectedPodCount, readyPods, "All pods should be in a Ready state")
@@ -1675,13 +1666,9 @@ func TestModelServingControllerManagerRestart(t *testing.T) {
 		}
 		// Check that at least one controller-manager pod is running and ready
 		for _, pod := range pods.Items {
-			if pod.Status.Phase == corev1.PodRunning {
-				for _, condition := range pod.Status.Conditions {
-					if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionTrue {
-						t.Logf("Controller-manager pod is ready: %s", pod.Name)
-						return true
-					}
-				}
+			if utils.IsPodReady(pod) {
+				t.Logf("Controller-manager pod is ready: %s", pod.Name)
+				return true
 			}
 		}
 		return false

--- a/test/e2e/controller-manager/test_suite_test.go
+++ b/test/e2e/controller-manager/test_suite_test.go
@@ -28,7 +28,6 @@ import (
 	clientset "github.com/volcano-sh/kthena/client-go/clientset/versioned"
 	"github.com/volcano-sh/kthena/test/e2e/framework"
 	"github.com/volcano-sh/kthena/test/e2e/utils"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
@@ -67,42 +66,17 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	ctx := context.Background()
-	ns := &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: testNamespace,
-		},
-	}
-	_, err = kubeClient.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
-	if err != nil {
-		fmt.Printf("Failed to create test namespace %s: %v\n", testNamespace, err)
+	if err := utils.CreateTestNamespace(kubeClient, testNamespace); err != nil {
 		_ = framework.UninstallKthena(config.Namespace)
 		os.Exit(1)
 	}
-	fmt.Printf("Created test namespace: %s\n", testNamespace)
 
 	// Run tests
 	code := m.Run()
 
 	// Cleanup test namespace
-	fmt.Printf("Deleting test namespace: %s\n", testNamespace)
-	err = kubeClient.CoreV1().Namespaces().Delete(ctx, testNamespace, metav1.DeleteOptions{})
-	if err != nil {
-		fmt.Printf("Failed to delete test namespace %s: %v\n", testNamespace, err)
-	}
-
-	// Wait for namespace to be deleted
-	waitCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
-	defer cancel()
-	err = wait.PollUntilContextCancel(waitCtx, 2*time.Second, true, func(ctx context.Context) (bool, error) {
-		_, err := kubeClient.CoreV1().Namespaces().Get(ctx, testNamespace, metav1.GetOptions{})
-		if err != nil {
-			return true, nil // namespace is gone
-		}
-		return false, nil
-	})
-	if err != nil {
-		fmt.Printf("Timeout waiting for namespace %s deletion: %v\n", testNamespace, err)
+	if err := utils.DeleteTestNamespaceAndWait(kubeClient, testNamespace, 2*time.Minute); err != nil {
+		fmt.Printf("Warning: Failed to delete test namespace %s: %v\n", testNamespace, err)
 	}
 
 	if err := framework.UninstallKthena(config.Namespace); err != nil {

--- a/test/e2e/router/context/context.go
+++ b/test/e2e/router/context/context.go
@@ -27,7 +27,6 @@ import (
 	networkingv1alpha1 "github.com/volcano-sh/kthena/pkg/apis/networking/v1alpha1"
 	"github.com/volcano-sh/kthena/test/e2e/utils"
 	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -43,7 +42,7 @@ const (
 	ModelServer1_5bName   = "deepseek-r1-1-5b"
 	ModelServer7bName     = "deepseek-r1-7b"
 	ModelServerSglangName = "sglang-mock"
-	testDataDir           = "test/e2e/router/testdata"
+	TestDataDir           = "test/e2e/router/testdata"
 )
 
 // RouterTestContext holds the clients needed for router tests
@@ -89,29 +88,12 @@ func NewRouterTestContext(namespace string) (*RouterTestContext, error) {
 
 // CreateTestNamespace creates the test namespace if it doesn't exist.
 func (c *RouterTestContext) CreateTestNamespace() error {
-	fmt.Printf("Creating test namespace: %s\n", c.Namespace)
-	ctx := stdcontext.Background()
-	ns := &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: c.Namespace,
-		},
-	}
-	_, err := c.KubeClient.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
-	if err != nil && !apierrors.IsAlreadyExists(err) {
-		return fmt.Errorf("failed to create namespace %s: %w", c.Namespace, err)
-	}
-	return nil
+	return utils.CreateTestNamespace(c.KubeClient, c.Namespace)
 }
 
 // DeleteTestNamespace deletes the test namespace.
 func (c *RouterTestContext) DeleteTestNamespace() error {
-	fmt.Printf("Deleting test namespace: %s\n", c.Namespace)
-	ctx := stdcontext.Background()
-	err := c.KubeClient.CoreV1().Namespaces().Delete(ctx, c.Namespace, metav1.DeleteOptions{})
-	if err != nil && !apierrors.IsNotFound(err) {
-		return fmt.Errorf("failed to delete namespace %s: %w", c.Namespace, err)
-	}
-	return nil
+	return utils.DeleteTestNamespaceAndWait(c.KubeClient, c.Namespace, 2*time.Minute)
 }
 
 // SetupCommonComponents deploys common components that will be used by all router test cases.
@@ -121,7 +103,7 @@ func (c *RouterTestContext) SetupCommonComponents() error {
 
 	// Deploy LLM Mock DS1.5B Deployment
 	fmt.Println("Deploying LLM Mock DS1.5B Deployment...")
-	deployment1_5b := utils.LoadYAMLFromFile[appsv1.Deployment](filepath.Join(testDataDir, "LLM-Mock-ds1.5b.yaml"))
+	deployment1_5b := utils.LoadYAMLFromFile[appsv1.Deployment](filepath.Join(TestDataDir, "LLM-Mock-ds1.5b.yaml"))
 	deployment1_5b.Namespace = c.Namespace
 	_, err := c.KubeClient.AppsV1().Deployments(c.Namespace).Create(ctx, deployment1_5b, metav1.CreateOptions{})
 	if err != nil && !apierrors.IsAlreadyExists(err) {
@@ -130,7 +112,7 @@ func (c *RouterTestContext) SetupCommonComponents() error {
 
 	// Deploy LLM Mock DS7B Deployment
 	fmt.Println("Deploying LLM Mock DS7B Deployment...")
-	deployment7b := utils.LoadYAMLFromFile[appsv1.Deployment](filepath.Join(testDataDir, "LLM-Mock-ds7b.yaml"))
+	deployment7b := utils.LoadYAMLFromFile[appsv1.Deployment](filepath.Join(TestDataDir, "LLM-Mock-ds7b.yaml"))
 	deployment7b.Namespace = c.Namespace
 	_, err = c.KubeClient.AppsV1().Deployments(c.Namespace).Create(ctx, deployment7b, metav1.CreateOptions{})
 	if err != nil && !apierrors.IsAlreadyExists(err) {
@@ -139,7 +121,7 @@ func (c *RouterTestContext) SetupCommonComponents() error {
 
 	// Deploy SGLang Mock Deployment
 	fmt.Println("Deploying SGLang Mock Deployment...")
-	deploymentSglang := utils.LoadYAMLFromFile[appsv1.Deployment](filepath.Join(testDataDir, "LLM-Mock-sglang.yaml"))
+	deploymentSglang := utils.LoadYAMLFromFile[appsv1.Deployment](filepath.Join(TestDataDir, "LLM-Mock-sglang.yaml"))
 	deploymentSglang.Namespace = c.Namespace
 	_, err = c.KubeClient.AppsV1().Deployments(c.Namespace).Create(ctx, deploymentSglang, metav1.CreateOptions{})
 	if err != nil && !apierrors.IsAlreadyExists(err) {
@@ -148,27 +130,14 @@ func (c *RouterTestContext) SetupCommonComponents() error {
 
 	// Wait for deployments to be ready
 	fmt.Println("Waiting for deployments to be ready...")
-	timeoutCtx, cancel := stdcontext.WithTimeout(ctx, 5*time.Minute)
-	defer cancel()
-	err = wait.PollUntilContextTimeout(timeoutCtx, 5*time.Second, 5*time.Minute, true, func(ctx stdcontext.Context) (bool, error) {
-		deploy1_5b, err := c.KubeClient.AppsV1().Deployments(c.Namespace).Get(ctx, Deployment1_5bName, metav1.GetOptions{})
-		if err != nil {
-			return false, nil
-		}
-		deploy7b, err := c.KubeClient.AppsV1().Deployments(c.Namespace).Get(ctx, Deployment7bName, metav1.GetOptions{})
-		if err != nil {
-			return false, nil
-		}
-		deploySglang, err := c.KubeClient.AppsV1().Deployments(c.Namespace).Get(ctx, DeploymentSglangName, metav1.GetOptions{})
-		if err != nil {
-			return false, nil
-		}
-		return deploy1_5b.Status.ReadyReplicas == *deploy1_5b.Spec.Replicas &&
-			deploy7b.Status.ReadyReplicas == *deploy7b.Spec.Replicas &&
-			deploySglang.Status.ReadyReplicas == *deploySglang.Spec.Replicas, nil
-	})
-	if err != nil {
-		return fmt.Errorf("deployments did not become ready: %w", err)
+	if err := utils.WaitForDeploymentReadyE(ctx, c.KubeClient, c.Namespace, Deployment1_5bName, 5*time.Minute); err != nil {
+		return err
+	}
+	if err := utils.WaitForDeploymentReadyE(ctx, c.KubeClient, c.Namespace, Deployment7bName, 5*time.Minute); err != nil {
+		return err
+	}
+	if err := utils.WaitForDeploymentReadyE(ctx, c.KubeClient, c.Namespace, DeploymentSglangName, 5*time.Minute); err != nil {
+		return err
 	}
 
 	if err := c.waitForRouterValidatingWebhook(ctx); err != nil {
@@ -177,7 +146,7 @@ func (c *RouterTestContext) SetupCommonComponents() error {
 
 	// Deploy ModelServer DS1.5B
 	fmt.Println("Deploying ModelServer DS1.5B...")
-	modelServer1_5b := utils.LoadYAMLFromFile[networkingv1alpha1.ModelServer](filepath.Join(testDataDir, "ModelServer-ds1.5b.yaml"))
+	modelServer1_5b := utils.LoadYAMLFromFile[networkingv1alpha1.ModelServer](filepath.Join(TestDataDir, "ModelServer-ds1.5b.yaml"))
 	modelServer1_5b.Namespace = c.Namespace
 	_, err = c.KthenaClient.NetworkingV1alpha1().ModelServers(c.Namespace).Create(ctx, modelServer1_5b, metav1.CreateOptions{})
 	if err != nil && !apierrors.IsAlreadyExists(err) {
@@ -186,7 +155,7 @@ func (c *RouterTestContext) SetupCommonComponents() error {
 
 	// Deploy ModelServer DS7B
 	fmt.Println("Deploying ModelServer DS7B...")
-	modelServer7b := utils.LoadYAMLFromFile[networkingv1alpha1.ModelServer](filepath.Join(testDataDir, "ModelServer-ds7b.yaml"))
+	modelServer7b := utils.LoadYAMLFromFile[networkingv1alpha1.ModelServer](filepath.Join(TestDataDir, "ModelServer-ds7b.yaml"))
 	modelServer7b.Namespace = c.Namespace
 	_, err = c.KthenaClient.NetworkingV1alpha1().ModelServers(c.Namespace).Create(ctx, modelServer7b, metav1.CreateOptions{})
 	if err != nil && !apierrors.IsAlreadyExists(err) {
@@ -195,7 +164,7 @@ func (c *RouterTestContext) SetupCommonComponents() error {
 
 	// Deploy ModelServer SGLang
 	fmt.Println("Deploying ModelServer SGLang...")
-	modelServerSglang := utils.LoadYAMLFromFile[networkingv1alpha1.ModelServer](filepath.Join(testDataDir, "ModelServer-sglang.yaml"))
+	modelServerSglang := utils.LoadYAMLFromFile[networkingv1alpha1.ModelServer](filepath.Join(TestDataDir, "ModelServer-sglang.yaml"))
 	modelServerSglang.Namespace = c.Namespace
 	_, err = c.KthenaClient.NetworkingV1alpha1().ModelServers(c.Namespace).Create(ctx, modelServerSglang, metav1.CreateOptions{})
 	if err != nil && !apierrors.IsAlreadyExists(err) {
@@ -209,7 +178,7 @@ func (c *RouterTestContext) SetupCommonComponents() error {
 func (c *RouterTestContext) waitForRouterValidatingWebhook(ctx stdcontext.Context) error {
 	fmt.Println("Waiting for kthena-router validating webhook to accept requests...")
 
-	probeTemplate := utils.LoadYAMLFromFile[networkingv1alpha1.ModelServer](filepath.Join(testDataDir, "ModelServer-ds1.5b.yaml"))
+	probeTemplate := utils.LoadYAMLFromFile[networkingv1alpha1.ModelServer](filepath.Join(TestDataDir, "ModelServer-ds1.5b.yaml"))
 	probeTemplate.Namespace = c.Namespace
 
 	waitCtx, cancel := stdcontext.WithTimeout(ctx, 2*time.Minute)

--- a/test/e2e/router/gateway-api/e2e_test.go
+++ b/test/e2e/router/gateway-api/e2e_test.go
@@ -42,8 +42,6 @@ var (
 	kthenaNamespace string
 )
 
-const testDataDir = "test/e2e/router/testdata"
-
 // TestMain runs setup and cleanup for all tests in this package.
 func TestMain(m *testing.M) {
 	testNamespace = "kthena-e2e-gateway-" + utils.RandomString(5)
@@ -176,7 +174,7 @@ func TestDuplicateModelName(t *testing.T) {
 
 	// 1. Deploy ModelRouteSimple.yaml with parentRefs to default Gateway
 	t.Log("Deploying ModelRouteSimple binding to default Gateway...")
-	modelRoute1 := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute](filepath.Join(testDataDir, "ModelRouteSimple.yaml"))
+	modelRoute1 := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute](filepath.Join(routercontext.TestDataDir, "ModelRouteSimple.yaml"))
 	modelRoute1.Namespace = testNamespace
 	modelRoute1.Name = "deepseek-simple-default"
 
@@ -205,7 +203,7 @@ func TestDuplicateModelName(t *testing.T) {
 
 	// 2. Create custom Gateway with port 8081
 	t.Log("Creating custom Gateway with port 8081...")
-	customGateway := utils.LoadYAMLFromFile[gatewayv1.Gateway](filepath.Join(testDataDir, "Gateway.yaml"))
+	customGateway := utils.LoadYAMLFromFile[gatewayv1.Gateway](filepath.Join(routercontext.TestDataDir, "Gateway.yaml"))
 	customGateway.Namespace = kthenaNamespace
 	customGateway.Name = "kthena-gateway-custom"
 	customGateway.Spec.Listeners[0].Port = gatewayv1.PortNumber(8081)

--- a/test/e2e/router/gateway-inference-extension/e2e_test.go
+++ b/test/e2e/router/gateway-inference-extension/e2e_test.go
@@ -41,8 +41,6 @@ var (
 	kthenaNamespace string
 )
 
-const testDataDir = "test/e2e/router/testdata"
-
 func TestMain(m *testing.M) {
 	testNamespace = "kthena-e2e-gie-" + utils.RandomString(5)
 
@@ -100,7 +98,7 @@ func TestGatewayInferenceExtension(t *testing.T) {
 
 	// 1. Deploy InferencePool
 	t.Log("Deploying InferencePool...")
-	inferencePool := utils.LoadYAMLFromFile[inferencev1.InferencePool](filepath.Join(testDataDir, "InferencePool.yaml"))
+	inferencePool := utils.LoadYAMLFromFile[inferencev1.InferencePool](filepath.Join(routercontext.TestDataDir, "InferencePool.yaml"))
 	inferencePool.Namespace = testNamespace
 
 	createdInferencePool, err := testCtx.InferenceClient.InferenceV1().InferencePools(testNamespace).Create(ctx, inferencePool, metav1.CreateOptions{})
@@ -114,7 +112,7 @@ func TestGatewayInferenceExtension(t *testing.T) {
 
 	// 2. Deploy HTTPRoute
 	t.Log("Deploying HTTPRoute...")
-	httpRoute := utils.LoadYAMLFromFile[gatewayv1.HTTPRoute](filepath.Join(testDataDir, "HTTPRoute.yaml"))
+	httpRoute := utils.LoadYAMLFromFile[gatewayv1.HTTPRoute](filepath.Join(routercontext.TestDataDir, "HTTPRoute.yaml"))
 	httpRoute.Namespace = testNamespace
 
 	// Update parentRefs to point to the kthena installation namespace
@@ -171,7 +169,7 @@ func TestBothAPIsConfigured(t *testing.T) {
 
 	// 1. Deploy ModelRoute and ModelServer for ModelRoute/ModelServer API
 	t.Log("Deploying ModelRoute...")
-	modelRoute := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute](filepath.Join(testDataDir, "ModelRoute-binding-gateway.yaml"))
+	modelRoute := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute](filepath.Join(routercontext.TestDataDir, "ModelRoute-binding-gateway.yaml"))
 	modelRoute.Namespace = testNamespace
 
 	// Update parentRefs to point to the kthena installation namespace
@@ -229,7 +227,7 @@ func TestBothAPIsConfigured(t *testing.T) {
 
 	// 3. Deploy HTTPRoute pointing to the 7b InferencePool
 	t.Log("Deploying HTTPRoute...")
-	httpRoute := utils.LoadYAMLFromFile[gatewayv1.HTTPRoute](filepath.Join(testDataDir, "HTTPRoute.yaml"))
+	httpRoute := utils.LoadYAMLFromFile[gatewayv1.HTTPRoute](filepath.Join(routercontext.TestDataDir, "HTTPRoute.yaml"))
 	httpRoute.Namespace = testNamespace
 	httpRoute.Name = "llm-route-7b"
 
@@ -281,7 +279,7 @@ func TestHTTPRouteNotSkippedAfterRouterRestart(t *testing.T) {
 
 	// 1. Deploy InferencePool
 	t.Log("Deploying InferencePool...")
-	inferencePool := utils.LoadYAMLFromFile[inferencev1.InferencePool](filepath.Join(testDataDir, "InferencePool.yaml"))
+	inferencePool := utils.LoadYAMLFromFile[inferencev1.InferencePool](filepath.Join(routercontext.TestDataDir, "InferencePool.yaml"))
 	inferencePool.Namespace = testNamespace
 
 	createdInferencePool, err := testCtx.InferenceClient.InferenceV1().InferencePools(testNamespace).Create(ctx, inferencePool, metav1.CreateOptions{})
@@ -293,7 +291,7 @@ func TestHTTPRouteNotSkippedAfterRouterRestart(t *testing.T) {
 
 	// 2. Create HTTPRoute volcano-router-gateway (parentRef to default Gateway, which listens on port 80)
 	t.Log("Creating HTTPRoute volcano-router-gateway...")
-	httpRoute := utils.LoadYAMLFromFile[gatewayv1.HTTPRoute](filepath.Join(testDataDir, "HTTPRoute.yaml"))
+	httpRoute := utils.LoadYAMLFromFile[gatewayv1.HTTPRoute](filepath.Join(routercontext.TestDataDir, "HTTPRoute.yaml"))
 	httpRoute.Name, httpRoute.Namespace = httpRouteName, testNamespace
 	httpRoute.Spec.ParentRefs = []gatewayv1.ParentReference{
 		{Group: ptr(gatewayv1.Group("gateway.networking.k8s.io")), Kind: ptr(gatewayv1.Kind("Gateway")), Name: gatewayv1.ObjectName("default"), Namespace: &ktNamespace},
@@ -357,7 +355,7 @@ func TestGatewayCreatedLaterThanHTTPRoute(t *testing.T) {
 
 	// 1. Create HTTPRoute first (parentRef to Gateway that does not exist yet)
 	t.Log("Creating HTTPRoute before Gateway...")
-	httpRoute := utils.LoadYAMLFromFile[gatewayv1.HTTPRoute](filepath.Join(testDataDir, "HTTPRoute.yaml"))
+	httpRoute := utils.LoadYAMLFromFile[gatewayv1.HTTPRoute](filepath.Join(routercontext.TestDataDir, "HTTPRoute.yaml"))
 	httpRoute.Name, httpRoute.Namespace = httpRouteName, testNamespace
 	httpRoute.Spec.ParentRefs = []gatewayv1.ParentReference{
 		{Group: ptr(gatewayv1.Group("gateway.networking.k8s.io")), Kind: ptr(gatewayv1.Kind("Gateway")), Name: gatewayv1.ObjectName(gatewayName), Namespace: &ktNamespace},
@@ -372,7 +370,7 @@ func TestGatewayCreatedLaterThanHTTPRoute(t *testing.T) {
 
 	// 2. Deploy InferencePool
 	t.Log("Deploying InferencePool...")
-	inferencePool := utils.LoadYAMLFromFile[inferencev1.InferencePool](filepath.Join(testDataDir, "InferencePool.yaml"))
+	inferencePool := utils.LoadYAMLFromFile[inferencev1.InferencePool](filepath.Join(routercontext.TestDataDir, "InferencePool.yaml"))
 	inferencePool.Namespace = testNamespace
 
 	createdInferencePool, err := testCtx.InferenceClient.InferenceV1().InferencePools(testNamespace).Create(ctx, inferencePool, metav1.CreateOptions{})

--- a/test/e2e/router/shared.go
+++ b/test/e2e/router/shared.go
@@ -42,7 +42,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
@@ -51,10 +50,8 @@ import (
 )
 
 const (
-	defaultMetricsURL      = "http://127.0.0.1:8080/metrics"
-	defaultPollingInterval = 2 * time.Second
-	defaultScalingTimeout  = 3 * time.Minute
-	testDataDir            = "test/e2e/router/testdata"
+	defaultMetricsURL     = "http://127.0.0.1:8080/metrics"
+	defaultScalingTimeout = 3 * time.Minute
 )
 
 func getCounterValue(metrics map[string]*dto.MetricFamily, metricName string, labels map[string]string) float64 {
@@ -83,31 +80,6 @@ func getHistogramCount(metrics map[string]*dto.MetricFamily, metricName string, 
 	return 0
 }
 
-func isPodReady(pod corev1.Pod) bool {
-	if pod.Status.Phase != corev1.PodRunning {
-		return false
-	}
-
-	for _, cond := range pod.Status.Conditions {
-		if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
-			return true
-		}
-	}
-	return false
-}
-
-func waitForDeploymentReady(t *testing.T, ctx context.Context, kubeClient kubernetes.Interface, namespace, name string, replicas int32, timeout time.Duration) {
-	t.Helper()
-	err := wait.PollUntilContextTimeout(ctx, defaultPollingInterval, timeout, true, func(ctx context.Context) (bool, error) {
-		deploy, err := kubeClient.AppsV1().Deployments(namespace).Get(ctx, name, metav1.GetOptions{})
-		if err != nil {
-			return false, nil
-		}
-		return deploy.Status.ReadyReplicas >= replicas, nil
-	})
-	require.NoError(t, err, "Deployment %q did not become ready after scaling to %d replicas within %v", name, replicas, timeout)
-}
-
 func matchLabels(metricLabels []*dto.LabelPair, wantLabels map[string]string) bool {
 	labelMap := make(map[string]string)
 	for _, lp := range metricLabels {
@@ -131,7 +103,7 @@ func ensureRedis(t *testing.T, kubeClient kubernetes.Interface, namespace string
 	dynamicClient, err := dynamic.NewForConfig(config)
 	require.NoError(t, err, "Failed to create dynamic client")
 
-	redisManifestPath := filepath.Join(testDataDir, "redis-standalone.yaml")
+	redisManifestPath := filepath.Join(routercontext.TestDataDir, "redis-standalone.yaml")
 
 	redisObjects := utils.LoadUnstructuredYAMLFromFile(redisManifestPath)
 	require.NotEmpty(t, redisObjects, "Redis manifest is empty")
@@ -181,7 +153,7 @@ func ensureRedis(t *testing.T, kubeClient kubernetes.Interface, namespace string
 
 	require.NotEmpty(t, redisDeploymentName, "Redis Deployment not found in manifest")
 
-	waitForDeploymentReady(t, ctx, kubeClient, namespace, redisDeploymentName, 1, 2*time.Minute)
+	utils.WaitForDeploymentReady(t, ctx, kubeClient, namespace, redisDeploymentName, 1, 2*time.Minute)
 	t.Log("Redis is ready")
 
 	return func() {
@@ -217,7 +189,7 @@ func scaleRouterDeployment(t *testing.T, kubeClient kubernetes.Interface, namesp
 		require.NoError(t, err, "Failed to scale kthena-router deployment")
 	}
 
-	waitForDeploymentReady(t, ctx, kubeClient, namespace, deploymentName, replicas, defaultScalingTimeout)
+	utils.WaitForDeploymentReady(t, ctx, kubeClient, namespace, deploymentName, replicas, defaultScalingTimeout)
 	t.Log("kthena-router deployment is ready")
 
 	return func() {
@@ -232,38 +204,6 @@ func scaleRouterDeployment(t *testing.T, kubeClient kubernetes.Interface, namesp
 		deploy.Spec.Replicas = &originalReplicas
 		_, _ = kubeClient.AppsV1().Deployments(namespace).Update(restoreCtx, deploy, metav1.UpdateOptions{})
 	}
-}
-
-func getRouterPods(t *testing.T, kubeClient kubernetes.Interface, namespace string) []corev1.Pod {
-	t.Helper()
-	ctx := context.Background()
-	deployment, err := kubeClient.AppsV1().Deployments(namespace).Get(ctx, "kthena-router", metav1.GetOptions{})
-	require.NoError(t, err, "Failed to get router deployment")
-
-	labelSelector := ""
-	for key, value := range deployment.Spec.Selector.MatchLabels {
-		if labelSelector != "" {
-			labelSelector += ","
-		}
-		labelSelector += key + "=" + value
-	}
-
-	pods, err := kubeClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
-		LabelSelector: labelSelector,
-	})
-	require.NoError(t, err, "Failed to list router pods")
-	require.NotEmpty(t, pods.Items, "No router pods found")
-
-	readyPods := make([]corev1.Pod, 0, len(pods.Items))
-	for _, pod := range pods.Items {
-		if isPodReady(pod) {
-			readyPods = append(readyPods, pod)
-		}
-	}
-	require.NotEmpty(t, readyPods, "No ready router pods found")
-	t.Logf("Found %d ready router pods", len(readyPods))
-
-	return readyPods
 }
 
 // setupModelRouteWithGatewayAPI configures ModelRoute with ParentRefs to default Gateway if useGatewayAPI is true.
@@ -296,7 +236,7 @@ func TestModelRouteSimpleShared(t *testing.T, testCtx *routercontext.RouterTestC
 
 	// Deploy ModelRoute
 	t.Log("Deploying ModelRoute...")
-	modelRoute := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute](filepath.Join(testDataDir, "ModelRouteSimple.yaml"))
+	modelRoute := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute](filepath.Join(routercontext.TestDataDir, "ModelRouteSimple.yaml"))
 	modelRoute.Namespace = testNamespace
 
 	// Configure ParentRefs if using Gateway API
@@ -345,7 +285,7 @@ func TestModelRouteSimpleShared(t *testing.T, testCtx *routercontext.RouterTestC
 func TestModelRouteMultiModelsShared(t *testing.T, testCtx *routercontext.RouterTestContext, testNamespace string, useGatewayAPI bool, kthenaNamespace string) {
 	ctx := context.Background()
 
-	modelRoute := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute](filepath.Join(testDataDir, "ModelRouteMultiModels.yaml"))
+	modelRoute := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute](filepath.Join(routercontext.TestDataDir, "ModelRouteMultiModels.yaml"))
 	modelRoute.Namespace = testNamespace
 
 	// Configure ParentRefs if using Gateway API
@@ -416,7 +356,7 @@ func TestModelRoutePrefillDecodeDisaggregationShared(t *testing.T, testCtx *rout
 
 	// Deploy ModelServing
 	t.Log("Deploying ModelServing for PD disaggregation...")
-	modelServing := utils.LoadYAMLFromFile[workloadv1alpha1.ModelServing](filepath.Join(testDataDir, "ModelServing-ds1.5b-pd-disaggregation.yaml"))
+	modelServing := utils.LoadYAMLFromFile[workloadv1alpha1.ModelServing](filepath.Join(routercontext.TestDataDir, "ModelServing-ds1.5b-pd-disaggregation.yaml"))
 	modelServing.Namespace = testNamespace
 	createdModelServing, err := testCtx.KthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Create(ctx, modelServing, metav1.CreateOptions{})
 	require.NoError(t, err, "Failed to create ModelServing")
@@ -437,7 +377,7 @@ func TestModelRoutePrefillDecodeDisaggregationShared(t *testing.T, testCtx *rout
 
 	// Deploy ModelServer
 	t.Log("Deploying ModelServer for PD disaggregation...")
-	modelServer := utils.LoadYAMLFromFile[networkingv1alpha1.ModelServer](filepath.Join(testDataDir, "ModelServer-ds1.5b-pd-disaggregation.yaml"))
+	modelServer := utils.LoadYAMLFromFile[networkingv1alpha1.ModelServer](filepath.Join(routercontext.TestDataDir, "ModelServer-ds1.5b-pd-disaggregation.yaml"))
 	modelServer.Namespace = testNamespace
 	createdModelServer, err := testCtx.KthenaClient.NetworkingV1alpha1().ModelServers(testNamespace).Create(ctx, modelServer, metav1.CreateOptions{})
 	require.NoError(t, err, "Failed to create ModelServer")
@@ -455,7 +395,7 @@ func TestModelRoutePrefillDecodeDisaggregationShared(t *testing.T, testCtx *rout
 
 	// Deploy ModelRoute
 	t.Log("Deploying ModelRoute for PD disaggregation...")
-	modelRoute := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute](filepath.Join(testDataDir, "ModelRoute-ds1.5b-pd-disaggregation.yaml"))
+	modelRoute := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute](filepath.Join(routercontext.TestDataDir, "ModelRoute-ds1.5b-pd-disaggregation.yaml"))
 	modelRoute.Namespace = testNamespace
 
 	// Configure ParentRefs if using Gateway API
@@ -510,7 +450,7 @@ func TestModelRouteSubsetShared(t *testing.T, testCtx *routercontext.RouterTestC
 	t.Log("Deploying Canary ModelServers and LLM-Mock deployments...")
 
 	// Deploy Canary LLM-Mock deployments from YAML file
-	canaryDeployments := utils.LoadMultiResourceYAMLFromFile[appsv1.Deployment](filepath.Join(testDataDir, "LLM-Mock-ds1.5b-Canary.yaml"))
+	canaryDeployments := utils.LoadMultiResourceYAMLFromFile[appsv1.Deployment](filepath.Join(routercontext.TestDataDir, "LLM-Mock-ds1.5b-Canary.yaml"))
 	require.Len(t, canaryDeployments, 2, "Canary YAML should contain 2 deployments")
 
 	deploymentV1 := canaryDeployments[0]
@@ -524,21 +464,11 @@ func TestModelRouteSubsetShared(t *testing.T, testCtx *routercontext.RouterTestC
 	require.NoError(t, err, "Failed to create Canary deployment v2")
 
 	// Wait for deployments to be ready
-	require.Eventually(t, func() bool {
-		deployV1, err := testCtx.KubeClient.AppsV1().Deployments(testNamespace).Get(ctx, "deepseek-r1-1-5b-v1", metav1.GetOptions{})
-		if err != nil {
-			return false
-		}
-		deployV2, err := testCtx.KubeClient.AppsV1().Deployments(testNamespace).Get(ctx, "deepseek-r1-1-5b-v2", metav1.GetOptions{})
-		if err != nil {
-			return false
-		}
-		return deployV1.Status.ReadyReplicas == *deployV1.Spec.Replicas &&
-			deployV2.Status.ReadyReplicas == *deployV2.Spec.Replicas
-	}, 5*time.Minute, 5*time.Second, "Canary deployments should be ready")
+	utils.WaitForDeploymentReady(t, ctx, testCtx.KubeClient, testNamespace, "deepseek-r1-1-5b-v1", 1, 2*time.Minute)
+	utils.WaitForDeploymentReady(t, ctx, testCtx.KubeClient, testNamespace, "deepseek-r1-1-5b-v2", 1, 2*time.Minute)
 
 	// Deploy Canary ModelServers from YAML file
-	canaryModelServers := utils.LoadMultiResourceYAMLFromFile[networkingv1alpha1.ModelServer](filepath.Join(testDataDir, "ModelServer-ds1.5b-Canary.yaml"))
+	canaryModelServers := utils.LoadMultiResourceYAMLFromFile[networkingv1alpha1.ModelServer](filepath.Join(routercontext.TestDataDir, "ModelServer-ds1.5b-Canary.yaml"))
 	require.Len(t, canaryModelServers, 2, "Canary YAML should contain 2 ModelServers")
 
 	modelServerV1 := canaryModelServers[0]
@@ -562,7 +492,7 @@ func TestModelRouteSubsetShared(t *testing.T, testCtx *routercontext.RouterTestC
 	})
 
 	// Create ModelRoute with Canary ModelServer names
-	modelRoute := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute](filepath.Join(testDataDir, "ModelRouteSubset.yaml"))
+	modelRoute := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute](filepath.Join(routercontext.TestDataDir, "ModelRouteSubset.yaml"))
 	modelRoute.Namespace = testNamespace
 
 	// Configure ParentRefs if using Gateway API
@@ -733,7 +663,7 @@ func TestModelRouteWithRateLimitShared(t *testing.T, testCtx *routercontext.Rout
 	t.Run("VerifyInputTokenRateLimitEnforcement", func(t *testing.T) {
 		t.Log("Test 1: Verifying input token rate limit")
 
-		modelRoute := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute](filepath.Join(testDataDir, "ModelRouteWithRateLimit.yaml"))
+		modelRoute := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute](filepath.Join(routercontext.TestDataDir, "ModelRouteWithRateLimit.yaml"))
 		modelRoute.Namespace = testNamespace
 		// Only test input rate limit; remove output limit to avoid 429 "output token rate limit exceeded"
 		if modelRoute.Spec.RateLimit != nil {
@@ -795,7 +725,7 @@ func TestModelRouteWithRateLimitShared(t *testing.T, testCtx *routercontext.Rout
 	t.Run("VerifyRateLimitWindowAccuracy", func(t *testing.T) {
 		t.Log("Test 2: Verifying rate limit window accuracy...")
 
-		modelRoute := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute](filepath.Join(testDataDir, "ModelRouteWithRateLimit.yaml"))
+		modelRoute := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute](filepath.Join(routercontext.TestDataDir, "ModelRouteWithRateLimit.yaml"))
 		modelRoute.Namespace = testNamespace
 		// Only test input rate limit; remove output limit to avoid 429 "output token rate limit exceeded"
 		if modelRoute.Spec.RateLimit != nil {
@@ -864,7 +794,7 @@ func TestModelRouteWithRateLimitShared(t *testing.T, testCtx *routercontext.Rout
 	t.Run("VerifyRateLimitResetMechanism", func(t *testing.T) {
 		t.Log("Test 3: Verifying rate limit reset mechanism...")
 
-		modelRoute := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute](filepath.Join(testDataDir, "ModelRouteWithRateLimit.yaml"))
+		modelRoute := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute](filepath.Join(routercontext.TestDataDir, "ModelRouteWithRateLimit.yaml"))
 		modelRoute.Namespace = testNamespace
 		// Only test input rate limit; remove output limit to avoid 429 "output token rate limit exceeded"
 		if modelRoute.Spec.RateLimit != nil {
@@ -934,7 +864,7 @@ func TestModelRouteWithRateLimitShared(t *testing.T, testCtx *routercontext.Rout
 	t.Run("VerifyOutputTokenRateLimitEnforcement", func(t *testing.T) {
 		t.Log("Test 4: Verifying output token rate limit (100 tokens/minute)...")
 
-		modelRoute := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute](filepath.Join(testDataDir, "ModelRouteWithRateLimit.yaml"))
+		modelRoute := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute](filepath.Join(routercontext.TestDataDir, "ModelRouteWithRateLimit.yaml"))
 		modelRoute.Namespace = testNamespace
 		setupModelRouteWithGatewayAPI(modelRoute, useGatewayApi, kthenaNamespace)
 
@@ -1024,7 +954,7 @@ func TestModelRouteWithGlobalRateLimitShared(t *testing.T, testCtx *routercontex
 	}
 
 	buildModelRoute := func(name, modelName, redisAddr string) *networkingv1alpha1.ModelRoute {
-		modelRoute := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute](filepath.Join(testDataDir, "ModelRouteWithGlobalRateLimit.yaml"))
+		modelRoute := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute](filepath.Join(routercontext.TestDataDir, "ModelRouteWithGlobalRateLimit.yaml"))
 		modelRoute.Namespace = testNamespace
 		modelRoute.Name = name
 		modelRoute.Spec.ModelName = modelName
@@ -1089,7 +1019,7 @@ func TestModelRouteWithGlobalRateLimitShared(t *testing.T, testCtx *routercontex
 			return err == nil && mr != nil
 		}, 2*time.Minute, 2*time.Second, "ModelRoute should be created")
 
-		pods := getRouterPods(t, testCtx.KubeClient, kthenaNamespace)
+		pods := utils.GetReadyRouterPods(t, testCtx.KubeClient, kthenaNamespace)
 		require.GreaterOrEqual(t, len(pods), 3, "Need at least three router pods for global sharing test")
 
 		pf1, err := utils.SetupPortForwardToPod(kthenaNamespace, pods[0].Name, "18080", "8080")
@@ -1214,7 +1144,7 @@ func TestModelRouteLoraShared(t *testing.T, testCtx *routercontext.RouterTestCon
 
 	// Deploy ModelRoute with LoRA adapters
 	t.Log("Deploying ModelRoute with LoRA adapters...")
-	modelRoute := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute](filepath.Join(testDataDir, "ModelRouteLora.yaml"))
+	modelRoute := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute](filepath.Join(routercontext.TestDataDir, "ModelRouteLora.yaml"))
 	modelRoute.Namespace = testNamespace
 
 	// Configure ParentRefs if using Gateway API
@@ -1418,7 +1348,7 @@ func TestMetricsShared(t *testing.T, testCtx *routercontext.RouterTestContext, t
 
 	// Deploy ModelRoute
 	t.Log("Deploying ModelRoute...")
-	modelRoute := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute](filepath.Join(testDataDir, "ModelRouteSimple.yaml"))
+	modelRoute := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute](filepath.Join(routercontext.TestDataDir, "ModelRouteSimple.yaml"))
 	modelRoute.Namespace = testNamespace
 
 	setupModelRouteWithGatewayAPI(modelRoute, useGatewayAPI, kthenaNamespace)
@@ -1570,7 +1500,7 @@ func TestRateLimitMetricsShared(t *testing.T, testCtx *routercontext.RouterTestC
 
 	// Deploy ModelRoute with rate limiting
 	t.Log("Deploying ModelRoute with rate limiting...")
-	modelRoute := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute](filepath.Join(testDataDir, "ModelRouteWithRateLimit.yaml"))
+	modelRoute := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute](filepath.Join(routercontext.TestDataDir, "ModelRouteWithRateLimit.yaml"))
 	modelRoute.Namespace = testNamespace
 
 	setupModelRouteWithGatewayAPI(modelRoute, useGatewayAPI, kthenaNamespace)

--- a/test/e2e/utils/pod.go
+++ b/test/e2e/utils/pod.go
@@ -28,10 +28,19 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-// GetRouterPod is a helper function to get the router pod
-func GetRouterPod(t *testing.T, kubeClient kubernetes.Interface, kthenaNamespace string) *corev1.Pod {
-	deployment, err := kubeClient.AppsV1().Deployments(kthenaNamespace).Get(context.Background(), "kthena-router", metav1.GetOptions{})
-	require.NoError(t, err, "Failed to get router deployment")
+// GetRouterPod is a helper function to get the first ready router pod.
+func GetRouterPod(t *testing.T, kubeClient kubernetes.Interface, namespace string) *corev1.Pod {
+	t.Helper()
+	readyPods := GetReadyRouterPods(t, kubeClient, namespace)
+	return &readyPods[0]
+}
+
+// GetReadyRouterPods returns all ready pods for the kthena-router deployment.
+func GetReadyRouterPods(t *testing.T, kubeClient kubernetes.Interface, namespace string) []corev1.Pod {
+	t.Helper()
+	ctx := context.Background()
+	deployment, err := kubeClient.AppsV1().Deployments(namespace).Get(ctx, "kthena-router", metav1.GetOptions{})
+	require.NoError(t, err, "Failed to get kthena-router deployment")
 
 	// Build label selector from deployment selector
 	labelSelector := ""
@@ -42,14 +51,22 @@ func GetRouterPod(t *testing.T, kubeClient kubernetes.Interface, kthenaNamespace
 		labelSelector += key + "=" + value
 	}
 
-	// Get router pod
-	pods, err := kubeClient.CoreV1().Pods(kthenaNamespace).List(context.Background(), metav1.ListOptions{
+	pods, err := kubeClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
 		LabelSelector: labelSelector,
 	})
 	require.NoError(t, err, "Failed to list router pods")
 	require.NotEmpty(t, pods.Items, "No router pods found")
 
-	return &pods.Items[0]
+	readyPods := make([]corev1.Pod, 0, len(pods.Items))
+	for _, pod := range pods.Items {
+		if IsPodReady(pod) {
+			readyPods = append(readyPods, pod)
+		}
+	}
+	require.NotEmpty(t, readyPods, "No ready router pods found")
+	t.Logf("Found %d ready router pods", len(readyPods))
+
+	return readyPods
 }
 
 // ListPodsByLabel lists pods matching the given label selector in the namespace.

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -18,13 +18,21 @@ package utils
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 	clientset "github.com/volcano-sh/kthena/client-go/clientset/versioned"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	defaultPollingInterval = 2 * time.Second
 )
 
 // WaitForModelServingReady waits for a ModelServing to become ready by checking
@@ -45,4 +53,99 @@ func WaitForModelServingReady(t *testing.T, ctx context.Context, kthenaClient *c
 		return ms.Status.AvailableReplicas >= expectedReplicas, nil
 	})
 	require.NoError(t, err, "ModelServing did not become ready")
+}
+
+// IsPodReady checks if a pod is in Running phase and has PodReady condition set to True.
+func IsPodReady(pod corev1.Pod) bool {
+	if pod.Status.Phase != corev1.PodRunning {
+		return false
+	}
+
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}
+
+// WaitForDeploymentReady polls until the named Deployment has at least replicas ready pods.
+func WaitForDeploymentReady(t *testing.T, ctx context.Context, kubeClient kubernetes.Interface, namespace, name string, replicas int32, timeout time.Duration) {
+	t.Helper()
+	err := wait.PollUntilContextTimeout(ctx, defaultPollingInterval, timeout, true, func(ctx context.Context) (bool, error) {
+		deploy, err := kubeClient.AppsV1().Deployments(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		return deploy.Status.ReadyReplicas >= replicas, nil
+	})
+	require.NoError(t, err, "Deployment %q did not become ready after scaling to %d replicas within %v", name, replicas, timeout)
+}
+
+// WaitForDeploymentReadyE is like WaitForDeploymentReady but returns an error instead of calling t.Fatal.
+// It polls until ReadyReplicas == *Spec.Replicas, or until ReadyReplicas >= 1 when Spec.Replicas is nil.
+func WaitForDeploymentReadyE(ctx context.Context, kubeClient kubernetes.Interface, namespace, name string, timeout time.Duration) error {
+	err := wait.PollUntilContextTimeout(ctx, defaultPollingInterval, timeout, true, func(ctx context.Context) (bool, error) {
+		deploy, err := kubeClient.AppsV1().Deployments(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		if deploy.Spec.Replicas == nil {
+			return deploy.Status.ReadyReplicas >= 1, nil
+		}
+		return deploy.Status.ReadyReplicas == *deploy.Spec.Replicas, nil
+	})
+	if err != nil {
+		return fmt.Errorf("deployment %q did not become ready within %v: %w", name, timeout, err)
+	}
+	return nil
+}
+
+// CreateTestNamespace creates a test namespace and tolerates if it already exists.
+func CreateTestNamespace(kubeClient kubernetes.Interface, name string) error {
+	fmt.Printf("Creating test namespace: %s\n", name)
+	ctx := context.Background()
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+	_, err := kubeClient.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("failed to create namespace %s: %w", name, err)
+	}
+	return nil
+}
+
+// DeleteTestNamespaceAndWait deletes a test namespace and polls until it is fully gone.
+func DeleteTestNamespaceAndWait(kubeClient kubernetes.Interface, name string, timeout time.Duration) error {
+	fmt.Printf("Deleting test namespace: %s\n", name)
+	ctx := context.Background()
+	err := kubeClient.CoreV1().Namespaces().Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("failed to delete namespace %s: %w", name, err)
+	}
+
+	waitCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	err = wait.PollUntilContextCancel(waitCtx, defaultPollingInterval, true, func(ctx context.Context) (bool, error) {
+		_, err := kubeClient.CoreV1().Namespaces().Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return true, nil // namespace is gone
+			}
+			return false, err
+		}
+		return false, nil
+	})
+	if err != nil {
+		return fmt.Errorf("timeout waiting for namespace %s deletion: %w", name, err)
+	}
+	return nil
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
Noticed pod readiness checks, deployment waits, and namespace create/delete were copy pasted between the router and controller-manager test suites. Moved them to test/e2e/utils/ so there's one copy.

testDataDir was also defined 3 times with the same value, now all use routercontext.TestDataDir.

Small fix: SetupCommonComponents was double-wrapping a context with two separate timeouts. Removed the outer one.

**Which issue(s) this PR fixes**:

None (cleanup suggested by @LiZhenCheng9527)

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```