### PR TITLE
feat: add STATUS and READY columns to kthena get output

### DIFF
--- a/cli/kthena/cmd/get.go
+++ b/cli/kthena/cmd/get.go
@@ -29,6 +29,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/yaml"
+
+	workload "github.com/volcano-sh/kthena/pkg/apis/workload/v1alpha1"
 )
 
 var (
@@ -241,6 +243,44 @@ func resolveGetNamespace() string {
 	return "default"
 }
 
+// getModelServingStatus derives a human-readable status from ModelServing conditions.
+func getModelServingStatus(conditions []metav1.Condition) string {
+	for _, c := range conditions {
+		if c.Type == string(workload.ModelServingAvailable) && c.Status == metav1.ConditionTrue {
+			return "Available"
+		}
+	}
+	for _, c := range conditions {
+		if c.Type == string(workload.ModelServingProgressing) && c.Status == metav1.ConditionTrue {
+			return "Progressing"
+		}
+		if c.Type == string(workload.ModelServingUpdateInProgress) && c.Status == metav1.ConditionTrue {
+			return "Updating"
+		}
+	}
+	return "Unknown"
+}
+
+// getModelBoosterStatus derives a human-readable status from ModelBooster conditions.
+func getModelBoosterStatus(conditions []metav1.Condition) string {
+	for _, c := range conditions {
+		if c.Type == string(workload.ModelStatusConditionTypeFailed) && c.Status == metav1.ConditionTrue {
+			return "Failed"
+		}
+	}
+	for _, c := range conditions {
+		if c.Type == string(workload.ModelStatusConditionTypeActive) && c.Status == metav1.ConditionTrue {
+			return "Active"
+		}
+	}
+	for _, c := range conditions {
+		if c.Type == string(workload.ModelStatusConditionTypeInitialized) && c.Status == metav1.ConditionTrue {
+			return "Initialized"
+		}
+	}
+	return "Unknown"
+}
+
 func runGetModelBoosters(cmd *cobra.Command, args []string) error {
 	client, err := getKthenaClient()
 	if err != nil {
@@ -285,19 +325,20 @@ func runGetModelBoosters(cmd *cobra.Command, args []string) error {
 	// Print header
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
 	if getAllNamespaces {
-		fmt.Fprintln(w, "NAMESPACE\tNAME\tAGE")
+		fmt.Fprintln(w, "NAMESPACE\tNAME\tSTATUS\tAGE")
 	} else {
-		fmt.Fprintln(w, "NAME\tAGE")
+		fmt.Fprintln(w, "NAME\tSTATUS\tAGE")
 	}
 
 	// Print matching Models
 	for _, model := range models.Items {
 		if nameFilter == "" || strings.Contains(strings.ToLower(model.Name), strings.ToLower(nameFilter)) {
 			age := time.Since(model.CreationTimestamp.Time).Truncate(time.Second)
+			status := getModelBoosterStatus(model.Status.Conditions)
 			if getAllNamespaces {
-				fmt.Fprintf(w, "%s\t%s\t%s\n", model.Namespace, model.Name, age)
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", model.Namespace, model.Name, status, age)
 			} else {
-				fmt.Fprintf(w, "%s\t%s\n", model.Name, age)
+				fmt.Fprintf(w, "%s\t%s\t%s\n", model.Name, status, age)
 			}
 		}
 	}
@@ -339,13 +380,14 @@ func runGetModelServings(cmd *cobra.Command, args []string) error {
 	// Print ModelServings
 	for _, ms := range modelServingList.Items {
 		age := time.Since(ms.CreationTimestamp.Time).Truncate(time.Second)
+		ready := fmt.Sprintf("%d/%d", ms.Status.AvailableReplicas, ms.Status.Replicas)
+		status := getModelServingStatus(ms.Status.Conditions)
 		if getAllNamespaces {
-			fmt.Fprintf(w, "%s\t%s\t%s\n", ms.Namespace, ms.Name, age)
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", ms.Namespace, ms.Name, ready, status, age)
 		} else {
-			fmt.Fprintf(w, "%s\t%s\n", ms.Name, age)
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", ms.Name, ready, status, age)
 		}
 	}
-
 	return w.Flush()
 }
 

--- a/cli/kthena/cmd/get.go
+++ b/cli/kthena/cmd/get.go
@@ -26,11 +26,10 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/volcano-sh/kthena/client-go/clientset/versioned"
+	workload "github.com/volcano-sh/kthena/pkg/apis/workload/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/yaml"
-
-	workload "github.com/volcano-sh/kthena/pkg/apis/workload/v1alpha1"
 )
 
 var (

--- a/cli/kthena/cmd/get.go
+++ b/cli/kthena/cmd/get.go
@@ -251,11 +251,13 @@ func getModelServingStatus(conditions []metav1.Condition) string {
 		}
 	}
 	for _, c := range conditions {
-		if c.Type == string(workload.ModelServingProgressing) && c.Status == metav1.ConditionTrue {
-			return "Progressing"
-		}
 		if c.Type == string(workload.ModelServingUpdateInProgress) && c.Status == metav1.ConditionTrue {
 			return "Updating"
+		}
+	}
+	for _, c := range conditions {
+		if c.Type == string(workload.ModelServingProgressing) && c.Status == metav1.ConditionTrue {
+			return "Progressing"
 		}
 	}
 	return "Unknown"
@@ -372,9 +374,9 @@ func runGetModelServings(cmd *cobra.Command, args []string) error {
 	// Print header
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
 	if getAllNamespaces {
-		fmt.Fprintln(w, "NAMESPACE\tNAME\tAGE")
+		fmt.Fprintln(w, "NAMESPACE\tNAME\tREADY\tSTATUS\tAGE")
 	} else {
-		fmt.Fprintln(w, "NAME\tAGE")
+		fmt.Fprintln(w, "NAME\tREADY\tSTATUS\tAGE")
 	}
 
 	// Print ModelServings

--- a/cli/kthena/cmd/get_test.go
+++ b/cli/kthena/cmd/get_test.go
@@ -1,0 +1,204 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	workload "github.com/volcano-sh/kthena/pkg/apis/workload/v1alpha1"
+)
+
+func TestGetModelServingStatus(t *testing.T) {
+	tests := []struct {
+		name       string
+		conditions []metav1.Condition
+		expected   string
+	}{
+		{
+			name:       "NoConditions",
+			conditions: []metav1.Condition{},
+			expected:   "Unknown",
+		},
+		{
+			name: "Available",
+			conditions: []metav1.Condition{
+				{
+					Type:   string(workload.ModelServingAvailable),
+					Status: metav1.ConditionTrue,
+				},
+			},
+			expected: "Available",
+		},
+		{
+			name: "Progressing",
+			conditions: []metav1.Condition{
+				{
+					Type:   string(workload.ModelServingProgressing),
+					Status: metav1.ConditionTrue,
+				},
+			},
+			expected: "Progressing",
+		},
+		{
+			name: "Updating",
+			conditions: []metav1.Condition{
+				{
+					Type:   string(workload.ModelServingUpdateInProgress),
+					Status: metav1.ConditionTrue,
+				},
+			},
+			expected: "Updating",
+		},
+		{
+			name: "AvailableTakesPriorityOverProgressing",
+			conditions: []metav1.Condition{
+				{
+					Type:   string(workload.ModelServingProgressing),
+					Status: metav1.ConditionTrue,
+				},
+				{
+					Type:   string(workload.ModelServingAvailable),
+					Status: metav1.ConditionTrue,
+				},
+			},
+			expected: "Available",
+		},
+		{
+			name: "UpdateInProgressTakesPriorityOverProgressing",
+			conditions: []metav1.Condition{
+				{
+					Type:   string(workload.ModelServingUpdateInProgress),
+					Status: metav1.ConditionTrue,
+				},
+				{
+					Type:   string(workload.ModelServingProgressing),
+					Status: metav1.ConditionTrue,
+				},
+			},
+			expected: "Updating",
+		},
+		{
+			name: "ConditionFalseIgnored",
+			conditions: []metav1.Condition{
+				{
+					Type:   string(workload.ModelServingAvailable),
+					Status: metav1.ConditionFalse,
+				},
+			},
+			expected: "Unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getModelServingStatus(tt.conditions)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGetModelBoosterStatus(t *testing.T) {
+	tests := []struct {
+		name       string
+		conditions []metav1.Condition
+		expected   string
+	}{
+		{
+			name:       "NoConditions",
+			conditions: []metav1.Condition{},
+			expected:   "Unknown",
+		},
+		{
+			name: "Active",
+			conditions: []metav1.Condition{
+				{
+					Type:   string(workload.ModelStatusConditionTypeActive),
+					Status: metav1.ConditionTrue,
+				},
+			},
+			expected: "Active",
+		},
+		{
+			name: "Failed",
+			conditions: []metav1.Condition{
+				{
+					Type:   string(workload.ModelStatusConditionTypeFailed),
+					Status: metav1.ConditionTrue,
+				},
+			},
+			expected: "Failed",
+		},
+		{
+			name: "Initialized",
+			conditions: []metav1.Condition{
+				{
+					Type:   string(workload.ModelStatusConditionTypeInitialized),
+					Status: metav1.ConditionTrue,
+				},
+			},
+			expected: "Initialized",
+		},
+		{
+			name: "FailedTakesPriorityOverActive",
+			conditions: []metav1.Condition{
+				{
+					Type:   string(workload.ModelStatusConditionTypeActive),
+					Status: metav1.ConditionTrue,
+				},
+				{
+					Type:   string(workload.ModelStatusConditionTypeFailed),
+					Status: metav1.ConditionTrue,
+				},
+			},
+			expected: "Failed",
+		},
+		{
+			name: "ActiveTakesPriorityOverInitialized",
+			conditions: []metav1.Condition{
+				{
+					Type:   string(workload.ModelStatusConditionTypeInitialized),
+					Status: metav1.ConditionTrue,
+				},
+				{
+					Type:   string(workload.ModelStatusConditionTypeActive),
+					Status: metav1.ConditionTrue,
+				},
+			},
+			expected: "Active",
+		},
+		{
+			name: "ConditionFalseIgnored",
+			conditions: []metav1.Condition{
+				{
+					Type:   string(workload.ModelStatusConditionTypeActive),
+					Status: metav1.ConditionFalse,
+				},
+			},
+			expected: "Unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getModelBoosterStatus(tt.conditions)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
`kthena get model-servings` and `kthena get model-boosters` only showed `NAME` and `AGE` columns. The underlying CRDs already expose  status information — `ModelServing` has `AvailableReplicas`, `Replicas`, and `Conditions` (`Available`, `Progressing`, `UpdateInProgress`); `ModelBooster` has `Conditions` (`Active`, `Failed`, `Initialized`) — but none of it was surfaced in the table output. users had no way to tell if a serving was available or failing without running `kubectl get` or `kthena describe` separately. This PR adds `READY` (available/total replicas) and `STATUS` columns to `kthena get model-servings`, and a `STATUS` column to `kthena get model-boosters`.

**Which issue(s) this PR fixes**:
Fixes #977

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
`kthena get model-servings` now shows READY and STATUS columns.
`kthena get model-boosters` now shows a STATUS column.
```
