### PR TITLE
Use startupProbe for vLLM engine containers

### DIFF
--- a/pkg/model-booster-controller/convert/templates/vllm-pd.yaml
+++ b/pkg/model-booster-controller/convert/templates/vllm-pd.yaml
@@ -44,20 +44,25 @@ spec:
                 command: ${ENGINE_PREFILL_COMMAND}
                 imagePullPolicy: IfNotPresent
                 resources: ${ENGINE_PREFILL_RESOURCES}
-                readinessProbe:
+                startupProbe:
+                  httpGet:
+                    path: /health
+                    port: 8000
                   initialDelaySeconds: 5
                   periodSeconds: 5
-                  failureThreshold: 3
+                  failureThreshold: 60
+                readinessProbe:
                   httpGet:
                     path: /health
                     port: 8000
-                livenessProbe:
-                  initialDelaySeconds: 180
                   periodSeconds: 5
                   failureThreshold: 3
+                livenessProbe:
                   httpGet:
                     path: /health
                     port: 8000
+                  periodSeconds: 5
+                  failureThreshold: 3
                 volumeMounts: ${VOLUME_MOUNTS}
             volumes: ${VOLUMES}
         workerReplicas: 0
@@ -98,20 +103,25 @@ spec:
                 command: ${ENGINE_DECODE_COMMAND}
                 imagePullPolicy: IfNotPresent
                 resources: ${ENGINE_DECODE_RESOURCES}
-                readinessProbe:
+                startupProbe:
+                  httpGet:
+                    path: /health
+                    port: 8000
                   initialDelaySeconds: 5
                   periodSeconds: 5
-                  failureThreshold: 3
+                  failureThreshold: 60
+                readinessProbe:
                   httpGet:
                     path: /health
                     port: 8000
-                livenessProbe:
-                  initialDelaySeconds: 180
                   periodSeconds: 5
                   failureThreshold: 3
+                livenessProbe:
                   httpGet:
                     path: /health
                     port: 8000
+                  periodSeconds: 5
+                  failureThreshold: 3
                 volumeMounts: ${VOLUME_MOUNTS}
             volumes: ${VOLUMES}
         workerReplicas: 0

--- a/pkg/model-booster-controller/convert/templates/vllm.yaml
+++ b/pkg/model-booster-controller/convert/templates/vllm.yaml
@@ -57,13 +57,19 @@ spec:
                 env: ${ENGINE_ENV}
                 resources: ${ENGINE_SERVER_RESOURCES}
                 volumeMounts: ${VOLUME_MOUNTS}
+                startupProbe:
+                  failureThreshold: 60
+                  httpGet:
+                    path: /health
+                    port: 8000
+                    scheme: HTTP
+                  periodSeconds: 5
                 readinessProbe:
                   failureThreshold: 3
                   httpGet:
                     path: /health
                     port: 8000
                     scheme: HTTP
-                  initialDelaySeconds: 180
                   periodSeconds: 5
                   successThreshold: 1
                   timeoutSeconds: 1

--- a/pkg/model-booster-controller/convert/testdata/expected/disaggregated-model-serving-mooncake.yaml
+++ b/pkg/model-booster-controller/convert/testdata/expected/disaggregated-model-serving-mooncake.yaml
@@ -141,12 +141,12 @@ spec:
                         fieldPath: status.podIP
                 image: vllm-prefill:latest
                 imagePullPolicy: IfNotPresent
-                livenessProbe:
-                  failureThreshold: 3
+                startupProbe:
+                  failureThreshold: 60
                   httpGet:
                     path: /health
                     port: 8000
-                  initialDelaySeconds: 180
+                  initialDelaySeconds: 5
                   periodSeconds: 5
                 name: vllm
                 ports:
@@ -156,7 +156,12 @@ spec:
                   httpGet:
                     path: /health
                     port: 8000
-                  initialDelaySeconds: 5
+                  periodSeconds: 5
+                livenessProbe:
+                  failureThreshold: 3
+                  httpGet:
+                    path: /health
+                    port: 8000
                   periodSeconds: 5
                 resources:
                   limits:
@@ -317,12 +322,12 @@ spec:
                     value: eth0
                 image: vllm-decode:latest
                 imagePullPolicy: IfNotPresent
-                livenessProbe:
-                  failureThreshold: 3
+                startupProbe:
+                  failureThreshold: 60
                   httpGet:
                     path: /health
                     port: 8000
-                  initialDelaySeconds: 180
+                  initialDelaySeconds: 5
                   periodSeconds: 5
                 name: vllm
                 ports:
@@ -332,7 +337,12 @@ spec:
                   httpGet:
                     path: /health
                     port: 8000
-                  initialDelaySeconds: 5
+                  periodSeconds: 5
+                livenessProbe:
+                  failureThreshold: 3
+                  httpGet:
+                    path: /health
+                    port: 8000
                   periodSeconds: 5
                 resources:
                   limits:

--- a/pkg/model-booster-controller/convert/testdata/expected/disaggregated-model-serving.yaml
+++ b/pkg/model-booster-controller/convert/testdata/expected/disaggregated-model-serving.yaml
@@ -149,12 +149,12 @@ spec:
                         fieldPath: status.podIP
                 image: vllm-prefill:latest
                 imagePullPolicy: IfNotPresent
-                livenessProbe:
-                  failureThreshold: 3
+                startupProbe:
+                  failureThreshold: 60
                   httpGet:
                     path: /health
                     port: 8000
-                  initialDelaySeconds: 180
+                  initialDelaySeconds: 5
                   periodSeconds: 5
                 name: vllm
                 ports:
@@ -164,7 +164,12 @@ spec:
                   httpGet:
                     path: /health
                     port: 8000
-                  initialDelaySeconds: 5
+                  periodSeconds: 5
+                livenessProbe:
+                  failureThreshold: 3
+                  httpGet:
+                    path: /health
+                    port: 8000
                   periodSeconds: 5
                 resources:
                   limits:
@@ -339,12 +344,12 @@ spec:
                     value: eth0
                 image: vllm-decode:latest
                 imagePullPolicy: IfNotPresent
-                livenessProbe:
-                  failureThreshold: 3
+                startupProbe:
+                  failureThreshold: 60
                   httpGet:
                     path: /health
                     port: 8000
-                  initialDelaySeconds: 180
+                  initialDelaySeconds: 5
                   periodSeconds: 5
                 name: vllm
                 ports:
@@ -354,7 +359,12 @@ spec:
                   httpGet:
                     path: /health
                     port: 8000
-                  initialDelaySeconds: 5
+                  periodSeconds: 5
+                livenessProbe:
+                  failureThreshold: 3
+                  httpGet:
+                    path: /health
+                    port: 8000
                   periodSeconds: 5
                 resources:
                   limits:

--- a/pkg/model-booster-controller/convert/testdata/expected/model-serving.yaml
+++ b/pkg/model-booster-controller/convert/testdata/expected/model-serving.yaml
@@ -156,13 +156,19 @@ spec:
                         key: REDIS_PASSWORD
                         name: redis-secret
                         optional: true
+                startupProbe:
+                  failureThreshold: 60
+                  httpGet:
+                    path: /health
+                    port: 8000
+                    scheme: HTTP
+                  periodSeconds: 5
                 readinessProbe:
                   failureThreshold: 3
                   httpGet:
                     path: /health
                     port: 8000
                     scheme: HTTP
-                  initialDelaySeconds: 180
                   periodSeconds: 5
                   successThreshold: 1
                   timeoutSeconds: 1


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:
Replace livenessProbe initialDelaySeconds with startupProbe in vLLM templates to allow dynamic startup time based on actual model loading duration, preventing premature restarts for large models while enabling faster startup detection for small models.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```
