### PR TITLE
fix(nixl): rebuild prefill/decode request bodies on every Proxy call

### DIFF
--- a/pkg/kthena-router/connectors/http.go
+++ b/pkg/kthena-router/connectors/http.go
@@ -70,15 +70,11 @@ func (h *HTTPConnector) Proxy(c *gin.Context, reqBody map[string]interface{}, pr
 		}
 	}
 
-	if h.decodeRequest == nil {
-		h.decodeRequest = BuildDecodeRequest(c, c.Request, reqBody)
-	}
+	decodeBody := cloneReqBody(reqBody)
+	h.decodeRequest = BuildDecodeRequest(c, c.Request, decodeBody)
 
-	// build prefillRequest after decodeRequest, because prefillRequest needs to delete stream and stream_options
-	// and modify the max_tokens
-	if h.prefillRequest == nil {
-		h.prefillRequest = buildPrefillRequest(c.Request, reqBody)
-	}
+	prefillBody := cloneReqBody(reqBody)
+	h.prefillRequest = buildPrefillRequest(c.Request, prefillBody)
 
 	// Start prefill phase metrics and increment upstream request
 	if metricsRecorder != nil {

--- a/pkg/kthena-router/connectors/nixl.go
+++ b/pkg/kthena-router/connectors/nixl.go
@@ -63,7 +63,8 @@ func (n *NIXLConnector) Proxy(c *gin.Context, reqBody map[string]interface{}, pr
 	req := c.Request
 	prefillBody := cloneReqBody(reqBody)
 	n.prefillRequest = n.buildPrefillRequest(req, prefillBody)
-	n.decodeRequestBody = addTokenUsage(c, reqBody)
+	decodeBody := cloneReqBody(reqBody)
+	n.decodeRequestBody = addTokenUsage(c, decodeBody)
 
 	// Start prefill phase metrics and increment upstream request
 	if metricsRecorder != nil {

--- a/pkg/kthena-router/connectors/nixl.go
+++ b/pkg/kthena-router/connectors/nixl.go
@@ -61,13 +61,9 @@ func (n *NIXLConnector) Proxy(c *gin.Context, reqBody map[string]interface{}, pr
 	}
 
 	req := c.Request
-	if n.prefillRequest == nil {
-		prefillBody := cloneReqBody(reqBody)
-		n.prefillRequest = n.buildPrefillRequest(req, prefillBody)
-	}
-	if n.decodeRequestBody == nil {
-		n.decodeRequestBody = addTokenUsage(c, reqBody)
-	}
+	prefillBody := cloneReqBody(reqBody)
+	n.prefillRequest = n.buildPrefillRequest(req, prefillBody)
+	n.decodeRequestBody = addTokenUsage(c, reqBody)
 
 	// Start prefill phase metrics and increment upstream request
 	if metricsRecorder != nil {

--- a/pkg/kthena-router/connectors/nixl_test.go
+++ b/pkg/kthena-router/connectors/nixl_test.go
@@ -17,9 +17,12 @@ limitations under the License.
 package connectors
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -373,4 +376,89 @@ func TestNIXLConnectorProxy(t *testing.T) {
 			}
 		}
 	})
+}
+
+// TestNIXLConnectorRetryBodyNotDrained checks that calling Proxy() twice on the
+// same connector instance (as proxyToPDDisaggregated does during retries) sends
+// a non-empty body to the prefill backend on both attempts.
+func TestNIXLConnectorRetryBodyNotDrained(t *testing.T) {
+	var callCount int32
+	var bodyLengths [2]int64
+
+	// prefill server records body size for each call and returns valid kv_transfer_params
+	prefillServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		idx := atomic.AddInt32(&callCount, 1) - 1
+		body, _ := io.ReadAll(r.Body)
+		if idx < 2 {
+			bodyLengths[idx] = int64(len(body))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{"kv_transfer_params": nil})
+	}))
+	defer prefillServer.Close()
+
+	connector := NewNIXLConnector()
+
+	reqBody := map[string]interface{}{
+		"model":      "test-model",
+		"max_tokens": 100,
+		"messages": []interface{}{
+			map[string]interface{}{"role": "user", "content": "hello"},
+		},
+	}
+
+	makeCtx := func() *gin.Context {
+		req, _ := http.NewRequest("POST", "/v1/chat/completions", nil)
+		c, _ := gin.CreateTestContext(httptest.NewRecorder())
+		c.Request = req
+		return c
+	}
+
+	prefillAddr := prefillServer.Listener.Addr().String()
+	decodeAddr := "127.0.0.1:1" // nothing listening here; decode will fail
+
+	// First call — simulates retry iteration 0
+	connector.Proxy(makeCtx(), reqBody, prefillAddr, decodeAddr)
+	// Second call — simulates retry iteration 1 on the same connector instance
+	connector.Proxy(makeCtx(), reqBody, prefillAddr, decodeAddr)
+
+	if bodyLengths[0] == 0 {
+		t.Error("first Proxy call sent empty body to prefill backend")
+	}
+	if bodyLengths[1] == 0 {
+		t.Error("second Proxy call sent empty body to prefill backend — request body was drained and reused")
+	}
+}
+
+// TestNIXLConnectorReqBodyNotMutated checks that Proxy() does not mutate the
+// caller's reqBody map. proxyToPDDisaggregated passes the same modelRequest
+// across all retry iterations, so mutations would bleed between retries.
+func TestNIXLConnectorReqBodyNotMutated(t *testing.T) {
+	connector := NewNIXLConnector()
+
+	req, _ := http.NewRequest("POST", "/v1/chat/completions", nil)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = req
+
+	reqBody := map[string]interface{}{
+		"model":      "test-model",
+		"max_tokens": 100,
+		"messages": []interface{}{
+			map[string]interface{}{"role": "user", "content": "hello"},
+		},
+	}
+
+	// snapshot keys present before
+	keysBefore := make(map[string]struct{})
+	for k := range reqBody {
+		keysBefore[k] = struct{}{}
+	}
+
+	connector.Proxy(c, reqBody, "127.0.0.1:1", "127.0.0.1:2")
+
+	for k := range reqBody {
+		if _, existed := keysBefore[k]; !existed {
+			t.Errorf("Proxy() mutated caller reqBody by adding key %q", k)
+		}
+	}
 }

--- a/pkg/kthena-router/connectors/transport.go
+++ b/pkg/kthena-router/connectors/transport.go
@@ -114,12 +114,12 @@ func BuildDecodeRequest(c *gin.Context, req *http.Request, modelRequest map[stri
 		return nil
 	}
 
-	// build request
-	req.URL.Scheme = "http"
-	req.Body = io.NopCloser(bytes.NewBuffer(body))
-	req.ContentLength = int64(len(body))
+	reqCopy := req.Clone(req.Context())
+	reqCopy.URL.Scheme = "http"
+	reqCopy.Body = io.NopCloser(bytes.NewBuffer(body))
+	reqCopy.ContentLength = int64(len(body))
 
-	return req
+	return reqCopy
 }
 
 // addTokenUsage adds token usage to the request body if it is not already present


### PR DESCRIPTION
## **What type of PR is this?**

/kind bug

## **What this PR does / why we need it**:
                                                                                                                                            
So the NIXL connector was caching the prefill request on the struct after it was built  the first time. The idea was to avoid rebuilding it on repeated calls, but the problem is `http.Request` bodies are backed by `bytes.Buffer` which is non-rewindable. Once   `RoundTrip` drains it, it's gone. So on a retry, the same drained request gets reused  and the prefill backend receives a request with zero body.

This shows up in `proxyToPDDisaggregated` where a single connector instance is used across the whole retry loop. If the first prefill pod fails for any reason (rolling update, transient error, pod restart) the retry picks the next pod but still sends an empty body to it. Both attempts fail even though a perfectly healthy pod was available.
  
### Fix
Dropped the `nil` guards on `prefillRequest` and `decodeRequestBody` in `Proxy()`. Now they get rebuilt on every call so the body is always fresh. The SGLang connector already does this correctly with the `lastPrefillAddr` check, NIXL just missed it.
  
  **Does this PR introduce a user-facing change?**:

```release-note
Fixed a bug in the NIXL connector where retrying a failed PD-disaggregated request would send an empty body to the prefill backend. If your first prefill pod fails, the retry now actually works instead of silently failing too.
```
