### PR TITLE
Fix flaky controller tests

### DIFF
--- a/pkg/kthena-router/controller/modelserver_controller_test.go
+++ b/pkg/kthena-router/controller/modelserver_controller_test.go
@@ -105,7 +105,7 @@ func TestModelServerController_ModelServerLifecycle(t *testing.T) {
 			t.Fatal("Failed to sync caches within timeout")
 		}
 
-		require.NoError(t, modelServerIndexer.Update(ms.DeepCopy()))
+		require.NoError(t, modelServerIndexer.Add(ms.DeepCopy()))
 		_, err := controller.modelServerLister.ModelServers("default").Get("test-modelserver")
 		require.NoError(t, err)
 
@@ -146,7 +146,7 @@ func TestModelServerController_ModelServerLifecycle(t *testing.T) {
 			},
 		}
 
-		require.NoError(t, modelServerIndexer.Update(ms.DeepCopy()))
+		require.NoError(t, modelServerIndexer.Add(ms.DeepCopy()))
 		_, err := controller.modelServerLister.ModelServers("default").Get("test-modelserver-update")
 		require.NoError(t, err)
 
@@ -207,7 +207,7 @@ func TestModelServerController_ModelServerLifecycle(t *testing.T) {
 			},
 		}
 
-		require.NoError(t, modelServerIndexer.Update(ms.DeepCopy()))
+		require.NoError(t, modelServerIndexer.Add(ms.DeepCopy()))
 		_, err := controller.modelServerLister.ModelServers("default").Get("test-modelserver-delete")
 		require.NoError(t, err)
 

--- a/pkg/kthena-router/controller/modelserver_controller_test.go
+++ b/pkg/kthena-router/controller/modelserver_controller_test.go
@@ -23,6 +23,7 @@ import (
 
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -74,6 +75,7 @@ func TestModelServerController_ModelServerLifecycle(t *testing.T) {
 		kubeInformerFactory,
 		store,
 	)
+	modelServerIndexer := kthenaInformerFactory.Networking().V1alpha1().ModelServers().Informer().GetIndexer()
 
 	stop := make(chan struct{})
 	defer close(stop)
@@ -98,24 +100,15 @@ func TestModelServerController_ModelServerLifecycle(t *testing.T) {
 			},
 		}
 
-		// Add ModelServer to fake client
-		_, err := kthenaClient.NetworkingV1alpha1().ModelServers("default").Create(
-			context.Background(), ms, metav1.CreateOptions{})
-		assert.NoError(t, err)
-
 		// Wait for cache to sync gracefully
 		if !waitForCacheSync(t, 5*time.Second, controller.modelServerSynced, controller.podSynced) {
 			t.Fatal("Failed to sync caches within timeout")
 		}
 
-		// Additionally wait for the specific object to be available in cache
-		found := waitForObjectInCache(t, 2*time.Second, func() bool {
-			_, err := controller.modelServerLister.ModelServers("default").Get("test-modelserver")
-			return err == nil
-		})
-		if !found {
-			t.Log("ModelServer not found in cache - proceeding anyway for unit test")
-		}
+		require.NoError(t, modelServerIndexer.Update(ms.DeepCopy()))
+		_, err := controller.modelServerLister.ModelServers("default").Get("test-modelserver")
+		require.NoError(t, err)
+
 		// Simulate controller receiving the event
 		controller.enqueueModelServer(ms)
 		assert.Equal(t, 1, controller.workqueue.Len())
@@ -129,7 +122,7 @@ func TestModelServerController_ModelServerLifecycle(t *testing.T) {
 			Namespace: "default",
 			Name:      "test-modelserver",
 		})
-		assert.NotNil(t, storedMS, "ModelServer should be found in store after creation")
+		require.NotNil(t, storedMS, "ModelServer should be found in store after creation")
 		assert.Equal(t, "test-modelserver", storedMS.Name)
 	})
 
@@ -153,19 +146,10 @@ func TestModelServerController_ModelServerLifecycle(t *testing.T) {
 			},
 		}
 
-		// Create initial ModelServer
-		_, err := kthenaClient.NetworkingV1alpha1().ModelServers("default").Create(
-			context.Background(), ms, metav1.CreateOptions{})
-		assert.NoError(t, err)
+		require.NoError(t, modelServerIndexer.Update(ms.DeepCopy()))
+		_, err := controller.modelServerLister.ModelServers("default").Get("test-modelserver-update")
+		require.NoError(t, err)
 
-		// Additionally wait for the specific object to be available in cache
-		found := waitForObjectInCache(t, 2*time.Second, func() bool {
-			_, err := controller.modelServerLister.ModelServers("default").Get("test-modelserver-update")
-			return err == nil
-		})
-		if !found {
-			t.Log("ModelServer not found in cache after creation - proceeding anyway")
-		}
 		// Process initial creation
 		controller.enqueueModelServer(ms)
 		err = controller.syncModelServerHandler("default/test-modelserver-update")
@@ -176,18 +160,11 @@ func TestModelServerController_ModelServerLifecycle(t *testing.T) {
 		updatedMS.Labels["version"] = "v2"
 		updatedMS.Spec.WorkloadSelector.MatchLabels["environment"] = "production"
 
-		_, err = kthenaClient.NetworkingV1alpha1().ModelServers("default").Update(
-			context.Background(), updatedMS, metav1.UpdateOptions{})
-		assert.NoError(t, err)
+		require.NoError(t, modelServerIndexer.Update(updatedMS.DeepCopy()))
+		cachedMS, err := controller.modelServerLister.ModelServers("default").Get("test-modelserver-update")
+		require.NoError(t, err)
+		assert.Equal(t, "v2", cachedMS.Labels["version"])
 
-		// Additionally wait for the specific object to be available in cache
-		found = waitForObjectInCache(t, 2*time.Second, func() bool {
-			ms, err := controller.modelServerLister.ModelServers("default").Get("test-modelserver-update")
-			return err == nil && ms.Labels["version"] == "v2"
-		})
-		if !found {
-			t.Log("ModelServer not found in cache after creation - proceeding anyway")
-		}
 		// Simulate controller receiving update event
 		controller.enqueueModelServer(updatedMS)
 		// Clear any previous items from queue
@@ -208,7 +185,7 @@ func TestModelServerController_ModelServerLifecycle(t *testing.T) {
 			Namespace: "default",
 			Name:      "test-modelserver-update",
 		})
-		assert.NotNil(t, storedMS, "ModelServer should be found in store after update")
+		require.NotNil(t, storedMS, "ModelServer should be found in store after update")
 		assert.Equal(t, "v2", storedMS.Labels["version"])
 		assert.Equal(t, "production", storedMS.Spec.WorkloadSelector.MatchLabels["environment"])
 	})
@@ -230,15 +207,9 @@ func TestModelServerController_ModelServerLifecycle(t *testing.T) {
 			},
 		}
 
-		// Create ModelServer first
-		_, err := kthenaClient.NetworkingV1alpha1().ModelServers("default").Create(
-			context.Background(), ms, metav1.CreateOptions{})
-		assert.NoError(t, err)
-
-		waitForObjectInCache(t, 2*time.Second, func() bool {
-			_, err := controller.modelServerLister.ModelServers("default").Get("test-modelserver-delete")
-			return err == nil
-		})
+		require.NoError(t, modelServerIndexer.Update(ms.DeepCopy()))
+		_, err := controller.modelServerLister.ModelServers("default").Get("test-modelserver-delete")
+		require.NoError(t, err)
 
 		// Process creation
 		err = controller.syncModelServerHandler("default/test-modelserver-delete")
@@ -249,17 +220,11 @@ func TestModelServerController_ModelServerLifecycle(t *testing.T) {
 			Namespace: "default",
 			Name:      "test-modelserver-delete",
 		})
-		assert.NotNil(t, storedMS, "ModelServer should be found in store before deletion")
+		require.NotNil(t, storedMS, "ModelServer should be found in store before deletion")
 
-		// Delete ModelServer
-		err = kthenaClient.NetworkingV1alpha1().ModelServers("default").Delete(
-			context.Background(), "test-modelserver-delete", metav1.DeleteOptions{})
-		assert.NoError(t, err)
-
-		waitForObjectInCache(t, 2*time.Second, func() bool {
-			_, err := controller.modelServerLister.ModelServers("default").Get("test-modelserver-delete")
-			return err != nil
-		})
+		require.NoError(t, modelServerIndexer.Delete(ms.DeepCopy()))
+		_, err = controller.modelServerLister.ModelServers("default").Get("test-modelserver-delete")
+		assert.Error(t, err)
 
 		// Process the deletion - this should handle the NotFound error gracefully
 		err = controller.syncModelServerHandler("default/test-modelserver-delete")

--- a/pkg/model-serving-controller/controller/model_serving_controller_test.go
+++ b/pkg/model-serving-controller/controller/model_serving_controller_test.go
@@ -1993,6 +1993,20 @@ func TestModelServingControllerModelServingLifecycle(t *testing.T) {
 	})
 }
 
+// assertPodDeleted asserts that a pod delete action was recorded by the fake client after startActions.
+func assertPodDeleted(t *testing.T, kubeClient *kubefake.Clientset, startActions int, podName string, msg string) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		for _, action := range kubeClient.Actions()[startActions:] {
+			deleteAction, ok := action.(kubetesting.DeleteAction)
+			if ok && action.Matches("delete", "pods") && deleteAction.GetName() == podName {
+				return true
+			}
+		}
+		return false
+	}, 2*time.Second, 10*time.Millisecond, msg)
+}
+
 // waitForObjectInCache waits for a specific object to appear in the cache
 func waitForObjectInCache(t *testing.T, timeout time.Duration, checkFunc func() bool) bool {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
@@ -5407,15 +5421,7 @@ func TestSyncAllWithFailedPods(t *testing.T) {
 	// Verify initialSync is true after syncAll
 	assert.True(t, controller.initialSync, "initialSync should be true after syncAll")
 
-	require.Eventually(t, func() bool {
-		for _, action := range kubeClient.Actions()[startActions:] {
-			deleteAction, ok := action.(kubetesting.DeleteAction)
-			if ok && action.Matches("delete", "pods") && deleteAction.GetName() == failedPod.Name {
-				return true
-			}
-		}
-		return false
-	}, 2*time.Second, 10*time.Millisecond, "Failed pod should be deleted after syncAll processes it")
+	assertPodDeleted(t, kubeClient, startActions, failedPod.Name, "Failed pod should be deleted after syncAll processes it")
 }
 
 // TestSyncAllWithContainerRestartedPods tests that pods with restarted containers
@@ -5508,15 +5514,7 @@ func TestSyncAllWithContainerRestartedPods(t *testing.T) {
 	// Call syncAll
 	controller.syncAll()
 
-	require.Eventually(t, func() bool {
-		for _, action := range kubeClient.Actions()[startActions:] {
-			deleteAction, ok := action.(kubetesting.DeleteAction)
-			if ok && action.Matches("delete", "pods") && deleteAction.GetName() == restartedPod.Name {
-				return true
-			}
-		}
-		return false
-	}, 2*time.Second, 10*time.Millisecond, "Pod with restarted container should be deleted after syncAll")
+	assertPodDeleted(t, kubeClient, startActions, restartedPod.Name, "Pod with restarted container should be deleted after syncAll")
 }
 
 // TestSyncAllWithMixedPods tests that syncAll properly handles a mix of
@@ -5800,15 +5798,7 @@ func TestSyncAllBeforeFixBehavior(t *testing.T) {
 	// Call syncAll which should now properly handle the failed pod
 	controller.syncAll()
 
-	require.Eventually(t, func() bool {
-		for _, action := range kubeClient.Actions()[startActions:] {
-			deleteAction, ok := action.(kubetesting.DeleteAction)
-			if ok && action.Matches("delete", "pods") && deleteAction.GetName() == failedPod.Name {
-				return true
-			}
-		}
-		return false
-	}, 2*time.Second, 10*time.Millisecond,
+	assertPodDeleted(t, kubeClient, startActions, failedPod.Name,
 		"After fix: Failed pod should be deleted. "+
 			"Before fix: This would be false because updatePod returned early when initialSync=false")
 }

--- a/pkg/model-serving-controller/controller/model_serving_controller_test.go
+++ b/pkg/model-serving-controller/controller/model_serving_controller_test.go
@@ -5394,6 +5394,10 @@ func TestSyncAllWithFailedPods(t *testing.T) {
 	err = controller.modelServingsInformer.GetIndexer().Add(ms)
 	assert.NoError(t, err)
 
+	_, err = kubeClient.CoreV1().Pods(ns).Create(context.Background(), failedPod.DeepCopy(), metav1.CreateOptions{})
+	assert.NoError(t, err)
+	startActions := len(kubeClient.Actions())
+
 	// Verify initialSync is false before syncAll
 	assert.False(t, controller.initialSync, "initialSync should be false before syncAll")
 
@@ -5403,12 +5407,15 @@ func TestSyncAllWithFailedPods(t *testing.T) {
 	// Verify initialSync is true after syncAll
 	assert.True(t, controller.initialSync, "initialSync should be true after syncAll")
 
-	// Verify the failed pod was added to graceMap (this happens in handleErrorPod)
-	_, existsInGraceMap := controller.graceMap.Load(types.NamespacedName{
-		Namespace: ns,
-		Name:      failedPod.Name,
-	})
-	assert.True(t, existsInGraceMap, "Failed pod should be added to graceMap after syncAll processes it")
+	require.Eventually(t, func() bool {
+		for _, action := range kubeClient.Actions()[startActions:] {
+			deleteAction, ok := action.(kubetesting.DeleteAction)
+			if ok && action.Matches("delete", "pods") && deleteAction.GetName() == failedPod.Name {
+				return true
+			}
+		}
+		return false
+	}, 2*time.Second, 10*time.Millisecond, "Failed pod should be deleted after syncAll processes it")
 }
 
 // TestSyncAllWithContainerRestartedPods tests that pods with restarted containers
@@ -5494,15 +5501,22 @@ func TestSyncAllWithContainerRestartedPods(t *testing.T) {
 	err = controller.modelServingsInformer.GetIndexer().Add(ms)
 	assert.NoError(t, err)
 
+	_, err = kubeClient.CoreV1().Pods(ns).Create(context.Background(), restartedPod.DeepCopy(), metav1.CreateOptions{})
+	assert.NoError(t, err)
+	startActions := len(kubeClient.Actions())
+
 	// Call syncAll
 	controller.syncAll()
 
-	// Verify the restarted container pod was added to graceMap
-	_, existsInGraceMap := controller.graceMap.Load(types.NamespacedName{
-		Namespace: ns,
-		Name:      restartedPod.Name,
-	})
-	assert.True(t, existsInGraceMap, "Pod with restarted container should be added to graceMap after syncAll")
+	require.Eventually(t, func() bool {
+		for _, action := range kubeClient.Actions()[startActions:] {
+			deleteAction, ok := action.(kubetesting.DeleteAction)
+			if ok && action.Matches("delete", "pods") && deleteAction.GetName() == restartedPod.Name {
+				return true
+			}
+		}
+		return false
+	}, 2*time.Second, 10*time.Millisecond, "Pod with restarted container should be deleted after syncAll")
 }
 
 // TestSyncAllWithMixedPods tests that syncAll properly handles a mix of
@@ -5649,6 +5663,14 @@ func TestSyncAllWithMixedPods(t *testing.T) {
 	err = controller.modelServingsInformer.GetIndexer().Add(ms)
 	assert.NoError(t, err)
 
+	_, err = kubeClient.CoreV1().Pods(ns).Create(context.Background(), runningPod.DeepCopy(), metav1.CreateOptions{})
+	assert.NoError(t, err)
+	_, err = kubeClient.CoreV1().Pods(ns).Create(context.Background(), failedPod.DeepCopy(), metav1.CreateOptions{})
+	assert.NoError(t, err)
+	_, err = kubeClient.CoreV1().Pods(ns).Create(context.Background(), restartedPod.DeepCopy(), metav1.CreateOptions{})
+	assert.NoError(t, err)
+	startActions := len(kubeClient.Actions())
+
 	// Call syncAll
 	controller.syncAll()
 
@@ -5662,19 +5684,17 @@ func TestSyncAllWithMixedPods(t *testing.T) {
 	})
 	assert.False(t, runningInGraceMap, "Running pod should NOT be in graceMap")
 
-	// Verify failed pod IS in graceMap
-	_, failedInGraceMap := controller.graceMap.Load(types.NamespacedName{
-		Namespace: ns,
-		Name:      failedPod.Name,
-	})
-	assert.True(t, failedInGraceMap, "Failed pod should be in graceMap")
-
-	// Verify restarted pod IS in graceMap
-	_, restartedInGraceMap := controller.graceMap.Load(types.NamespacedName{
-		Namespace: ns,
-		Name:      restartedPod.Name,
-	})
-	assert.True(t, restartedInGraceMap, "Restarted pod should be in graceMap")
+	require.Eventually(t, func() bool {
+		deletedPods := map[string]bool{}
+		for _, action := range kubeClient.Actions()[startActions:] {
+			deleteAction, ok := action.(kubetesting.DeleteAction)
+			if !ok || !action.Matches("delete", "pods") {
+				continue
+			}
+			deletedPods[deleteAction.GetName()] = true
+		}
+		return deletedPods[failedPod.Name] && deletedPods[restartedPod.Name] && !deletedPods[runningPod.Name]
+	}, 2*time.Second, 10*time.Millisecond, "Failed and restarted pods should be deleted while the running pod remains")
 
 	// Verify all pods have their serving groups tracked
 	servingGroups, err := controller.store.GetServingGroupByModelServing(types.NamespacedName{
@@ -5766,6 +5786,10 @@ func TestSyncAllBeforeFixBehavior(t *testing.T) {
 	err = controller.modelServingsInformer.GetIndexer().Add(ms)
 	assert.NoError(t, err)
 
+	_, err = kubeClient.CoreV1().Pods(ns).Create(context.Background(), failedPod.DeepCopy(), metav1.CreateOptions{})
+	assert.NoError(t, err)
+	startActions := len(kubeClient.Actions())
+
 	// Verify before syncAll, initialSync is false
 	assert.False(t, controller.initialSync)
 
@@ -5776,14 +5800,16 @@ func TestSyncAllBeforeFixBehavior(t *testing.T) {
 	// Call syncAll which should now properly handle the failed pod
 	controller.syncAll()
 
-	// After the fix, the failed pod should be in graceMap
-	// This proves the fix works - before the fix, this would be empty
-	_, exists := controller.graceMap.Load(types.NamespacedName{
-		Namespace: ns,
-		Name:      failedPod.Name,
-	})
-	assert.True(t, exists,
-		"After fix: Failed pod should be in graceMap. "+
+	require.Eventually(t, func() bool {
+		for _, action := range kubeClient.Actions()[startActions:] {
+			deleteAction, ok := action.(kubetesting.DeleteAction)
+			if ok && action.Matches("delete", "pods") && deleteAction.GetName() == failedPod.Name {
+				return true
+			}
+		}
+		return false
+	}, 2*time.Second, 10*time.Millisecond,
+		"After fix: Failed pod should be deleted. "+
 			"Before fix: This would be false because updatePod returned early when initialSync=false")
 }
 


### PR DESCRIPTION
 **What this PR does / why we need it**:

  Fix flaky controller tests caused by two race conditions:

  1. **ModelServer lifecycle test**: Relied on fake client watch delivery into informer caches, which is asynchronous and unreliable in unit tests. Replaced with direct indexer
   seeding.

  2. **ModelServing syncAll tests**: Asserted on `graceMap` state that gets cleared immediately when restart grace period is zero/nil. Also deleted Pods against an empty fake
  kube client, producing `NotFound` noise. Changed to assert on observable delete actions instead.

  **Which issue(s) this PR fixes**:
 Fixes #951

  **Special notes for your reviewer**:

  No production code changes. Both fixes narrow test assertions to stable boundaries: indexer state for the handler input, and fake client actions for the output.

  **Does this PR introduce a user-facing change?**:

  ```release-note
  NONE
