### PR TITLE
feat: make gangPolicy optional (#448)

### DIFF
--- a/charts/kthena/charts/workload/crds/workload.serving.volcano.sh_modelboosters.yaml
+++ b/charts/kthena/charts/workload/crds/workload.serving.volcano.sh_modelboosters.yaml
@@ -216,6 +216,13 @@ spec:
                       Support hostpath://, pvc://.
                     pattern: ^(hostpath://|pvc://).+
                     type: string
+                  disableGangScheduling:
+                    description: |-
+                      DisableGangScheduling disables gang scheduling for the generated ModelServing.
+                      When set to true, the gangPolicy will not be included in the ServingGroup template.
+                      If the schedulerName is "volcano", it will be cleared to ensure gang scheduling is disabled.
+                      Default is false (gangPolicy is enabled).
+                    type: boolean
                   env:
                     description: |-
                       List of environment variables to set in the container.

--- a/client-go/applyconfiguration/workload/v1alpha1/modelbackend.go
+++ b/client-go/applyconfiguration/workload/v1alpha1/modelbackend.go
@@ -26,16 +26,17 @@ import (
 // ModelBackendApplyConfiguration represents a declarative configuration of the ModelBackend type for use
 // with apply.
 type ModelBackendApplyConfiguration struct {
-	Name          *string                            `json:"name,omitempty"`
-	Type          *workloadv1alpha1.ModelBackendType `json:"type,omitempty"`
-	ModelURI      *string                            `json:"modelURI,omitempty"`
-	CacheURI      *string                            `json:"cacheURI,omitempty"`
-	EnvFrom       []v1.EnvFromSource                 `json:"envFrom,omitempty"`
-	Env           []v1.EnvVar                        `json:"env,omitempty"`
-	MinReplicas   *int32                             `json:"minReplicas,omitempty"`
-	MaxReplicas   *int32                             `json:"maxReplicas,omitempty"`
-	Workers       []ModelWorkerApplyConfiguration    `json:"workers,omitempty"`
-	SchedulerName *string                            `json:"schedulerName,omitempty"`
+	Name                  *string                            `json:"name,omitempty"`
+	Type                  *workloadv1alpha1.ModelBackendType `json:"type,omitempty"`
+	ModelURI              *string                            `json:"modelURI,omitempty"`
+	CacheURI              *string                            `json:"cacheURI,omitempty"`
+	EnvFrom               []v1.EnvFromSource                 `json:"envFrom,omitempty"`
+	Env                   []v1.EnvVar                        `json:"env,omitempty"`
+	MinReplicas           *int32                             `json:"minReplicas,omitempty"`
+	MaxReplicas           *int32                             `json:"maxReplicas,omitempty"`
+	Workers               []ModelWorkerApplyConfiguration    `json:"workers,omitempty"`
+	SchedulerName         *string                            `json:"schedulerName,omitempty"`
+	DisableGangScheduling *bool                              `json:"disableGangScheduling,omitempty"`
 }
 
 // ModelBackendApplyConfiguration constructs a declarative configuration of the ModelBackend type for use with
@@ -130,5 +131,13 @@ func (b *ModelBackendApplyConfiguration) WithWorkers(values ...*ModelWorkerApply
 // If called multiple times, the SchedulerName field is set to the value of the last call.
 func (b *ModelBackendApplyConfiguration) WithSchedulerName(value string) *ModelBackendApplyConfiguration {
 	b.SchedulerName = &value
+	return b
+}
+
+// WithDisableGangScheduling sets the DisableGangScheduling field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the DisableGangScheduling field is set to the value of the last call.
+func (b *ModelBackendApplyConfiguration) WithDisableGangScheduling(value bool) *ModelBackendApplyConfiguration {
+	b.DisableGangScheduling = &value
 	return b
 }

--- a/docs/kthena/docs/reference/crd/workload.serving.volcano.sh.md
+++ b/docs/kthena/docs/reference/crd/workload.serving.volcano.sh.md
@@ -372,6 +372,7 @@ _Appears in:_
 | `maxReplicas` _integer_ | MaxReplicas is the maximum number of replicas for the backend. |  | Maximum: 1e+06 <br />Minimum: 1 <br /> |
 | `workers` _[ModelWorker](#modelworker) array_ | Workers is the list of workers associated with this backend. |  | MaxItems: 1000 <br />MinItems: 1 <br /> |
 | `schedulerName` _string_ | SchedulerName defines the name of the scheduler used by ModelServing for this backend. |  |  |
+| `disableGangScheduling` _boolean_ | DisableGangScheduling disables gang scheduling for the generated ModelServing.<br />When set to true, the gangPolicy will not be included in the ServingGroup template.<br />If the schedulerName is "volcano", it will be cleared to ensure gang scheduling is disabled.<br />Default is false (gangPolicy is enabled). |  |  |
 
 
 #### ModelBackendType

--- a/pkg/apis/workload/v1alpha1/model_booster_types.go
+++ b/pkg/apis/workload/v1alpha1/model_booster_types.go
@@ -101,6 +101,13 @@ type ModelBackend struct {
 	// SchedulerName defines the name of the scheduler used by ModelServing for this backend.
 	// +optional
 	SchedulerName string `json:"schedulerName,omitempty"`
+
+	// DisableGangScheduling disables gang scheduling for the generated ModelServing.
+	// When set to true, the gangPolicy will not be included in the ServingGroup template.
+	// If the schedulerName is "volcano", it will be cleared to ensure gang scheduling is disabled.
+	// Default is false (gangPolicy is enabled).
+	// +optional
+	DisableGangScheduling bool `json:"disableGangScheduling,omitempty"`
 }
 
 // ModelBackendType defines the type of model backend.

--- a/pkg/model-booster-controller/convert/model_serving.go
+++ b/pkg/model-booster-controller/convert/model_serving.go
@@ -69,6 +69,12 @@ func BuildModelServing(model *workload.ModelBooster) (*workload.ModelServing, er
 	if err != nil {
 		return nil, err
 	}
+	if backend.DisableGangScheduling {
+		serving.Spec.Template.GangPolicy = nil
+		if serving.Spec.SchedulerName == "volcano" {
+			serving.Spec.SchedulerName = ""
+		}
+	}
 	return serving, nil
 }
 

--- a/pkg/model-booster-controller/convert/model_serving_test.go
+++ b/pkg/model-booster-controller/convert/model_serving_test.go
@@ -196,6 +196,50 @@ func TestBuildModelServingSkipEngineDependencyInstall(t *testing.T) {
 	}
 }
 
+func TestBuildModelServingDisableGangScheduling(t *testing.T) {
+	tests := []struct {
+		name                 string
+		input                string
+		expectSchedulerEmpty bool
+	}{
+		{
+			name:                 "vLLM backend with gang scheduling disabled",
+			input:                "testdata/input/model.yaml",
+			expectSchedulerEmpty: false,
+		},
+		{
+			name:                 "vLLMDisaggregated backend with gang scheduling disabled and volcano scheduler cleared",
+			input:                "testdata/input/pd-disaggregated-model-mooncake.yaml",
+			expectSchedulerEmpty: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := loadYaml[workload.ModelBooster](t, tt.input)
+			model.Spec.Backend.DisableGangScheduling = true
+
+			serving, err := BuildModelServing(model)
+			assert.NoError(t, err)
+			assert.Nil(t, serving.Spec.Template.GangPolicy, "gangPolicy should be nil when DisableGangScheduling is true")
+			if tt.expectSchedulerEmpty {
+				assert.Empty(t, serving.Spec.SchedulerName, "schedulerName should be cleared when disabling gang scheduling with volcano scheduler")
+			} else {
+				assert.Equal(t, model.Spec.Backend.SchedulerName, serving.Spec.SchedulerName, "schedulerName should not be modified if it is not volcano")
+			}
+		})
+	}
+
+	// Verify default behavior: gangPolicy is present when DisableGangScheduling is not set
+	t.Run("default behavior preserves gangPolicy", func(t *testing.T) {
+		model := loadYaml[workload.ModelBooster](t, "testdata/input/model.yaml")
+
+		serving, err := BuildModelServing(model)
+		assert.NoError(t, err)
+		assert.NotNil(t, serving.Spec.Template.GangPolicy, "gangPolicy should be present by default")
+	})
+}
+
 func TestBuildCacheVolume(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/pkg/model-booster-controller/convert/testdata/expected/disaggregated-model-serving-mooncake.yaml
+++ b/pkg/model-booster-controller/convert/testdata/expected/disaggregated-model-serving-mooncake.yaml
@@ -6,7 +6,7 @@ metadata:
     workload.serving.volcano.sh/managed-by: workload.serving.volcano.sh
     workload.serving.volcano.sh/model-name: ds-r1-qwen-7b-pd
     workload.serving.volcano.sh/model-uid: randomUID
-    workload.serving.volcano.sh/revision: 59fc79f5f5
+    workload.serving.volcano.sh/revision: 5db44fd78
   name: ds-r1-qwen-7b-pd-ds-r1-qwen-7b-pd
   namespace: demo
   ownerReferences:
@@ -31,7 +31,7 @@ spec:
               workload.serving.volcano.sh/managed-by: workload.serving.volcano.sh
               workload.serving.volcano.sh/model-name: ds-r1-qwen-7b-pd
               workload.serving.volcano.sh/model-uid: randomUID
-              workload.serving.volcano.sh/revision: 59fc79f5f5
+              workload.serving.volcano.sh/revision: 5db44fd78
           spec:
             containers:
               - args:
@@ -200,7 +200,7 @@ spec:
               workload.serving.volcano.sh/managed-by: workload.serving.volcano.sh
               workload.serving.volcano.sh/model-name: ds-r1-qwen-7b-pd
               workload.serving.volcano.sh/model-uid: randomUID
-              workload.serving.volcano.sh/revision: 59fc79f5f5
+              workload.serving.volcano.sh/revision: 5db44fd78
           spec:
             containers:
               - args:

--- a/pkg/model-booster-controller/convert/testdata/expected/disaggregated-model-serving.yaml
+++ b/pkg/model-booster-controller/convert/testdata/expected/disaggregated-model-serving.yaml
@@ -6,7 +6,7 @@ metadata:
     workload.serving.volcano.sh/managed-by: workload.serving.volcano.sh
     workload.serving.volcano.sh/model-name: ds-r1-qwen-7b-pd
     workload.serving.volcano.sh/model-uid: randomUID
-    workload.serving.volcano.sh/revision: b9c86698
+    workload.serving.volcano.sh/revision: 67485d9d55
   name: ds-r1-qwen-7b-pd-ds-r1-qwen-7b-pd
   namespace: demo
   ownerReferences:
@@ -31,7 +31,7 @@ spec:
               workload.serving.volcano.sh/managed-by: workload.serving.volcano.sh
               workload.serving.volcano.sh/model-name: ds-r1-qwen-7b-pd
               workload.serving.volcano.sh/model-uid: randomUID
-              workload.serving.volcano.sh/revision: b9c86698
+              workload.serving.volcano.sh/revision: 67485d9d55
           spec:
             containers:
               - args:
@@ -214,7 +214,7 @@ spec:
               workload.serving.volcano.sh/managed-by: workload.serving.volcano.sh
               workload.serving.volcano.sh/model-name: ds-r1-qwen-7b-pd
               workload.serving.volcano.sh/model-uid: randomUID
-              workload.serving.volcano.sh/revision: b9c86698
+              workload.serving.volcano.sh/revision: 67485d9d55
           spec:
             containers:
               - args:

--- a/pkg/model-booster-controller/convert/testdata/expected/model-serving.yaml
+++ b/pkg/model-booster-controller/convert/testdata/expected/model-serving.yaml
@@ -6,7 +6,7 @@ metadata:
     workload.serving.volcano.sh/managed-by: workload.serving.volcano.sh
     workload.serving.volcano.sh/model-name: test-model
     workload.serving.volcano.sh/model-uid: randomUID
-    workload.serving.volcano.sh/revision: 55d7bd6c6d
+    workload.serving.volcano.sh/revision: 6869b59485
   name: test-model-backend1
   namespace: default
   ownerReferences:
@@ -30,7 +30,7 @@ spec:
               workload.serving.volcano.sh/managed-by: workload.serving.volcano.sh
               workload.serving.volcano.sh/model-name: test-model
               workload.serving.volcano.sh/model-uid: randomUID
-              workload.serving.volcano.sh/revision: 55d7bd6c6d
+              workload.serving.volcano.sh/revision: 6869b59485
           spec:
             containers:
               - args:
@@ -213,7 +213,7 @@ spec:
               workload.serving.volcano.sh/managed-by: workload.serving.volcano.sh
               workload.serving.volcano.sh/model-name: test-model
               workload.serving.volcano.sh/model-uid: randomUID
-              workload.serving.volcano.sh/revision: 55d7bd6c6d
+              workload.serving.volcano.sh/revision: 6869b59485
           spec:
             containers:
               - command:


### PR DESCRIPTION
**What type of PR is this?**

<!--
/kind feature
-->

**What this PR does / why we need it**:
This PR introduces a `disableGangScheduling` toggle to the ModelBooster API. Previously, gangPolicy was unconditionally injected into generated ModelServing resources. This change allows users to opt-out of gang scheduling for environments where it is not required or supported.

**Which issue(s) this PR fixes**:
Fixes #448 

