### PR TITLE
fix: use PVC name directly as ClaimName instead of path

### DIFF
--- a/pkg/model-booster-controller/convert/model_serving.go
+++ b/pkg/model-booster-controller/convert/model_serving.go
@@ -432,7 +432,7 @@ func buildCacheVolume(backend *workload.ModelBackend) (*corev1.Volume, error) {
 			Name: volumeName,
 			VolumeSource: corev1.VolumeSource{
 				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-					ClaimName: strings.TrimPrefix(backend.CacheURI, CacheURIPrefixPVC),
+					ClaimName: strings.Trim(strings.TrimPrefix(backend.CacheURI, CacheURIPrefixPVC), "/"),
 				},
 			},
 		}, nil

--- a/pkg/model-booster-controller/convert/model_serving.go
+++ b/pkg/model-booster-controller/convert/model_serving.go
@@ -432,7 +432,7 @@ func buildCacheVolume(backend *workload.ModelBackend) (*corev1.Volume, error) {
 			Name: volumeName,
 			VolumeSource: corev1.VolumeSource{
 				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-					ClaimName: GetCachePath(backend.CacheURI),
+					ClaimName: strings.TrimPrefix(backend.CacheURI, CacheURIPrefixPVC),
 				},
 			},
 		}, nil

--- a/pkg/model-booster-controller/convert/model_serving.go
+++ b/pkg/model-booster-controller/convert/model_serving.go
@@ -432,7 +432,7 @@ func buildCacheVolume(backend *workload.ModelBackend) (*corev1.Volume, error) {
 			Name: volumeName,
 			VolumeSource: corev1.VolumeSource{
 				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-					ClaimName: strings.Trim(strings.TrimPrefix(backend.CacheURI, CacheURIPrefixPVC), "/"),
+					ClaimName: GetPVCClaimName(backend.CacheURI),
 				},
 			},
 		}, nil
@@ -450,7 +450,11 @@ func buildCacheVolume(backend *workload.ModelBackend) (*corev1.Volume, error) {
 	return nil, fmt.Errorf("not support prefix in CacheURI: %s", backend.CacheURI)
 }
 
-// GetCachePath gets the path from string after "://". For example, for "pvc://my-pvc", it returns "/my-pvc".
+// GetCachePath returns the in-container mount path derived from a cache URI.
+// It takes the substring after "://", trims surrounding slashes, and prepends a
+// single "/" so the result is a valid absolute path suitable for a container's
+// VolumeMount.MountPath or HostPath.Path. For example, for "pvc://my-pvc" it
+// returns "/my-pvc". It is NOT a PVC ClaimName; use GetPVCClaimName for that.
 func GetCachePath(path string) string {
 	if path == "" || !strings.Contains(path, URIPrefixSeparator) {
 		return ""
@@ -461,6 +465,13 @@ func GetCachePath(path string) string {
 	builder.WriteString("/")
 	builder.WriteString(s)
 	return builder.String()
+}
+
+// GetPVCClaimName extracts the bare PVC name from a "pvc://" cache URI, trimming
+// surrounding slashes so malformed inputs like "pvc:///my-pvc" still yield a
+// valid Kubernetes resource name (which cannot contain slashes).
+func GetPVCClaimName(uri string) string {
+	return strings.Trim(strings.TrimPrefix(uri, CacheURIPrefixPVC), "/")
 }
 
 func getVolumeName(backendName string) string {

--- a/pkg/model-booster-controller/convert/model_serving_test.go
+++ b/pkg/model-booster-controller/convert/model_serving_test.go
@@ -232,6 +232,21 @@ func TestBuildCacheVolume(t *testing.T) {
 			},
 		},
 		{
+			name: "PVC URI with extra slashes",
+			input: &workload.ModelBackend{
+				Name:     "test-backend",
+				CacheURI: "pvc:///test-pvc",
+			},
+			expected: &corev1.Volume{
+				Name: "test-backend-weights",
+				VolumeSource: corev1.VolumeSource{
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: "test-pvc",
+					},
+				},
+			},
+		},
+		{
 			name: "HostPath URI",
 			input: &workload.ModelBackend{
 				Name:     "test-backend",

--- a/pkg/model-booster-controller/convert/model_serving_test.go
+++ b/pkg/model-booster-controller/convert/model_serving_test.go
@@ -226,7 +226,7 @@ func TestBuildCacheVolume(t *testing.T) {
 				Name: "test-backend-weights",
 				VolumeSource: corev1.VolumeSource{
 					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-						ClaimName: "/test-pvc",
+						ClaimName: "test-pvc",
 					},
 				},
 			},

--- a/pkg/model-booster-controller/convert/model_serving_test.go
+++ b/pkg/model-booster-controller/convert/model_serving_test.go
@@ -105,6 +105,47 @@ func TestGetCachePath(t *testing.T) {
 	}
 }
 
+func TestGetPVCClaimName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "normal pvc URI",
+			input:    "pvc://my-pvc",
+			expected: "my-pvc",
+		},
+		{
+			name:     "extra leading slashes",
+			input:    "pvc:///my-pvc",
+			expected: "my-pvc",
+		},
+		{
+			name:     "trailing slash",
+			input:    "pvc://my-pvc/",
+			expected: "my-pvc",
+		},
+		{
+			name:     "multiple surrounding slashes",
+			input:    "pvc:////my-pvc////",
+			expected: "my-pvc",
+		},
+		{
+			name:     "empty",
+			input:    "",
+			expected: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetPVCClaimName(tt.input); got != tt.expected {
+				t.Errorf("GetPVCClaimName() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
 func TestCreateModelServingResources(t *testing.T) {
 	tests := []struct {
 		name         string


### PR DESCRIPTION
## What

Fix incorrect PVC `ClaimName` generated when `cacheURI` uses the `pvc://` scheme in `ModelBooster`.

Fixes #973

## Why

`GetCachePath()` returns a filesystem path with a leading slash (e.g. `/model-cache`), which is correct for container `MountPath` but wrong for PVC `ClaimName`. Using it as `ClaimName` causes the scheduler to fail:

```
persistentvolumeclaim "/model-cache" not found
```

## How

In `buildCacheVolume()`, replace `GetCachePath()` with `strings.Trim(strings.TrimPrefix(...))` to extract the bare PVC name from the `pvc://` URI, also handling malformed URIs with extra slashes (e.g. `pvc:///model-cache`).

```go
// Before
ClaimName: GetCachePath(backend.CacheURI),  // "/model-cache" — wrong

// After
ClaimName: strings.Trim(strings.TrimPrefix(backend.CacheURI, CacheURIPrefixPVC), "/"),  // "model-cache" — correct
```

## Testing

- Updated existing unit test to assert correct `ClaimName` without leading slash
- Added test case for malformed URI `pvc:///test-pvc` to cover extra-slash edge case