### PR TITLE
fix(autoscaler): use maximum sliding window for scale-down stabilization

### DIFF
--- a/pkg/autoscaler/autoscaler/status.go
+++ b/pkg/autoscaler/autoscaler/status.go
@@ -56,7 +56,7 @@ func NewStatus(behavior *v1alpha1.AutoscalingPolicyBehavior) *Status {
 		History: &algorithm.History{
 			MaxRecommendation:     datastructure.NewMaximumRecordSlidingWindow[int32](scaleDownStabilizationWindowMilliseconds),
 			MinRecommendation:     datastructure.NewMinimumRecordSlidingWindow[int32](scaleUpStabilizationWindowMilliseconds),
-			MaxCorrected:          datastructure.NewMinimumLineChartSlidingWindow[int32](scaleDownPeriodMilliseconds),
+			MaxCorrected:          datastructure.NewMaximumLineChartSlidingWindow[int32](scaleDownPeriodMilliseconds),
 			MinCorrectedForStable: datastructure.NewMinimumLineChartSlidingWindow[int32](scaleUpStablePolicyPeriodMilliseconds),
 			MinCorrectedForPanic:  datastructure.NewMinimumLineChartSlidingWindow[int32](behavior.ScaleUp.PanicPolicy.Period.Milliseconds()),
 		},


### PR DESCRIPTION
### Summary
The scale-down stabilization logic in `status.go` was using a
`NewMinimumLineChartSlidingWindow` for `MaxCorrected` tracking.
This caused the stabilizer to record the **lowest** corrected value
over the window, making it underestimate the safe scale-down limit.
As a result, the autoscaler could scale down more aggressively than
intended.

### Fix
Flip the sliding window from `Minimum` to `Maximum` so that the
highest corrected value over the window is used, providing the
intended conservative scale-down behavior.

### Impact
Fixes overly aggressive scale-down during stabilization.

### Related files
pkg/autoscaler/autoscaler/status.go