### PR TITLE
examples: remove mocker command overrides

### DIFF
--- a/docs/kthena/docs/assets/examples/kthena-router/LLM-Mock-ds1.5b-Canary.yaml
+++ b/docs/kthena/docs/assets/examples/kthena-router/LLM-Mock-ds1.5b-Canary.yaml
@@ -27,9 +27,6 @@ spec:
             # specify the model name to mock
             - name: MODEL_NAME
               value: "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B-v1"
-          command:
-            - python3
-            - app.py
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -55,6 +52,3 @@ spec:
             # specify the model name to mock
             - name: MODEL_NAME
               value: "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B-v2"
-          command:
-            - python3
-            - app.py

--- a/docs/kthena/docs/assets/examples/kthena-router/LLM-Mock-ds1.5b.yaml
+++ b/docs/kthena/docs/assets/examples/kthena-router/LLM-Mock-ds1.5b.yaml
@@ -25,7 +25,4 @@ spec:
             # specify the model name to mock
             - name: MODEL_NAME
               value: "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
-          command:
-            - python3
-            - app.py
 

--- a/docs/kthena/docs/assets/examples/kthena-router/LLM-Mock-ds7b.yaml
+++ b/docs/kthena/docs/assets/examples/kthena-router/LLM-Mock-ds7b.yaml
@@ -25,6 +25,3 @@ spec:
             # specify the model name to mock
             - name: MODEL_NAME
               value: "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B"
-          command:
-            - python3
-            - app.py

--- a/docs/kthena/docs/assets/examples/kthena-router/LLM-Mock.yaml
+++ b/docs/kthena/docs/assets/examples/kthena-router/LLM-Mock.yaml
@@ -27,9 +27,6 @@ spec:
             # specify the model name to mock
             - name: MODEL_NAME
               value: "meta-llama/Llama-3.1-8B-Instruct"
-          command:
-            - python3
-            - app.py
 ---
 apiVersion: networking.serving.volcano.sh/v1alpha1
 kind: ModelRoute

--- a/docs/kthena/versioned_docs/version-v0.1.0/assets/examples/kthena-router/LLM-Mock-ds1.5b-Canary.yaml
+++ b/docs/kthena/versioned_docs/version-v0.1.0/assets/examples/kthena-router/LLM-Mock-ds1.5b-Canary.yaml
@@ -27,9 +27,6 @@ spec:
             # specify the model name to mock
             - name: MODEL_NAME
               value: "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B-v1"
-          command:
-            - python3
-            - app.py
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -55,6 +52,3 @@ spec:
             # specify the model name to mock
             - name: MODEL_NAME
               value: "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B-v2"
-          command:
-            - python3
-            - app.py

--- a/docs/kthena/versioned_docs/version-v0.1.0/assets/examples/kthena-router/LLM-Mock-ds1.5b.yaml
+++ b/docs/kthena/versioned_docs/version-v0.1.0/assets/examples/kthena-router/LLM-Mock-ds1.5b.yaml
@@ -25,7 +25,4 @@ spec:
             # specify the model name to mock
             - name: MODEL_NAME
               value: "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
-          command:
-            - python3
-            - app.py
 

--- a/docs/kthena/versioned_docs/version-v0.1.0/assets/examples/kthena-router/LLM-Mock-ds7b.yaml
+++ b/docs/kthena/versioned_docs/version-v0.1.0/assets/examples/kthena-router/LLM-Mock-ds7b.yaml
@@ -25,6 +25,3 @@ spec:
             # specify the model name to mock
             - name: MODEL_NAME
               value: "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B"
-          command:
-            - python3
-            - app.py

--- a/docs/kthena/versioned_docs/version-v0.1.0/assets/examples/kthena-router/LLM-Mock.yaml
+++ b/docs/kthena/versioned_docs/version-v0.1.0/assets/examples/kthena-router/LLM-Mock.yaml
@@ -27,9 +27,6 @@ spec:
             # specify the model name to mock
             - name: MODEL_NAME
               value: "meta-llama/Llama-3.1-8B-Instruct"
-          command:
-            - python3
-            - app.py
 ---
 apiVersion: networking.serving.volcano.sh/v1alpha1
 kind: ModelRoute

--- a/docs/kthena/versioned_docs/version-v0.2.0/assets/examples/kthena-router/LLM-Mock-ds1.5b-Canary.yaml
+++ b/docs/kthena/versioned_docs/version-v0.2.0/assets/examples/kthena-router/LLM-Mock-ds1.5b-Canary.yaml
@@ -27,9 +27,6 @@ spec:
             # specify the model name to mock
             - name: MODEL_NAME
               value: "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B-v1"
-          command:
-            - python3
-            - app.py
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -55,6 +52,3 @@ spec:
             # specify the model name to mock
             - name: MODEL_NAME
               value: "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B-v2"
-          command:
-            - python3
-            - app.py

--- a/docs/kthena/versioned_docs/version-v0.2.0/assets/examples/kthena-router/LLM-Mock-ds1.5b.yaml
+++ b/docs/kthena/versioned_docs/version-v0.2.0/assets/examples/kthena-router/LLM-Mock-ds1.5b.yaml
@@ -25,7 +25,4 @@ spec:
             # specify the model name to mock
             - name: MODEL_NAME
               value: "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
-          command:
-            - python3
-            - app.py
 

--- a/docs/kthena/versioned_docs/version-v0.2.0/assets/examples/kthena-router/LLM-Mock-ds7b.yaml
+++ b/docs/kthena/versioned_docs/version-v0.2.0/assets/examples/kthena-router/LLM-Mock-ds7b.yaml
@@ -25,6 +25,3 @@ spec:
             # specify the model name to mock
             - name: MODEL_NAME
               value: "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B"
-          command:
-            - python3
-            - app.py

--- a/docs/kthena/versioned_docs/version-v0.2.0/assets/examples/kthena-router/LLM-Mock.yaml
+++ b/docs/kthena/versioned_docs/version-v0.2.0/assets/examples/kthena-router/LLM-Mock.yaml
@@ -27,9 +27,6 @@ spec:
             # specify the model name to mock
             - name: MODEL_NAME
               value: "meta-llama/Llama-3.1-8B-Instruct"
-          command:
-            - python3
-            - app.py
 ---
 apiVersion: networking.serving.volcano.sh/v1alpha1
 kind: ModelRoute

--- a/docs/kthena/versioned_docs/version-v0.3.0/assets/examples/kthena-router/LLM-Mock-ds1.5b-Canary.yaml
+++ b/docs/kthena/versioned_docs/version-v0.3.0/assets/examples/kthena-router/LLM-Mock-ds1.5b-Canary.yaml
@@ -27,9 +27,6 @@ spec:
             # specify the model name to mock
             - name: MODEL_NAME
               value: "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B-v1"
-          command:
-            - python3
-            - app.py
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -55,6 +52,3 @@ spec:
             # specify the model name to mock
             - name: MODEL_NAME
               value: "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B-v2"
-          command:
-            - python3
-            - app.py

--- a/docs/kthena/versioned_docs/version-v0.3.0/assets/examples/kthena-router/LLM-Mock-ds1.5b.yaml
+++ b/docs/kthena/versioned_docs/version-v0.3.0/assets/examples/kthena-router/LLM-Mock-ds1.5b.yaml
@@ -25,7 +25,4 @@ spec:
             # specify the model name to mock
             - name: MODEL_NAME
               value: "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
-          command:
-            - python3
-            - app.py
 

--- a/docs/kthena/versioned_docs/version-v0.3.0/assets/examples/kthena-router/LLM-Mock-ds7b.yaml
+++ b/docs/kthena/versioned_docs/version-v0.3.0/assets/examples/kthena-router/LLM-Mock-ds7b.yaml
@@ -25,6 +25,3 @@ spec:
             # specify the model name to mock
             - name: MODEL_NAME
               value: "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B"
-          command:
-            - python3
-            - app.py

--- a/docs/kthena/versioned_docs/version-v0.3.0/assets/examples/kthena-router/LLM-Mock.yaml
+++ b/docs/kthena/versioned_docs/version-v0.3.0/assets/examples/kthena-router/LLM-Mock.yaml
@@ -27,9 +27,6 @@ spec:
             # specify the model name to mock
             - name: MODEL_NAME
               value: "meta-llama/Llama-3.1-8B-Instruct"
-          command:
-            - python3
-            - app.py
 ---
 apiVersion: networking.serving.volcano.sh/v1alpha1
 kind: ModelRoute

--- a/examples/kthena-router/LLM-Mock-ds1.5b-Canary.yaml
+++ b/examples/kthena-router/LLM-Mock-ds1.5b-Canary.yaml
@@ -27,9 +27,6 @@ spec:
             # specify the model name to mock
             - name: MODEL_NAME
               value: "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B-v1"
-          command:
-            - python3
-            - app.py
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -55,6 +52,3 @@ spec:
             # specify the model name to mock
             - name: MODEL_NAME
               value: "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B-v2"
-          command:
-            - python3
-            - app.py

--- a/examples/kthena-router/LLM-Mock-ds1.5b.yaml
+++ b/examples/kthena-router/LLM-Mock-ds1.5b.yaml
@@ -25,7 +25,4 @@ spec:
             # specify the model name to mock
             - name: MODEL_NAME
               value: "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
-          command:
-            - python3
-            - app.py
 

--- a/examples/kthena-router/LLM-Mock-ds7b.yaml
+++ b/examples/kthena-router/LLM-Mock-ds7b.yaml
@@ -25,6 +25,3 @@ spec:
             # specify the model name to mock
             - name: MODEL_NAME
               value: "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B"
-          command:
-            - python3
-            - app.py

--- a/examples/kthena-router/LLM-Mock.yaml
+++ b/examples/kthena-router/LLM-Mock.yaml
@@ -27,9 +27,6 @@ spec:
             # specify the model name to mock
             - name: MODEL_NAME
               value: "meta-llama/Llama-3.1-8B-Instruct"
-          command:
-            - python3
-            - app.py
 ---
 apiVersion: networking.serving.volcano.sh/v1alpha1
 kind: ModelRoute


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:

The mock vLLM image now provides its own entrypoint, so explicit python app.py commands are no longer needed in mocker examples.

**Which issue(s) this PR fixes**:
Fixes #949 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```
