### PR TITLE
fix: use GetGauge() instead of GetCounter() for sglang metrics

### DIFF
--- a/pkg/kthena-router/backend/sglang/metrics.go
+++ b/pkg/kthena-router/backend/sglang/metrics.go
@@ -83,7 +83,7 @@ func (engine *sglangEngine) GetCountMetricsInfo(allMetrics map[string]*dto.Metri
 			continue
 		}
 		for _, metric := range metricInfo.Metric {
-			metricValue := metric.GetCounter().GetValue()
+			metricValue := metric.GetGauge().GetValue()
 			wantMetrics[mapOfMetricsName[metricName]] = metricValue
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
`GetCountMetricsInfo()` in the sglang backend was using `metric.GetCounter().GetValue()` to read `sglang:token_usage` and `sglang:num_queue_reqs`. Both are gauge metrics per SGLang's official Prometheus documentation — calling `GetCounter()` on a gauge always returns 0. This caused the least-request and kvcache-aware schedulers to silently receive zero values for all SGLang backends. The vllm backend correctly uses `metric.GetGauge().GetValue()` for equivalent metrics — this PR brings sglang in line with that.

**Which issue(s) this PR fixes**:
Fixes #975

**Special notes for your reviewer**:
this is just a one-line fix. no logic changes beyond correcting the metric type accessor to match what SGLang actually exposes.

**Does this PR introduce a user-facing change?**:
```release-note

```
