### PR TITLE
feat(router): add SGLang tokenizer adapter for kvcache-aware plugin

### DIFF
--- a/pkg/kthena-router/scheduler/plugins/kvcache_aware.go
+++ b/pkg/kthena-router/scheduler/plugins/kvcache_aware.go
@@ -126,8 +126,10 @@ func NewKVCacheAware(pluginArg runtime.RawExtension) *KVCacheAware {
 	klog.Infof("KVCacheAware: config blockSizeToHash=%d, maxBlocksToMatch=%d", blockSizeToHash, maxBlocksToMatch)
 
 	managerConfig := tokenization.TokenizerManagerConfig{
-		EnableVLLMRemote: true,
-		EndpointTemplate: "http://%s:8000",
+		EndpointTemplates: map[string]string{
+			"vllm":   "http://%s:8000",
+			"sglang": "http://%s:30000",
+		},
 	}
 	manager := tokenization.NewTokenizerManager(managerConfig)
 

--- a/pkg/kthena-router/scheduler/plugins/tokenization/sglang.go
+++ b/pkg/kthena-router/scheduler/plugins/tokenization/sglang.go
@@ -1,0 +1,80 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tokenization
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+const (
+	sglangTokenizePath = "/tokenize"
+)
+
+type sglangAdapter struct {
+	model string
+}
+
+func newSGLangAdapter(model string) *sglangAdapter {
+	return &sglangAdapter{
+		model: model,
+	}
+}
+
+func (sa *sglangAdapter) GetTokenizePath() string {
+	return sglangTokenizePath
+}
+
+func (sa *sglangAdapter) PrepareTokenizeRequest(input TokenizeInput) (interface{}, error) {
+	switch input.Type {
+	case CompletionInput:
+		req := &sglangTokenizeCompletionRequest{
+			Prompt:           input.Text,
+			AddSpecialTokens: &input.AddSpecialTokens,
+		}
+		if sa.model != "" {
+			req.Model = sa.model
+		}
+		return req, nil
+
+	case ChatInput:
+		req := &sglangTokenizeChatRequest{
+			Messages:         input.Messages,
+			AddSpecialTokens: &input.AddSpecialTokens,
+		}
+		if sa.model != "" {
+			req.Model = sa.model
+		}
+		return req, nil
+
+	default:
+		return nil, fmt.Errorf("unsupported input type: %s", input.Type)
+	}
+}
+
+func (sa *sglangAdapter) ParseTokenizeResponse(data []byte) (*TokenizeResult, error) {
+	var resp sglangTokenizeResponse
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return nil, fmt.Errorf("failed to parse tokenize response: %w", err)
+	}
+
+	return &TokenizeResult{
+		Count:       resp.Count,
+		MaxModelLen: resp.MaxModelLen,
+		Tokens:      resp.Tokens,
+	}, nil
+}

--- a/pkg/kthena-router/scheduler/plugins/tokenization/tokenization_test.go
+++ b/pkg/kthena-router/scheduler/plugins/tokenization/tokenization_test.go
@@ -31,7 +31,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// Test utility functions
 func TestIntToByteArray(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -70,11 +69,12 @@ func TestIntToByteArray(t *testing.T) {
 	}
 }
 
-// Test TokenizerManager
 func TestTokenizerManager(t *testing.T) {
 	config := TokenizerManagerConfig{
-		EnableVLLMRemote: true,
-		EndpointTemplate: "http://%s:8000",
+		EndpointTemplates: map[string]string{
+			"vllm":   "http://%s:8000",
+			"sglang": "http://%s:30000",
+		},
 	}
 
 	manager := NewTokenizerManager(config)
@@ -82,7 +82,6 @@ func TestTokenizerManager(t *testing.T) {
 		t.Fatal("Expected non-nil TokenizerManager")
 	}
 
-	// Test with empty model name
 	t.Run("Empty model name", func(t *testing.T) {
 		pods := []*datastore.PodInfo{}
 		result := manager.GetTokenizer("", pods)
@@ -91,7 +90,6 @@ func TestTokenizerManager(t *testing.T) {
 		}
 	})
 
-	// Test with empty pods
 	t.Run("Empty pods", func(t *testing.T) {
 		result := manager.GetTokenizer("test-model", []*datastore.PodInfo{})
 		if result != nil {
@@ -99,7 +97,6 @@ func TestTokenizerManager(t *testing.T) {
 		}
 	})
 
-	// Test with pod without tokenizer annotation
 	t.Run("Pod without tokenizer annotation", func(t *testing.T) {
 		pods := []*datastore.PodInfo{
 			{
@@ -117,13 +114,10 @@ func TestTokenizerManager(t *testing.T) {
 		}
 
 		result := manager.GetTokenizer("test-model", pods)
-		// Note: The actual implementation may return a tokenizer even without annotation
-		// This test verifies the behavior doesn't panic
 		t.Logf("GetTokenizer returned: %v", result)
 	})
 }
 
-// Test error types
 func TestErrorTypes(t *testing.T) {
 	t.Run("ErrTokenizationFailed", func(t *testing.T) {
 		err := ErrTokenizationFailed{
@@ -131,7 +125,6 @@ func TestErrorTypes(t *testing.T) {
 			Cause:   fmt.Errorf("underlying error"),
 		}
 
-		// The actual error message format includes "tokenization failed: " prefix
 		expected := "tokenization failed: test error: underlying error"
 		if err.Error() != expected {
 			t.Errorf("Expected error message '%s', got '%s'", expected, err.Error())
@@ -144,7 +137,6 @@ func TestErrorTypes(t *testing.T) {
 			Message:    "Not Found",
 		}
 
-		// The actual error message format is "HTTP {code}: {message}"
 		expected := "HTTP 404: Not Found"
 		if err.Error() != expected {
 			t.Errorf("Expected error message '%s', got '%s'", expected, err.Error())
@@ -152,17 +144,14 @@ func TestErrorTypes(t *testing.T) {
 	})
 }
 
-// Test vLLM adapter
 func TestVLLMAdapter(t *testing.T) {
 	adapter := newVLLMAdapter("test-model")
 
-	// Test GetTokenizePath returns a non-empty path
 	path := adapter.GetTokenizePath()
 	if path == "" {
 		t.Error("GetTokenizePath should return a non-empty path")
 	}
 
-	// Test PrepareTokenizeRequest for completion
 	t.Run("Completion request", func(t *testing.T) {
 		input := TokenizeInput{
 			Type:               CompletionInput,
@@ -189,7 +178,6 @@ func TestVLLMAdapter(t *testing.T) {
 		}
 	})
 
-	// Test PrepareTokenizeRequest for chat
 	t.Run("Chat request", func(t *testing.T) {
 		input := TokenizeInput{
 			Type: ChatInput,
@@ -219,7 +207,6 @@ func TestVLLMAdapter(t *testing.T) {
 		}
 	})
 
-	// Test ParseTokenizeResponse
 	t.Run("Parse response", func(t *testing.T) {
 		jsonData := `{"count":3,"max_model_len":2048,"tokens":[1,2,3],"token_strs":["Hello","world","!"]}`
 
@@ -243,9 +230,7 @@ func TestVLLMAdapter(t *testing.T) {
 	})
 }
 
-// Test remote tokenizer creation and basic functionality
 func TestRemoteTokenizerCreation(t *testing.T) {
-	// Test valid configuration
 	t.Run("Valid configuration", func(t *testing.T) {
 		config := RemoteTokenizerConfig{
 			Engine:   "vllm",
@@ -262,7 +247,6 @@ func TestRemoteTokenizerCreation(t *testing.T) {
 		}
 	})
 
-	// Test unsupported engine
 	t.Run("Unsupported engine", func(t *testing.T) {
 		config := RemoteTokenizerConfig{
 			Engine:   "unsupported",
@@ -270,12 +254,33 @@ func TestRemoteTokenizerCreation(t *testing.T) {
 		}
 
 		tokenizer, err := NewRemoteTokenizer(config)
-		// The actual implementation may not validate engine type at creation time
-		// Just verify it doesn't panic
-		t.Logf("NewRemoteTokenizer with unsupported engine: tokenizer=%v, err=%v", tokenizer != nil, err)
+		if err == nil {
+			t.Fatal("Expected error for unsupported engine")
+		}
+		if tokenizer != nil {
+			t.Error("Expected nil tokenizer for unsupported engine")
+		}
+		if _, ok := err.(ErrInvalidConfig); !ok {
+			t.Errorf("Expected ErrInvalidConfig, got %T: %v", err, err)
+		}
 	})
 
-	// Test empty endpoint
+	t.Run("SGLang engine", func(t *testing.T) {
+		config := RemoteTokenizerConfig{
+			Engine:   "sglang",
+			Endpoint: "http://localhost:30000",
+			Model:    "test-model",
+		}
+
+		tokenizer, err := NewRemoteTokenizer(config)
+		if err != nil {
+			t.Fatalf("Failed to create SGLang tokenizer: %v", err)
+		}
+		if tokenizer == nil {
+			t.Fatal("Expected non-nil tokenizer for SGLang engine")
+		}
+	})
+
 	t.Run("Empty endpoint", func(t *testing.T) {
 		config := RemoteTokenizerConfig{
 			Engine:   "vllm",
@@ -283,22 +288,17 @@ func TestRemoteTokenizerCreation(t *testing.T) {
 		}
 
 		tokenizer, err := NewRemoteTokenizer(config)
-		// The actual implementation may not validate endpoint at creation time
-		// Just verify it doesn't panic
 		t.Logf("NewRemoteTokenizer with empty endpoint: tokenizer=%v, err=%v", tokenizer != nil, err)
 	})
 }
 
-// Test remote tokenizer with mock server
 func TestRemoteTokenizerWithMockServer(t *testing.T) {
-	// Create mock vLLM server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/tokenize" {
 			http.NotFound(w, r)
 			return
 		}
 
-		// Simple response for testing
 		response := map[string]interface{}{
 			"count":         3,
 			"max_model_len": 2048,
@@ -321,14 +321,12 @@ func TestRemoteTokenizerWithMockServer(t *testing.T) {
 		t.Fatalf("Failed to create tokenizer: %v", err)
 	}
 
-	// Test TokenizeInputText
 	t.Run("TokenizeInputText", func(t *testing.T) {
 		result, err := tokenizer.TokenizeInputText("Hello world test")
 		if err != nil {
 			t.Fatalf("TokenizeInputText failed: %v", err)
 		}
 
-		// Should return 3 tokens * 4 bytes each = 12 bytes
 		expectedLen := 3 * 4
 		if len(result) != expectedLen {
 			t.Errorf("Expected %d bytes, got %d", expectedLen, len(result))
@@ -336,9 +334,7 @@ func TestRemoteTokenizerWithMockServer(t *testing.T) {
 	})
 }
 
-// Test error scenarios
 func TestErrorScenarios(t *testing.T) {
-	// Test HTTP errors
 	t.Run("HTTP 500 error", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
@@ -361,7 +357,6 @@ func TestErrorScenarios(t *testing.T) {
 			t.Error("Expected error for HTTP 500")
 		}
 
-		// Check if it's an ErrHTTPRequest
 		if httpErr, ok := err.(ErrHTTPRequest); ok {
 			if httpErr.StatusCode != 500 {
 				t.Errorf("Expected status code 500, got %d", httpErr.StatusCode)
@@ -369,7 +364,6 @@ func TestErrorScenarios(t *testing.T) {
 		}
 	})
 
-	// Test invalid JSON response
 	t.Run("Invalid JSON response", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
@@ -395,9 +389,7 @@ func TestErrorScenarios(t *testing.T) {
 	})
 }
 
-// Test JSON serialization/deserialization
 func TestJSONSerialization(t *testing.T) {
-	// Test TokenizeResult
 	t.Run("TokenizeResult", func(t *testing.T) {
 		original := TokenizeResult{
 			Count:        3,
@@ -422,7 +414,6 @@ func TestJSONSerialization(t *testing.T) {
 		}
 	})
 
-	// Test vLLM request structures
 	t.Run("vLLM completion request", func(t *testing.T) {
 		addSpecialTokens := true
 		returnTokenStrs := false
@@ -439,7 +430,6 @@ func TestJSONSerialization(t *testing.T) {
 			t.Fatalf("Failed to marshal: %v", err)
 		}
 
-		// Verify JSON contains expected fields
 		var unmarshaled map[string]interface{}
 		err = json.Unmarshal(jsonData, &unmarshaled)
 		if err != nil {
@@ -455,13 +445,11 @@ func TestJSONSerialization(t *testing.T) {
 	})
 }
 
-// Test concurrent access
 func TestConcurrentAccess(t *testing.T) {
-	// Create a mock server for concurrent testing
 	requestCount := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
-		time.Sleep(10 * time.Millisecond) // Simulate processing time
+		time.Sleep(10 * time.Millisecond)
 		response := map[string]interface{}{
 			"count":         1,
 			"max_model_len": 1024,
@@ -483,7 +471,6 @@ func TestConcurrentAccess(t *testing.T) {
 		t.Fatalf("Failed to create tokenizer: %v", err)
 	}
 
-	// Run concurrent requests
 	const numRequests = 5
 	results := make(chan error, numRequests)
 
@@ -494,7 +481,6 @@ func TestConcurrentAccess(t *testing.T) {
 		}(i)
 	}
 
-	// Collect results
 	for i := 0; i < numRequests; i++ {
 		err := <-results
 		if err != nil {
@@ -502,13 +488,11 @@ func TestConcurrentAccess(t *testing.T) {
 		}
 	}
 
-	// Verify that all requests were processed
 	if requestCount != numRequests {
 		t.Errorf("Expected %d requests, got %d", numRequests, requestCount)
 	}
 }
 
-// Benchmark tests
 func BenchmarkIntToByteArray(b *testing.B) {
 	input := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
 
@@ -547,11 +531,326 @@ func BenchmarkTokenizeInputText(b *testing.B) {
 	}
 }
 
-// Test TokenizerManager.TokenizePrompt
+func TestSGLangAdapter(t *testing.T) {
+	adapter := newSGLangAdapter("test-model")
+
+	t.Run("GetTokenizePath", func(t *testing.T) {
+		if got := adapter.GetTokenizePath(); got != "/tokenize" {
+			t.Errorf("Expected '/tokenize', got %q", got)
+		}
+	})
+
+	t.Run("Completion request", func(t *testing.T) {
+		input := TokenizeInput{
+			Type:               CompletionInput,
+			Text:               "Hello SGLang",
+			AddSpecialTokens:   true,
+			ReturnTokenStrings: false,
+		}
+
+		result, err := adapter.PrepareTokenizeRequest(input)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		req, ok := result.(*sglangTokenizeCompletionRequest)
+		if !ok {
+			t.Fatalf("Expected *sglangTokenizeCompletionRequest, got %T", result)
+		}
+
+		if req.Model != "test-model" {
+			t.Errorf("Expected model 'test-model', got %s", req.Model)
+		}
+		if req.Prompt != "Hello SGLang" {
+			t.Errorf("Expected prompt 'Hello SGLang', got %s", req.Prompt)
+		}
+		if req.AddSpecialTokens == nil || *req.AddSpecialTokens != true {
+			t.Errorf("Expected AddSpecialTokens=true, got %v", req.AddSpecialTokens)
+		}
+	})
+
+	t.Run("Chat request", func(t *testing.T) {
+		input := TokenizeInput{
+			Type: ChatInput,
+			Messages: []common.Message{
+				{Role: "user", Content: "Hello"},
+				{Role: "assistant", Content: "Hi!"},
+			},
+			AddSpecialTokens: false,
+		}
+
+		result, err := adapter.PrepareTokenizeRequest(input)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		req, ok := result.(*sglangTokenizeChatRequest)
+		if !ok {
+			t.Fatalf("Expected *sglangTokenizeChatRequest, got %T", result)
+		}
+
+		if req.Model != "test-model" {
+			t.Errorf("Expected model 'test-model', got %s", req.Model)
+		}
+		if len(req.Messages) != 2 {
+			t.Errorf("Expected 2 messages, got %d", len(req.Messages))
+		}
+		if req.AddSpecialTokens == nil || *req.AddSpecialTokens != false {
+			t.Errorf("Expected AddSpecialTokens=false, got %v", req.AddSpecialTokens)
+		}
+	})
+
+	t.Run("Empty model omits model in JSON", func(t *testing.T) {
+		emptyAdapter := newSGLangAdapter("")
+		result, err := emptyAdapter.PrepareTokenizeRequest(TokenizeInput{
+			Type: CompletionInput,
+			Text: "x",
+		})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		data, err := json.Marshal(result)
+		if err != nil {
+			t.Fatalf("Failed to marshal: %v", err)
+		}
+
+		var m map[string]interface{}
+		if err := json.Unmarshal(data, &m); err != nil {
+			t.Fatalf("Failed to unmarshal: %v", err)
+		}
+		if _, ok := m["model"]; ok {
+			t.Errorf("Expected 'model' field to be omitted in JSON when empty, got %v", m["model"])
+		}
+	})
+
+	t.Run("Unsupported input type", func(t *testing.T) {
+		_, err := adapter.PrepareTokenizeRequest(TokenizeInput{Type: "unknown"})
+		if err == nil {
+			t.Error("Expected error for unsupported input type")
+		}
+	})
+
+	t.Run("Parse response", func(t *testing.T) {
+		jsonData := `{"count":3,"max_model_len":2048,"tokens":[10,20,30]}`
+		result, err := adapter.ParseTokenizeResponse([]byte(jsonData))
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		if result.Count != 3 {
+			t.Errorf("Expected count 3, got %d", result.Count)
+		}
+		if result.MaxModelLen != 2048 {
+			t.Errorf("Expected max_model_len 2048, got %d", result.MaxModelLen)
+		}
+		if !reflect.DeepEqual(result.Tokens, []int{10, 20, 30}) {
+			t.Errorf("Expected tokens [10,20,30], got %v", result.Tokens)
+		}
+	})
+
+	t.Run("Parse invalid JSON", func(t *testing.T) {
+		_, err := adapter.ParseTokenizeResponse([]byte("not json"))
+		if err == nil {
+			t.Error("Expected error for invalid JSON")
+		}
+	})
+
+	t.Run("Parse empty response", func(t *testing.T) {
+		result, err := adapter.ParseTokenizeResponse([]byte(`{}`))
+		if err != nil {
+			t.Fatalf("Unexpected error for empty JSON object: %v", err)
+		}
+		if result.Count != 0 || len(result.Tokens) != 0 {
+			t.Errorf("Expected zero-valued result, got %+v", result)
+		}
+	})
+}
+
+func TestNewEngineAdapter(t *testing.T) {
+	cases := []struct {
+		name      string
+		engine    string
+		wantType  engineAdapter
+		wantError bool
+	}{
+		{"vllm", "vllm", &vllmAdapter{}, false},
+		{"sglang", "sglang", &sglangAdapter{}, false},
+		{"empty defaults to vllm", "", &vllmAdapter{}, false},
+		{"vllm uppercase", "VLLM", &vllmAdapter{}, false},
+		{"sglang mixed case", "SGLang", &sglangAdapter{}, false},
+		{"sglang with whitespace", "  sglang  ", &sglangAdapter{}, false},
+		{"unsupported", "unsupported", nil, true},
+		{"random string", "openai", nil, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			adapter, err := newEngineAdapter(tc.engine, "test-model")
+			if tc.wantError {
+				if err == nil {
+					t.Fatalf("Expected error for engine %q", tc.engine)
+				}
+				if _, ok := err.(ErrInvalidConfig); !ok {
+					t.Errorf("Expected ErrInvalidConfig, got %T: %v", err, err)
+				}
+				if adapter != nil {
+					t.Errorf("Expected nil adapter on error, got %T", adapter)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			if reflect.TypeOf(adapter) != reflect.TypeOf(tc.wantType) {
+				t.Errorf("Expected %T, got %T", tc.wantType, adapter)
+			}
+		})
+	}
+}
+
+func TestRemoteTokenizerSGLangWithMockServer(t *testing.T) {
+	t.Run("Standard tokens response", func(t *testing.T) {
+		var capturedBody map[string]interface{}
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/tokenize" {
+				http.NotFound(w, r)
+				return
+			}
+			if err := json.NewDecoder(r.Body).Decode(&capturedBody); err != nil {
+				t.Errorf("Failed to decode request body: %v", err)
+			}
+
+			response := map[string]interface{}{
+				"count":         3,
+				"max_model_len": 4096,
+				"tokens":        []int{100, 200, 300},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(response)
+		}))
+		defer server.Close()
+
+		config := RemoteTokenizerConfig{
+			Engine:   "sglang",
+			Endpoint: server.URL,
+			Model:    "sglang-model",
+		}
+
+		tokenizer, err := NewRemoteTokenizer(config)
+		if err != nil {
+			t.Fatalf("Failed to create tokenizer: %v", err)
+		}
+
+		result, err := tokenizer.TokenizeInputText("Hello SGLang")
+		if err != nil {
+			t.Fatalf("TokenizeInputText failed: %v", err)
+		}
+
+		expectedLen := 3 * 4
+		if len(result) != expectedLen {
+			t.Errorf("Expected %d bytes, got %d", expectedLen, len(result))
+		}
+
+		if capturedBody["model"] != "sglang-model" {
+			t.Errorf("Expected request model 'sglang-model', got %v", capturedBody["model"])
+		}
+		if capturedBody["prompt"] != "Hello SGLang" {
+			t.Errorf("Expected request prompt 'Hello SGLang', got %v", capturedBody["prompt"])
+		}
+	})
+
+	t.Run("HTTP 500 propagates error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		}))
+		defer server.Close()
+
+		config := RemoteTokenizerConfig{
+			Engine:   "sglang",
+			Endpoint: server.URL,
+			Model:    "sglang-model",
+		}
+
+		tokenizer, err := NewRemoteTokenizer(config)
+		if err != nil {
+			t.Fatalf("Failed to create tokenizer: %v", err)
+		}
+
+		_, err = tokenizer.TokenizeInputText("test")
+		if err == nil {
+			t.Error("Expected error for HTTP 500")
+		}
+	})
+}
+
+func TestSGLangJSONSerialization(t *testing.T) {
+	t.Run("Completion request omits empty model", func(t *testing.T) {
+		addSpecialTokens := true
+		req := sglangTokenizeCompletionRequest{
+			Prompt:           "Hello",
+			AddSpecialTokens: &addSpecialTokens,
+		}
+
+		data, err := json.Marshal(req)
+		if err != nil {
+			t.Fatalf("Failed to marshal: %v", err)
+		}
+
+		var m map[string]interface{}
+		if err := json.Unmarshal(data, &m); err != nil {
+			t.Fatalf("Failed to unmarshal: %v", err)
+		}
+
+		if _, ok := m["model"]; ok {
+			t.Error("Expected 'model' field to be omitted when empty")
+		}
+		if m["prompt"] != "Hello" {
+			t.Errorf("Expected prompt 'Hello', got %v", m["prompt"])
+		}
+		if m["add_special_tokens"] != true {
+			t.Errorf("Expected add_special_tokens=true, got %v", m["add_special_tokens"])
+		}
+	})
+
+	t.Run("Chat request includes messages", func(t *testing.T) {
+		addSpecialTokens := true
+		req := sglangTokenizeChatRequest{
+			Model: "m",
+			Messages: []common.Message{
+				{Role: "user", Content: "hi"},
+			},
+			AddSpecialTokens: &addSpecialTokens,
+		}
+
+		data, err := json.Marshal(req)
+		if err != nil {
+			t.Fatalf("Failed to marshal: %v", err)
+		}
+
+		var m map[string]interface{}
+		if err := json.Unmarshal(data, &m); err != nil {
+			t.Fatalf("Failed to unmarshal: %v", err)
+		}
+
+		msgs, ok := m["messages"].([]interface{})
+		if !ok {
+			t.Fatalf("Expected messages array, got %T", m["messages"])
+		}
+		if len(msgs) != 1 {
+			t.Errorf("Expected 1 message, got %d", len(msgs))
+		}
+		if m["add_special_tokens"] != true {
+			t.Errorf("Expected add_special_tokens=true, got %v", m["add_special_tokens"])
+		}
+	})
+}
+
 func TestTokenizerManagerTokenizePrompt(t *testing.T) {
 	config := TokenizerManagerConfig{
-		EnableVLLMRemote: true,
-		EndpointTemplate: "http://%s:8000",
+		EndpointTemplates: map[string]string{
+			"vllm":   "http://%s:8000",
+			"sglang": "http://%s:30000",
+		},
 	}
 
 	manager := NewTokenizerManager(config)
@@ -559,7 +858,6 @@ func TestTokenizerManagerTokenizePrompt(t *testing.T) {
 		t.Fatal("Expected non-nil TokenizerManager")
 	}
 
-	// Test with empty pods
 	t.Run("Empty pods", func(t *testing.T) {
 		prompt := common.ChatMessage{Text: "Hello world"}
 
@@ -569,13 +867,112 @@ func TestTokenizerManagerTokenizePrompt(t *testing.T) {
 		}
 	})
 
-	// Test with empty prompt
 	t.Run("Empty prompt", func(t *testing.T) {
 		prompt := common.ChatMessage{}
 
 		_, err := manager.TokenizePrompt("test-model", prompt, []*datastore.PodInfo{})
 		if err == nil {
 			t.Error("Expected error for empty prompt")
+		}
+	})
+}
+
+func TestNormalizeEngineName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"vLLM canonical casing", "vLLM", "vllm"},
+		{"SGLang canonical casing", "SGLang", "sglang"},
+		{"already lowercase vllm", "vllm", "vllm"},
+		{"already lowercase sglang", "sglang", "sglang"},
+		{"mixed case sglang", "SgLaNg", "sglang"},
+		{"surrounding whitespace", "  vllm  ", "vllm"},
+		{"empty string defaults to vllm", "", "vllm"},
+		{"whitespace only defaults to vllm", "   ", "vllm"},
+		{"unknown engine passes through normalized", "TensorRT", "tensorrt"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeEngineName(tt.input)
+			if got != tt.expected {
+				t.Errorf("normalizeEngineName(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestTokenizerManagerEndpointTemplateLookup(t *testing.T) {
+	pod := &datastore.PodInfo{
+		Pod: &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod1",
+				Namespace: "default",
+			},
+			Status: v1.PodStatus{
+				Phase: v1.PodRunning,
+				PodIP: "10.0.0.1",
+			},
+		},
+	}
+
+	t.Run("vllm template matches default engine", func(t *testing.T) {
+		mgr := NewTokenizerManager(TokenizerManagerConfig{
+			EndpointTemplates: map[string]string{
+				"vllm": "http://%s:8000",
+			},
+		})
+		tok := mgr.GetTokenizer("test-model", []*datastore.PodInfo{pod})
+		if tok == nil {
+			t.Fatal("expected tokenizer for vllm-templated pod")
+		}
+		rt, ok := tok.(remoteTokenizer)
+		if !ok {
+			t.Fatalf("expected tokenizer to satisfy remoteTokenizer, got %T", tok)
+		}
+		if got, want := rt.GetEndpoint(), "http://10.0.0.1:8000"; got != want {
+			t.Errorf("endpoint = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("only sglang template skips empty-engine pod", func(t *testing.T) {
+		mgr := NewTokenizerManager(TokenizerManagerConfig{
+			EndpointTemplates: map[string]string{
+				"sglang": "http://%s:30000",
+			},
+		})
+		tok := mgr.GetTokenizer("test-model", []*datastore.PodInfo{pod})
+		if tok != nil {
+			t.Errorf("expected nil tokenizer (no template for vllm), got %T", tok)
+		}
+	})
+
+	t.Run("both templates configured prefers pod's engine", func(t *testing.T) {
+		mgr := NewTokenizerManager(TokenizerManagerConfig{
+			EndpointTemplates: map[string]string{
+				"vllm":   "http://%s:8000",
+				"sglang": "http://%s:30000",
+			},
+		})
+		tok := mgr.GetTokenizer("test-model", []*datastore.PodInfo{pod})
+		if tok == nil {
+			t.Fatal("expected tokenizer when both templates configured")
+		}
+		rt, ok := tok.(remoteTokenizer)
+		if !ok {
+			t.Fatalf("expected tokenizer to satisfy remoteTokenizer, got %T", tok)
+		}
+		if got, want := rt.GetEndpoint(), "http://10.0.0.1:8000"; got != want {
+			t.Errorf("endpoint = %q, want %q (empty engine should resolve to vllm)", got, want)
+		}
+	})
+
+	t.Run("nil EndpointTemplates skips all pods", func(t *testing.T) {
+		mgr := NewTokenizerManager(TokenizerManagerConfig{})
+		tok := mgr.GetTokenizer("test-model", []*datastore.PodInfo{pod})
+		if tok != nil {
+			t.Errorf("expected nil tokenizer with nil templates, got %T", tok)
 		}
 	})
 }

--- a/pkg/kthena-router/scheduler/plugins/tokenization/tokenizer.go
+++ b/pkg/kthena-router/scheduler/plugins/tokenization/tokenizer.go
@@ -18,6 +18,12 @@ package tokenization
 
 import (
 	"context"
+	"strings"
+)
+
+const (
+	engineVLLM   = "vllm"
+	engineSGLang = "sglang"
 )
 
 type remoteTokenizerImpl struct {
@@ -27,13 +33,27 @@ type remoteTokenizerImpl struct {
 }
 
 func NewRemoteTokenizer(config RemoteTokenizerConfig) (Tokenizer, error) {
-	adapter := newVLLMAdapter(config.Model)
+	adapter, err := newEngineAdapter(config.Engine, config.Model)
+	if err != nil {
+		return nil, err
+	}
 	client := newHTTPClient(config.Endpoint)
 	return &remoteTokenizerImpl{
 		config:  config,
 		client:  client,
 		adapter: adapter,
 	}, nil
+}
+
+func newEngineAdapter(engine, model string) (engineAdapter, error) {
+	switch strings.ToLower(strings.TrimSpace(engine)) {
+	case engineSGLang:
+		return newSGLangAdapter(model), nil
+	case engineVLLM, "":
+		return newVLLMAdapter(model), nil
+	default:
+		return nil, ErrInvalidConfig{Message: "unsupported engine: " + engine}
+	}
 }
 
 func (t *remoteTokenizerImpl) TokenizeInputText(text string) ([]byte, error) {

--- a/pkg/kthena-router/scheduler/plugins/tokenization/tokenizer_manager.go
+++ b/pkg/kthena-router/scheduler/plugins/tokenization/tokenizer_manager.go
@@ -21,6 +21,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math/rand"
+	"strings"
 	"time"
 
 	"github.com/volcano-sh/kthena/pkg/kthena-router/common"
@@ -29,8 +30,8 @@ import (
 )
 
 type TokenizerManagerConfig struct {
-	EnableVLLMRemote bool
-	EndpointTemplate string
+	// EndpointTemplates maps a lowercase engine name to a sprintf template with one %s for the pod IP.
+	EndpointTemplates map[string]string
 }
 
 type TokenizerManager struct {
@@ -43,7 +44,6 @@ func NewTokenizerManager(config TokenizerManagerConfig) *TokenizerManager {
 	}
 }
 
-// GetTokenizer creates a tokenizer by randomly selecting from the provided pods
 func (m *TokenizerManager) GetTokenizer(model string, pods []*datastore.PodInfo) Tokenizer {
 	return m.createTokenizerFromPods(model, pods)
 }
@@ -54,18 +54,22 @@ func (m *TokenizerManager) createTokenizerFromPods(model string, pods []*datasto
 		return nil
 	}
 
-	// Randomly select a pod to start with
 	startIdx := rand.Intn(len(pods))
-
-	// Try pods starting from random index, wrapping around if needed
 	for i := 0; i < len(pods); i++ {
 		podIdx := (startIdx + i) % len(pods)
 		podInfo := pods[podIdx]
 
-		endpoint := fmt.Sprintf(m.config.EndpointTemplate, podInfo.Pod.Status.PodIP)
+		engine := normalizeEngineName(podInfo.GetEngine())
+		template, ok := m.config.EndpointTemplates[engine]
+		if !ok {
+			klog.V(4).Infof("TokenizerManager: no endpoint template for engine %q (pod %s/%s), skipping",
+				engine, podInfo.Pod.Namespace, podInfo.Pod.Name)
+			continue
+		}
+		endpoint := fmt.Sprintf(template, podInfo.Pod.Status.PodIP)
 
 		config := RemoteTokenizerConfig{
-			Engine:             "vllm",
+			Engine:             engine,
 			Endpoint:           endpoint,
 			Model:              model,
 			AddSpecialTokens:   true,
@@ -74,11 +78,11 @@ func (m *TokenizerManager) createTokenizerFromPods(model string, pods []*datasto
 
 		tok, err := NewRemoteTokenizer(config)
 		if err != nil {
-			klog.Warningf("Failed to create vLLM tokenizer for model %s at endpoint %s: %v", model, endpoint, err)
+			klog.Warningf("Failed to create %s tokenizer for model %s at endpoint %s: %v", engine, model, endpoint, err)
 			continue
 		}
 
-		klog.V(4).Infof("TokenizerManager: successfully created tokenizer for model %s at endpoint %s", model, endpoint)
+		klog.V(4).Infof("TokenizerManager: successfully created %s tokenizer for model %s at endpoint %s", engine, model, endpoint)
 		return tok
 	}
 
@@ -86,7 +90,15 @@ func (m *TokenizerManager) createTokenizerFromPods(model string, pods []*datasto
 	return nil
 }
 
-// TokenizePrompt tokenizes a prompt (text or chat messages) and returns uint32 tokens
+// normalizeEngineName defaults empty to vllm for pods not yet reconciled against a ModelServer.
+func normalizeEngineName(engine string) string {
+	normalized := strings.ToLower(strings.TrimSpace(engine))
+	if normalized == "" {
+		return engineVLLM
+	}
+	return normalized
+}
+
 func (m *TokenizerManager) TokenizePrompt(
 	model string,
 	prompt common.ChatMessage,
@@ -97,14 +109,12 @@ func (m *TokenizerManager) TokenizePrompt(
 		return nil, fmt.Errorf("no tokenizer available for model %s", model)
 	}
 
-	// Handle text prompts directly
 	if prompt.Text != "" {
 		tokens, err := tokenizer.TokenizeInputText(prompt.Text)
 		if err != nil {
 			return nil, fmt.Errorf("text tokenization failed: %w", err)
 		}
 
-		// Convert byte array to uint32 tokens
 		tokens32 := make([]uint32, len(tokens)/4)
 		for i := 0; i < len(tokens32); i++ {
 			tokens32[i] = binary.BigEndian.Uint32(tokens[i*4 : (i+1)*4])
@@ -112,7 +122,6 @@ func (m *TokenizerManager) TokenizePrompt(
 		return tokens32, nil
 	}
 
-	// Handle chat messages with extended tokenizer
 	if len(prompt.Messages) > 0 {
 		extendedTok, ok := tokenizer.(ExtendedTokenizer)
 		if !ok {
@@ -135,7 +144,6 @@ func (m *TokenizerManager) TokenizePrompt(
 			return nil, fmt.Errorf("chat template tokenization failed: %w", err)
 		}
 
-		// Convert int tokens to uint32
 		tokens32 := make([]uint32, len(result.Tokens))
 		for i, token := range result.Tokens {
 			tokens32[i] = uint32(token)

--- a/pkg/kthena-router/scheduler/plugins/tokenization/types.go
+++ b/pkg/kthena-router/scheduler/plugins/tokenization/types.go
@@ -75,3 +75,21 @@ type vllmTokenizeResponse struct {
 	Tokens      []int    `json:"tokens"`
 	TokenStrs   []string `json:"token_strs,omitempty"`
 }
+
+type sglangTokenizeCompletionRequest struct {
+	Model            string `json:"model,omitempty"`
+	Prompt           string `json:"prompt"`
+	AddSpecialTokens *bool  `json:"add_special_tokens,omitempty"`
+}
+
+type sglangTokenizeChatRequest struct {
+	Model            string           `json:"model,omitempty"`
+	Messages         []common.Message `json:"messages"`
+	AddSpecialTokens *bool            `json:"add_special_tokens,omitempty"`
+}
+
+type sglangTokenizeResponse struct {
+	Count       int   `json:"count"`
+	MaxModelLen int   `json:"max_model_len"`
+	Tokens      []int `json:"tokens"`
+}


### PR DESCRIPTION
**Which issue(s) this PR fixes:
  Fixes #956 

**What this PR does / why we need it**:
  The kvcache-aware scheduler plugin currently only supports vLLM because
  the tokenization layer hardcodes a vLLM adapter. This PR introduces a
  pluggable `engineAdapter` factory and an SGLang adapter, enabling the
  router to tokenize prompts via SGLang's `/tokenize` endpoint.

**Scope**: router-side (consumer) only. The Python sidecar producer
  that publishes SGLang KV cache state to Redis is out of scope and will
  be addressed in a follow-up. Until then, SGLang pods will score 0 in
  the kvcache-aware plugin.