### PR TITLE
fix: replace testify/assert/yaml with sigs.k8s.io/yaml in scheduler p…

### DIFF
--- a/charts/kthena/charts/networking/templates/kthena-router/component/deployment.yaml
+++ b/charts/kthena/charts/networking/templates/kthena-router/component/deployment.yaml
@@ -107,7 +107,7 @@ spec:
             periodSeconds: 5
           readinessProbe:
             httpGet:
-              path: /healthz
+              path: /readyz
               port: {{ .Values.kthenaRouter.port }}
               {{- if and (eq .Values.global.certManagementMode "cert-manager") .Values.kthenaRouter.tls.enabled }}
               scheme: HTTPS

--- a/charts/kthena/charts/networking/templates/kthena-router/component/deployment.yaml
+++ b/charts/kthena/charts/networking/templates/kthena-router/component/deployment.yaml
@@ -107,7 +107,7 @@ spec:
             periodSeconds: 5
           readinessProbe:
             httpGet:
-              path: /readyz
+              path: /healthz
               port: {{ .Values.kthenaRouter.port }}
               {{- if and (eq .Values.global.certManagementMode "cert-manager") .Values.kthenaRouter.tls.enabled }}
               scheme: HTTPS

--- a/pkg/kthena-router/scheduler/plugins/least_latency.go
+++ b/pkg/kthena-router/scheduler/plugins/least_latency.go
@@ -19,7 +19,7 @@ package plugins
 import (
 	"math"
 
-	"github.com/stretchr/testify/assert/yaml"
+	"sigs.k8s.io/yaml"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
 

--- a/pkg/kthena-router/scheduler/plugins/least_latency.go
+++ b/pkg/kthena-router/scheduler/plugins/least_latency.go
@@ -19,9 +19,9 @@ package plugins
 import (
 	"math"
 
-	"sigs.k8s.io/yaml"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/yaml"
 
 	"github.com/volcano-sh/kthena/pkg/kthena-router/datastore"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/scheduler/framework"

--- a/pkg/kthena-router/scheduler/plugins/least_request.go
+++ b/pkg/kthena-router/scheduler/plugins/least_request.go
@@ -17,7 +17,7 @@ limitations under the License.
 package plugins
 
 import (
-	"github.com/stretchr/testify/assert/yaml"
+	"sigs.k8s.io/yaml"
 	"istio.io/istio/pkg/slices"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"

--- a/pkg/kthena-router/scheduler/plugins/least_request.go
+++ b/pkg/kthena-router/scheduler/plugins/least_request.go
@@ -17,10 +17,10 @@ limitations under the License.
 package plugins
 
 import (
-	"sigs.k8s.io/yaml"
 	"istio.io/istio/pkg/slices"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/yaml"
 
 	"github.com/volcano-sh/kthena/pkg/kthena-router/datastore"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/scheduler/framework"

--- a/pkg/kthena-router/scheduler/plugins/prefix.go
+++ b/pkg/kthena-router/scheduler/plugins/prefix.go
@@ -74,7 +74,7 @@ import (
 	"fmt"
 
 	"github.com/cespare/xxhash"
-	"github.com/stretchr/testify/assert/yaml"
+	"sigs.k8s.io/yaml"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"

--- a/pkg/kthena-router/scheduler/plugins/prefix.go
+++ b/pkg/kthena-router/scheduler/plugins/prefix.go
@@ -74,10 +74,10 @@ import (
 	"fmt"
 
 	"github.com/cespare/xxhash"
-	"sigs.k8s.io/yaml"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/yaml"
 
 	"github.com/volcano-sh/kthena/pkg/kthena-router/datastore"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/scheduler/framework"


### PR DESCRIPTION
…lugins

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
three scheduler plugins (`prefix.go`, `least_request.go`, `least_latency.go`) were importing `github.com/stretchr/testify/assert/yaml` for YAML unmarshalling in production code. `testify` is a test library and should never appear in production binaries. The rest of the codebase already uses `sigs.k8s.io/yaml` (see `kvcache_aware.go`, `conf/conf.go`). This PR replaces the incorrect import in all three files.

**Which issue(s) this PR fixes**:
Fixes #966

**Special notes for your reviewer**:
no logic changes — only the import is replaced. `sigs.k8s.io/yaml` exposes the same `Unmarshal` signature so the call sites are unchanged.

**Does this PR introduce a user-facing change?**:
```release-note

```
