### PR TITLE
feat(router): add per-pod on-flight request tracking with Redis sync

### DIFF
--- a/cmd/kthena-router/app/server.go
+++ b/cmd/kthena-router/app/server.go
@@ -18,11 +18,13 @@ package app
 
 import (
 	"context"
+	"os"
 
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
 	"github.com/volcano-sh/kthena/pkg/kthena-router/datastore"
+	"github.com/volcano-sh/kthena/pkg/kthena-router/utils"
 )
 
 type Server struct {
@@ -56,8 +58,21 @@ func NewServer(port string, enableTLS bool, cert, key string, enableGatewayAPI b
 }
 
 func (s *Server) Run(ctx context.Context) {
+	// Build store options. When REDIS_HOST is set, use a Redis-backed on-flight
+	// counter so that multiple router replicas share a globally consistent view
+	// of in-flight request counts, enabling better cross-router scheduling.
+	var storeOpts []datastore.Option
+	if os.Getenv("REDIS_HOST") != "" {
+		if redisClient := utils.TryGetRedisClient(); redisClient != nil {
+			klog.Infof("Redis on-flight counter enabled: cross-router in-flight tracking active")
+			storeOpts = append(storeOpts, datastore.WithRedisOnFlightCounter(datastore.NewRedisOnFlightCounter(redisClient)))
+		} else {
+			klog.Warningf("REDIS_HOST is set but Redis connection failed; falling back to local on-flight counter")
+		}
+	}
+
 	// create store
-	store := datastore.New()
+	store := datastore.New(storeOpts...)
 	s.store = store
 
 	// must be run before the controller, because it will register callbacks

--- a/pkg/kthena-router/connectors/connectors_test.go
+++ b/pkg/kthena-router/connectors/connectors_test.go
@@ -127,7 +127,7 @@ func TestHTTPConnectorProxy(t *testing.T) {
 
 		// The HTTP connector does support the Proxy method, but it will fail
 		// because the test addresses don't exist and the prefill/decode calls will fail
-		_, err := connector.Proxy(c, reqBody, "localhost:8000", "localhost:8001")
+		_, err := connector.Proxy(c, reqBody, "localhost:8000", "localhost:8001", nil)
 		if err == nil {
 			t.Error("Expected HTTP connector Proxy to return error due to network/connection issues")
 		}
@@ -213,7 +213,7 @@ func TestHTTPConnectorProxy(t *testing.T) {
 		}
 
 		// The HTTP connector will fail due to network issues
-		_, err := connector.Proxy(c, reqBody, "localhost:8000", "localhost:8001")
+		_, err := connector.Proxy(c, reqBody, "localhost:8000", "localhost:8001", nil)
 		if err == nil {
 			t.Error("Expected HTTP connector Proxy to return error due to network/connection issues")
 		}
@@ -307,7 +307,7 @@ func TestHTTPConnectorProxy(t *testing.T) {
 		}
 
 		// The HTTP connector will fail due to network issues
-		_, err := connector.Proxy(c, reqBody, "localhost:8000", "localhost:8001")
+		_, err := connector.Proxy(c, reqBody, "localhost:8000", "localhost:8001", nil)
 		if err == nil {
 			t.Error("Expected HTTP connector Proxy to return error due to network/connection issues")
 		}
@@ -365,7 +365,7 @@ func TestHTTPConnectorProxy(t *testing.T) {
 		}
 
 		// The HTTP connector will fail due to network issues
-		_, err := connector.Proxy(c, reqBody, "localhost:8000", "localhost:8001")
+		_, err := connector.Proxy(c, reqBody, "localhost:8000", "localhost:8001", nil)
 		if err == nil {
 			t.Error("Expected HTTP connector Proxy to return error due to network/connection issues")
 		}
@@ -458,7 +458,7 @@ func TestHTTPConnectorProxy(t *testing.T) {
 		}
 
 		// The HTTP connector will fail due to network issues
-		_, err := connector.Proxy(c, reqBodyCopy, "localhost:8000", "localhost:8001")
+		_, err := connector.Proxy(c, reqBodyCopy, "localhost:8000", "localhost:8001", nil)
 		if err == nil {
 			t.Error("Expected HTTP connector Proxy to return error due to network/connection issues")
 		}

--- a/pkg/kthena-router/connectors/http.go
+++ b/pkg/kthena-router/connectors/http.go
@@ -61,7 +61,7 @@ func (h *HTTPConnector) decode(c *gin.Context, req *http.Request, decodeAddr str
 }
 
 // Proxy executes the complete prefill-decode flow for HTTP connector
-func (h *HTTPConnector) Proxy(c *gin.Context, reqBody map[string]interface{}, prefillAddr, decodeAddr string) (int, error) {
+func (h *HTTPConnector) Proxy(c *gin.Context, reqBody map[string]interface{}, prefillAddr, decodeAddr string, hooks *OnFlightHooks) (int, error) {
 	// Get metrics recorder from context
 	var metricsRecorder *metrics.RequestMetricsRecorder
 	if recorder, exists := c.Get("metricsRecorder"); exists {
@@ -76,38 +76,49 @@ func (h *HTTPConnector) Proxy(c *gin.Context, reqBody map[string]interface{}, pr
 	prefillBody := cloneReqBody(reqBody)
 	h.prefillRequest = buildPrefillRequest(c.Request, prefillBody)
 
-	// Start prefill phase metrics and increment upstream request
+	// --- Prefill phase ---
 	if metricsRecorder != nil {
 		metricsRecorder.StartPrefillPhase()
 		metricsRecorder.IncActiveUpstreamRequests()
 	}
+	if hooks != nil && hooks.IncrPrefill != nil {
+		hooks.IncrPrefill()
+	}
 
 	err := h.prefill(h.prefillRequest, prefillAddr)
 
-	// End prefill phase metrics and handle upstream requests
+	if hooks != nil && hooks.DecrPrefill != nil {
+		hooks.DecrPrefill()
+	}
 	if metricsRecorder != nil {
-		statusCode := "200" // Default status code for successful prefill
+		statusCode := "200"
 		if err != nil {
 			statusCode = "500"
 		}
 		metricsRecorder.FinishPrefillPhase(statusCode)
 		metricsRecorder.DecActiveUpstreamRequests()
-
-		if err == nil {
-			metricsRecorder.StartDecodePhase()
-			metricsRecorder.IncActiveUpstreamRequests()
-		}
 	}
 
 	if err != nil {
 		return 0, err
 	}
 
+	// --- Decode phase ---
+	if metricsRecorder != nil {
+		metricsRecorder.StartDecodePhase()
+		metricsRecorder.IncActiveUpstreamRequests()
+	}
+	if hooks != nil && hooks.IncrDecode != nil {
+		hooks.IncrDecode()
+	}
+
 	result, decodeErr := h.decode(c, h.decodeRequest, decodeAddr)
 
-	// End decode phase metrics and decrement upstream request
+	if hooks != nil && hooks.DecrDecode != nil {
+		hooks.DecrDecode()
+	}
 	if metricsRecorder != nil {
-		statusCode := "200" // Default status code, will be updated by response
+		statusCode := "200"
 		if decodeErr != nil {
 			statusCode = "500"
 		}

--- a/pkg/kthena-router/connectors/interface.go
+++ b/pkg/kthena-router/connectors/interface.go
@@ -25,7 +25,9 @@ type KVConnector interface {
 	// Name returns the connector type name
 	Name() string
 
-	// Proxy executes the complete prefill-decode flow with KV cache coordination
-	// Returns the number of output tokens consumed, or error if the operation fails
-	Proxy(c *gin.Context, reqBody map[string]interface{}, prefillAddr, decodeAddr string) (int, error)
+	// Proxy executes the complete prefill-decode flow with KV cache coordination.
+	// hooks carries optional on-flight counter callbacks for the prefill and decode
+	// pods; pass nil when not needed.
+	// Returns the number of output tokens consumed, or error if the operation fails.
+	Proxy(c *gin.Context, reqBody map[string]interface{}, prefillAddr, decodeAddr string, hooks *OnFlightHooks) (int, error)
 }

--- a/pkg/kthena-router/connectors/nixl.go
+++ b/pkg/kthena-router/connectors/nixl.go
@@ -51,7 +51,7 @@ func (n *NIXLConnector) Name() string {
 }
 
 // Proxy executes the complete prefill-decode flow using NIXL for high-performance KV transfer
-func (n *NIXLConnector) Proxy(c *gin.Context, reqBody map[string]interface{}, prefillAddr, decodeAddr string) (int, error) {
+func (n *NIXLConnector) Proxy(c *gin.Context, reqBody map[string]interface{}, prefillAddr, decodeAddr string, hooks *OnFlightHooks) (int, error) {
 	// Get metrics recorder from context
 	var metricsRecorder *metrics.RequestMetricsRecorder
 	if recorder, exists := c.Get("metricsRecorder"); exists {
@@ -66,41 +66,52 @@ func (n *NIXLConnector) Proxy(c *gin.Context, reqBody map[string]interface{}, pr
 	decodeBody := cloneReqBody(reqBody)
 	n.decodeRequestBody = addTokenUsage(c, decodeBody)
 
-	// Start prefill phase metrics and increment upstream request
+	// --- Prefill phase ---
 	if metricsRecorder != nil {
 		metricsRecorder.StartPrefillPhase()
 		metricsRecorder.IncActiveUpstreamRequests()
+	}
+	if hooks != nil && hooks.IncrPrefill != nil {
+		hooks.IncrPrefill()
 	}
 
 	// 1. send prefill request
 	kvTransferParams, err := n.prefill(n.prefillRequest, prefillAddr)
 
-	// End prefill phase metrics and handle upstream requests
+	if hooks != nil && hooks.DecrPrefill != nil {
+		hooks.DecrPrefill()
+	}
 	if metricsRecorder != nil {
-		statusCode := "200" // Default status code for successful prefill
+		statusCode := "200"
 		if err != nil {
 			statusCode = "500"
 		}
 		metricsRecorder.FinishPrefillPhase(statusCode)
 		metricsRecorder.DecActiveUpstreamRequests()
-
-		if err == nil {
-			metricsRecorder.StartDecodePhase()
-			metricsRecorder.IncActiveUpstreamRequests()
-		}
 	}
 
 	if err != nil {
 		return 0, err
 	}
 
+	// --- Decode phase ---
+	if metricsRecorder != nil {
+		metricsRecorder.StartDecodePhase()
+		metricsRecorder.IncActiveUpstreamRequests()
+	}
+	if hooks != nil && hooks.IncrDecode != nil {
+		hooks.IncrDecode()
+	}
+
 	// 2. send decode request
 	decodeReq := n.buildDecodeRequest(c, n.decodeRequestBody, kvTransferParams)
 	result, decodeErr := n.decode(c, decodeReq, decodeAddr)
 
-	// End decode phase metrics and decrement upstream request
+	if hooks != nil && hooks.DecrDecode != nil {
+		hooks.DecrDecode()
+	}
 	if metricsRecorder != nil {
-		statusCode := "200" // Default status code, will be updated by response
+		statusCode := "200"
 		if decodeErr != nil {
 			statusCode = "500"
 		}

--- a/pkg/kthena-router/connectors/nixl_test.go
+++ b/pkg/kthena-router/connectors/nixl_test.go
@@ -51,7 +51,7 @@ func TestNIXLConnectorProxy(t *testing.T) {
 		}
 
 		// The NIXL connector will fail due to network issues (prefill request)
-		_, err := connector.Proxy(c, reqBody, "localhost:8000", "localhost:8001")
+		_, err := connector.Proxy(c, reqBody, "localhost:8000", "localhost:8001", nil)
 		if err == nil {
 			t.Error("Expected NIXL connector Proxy to return error due to network/connection issues")
 		}
@@ -147,7 +147,7 @@ func TestNIXLConnectorProxy(t *testing.T) {
 		}
 
 		// The NIXL connector will fail due to network issues
-		_, err := connector.Proxy(c, reqBody, "localhost:8000", "localhost:8001")
+		_, err := connector.Proxy(c, reqBody, "localhost:8000", "localhost:8001", nil)
 		if err == nil {
 			t.Error("Expected NIXL connector Proxy to return error due to network/connection issues")
 		}
@@ -241,7 +241,7 @@ func TestNIXLConnectorProxy(t *testing.T) {
 		}
 
 		// The NIXL connector will fail due to network issues
-		_, err := connector.Proxy(c, reqBody, "localhost:8000", "localhost:8001")
+		_, err := connector.Proxy(c, reqBody, "localhost:8000", "localhost:8001", nil)
 		if err == nil {
 			t.Error("Expected NIXL connector Proxy to return error due to network/connection issues")
 		}
@@ -285,7 +285,7 @@ func TestNIXLConnectorProxy(t *testing.T) {
 		}
 
 		// The NIXL connector will fail due to network issues
-		_, err := connector.Proxy(c, reqBody, "localhost:8000", "localhost:8001")
+		_, err := connector.Proxy(c, reqBody, "localhost:8000", "localhost:8001", nil)
 		if err == nil {
 			t.Error("Expected NIXL connector Proxy to return error due to network/connection issues")
 		}
@@ -342,7 +342,7 @@ func TestNIXLConnectorProxy(t *testing.T) {
 		}
 
 		// The NIXL connector will fail due to network issues
-		_, err := connector.Proxy(c, reqBody, "localhost:8000", "localhost:8001")
+		_, err := connector.Proxy(c, reqBody, "localhost:8000", "localhost:8001", nil)
 		if err == nil {
 			t.Error("Expected NIXL connector Proxy to return error due to network/connection issues")
 		}
@@ -418,9 +418,9 @@ func TestNIXLConnectorRetryBodyNotDrained(t *testing.T) {
 	decodeAddr := "127.0.0.1:1" // nothing listening here; decode will fail
 
 	// First call — simulates retry iteration 0
-	connector.Proxy(makeCtx(), reqBody, prefillAddr, decodeAddr)
+	connector.Proxy(makeCtx(), reqBody, prefillAddr, decodeAddr, nil)
 	// Second call — simulates retry iteration 1 on the same connector instance
-	connector.Proxy(makeCtx(), reqBody, prefillAddr, decodeAddr)
+	connector.Proxy(makeCtx(), reqBody, prefillAddr, decodeAddr, nil)
 
 	if bodyLengths[0] == 0 {
 		t.Error("first Proxy call sent empty body to prefill backend")
@@ -454,7 +454,7 @@ func TestNIXLConnectorReqBodyNotMutated(t *testing.T) {
 		keysBefore[k] = struct{}{}
 	}
 
-	connector.Proxy(c, reqBody, "127.0.0.1:1", "127.0.0.1:2")
+	connector.Proxy(c, reqBody, "127.0.0.1:1", "127.0.0.1:2", nil)
 
 	for k := range reqBody {
 		if _, existed := keysBefore[k]; !existed {

--- a/pkg/kthena-router/connectors/sglang.go
+++ b/pkg/kthena-router/connectors/sglang.go
@@ -79,7 +79,7 @@ func (s *SGLangConnector) Name() string {
 // prefill to time out and abort with "KVTransferError: Aborted by AbortReq".
 // The decode request carries bootstrap_host = prefillHost so the decode receiver can
 // locate the prefill's bootstrap server; both requests carry the same bootstrap_room.
-func (s *SGLangConnector) Proxy(c *gin.Context, reqBody map[string]interface{}, prefillAddr, decodeAddr string) (int, error) {
+func (s *SGLangConnector) Proxy(c *gin.Context, reqBody map[string]interface{}, prefillAddr, decodeAddr string, hooks *OnFlightHooks) (int, error) {
 	// Retrieve optional metrics recorder from context.
 	var metricsRecorder *metrics.RequestMetricsRecorder
 	if recorder, exists := c.Get("metricsRecorder"); exists {
@@ -87,6 +87,10 @@ func (s *SGLangConnector) Proxy(c *gin.Context, reqBody map[string]interface{}, 
 			metricsRecorder = rec
 		}
 	}
+
+	// hooks carries per-phase on-flight counter callbacks for the prefill and
+	// decode pods. For SGLang both phases are concurrent, so both pods are
+	// incr'd before launch and each decr'd individually as their phase finishes.
 
 	// Extract prefill pod IP from "IP:PORT" — the decode receiver uses this to
 	// query the prefill's bootstrap HTTP server.
@@ -135,6 +139,12 @@ func (s *SGLangConnector) Proxy(c *gin.Context, reqBody map[string]interface{}, 
 		metricsRecorder.IncActiveUpstreamRequests()
 		metricsRecorder.IncActiveUpstreamRequests()
 	}
+	if hooks != nil && hooks.IncrPrefill != nil {
+		hooks.IncrPrefill()
+	}
+	if hooks != nil && hooks.IncrDecode != nil {
+		hooks.IncrDecode()
+	}
 
 	// prefillCtx is cancelled if decode fails, which aborts the prefill HTTP
 	// request immediately instead of letting it hang waiting for a bootstrap
@@ -146,14 +156,22 @@ func (s *SGLangConnector) Proxy(c *gin.Context, reqBody map[string]interface{}, 
 	prefillCh := make(chan prefillOutcome, 1)
 
 	go func() {
-		prefillCh <- prefillOutcome{
-			err: s.prefill(prefillRequest.WithContext(prefillCtx), prefillAddr),
+		err := s.prefill(prefillRequest.WithContext(prefillCtx), prefillAddr)
+		// Decrement the prefill pod's on-flight counter as soon as prefill finishes,
+		// so the scheduler gets an accurate view even while decode is still running.
+		if hooks != nil && hooks.DecrPrefill != nil {
+			hooks.DecrPrefill()
 		}
+		prefillCh <- prefillOutcome{err: err}
 	}()
 
 	// Run decode in the current goroutine so that streaming writes reach the
 	// gin.Context from the request-handling goroutine.
 	result, decodeErr := s.decode(c, decodeRequest, decodeAddr)
+
+	if hooks != nil && hooks.DecrDecode != nil {
+		hooks.DecrDecode()
+	}
 
 	if decodeErr != nil {
 		// Decode failed: cancel the prefill context so the prefill goroutine is

--- a/pkg/kthena-router/connectors/sglang_test.go
+++ b/pkg/kthena-router/connectors/sglang_test.go
@@ -78,13 +78,13 @@ func TestSGLangConnectorRetryBodyNotDrained(t *testing.T) {
 	decodeAddr := decodeServer.Listener.Addr().String()
 
 	// First call — simulates retry iteration 0.
-	if _, err := connector.Proxy(makeCtx(), reqBody, prefillAddr, decodeAddr); err != nil {
+	if _, err := connector.Proxy(makeCtx(), reqBody, prefillAddr, decodeAddr, nil); err != nil {
 		t.Fatalf("first Proxy call failed: %v", err)
 	}
 	// Second call with the SAME prefill addr — simulates the scheduler reselecting
 	// the same prefill pod for a different decode pod on retry. This is the path
 	// where the previous (cached) request would have a drained body.
-	if _, err := connector.Proxy(makeCtx(), reqBody, prefillAddr, decodeAddr); err != nil {
+	if _, err := connector.Proxy(makeCtx(), reqBody, prefillAddr, decodeAddr, nil); err != nil {
 		t.Fatalf("second Proxy call failed: %v", err)
 	}
 
@@ -125,7 +125,7 @@ func TestSGLangConnectorReqBodyNotMutated(t *testing.T) {
 		keysBefore[k] = struct{}{}
 	}
 
-	_, _ = connector.Proxy(c, reqBody, "127.0.0.1:1", "127.0.0.1:2")
+	_, _ = connector.Proxy(c, reqBody, "127.0.0.1:1", "127.0.0.1:2", nil)
 
 	for k := range reqBody {
 		if _, existed := keysBefore[k]; !existed {

--- a/pkg/kthena-router/connectors/types.go
+++ b/pkg/kthena-router/connectors/types.go
@@ -25,3 +25,14 @@ type KVTransferParams struct {
 	RemoteHost      *string  `json:"remote_host,omitempty"`
 	RemotePort      *int     `json:"remote_port,omitempty"`
 }
+
+// OnFlightHooks carries per-request callbacks that the router passes into
+// Proxy() so connectors can track in-flight request counts on prefill and
+// decode pods at the precise point in their proxy lifecycle.
+// All fields are optional; a nil pointer or nil field is a no-op.
+type OnFlightHooks struct {
+	IncrPrefill func()
+	DecrPrefill func()
+	IncrDecode  func()
+	DecrDecode  func()
+}

--- a/pkg/kthena-router/datastore/on_flight_counter.go
+++ b/pkg/kthena-router/datastore/on_flight_counter.go
@@ -1,0 +1,112 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package datastore
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/redis/go-redis/v9"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+)
+
+// redisOnFlightHashKey is the Redis hash key used to store per-pod in-flight counts.
+const redisOnFlightHashKey = "kthena:on-flight-requests"
+
+// OnFlightCounter tracks the number of in-flight requests dispatched by the router
+// to each backend pod. In a multi-router deployment, a Redis-backed implementation
+// lets all router replicas share a single global counter, so scheduling decisions
+// incorporate cross-router visibility instead of only per-instance view.
+type OnFlightCounter interface {
+	// Incr atomically increments the counter for podName and returns the new value.
+	Incr(ctx context.Context, podName types.NamespacedName) (int64, error)
+	// Decr atomically decrements the counter for podName and returns the new value.
+	Decr(ctx context.Context, podName types.NamespacedName) (int64, error)
+	// Delete removes the counter entry for podName. Call this when a pod is
+	// removed so stale keys do not accumulate in Redis.
+	Delete(ctx context.Context, podName types.NamespacedName) error
+	// BatchGet retrieves current counters for a set of pods in one round-trip.
+	BatchGet(ctx context.Context, podNames []types.NamespacedName) (map[types.NamespacedName]int64, error)
+}
+
+func podOnFlightField(podName types.NamespacedName) string {
+	return podName.Namespace + "/" + podName.Name
+}
+
+// RedisOnFlightCounter uses a Redis hash (HINCRBY / HMGET) to maintain globally
+// visible in-flight request counts across multiple router replicas.
+type RedisOnFlightCounter struct {
+	client *redis.Client
+}
+
+// NewRedisOnFlightCounter creates a new Redis-backed on-flight counter.
+func NewRedisOnFlightCounter(client *redis.Client) *RedisOnFlightCounter {
+	return &RedisOnFlightCounter{client: client}
+}
+
+func (r *RedisOnFlightCounter) Incr(ctx context.Context, podName types.NamespacedName) (int64, error) {
+	return r.client.HIncrBy(ctx, redisOnFlightHashKey, podOnFlightField(podName), 1).Result()
+}
+
+func (r *RedisOnFlightCounter) Decr(ctx context.Context, podName types.NamespacedName) (int64, error) {
+	val, err := r.client.HIncrBy(ctx, redisOnFlightHashKey, podOnFlightField(podName), -1).Result()
+	if err != nil {
+		return 0, err
+	}
+	if val < 0 {
+		// Guard against stale negative values after a router restart.
+		_ = r.client.HSet(ctx, redisOnFlightHashKey, podOnFlightField(podName), 0).Err()
+		val = 0
+	}
+	return val, nil
+}
+
+func (r *RedisOnFlightCounter) Delete(ctx context.Context, podName types.NamespacedName) error {
+	return r.client.HDel(ctx, redisOnFlightHashKey, podOnFlightField(podName)).Err()
+}
+
+func (r *RedisOnFlightCounter) BatchGet(ctx context.Context, podNames []types.NamespacedName) (map[types.NamespacedName]int64, error) {
+	if len(podNames) == 0 {
+		return nil, nil
+	}
+	fields := make([]string, len(podNames))
+	for i, n := range podNames {
+		fields[i] = podOnFlightField(n)
+	}
+	vals, err := r.client.HMGet(ctx, redisOnFlightHashKey, fields...).Result()
+	if err != nil {
+		return nil, err
+	}
+	result := make(map[types.NamespacedName]int64, len(podNames))
+	for i, v := range vals {
+		if v == nil {
+			continue
+		}
+		s, ok := v.(string)
+		if !ok {
+			continue
+		}
+		n, err := strconv.ParseInt(s, 10, 64)
+		if err != nil {
+			klog.V(4).Infof("failed to parse on-flight count for pod %s: %v", podNames[i], err)
+			continue
+		}
+		result[podNames[i]] = n
+	}
+	return result, nil
+}

--- a/pkg/kthena-router/datastore/store.go
+++ b/pkg/kthena-router/datastore/store.go
@@ -65,6 +65,11 @@ const (
 	// Configuration constants for fairness scheduling
 	defaultQueueQPS = 100
 	uppdateInterval = 1 * time.Second
+
+	// onFlightSyncInterval caps Redis read traffic from SyncOnFlightCounts.
+	// At most one HMGET is issued per interval regardless of request rate;
+	// all other callers use the local atomic values maintained by Incr/Decr.
+	onFlightSyncInterval = 50 * time.Millisecond
 )
 
 // createTokenTracker creates a token tracker with configuration from environment variables
@@ -158,6 +163,15 @@ func WithPodRuntimeInspector(inspector PodRuntimeInspector) Option {
 	}
 }
 
+// WithRedisOnFlightCounter configures the store to maintain globally visible
+// in-flight request counts via Redis, enabling accurate scheduling across
+// multiple router replicas.
+func WithRedisOnFlightCounter(counter OnFlightCounter) Option {
+	return func(s *store) {
+		s.onFlightCounter = counter
+	}
+}
+
 // Store is an interface for storing and retrieving data
 type Store interface {
 	// Add modelServer which are selected by modelServer.Spec.WorkloadSelector
@@ -198,6 +212,22 @@ type Store interface {
 
 	// GetPodInfo returns the pod info for a given pod name (for testing)
 	GetPodInfo(podName types.NamespacedName) *PodInfo
+
+	// SyncOnFlightCounts fetches the current on-flight counts for all tracked
+	// pods from Redis in a single round-trip and updates their local counters.
+	// Call this immediately before scheduling so scores reflect cross-router
+	// traffic. Reads are rate-limited to at most one Redis HMGET per
+	// onFlightSyncInterval; all other callers use the local atomic values that
+	// Incr/Decr keep up to date. No-op when no Redis counter is configured.
+	SyncOnFlightCounts()
+
+	// IncrPodOnFlightRequests atomically increments the in-flight request counter for
+	// the given pod. Must be called just before dispatching a request to the pod.
+	IncrPodOnFlightRequests(podName types.NamespacedName)
+	// DecrPodOnFlightRequests atomically decrements the in-flight request counter for
+	// the given pod. Must be called once the response is received (or the request fails).
+	DecrPodOnFlightRequests(podName types.NamespacedName)
+
 	// GetTokenCount returns the token count for a user and model
 	GetTokenCount(userId, modelName string) (float64, error)
 	// UpdateTokenCount updates token usage for a user and model
@@ -262,6 +292,12 @@ type PodInfo struct {
 	TPOT               float64
 	TTFT               float64
 
+	// onFlightRequestNum tracks requests actively in-flight from the router to this pod.
+	// Updated atomically with zero delay — not subject to the ~1 s engine-metrics poll lag.
+	// When a Redis-backed OnFlightCounter is configured on the store this field is also
+	// kept in sync with the global Redis counter so it reflects cross-router traffic.
+	onFlightRequestNum atomic.Int64
+
 	mutex sync.RWMutex // Protects concurrent access to metrics, models and modelServer fields
 	// Protected fields - use accessor methods for thread-safe access
 	models      sets.Set[string]               // running models. Including base model and lora adapters.
@@ -283,6 +319,16 @@ type modelRouteInfo struct {
 type store struct {
 	modelServer sync.Map // map[types.NamespacedName]*modelServer
 	pods        sync.Map // map[types.NamespacedName]*PodInfo
+
+	// onFlightCounter is optional. When non-nil (Redis-backed), in-flight request
+	// counts are shared across all router replicas via Redis. When nil, only the
+	// local per-PodInfo atomic counter is used (suitable for single-router setups).
+	onFlightCounter OnFlightCounter
+	// lastOnFlightSync is the Unix nanosecond timestamp of the last sync attempt.
+	// Updated before the Redis call (not after) to prevent concurrent goroutines
+	// from all hitting Redis within the same window. Gates SyncOnFlightCounts to
+	// at most one Redis HMGET per onFlightSyncInterval.
+	lastOnFlightSync atomic.Int64
 
 	routeMutex sync.RWMutex
 	// Model routing fields
@@ -431,6 +477,54 @@ func (s *store) Run(ctx context.Context) {
 		}
 	}()
 }
+
+// SyncOnFlightCounts fetches current on-flight counts for all tracked pods from
+// Redis in one HMGET and updates their local atomic counters. Reads are
+// rate-limited by onFlightSyncInterval: at most one goroutine per interval
+// actually hits Redis (via a CAS on lastOnFlightSync); all other callers return
+// immediately and use the local values maintained by IncrPodOnFlightRequests /
+// DecrPodOnFlightRequests.
+func (s *store) SyncOnFlightCounts() {
+	if s.onFlightCounter == nil {
+		return
+	}
+
+	// Rate-gate: skip Redis if we synced recently.
+	now := time.Now().UnixNano()
+	lastSync := s.lastOnFlightSync.Load()
+	if now-lastSync < int64(onFlightSyncInterval) {
+		return
+	}
+	// CAS ensures exactly one goroutine wins the sync slot per interval.
+	// Using the previously loaded lastSync as the expected value prevents multiple
+	// goroutines from all winning the CAS when they observe the same stale timestamp.
+	if !s.lastOnFlightSync.CompareAndSwap(lastSync, now) {
+		return
+	}
+
+	var podNames []types.NamespacedName
+	s.pods.Range(func(k, v any) bool {
+		if nn, ok := k.(types.NamespacedName); ok {
+			podNames = append(podNames, nn)
+		}
+		return true
+	})
+	if len(podNames) == 0 {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	counts, err := s.onFlightCounter.BatchGet(ctx, podNames)
+	if err != nil {
+		klog.V(4).Infof("SyncOnFlightCounts: Redis batch get failed: %v", err)
+		return
+	}
+	for podName, count := range counts {
+		if value, ok := s.pods.Load(podName); ok {
+			value.(*PodInfo).SetOnFlightRequestNum(count)
+		}
+	}
+}
 func (s *store) GetTokenCount(userID, model string) (float64, error) {
 	return s.tokenTracker.GetTokenCount(userID, model)
 }
@@ -496,6 +590,51 @@ func (s *store) GetPodInfo(podName types.NamespacedName) *PodInfo {
 		return value.(*PodInfo)
 	}
 	return nil
+}
+
+// IncrPodOnFlightRequests increments the in-flight counter for the given pod.
+// When a Redis counter is configured the increment is performed atomically in
+// Redis and the returned global value is stored locally; otherwise the local
+// atomic counter is incremented directly.
+func (s *store) IncrPodOnFlightRequests(podName types.NamespacedName) {
+	value, ok := s.pods.Load(podName)
+	if !ok {
+		klog.V(4).Infof("IncrPodOnFlightRequests: pod %s not found in store", podName)
+		return
+	}
+	podInfo := value.(*PodInfo)
+	if s.onFlightCounter != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+		if count, err := s.onFlightCounter.Incr(ctx, podName); err == nil {
+			podInfo.SetOnFlightRequestNum(count)
+			return
+		} else {
+			klog.V(4).Infof("Redis on-flight incr failed for pod %s: %v, falling back to local counter", podName, err)
+		}
+	}
+	podInfo.IncrOnFlightRequests()
+}
+
+// DecrPodOnFlightRequests decrements the in-flight counter for the given pod.
+func (s *store) DecrPodOnFlightRequests(podName types.NamespacedName) {
+	value, ok := s.pods.Load(podName)
+	if !ok {
+		klog.V(4).Infof("DecrPodOnFlightRequests: pod %s not found in store", podName)
+		return
+	}
+	podInfo := value.(*PodInfo)
+	if s.onFlightCounter != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+		if count, err := s.onFlightCounter.Decr(ctx, podName); err == nil {
+			podInfo.SetOnFlightRequestNum(count)
+			return
+		} else {
+			klog.V(4).Infof("Redis on-flight decr failed for pod %s: %v, falling back to local counter", podName, err)
+		}
+	}
+	podInfo.DecrOnFlightRequests()
 }
 
 func (s *store) AddOrUpdateModelServer(ms *aiv1alpha1.ModelServer, pods sets.Set[types.NamespacedName]) error {
@@ -744,6 +883,14 @@ func (s *store) DeletePod(podName types.NamespacedName) error {
 			}
 		}
 		s.pods.Delete(podName)
+		// Remove the pod's Redis counter so stale keys do not accumulate.
+		if s.onFlightCounter != nil {
+			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+			defer cancel()
+			if err := s.onFlightCounter.Delete(ctx, podName); err != nil {
+				klog.V(4).Infof("failed to delete Redis on-flight counter for pod %s: %v", podName, err)
+			}
+		}
 	}
 
 	s.triggerCallbacks("Pod", EventData{
@@ -1421,6 +1568,30 @@ func (p *PodInfo) GetRequestRunningNum() float64 {
 	p.mutex.RLock()
 	defer p.mutex.RUnlock()
 	return p.RequestRunningNum
+}
+
+// IncrOnFlightRequests atomically increments the local in-flight counter and
+// returns the new value.
+func (p *PodInfo) IncrOnFlightRequests() int64 {
+	return p.onFlightRequestNum.Add(1)
+}
+
+// DecrOnFlightRequests atomically decrements the local in-flight counter and
+// returns the new value.
+func (p *PodInfo) DecrOnFlightRequests() int64 {
+	return p.onFlightRequestNum.Add(-1)
+}
+
+// SetOnFlightRequestNum atomically stores a new value for the in-flight counter
+// (used to sync the global Redis value into the local field).
+func (p *PodInfo) SetOnFlightRequestNum(v int64) {
+	p.onFlightRequestNum.Store(v)
+}
+
+// GetOnFlightRequestNum returns the current in-flight request count as tracked
+// by this router instance (or globally, if a Redis counter is configured).
+func (p *PodInfo) GetOnFlightRequestNum() int64 {
+	return p.onFlightRequestNum.Load()
 }
 
 // GetTPOT returns the time per output token

--- a/pkg/kthena-router/debug/handlers_test.go
+++ b/pkg/kthena-router/debug/handlers_test.go
@@ -324,6 +324,12 @@ func (m *MockStore) GetModelNames() []string {
 	return args.Get(0).([]string)
 }
 
+func (m *MockStore) SyncOnFlightCounts() {}
+
+func (m *MockStore) IncrPodOnFlightRequests(podName types.NamespacedName) {}
+
+func (m *MockStore) DecrPodOnFlightRequests(podName types.NamespacedName) {}
+
 func newTestContext(params gin.Params) (*gin.Context, *httptest.ResponseRecorder) {
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)

--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -712,15 +712,24 @@ func (r *Router) proxy(
 
 	for i := 0; i < len(ctx.BestPods); i++ {
 		req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+		pod := ctx.BestPods[i]
+		podName := types.NamespacedName{Namespace: pod.Pod.Namespace, Name: pod.Pod.Name}
+
+		// Track this request as in-flight to the chosen pod. This is instant and
+		// feeds the scheduler immediately, avoiding the ~1 s engine-metrics lag.
+		r.store.IncrPodOnFlightRequests(podName)
 
 		// Increment upstream request count with both modelServer and modelRoute
 		r.metrics.IncActiveUpstreamRequests(modelServerName, modelRouteName)
 
 		// Request dispatched to the pod.
-		err := proxyRequest(c, req, ctx.BestPods[i].Pod.Status.PodIP, port, stream, onUsage)
+		err := proxyRequest(c, req, pod.Pod.Status.PodIP, port, stream, onUsage)
 
 		// Decrement upstream request count when request completes
 		r.metrics.DecActiveUpstreamRequests(modelServerName, modelRouteName)
+
+		// Request is complete (success or failure) — decrement on-flight counter.
+		r.store.DecrPodOnFlightRequests(podName)
 
 		if err != nil {
 			klog.Errorf(" pod request error: %v", err)
@@ -1043,8 +1052,19 @@ func (r *Router) proxyToPDDisaggregated(
 
 		klog.V(4).Infof("Attempting PD disaggregated request: prefill=%s, decode=%s", prefillAddr, decodeAddr)
 
+		// Build on-flight hooks so the connector can update the per-pod counters
+		// at the precise point each phase starts and ends.
+		prefillPodName := types.NamespacedName{Namespace: ctx.PrefillPods[i].Pod.Namespace, Name: ctx.PrefillPods[i].Pod.Name}
+		decodePodName := types.NamespacedName{Namespace: ctx.DecodePods[i].Pod.Namespace, Name: ctx.DecodePods[i].Pod.Name}
+		hooks := &connectors.OnFlightHooks{
+			IncrPrefill: func() { r.store.IncrPodOnFlightRequests(prefillPodName) },
+			DecrPrefill: func() { r.store.DecrPodOnFlightRequests(prefillPodName) },
+			IncrDecode:  func() { r.store.IncrPodOnFlightRequests(decodePodName) },
+			DecrDecode:  func() { r.store.DecrPodOnFlightRequests(decodePodName) },
+		}
+
 		// Execute the PD disaggregated proxy operation
-		outputTokens, err := kvConnector.Proxy(c, modelRequest, prefillAddr, decodeAddr)
+		outputTokens, err := kvConnector.Proxy(c, modelRequest, prefillAddr, decodeAddr, hooks)
 
 		if err != nil {
 			klog.Errorf("proxy failed for prefill pod %s, decode pod %s: %v",

--- a/pkg/kthena-router/scheduler/plugins/least_request.go
+++ b/pkg/kthena-router/scheduler/plugins/least_request.go
@@ -17,6 +17,8 @@ limitations under the License.
 package plugins
 
 import (
+	"math"
+
 	"istio.io/istio/pkg/slices"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
@@ -32,11 +34,14 @@ var _ framework.ScorePlugin = &LeastRequest{}
 var _ framework.FilterPlugin = &LeastRequest{}
 
 type LeastRequest struct {
-	name              string
-	maxWaitingRequest int
+	name               string
+	maxWaitingRequests int
 }
 
 type LeastRequestArgs struct {
+	// MaxWaitingRequests filters out pods whose engine-reported waiting-queue
+	// depth exceeds this value. It captures backpressure that the router cannot
+	// observe directly (e.g. requests queued inside the engine before execution).
 	MaxWaitingRequests int `yaml:"maxWaitingRequests,omitempty"`
 }
 
@@ -45,13 +50,16 @@ func NewLeastRequest(pluginArg runtime.RawExtension) *LeastRequest {
 	if pluginArg.Raw == nil || yaml.Unmarshal(pluginArg.Raw, &leastRequestArgs) != nil {
 		klog.Errorf("Unmarshal LeastRequestArgs error, setting default value")
 		leastRequestArgs = LeastRequestArgs{
-			10,
+			MaxWaitingRequests: 10,
 		}
+	}
+	if leastRequestArgs.MaxWaitingRequests == 0 {
+		leastRequestArgs.MaxWaitingRequests = 10
 	}
 
 	return &LeastRequest{
-		name:              LeastRequestPluginName,
-		maxWaitingRequest: leastRequestArgs.MaxWaitingRequests,
+		name:               LeastRequestPluginName,
+		maxWaitingRequests: leastRequestArgs.MaxWaitingRequests,
 	}
 }
 
@@ -61,7 +69,9 @@ func (l *LeastRequest) Name() string {
 
 func (l *LeastRequest) Filter(ctx *framework.Context, pods []*datastore.PodInfo) []*datastore.PodInfo {
 	return slices.FilterInPlace(pods, func(info *datastore.PodInfo) bool {
-		return info.GetRequestWaitingNum() < float64(l.maxWaitingRequest)
+		// Filter on engine-reported waiting queue: catches backlog the router
+		// cannot observe (requests already inside the engine but not yet running).
+		return info.GetRequestWaitingNum() < float64(l.maxWaitingRequests)
 	})
 }
 
@@ -71,19 +81,29 @@ func (l *LeastRequest) Score(ctx *framework.Context, pods []*datastore.PodInfo) 
 		return scoreResults
 	}
 
-	// 1. Calculate the base score (running reqs + 100 * waiting reqs) for each pod
+	// Score formula: base = onFlight + 100 * max(onFlight - running, 0)
+	//
+	//   - onFlight: router-tracked in-flight count, updated with zero delay.
+	//     Acts as a proxy for current pod load and avoids the ~1 s engine-metrics
+	//     poll lag.
+	//   - max(onFlight - running, 0): estimates the number of requests that the
+	//     router has dispatched but the engine has not yet started executing
+	//     (i.e. likely queued inside the engine). Weighted ×100 to strongly
+	//     penalise pods whose queue is building up.
 	baseScores := make(map[*datastore.PodInfo]float64)
 	maxScore := 0.0
 	for _, info := range pods {
-		// The weight of waiting requests is 100. It's a magic number just to significantly lower the score of the pod when there are waiting reqs.
-		base := info.GetRequestRunningNum() + 100*info.GetRequestWaitingNum()
+		// Estimate queued requests as max(onFlight - running, 0). The engine-reported
+		// running count has a poll lag (~1 s), so this may briefly over-count, but
+		// it provides a leading indicator of queue build-up at the pod.
+		base := float64(info.GetOnFlightRequestNum()) + 100*math.Max(float64(info.GetOnFlightRequestNum())-float64(info.GetRequestRunningNum()), 0)
 		baseScores[info] = base
 		if base > maxScore {
 			maxScore = base
 		}
 	}
 
-	// 2. Calculate the score for each pod as a percentage of the max base score
+	// Normalise to [0, 100]: the least-loaded pod gets 100.
 	for _, info := range pods {
 		score := 100.0
 		if maxScore > 0 {

--- a/pkg/kthena-router/scheduler/plugins/least_request_test.go
+++ b/pkg/kthena-router/scheduler/plugins/least_request_test.go
@@ -26,6 +26,25 @@ import (
 	"github.com/volcano-sh/kthena/pkg/kthena-router/datastore"
 )
 
+func makePodWithOnFlight(name string, onFlight int64) *datastore.PodInfo {
+	p := &datastore.PodInfo{Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: name}}}
+	p.SetOnFlightRequestNum(onFlight)
+	return p
+}
+
+// makePodWithRunning creates a PodInfo with both an on-flight count and an
+// engine-reported running count. The scorer uses max(onFlight-running, 0) as
+// an estimate of requests that are in-flight at the router but not yet
+// executing at the engine (i.e. waiting in the engine queue).
+func makePodWithRunning(name string, onFlight int64, running float64) *datastore.PodInfo {
+	p := &datastore.PodInfo{
+		Pod:               &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: name}},
+		RequestRunningNum: running,
+	}
+	p.SetOnFlightRequestNum(onFlight)
+	return p
+}
+
 func TestLeastRequestScore(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -35,36 +54,51 @@ func TestLeastRequestScore(t *testing.T) {
 		{
 			name: "all pods idle",
 			pods: []*datastore.PodInfo{
-				{Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-1"}}, RequestRunningNum: 0, RequestWaitingNum: 0},
-				{Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-2"}}, RequestRunningNum: 0, RequestWaitingNum: 0},
-				{Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-3"}}, RequestRunningNum: 0, RequestWaitingNum: 0},
+				makePodWithOnFlight("pod-1", 0),
+				makePodWithOnFlight("pod-2", 0),
+				makePodWithOnFlight("pod-3", 0),
 			},
 			expectedScores: map[string]int{"pod-1": 100, "pod-2": 100, "pod-3": 100},
 		},
 		{
 			name: "single pod idle",
 			pods: []*datastore.PodInfo{
-				{Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-1"}}, RequestRunningNum: 0, RequestWaitingNum: 0},
+				makePodWithOnFlight("pod-1", 0),
 			},
 			expectedScores: map[string]int{"pod-1": 100},
 		},
 		{
-			name: "mixed load pods",
+			name: "mixed on-flight load",
 			pods: []*datastore.PodInfo{
-				{Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-1"}}, RequestRunningNum: 0, RequestWaitingNum: 0},
-				{Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-2"}}, RequestRunningNum: 10, RequestWaitingNum: 0},
-				{Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-3"}}, RequestRunningNum: 5, RequestWaitingNum: 0},
+				makePodWithOnFlight("pod-1", 0),
+				makePodWithOnFlight("pod-2", 10),
+				makePodWithOnFlight("pod-3", 5),
 			},
 			expectedScores: map[string]int{"pod-1": 100, "pod-2": 0, "pod-3": 50},
 		},
 		{
 			name: "normal non-zero case",
 			pods: []*datastore.PodInfo{
-				{Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-1"}}, RequestRunningNum: 1, RequestWaitingNum: 0},
-				{Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-2"}}, RequestRunningNum: 2, RequestWaitingNum: 0},
-				{Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-3"}}, RequestRunningNum: 3, RequestWaitingNum: 0},
+				makePodWithOnFlight("pod-1", 1),
+				makePodWithOnFlight("pod-2", 2),
+				makePodWithOnFlight("pod-3", 3),
 			},
 			expectedScores: map[string]int{"pod-1": 66, "pod-2": 33, "pod-3": 0},
+		},
+		{
+			// Demonstrates that the estimated engine-queue depth (onFlight - running)
+			// dominates scoring. pod-2 has 5 in-flight but none running yet, so all
+			// 5 are estimated as waiting → base = 5 + 100*5 = 505.
+			// pod-1 has the same on-flight count but all are already running → base = 5.
+			// pod-3 is idle → base = 0.
+			// Scores: pod-3=100, pod-1=int(500/505*100)=99, pod-2=0.
+			name: "estimated waiting dominates score",
+			pods: []*datastore.PodInfo{
+				makePodWithRunning("pod-1", 5, 5), // onFlight=running → estimated waiting=0 → base=5
+				makePodWithRunning("pod-2", 5, 0), // onFlight=5, running=0 → estimated waiting=5 → base=505
+				makePodWithRunning("pod-3", 0, 0), // idle → base=0
+			},
+			expectedScores: map[string]int{"pod-1": 99, "pod-2": 0, "pod-3": 100},
 		},
 	}
 

--- a/pkg/kthena-router/scheduler/scheduler_impl.go
+++ b/pkg/kthena-router/scheduler/scheduler_impl.go
@@ -44,6 +44,10 @@ type SchedulerImpl struct {
 	scorePlugins  []*scorePlugin
 
 	postScheduleHooks []framework.PostScheduleHook
+
+	// syncOnFlight is true when the least-request plugin is enabled.
+	// In that case Schedule() syncs on-flight counts from Redis before scoring.
+	syncOnFlight bool
 }
 
 type scorePlugin struct {
@@ -87,6 +91,22 @@ func NewScheduler(store datastore.Store, routerConfig *conf.RouterConfiguration)
 		}
 	}
 
+	leastRequestEnabled := false
+	for _, name := range filterPluginMap {
+		if name == plugins.LeastRequestPluginName {
+			leastRequestEnabled = true
+			break
+		}
+	}
+	if !leastRequestEnabled {
+		for name := range scorePluginMap {
+			if name == plugins.LeastRequestPluginName {
+				leastRequestEnabled = true
+				break
+			}
+		}
+	}
+
 	prefixCache := plugins.NewPrefixCache(store, pluginsArgMap[plugins.PrefixCachePluginName])
 	return &SchedulerImpl{
 		store:         store,
@@ -95,10 +115,17 @@ func NewScheduler(store datastore.Store, routerConfig *conf.RouterConfiguration)
 		postScheduleHooks: []framework.PostScheduleHook{
 			prefixCache,
 		},
+		syncOnFlight: leastRequestEnabled,
 	}
 }
 
 func (s *SchedulerImpl) Schedule(ctx *framework.Context, pods []*datastore.PodInfo) error {
+	// Sync on-flight counts from Redis before scoring when least-request is active,
+	// so cross-router traffic is reflected in pod scores. Rate-limited internally.
+	if s.syncOnFlight {
+		s.store.SyncOnFlightCounts()
+	}
+
 	// first filter out invalid pods that wonot be selected to loadbalance to.
 	pods, err := s.RunFilterPlugins(pods, ctx)
 	if err != nil {

--- a/pkg/kthena-router/scheduler/testdata/configmap.yaml
+++ b/pkg/kthena-router/scheduler/testdata/configmap.yaml
@@ -1,17 +1,17 @@
 scheduler:
   pluginConfig:
-  - name: least-request
-    args:
-      maxWaitingRequests: 10
-  - name: least-latency
-    args:
-      TTFTTPOTWeightFactor: 0.5
-  - name: prefix-cache
-    args:
-      blockSizeToHash: 64
-      maxBlocksToMatch: 128
-      maxHashCacheSize: 50000
-      topKMatches: 5
+    - name: least-request
+      args:
+        maxWaitingRequests: 10
+    - name: least-latency
+      args:
+        TTFTTPOTWeightFactor: 0.5
+    - name: prefix-cache
+      args:
+        blockSizeToHash: 64
+        maxBlocksToMatch: 128
+        maxHashCacheSize: 50000
+        topKMatches: 5
   plugins:
     Filter:
       enabled:

--- a/pkg/kthena-router/utils/testdata/configmap.yaml
+++ b/pkg/kthena-router/utils/testdata/configmap.yaml
@@ -1,7 +1,7 @@
 pluginConfig:
 - name: least-request
-  args: 
-    maxWaitingRequests: 10
+    args:
+      maxWaitingRequests: 10
 - name: least-latency
   args:
     TTFTTPOTWeightFactor: 0.5
@@ -19,11 +19,11 @@ plugins:
       - lora-affinity
   Score:
     enabled:
-      - name: least-request
-        weight: 1
-      - name: gpu-usage
-        weight: 1
-      - name: least-latency
-        weight: 1
-      - name: prefix-cache
-        weight: 1
+    - name: least-request
+      weight: 1
+    - name: gpu-usage
+      weight: 1
+    - name: least-latency
+      weight: 1
+    - name: prefix-cache
+      weight: 1


### PR DESCRIPTION
## Summary

This PR adds per-pod in-flight request tracking to the router, enabling the `least-request` scheduler plugin to make accurate scheduling decisions that reflect real-time request load — including traffic from other router replicas via a Redis-backed global counter.

## Changes

### On-flight counter infrastructure (`datastore/`)
- Add `OnFlightCounter` interface and `RedisOnFlightCounter` backed by Redis `HINCRBY`/`HDECRBY` + `HMGET` for cross-router visibility
- Add `onFlightRequestNum atomic.Int64` to `PodInfo` with thread-safe `Incr`/`Decr`/`Set`/`Get` accessors
- Add `IncrPodOnFlightRequests` / `DecrPodOnFlightRequests` to `Store` interface and `store` impl; falls back to local atomic when Redis is unavailable
- Add `SyncOnFlightCounts()` to `Store`: scans all pods in one `HMGET` and refreshes local atomics; rate-limited to at most one Redis read per 50 ms via a CAS time-gate (`lastOnFlightSync atomic.Int64`)

### KV connector hooks (`connectors/`)
- Add `OnFlightHooks` struct (`IncrPrefill/DecrPrefill/IncrDecode/DecrDecode func()`) as an explicit parameter to `KVConnector.Proxy()` so each connector can update counters at the precise phase boundary (prefill start/end, decode start/end)
- Update `http`, `nixl`, and `sglang` connectors to accept and invoke hooks; `sglang` calls both `Incr` hooks before launching concurrent phases and each `Decr` hook immediately when that phase completes

### Router wiring (`router/`)
- `proxyToPDDisaggregated()` builds `OnFlightHooks` closures and passes them directly to `KVConnector.Proxy()`
- `proxy()` (aggregated path) calls `Incr`/`Decr` around the forwarded request

### Scheduler integration (`scheduler/`)
- `SchedulerImpl` gains a `syncOnFlight bool` field, set to `true` in `NewScheduler()` **only when the `least-request` plugin is present** (filter or score map)
- `Schedule()` calls `s.store.SyncOnFlightCounts()` at the top when `syncOnFlight == true`, so Redis reads happen only when they affect scoring — and at most once per 50 ms
- Redis `OnFlightCounter` wired in `server.go` via `REDIS_HOST` env var

### LeastRequest scorer
- Score formula: `onFlight + 100 * max(onFlight - running, 0)` — strongly penalises pods with excess in-flight load relative to what the engine reports as running

## Testing
- All packages build and test cleanly; pre-existing `connectors` test failures (body-consumed-after-network-failure) are unrelated to this change
- `MockStore` in `debug/handlers_test.go` updated with no-op stubs for the three new interface methods