### PR TITLE
fix(autoscaler/metric_collector): exit decode loop on non-EOF error

### DIFF
--- a/pkg/autoscaler/autoscaler/metric_collector.go
+++ b/pkg/autoscaler/autoscaler/metric_collector.go
@@ -193,7 +193,7 @@ func (collector *MetricCollector) processPrometheusString(metricStr string, past
 		}
 		if err != nil {
 			klog.Errorf("error decoding metric: %v", err)
-			continue
+			break
 		}
 		if len(mf.Metric) < 1 {
 			klog.Errorf("metric is invalid")


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
In `processPrometheusString`, when `decoder.Decode` returned a non-EOF error, the loop used `continue`, which caused the same decoding error to be logged repeatedly in a tight loop. Once the underlying reader/decoder enters a bad state (e.g. Negative metrics cause parsing anomalies), `Decode` keeps returning the same error, so the loop spins and floods the log with identical `error decoding metric: ...` messages.

This PR changes that branch from `continue` to `break`, so the decoder loop exits on the first non-EOF decoding error instead of spinning forever.

The other two `continue` statements in the same loop are intentionally kept:

- `len(mf.Metric) < 1`: a successfully decoded but empty `MetricFamily` — the next `Decode` reads a new, independent family, so skipping only this one is correct.
- `WatchMetricList` miss: normal filtering of metrics we don't care about (e.g. `go_*` / `process_*`); breaking here would drop every watched metric that happens to be emitted after an unwatched one.

**Special notes for your reviewer**:
- Scope is intentionally minimal: only the decoder-error branch is changed; filtering / per-sample skip logic is untouched.
- Behavior change on malformed input: the collector now aborts parsing the current pod's metric payload on the first decode error instead of retrying in-place. Metrics already collected before the error in the same payload are still applied via `addMetric`. The next scrape cycle will try again normally.
- No new dependencies, no API / CRD / config changes.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```
