### PR TITLE
feat: add CLI support for ModelRoute and ModelServer resources

### DIFF
--- a/cli/kthena/cmd/describe.go
+++ b/cli/kthena/cmd/describe.go
@@ -87,6 +87,27 @@ This will display the autoscaling policy configuration and rules.`,
 	Args: cobra.ExactArgs(1),
 	RunE: runDescribeAutoscalingPolicy,
 }
+var describeModelRouteCmd = &cobra.Command{
+	Use:     "model-route [NAME]",
+	Aliases: []string{"mroute"},
+	Short:   "Show detailed information about a model route",
+	Long: `Show detailed information about a specific ModelRoute resource in the cluster.
+
+This will display the model route configuration including rules, target models, and rate limits.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runDescribeModelRoute,
+}
+
+var describeModelServerCmd = &cobra.Command{
+	Use:     "model-server [NAME]",
+	Aliases: []string{"mserver"},
+	Short:   "Show detailed information about a model server",
+	Long: `Show detailed information about a specific ModelServer resource in the cluster.
+
+This will display the model server configuration including inference engine, workload selector, and traffic policy.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runDescribeModelServer,
+}
 
 func init() {
 	rootCmd.AddCommand(describeCmd)
@@ -94,6 +115,8 @@ func init() {
 	describeCmd.AddCommand(describeModelBoosterCmd)
 	describeCmd.AddCommand(describeModelServingCmd)
 	describeCmd.AddCommand(describeAutoscalingPolicyCmd)
+	describeCmd.AddCommand(describeModelRouteCmd)
+	describeCmd.AddCommand(describeModelServerCmd)
 
 	// Add namespace flags
 	describeCmd.PersistentFlags().StringVarP(&getNamespace, "namespace", "n", "", "Kubernetes namespace (default: current context namespace)")
@@ -225,6 +248,79 @@ func runDescribeAutoscalingPolicy(cmd *cobra.Command, args []string) error {
 	data, err := yaml.Marshal(policy)
 	if err != nil {
 		return fmt.Errorf("failed to marshal AutoscalingPolicy to YAML: %v", err)
+	}
+
+	fmt.Println("Resource Details:")
+	fmt.Println("=================")
+	fmt.Print(string(data))
+
+	return nil
+}
+func runDescribeModelRoute(cmd *cobra.Command, args []string) error {
+	routeName := args[0]
+
+	client, err := getKthenaClient()
+	if err != nil {
+		return err
+	}
+
+	namespace := getNamespace
+	if namespace == "" {
+		namespace = "default"
+	}
+	ctx := context.Background()
+
+	route, err := client.NetworkingV1alpha1().ModelRoutes(namespace).Get(ctx, routeName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get ModelRoute '%s': %v", routeName, err)
+	}
+
+	fmt.Printf("ModelRoute: %s\n", route.Name)
+	fmt.Println("================")
+	fmt.Printf("Namespace: %s\n", route.Namespace)
+	fmt.Printf("Created: %s\n", route.CreationTimestamp.Time.Format(time.RFC3339))
+	fmt.Printf("Age: %s\n\n", time.Since(route.CreationTimestamp.Time).Truncate(time.Second))
+
+	data, err := yaml.Marshal(route)
+	if err != nil {
+		return fmt.Errorf("failed to marshal ModelRoute to YAML: %v", err)
+	}
+
+	fmt.Println("Resource Details:")
+	fmt.Println("=================")
+	fmt.Print(string(data))
+
+	return nil
+}
+
+func runDescribeModelServer(cmd *cobra.Command, args []string) error {
+	serverName := args[0]
+
+	client, err := getKthenaClient()
+	if err != nil {
+		return err
+	}
+
+	namespace := getNamespace
+	if namespace == "" {
+		namespace = "default"
+	}
+	ctx := context.Background()
+
+	server, err := client.NetworkingV1alpha1().ModelServers(namespace).Get(ctx, serverName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get ModelServer '%s': %v", serverName, err)
+	}
+
+	fmt.Printf("ModelServer: %s\n", server.Name)
+	fmt.Println("================")
+	fmt.Printf("Namespace: %s\n", server.Namespace)
+	fmt.Printf("Created: %s\n", server.CreationTimestamp.Time.Format(time.RFC3339))
+	fmt.Printf("Age: %s\n\n", time.Since(server.CreationTimestamp.Time).Truncate(time.Second))
+
+	data, err := yaml.Marshal(server)
+	if err != nil {
+		return fmt.Errorf("failed to marshal ModelServer to YAML: %v", err)
 	}
 
 	fmt.Println("Resource Details:")

--- a/cli/kthena/cmd/get.go
+++ b/cli/kthena/cmd/get.go
@@ -123,6 +123,8 @@ func init() {
 	getCmd.AddCommand(getModelServingsCmd)
 	getCmd.AddCommand(getAutoscalingPoliciesCmd)
 	getCmd.AddCommand(getAutoscalingPolicyBindingsCmd)
+	getCmd.AddCommand(getModelRoutesCmd)
+	getCmd.AddCommand(getModelServersCmd)
 
 	// Add output format flag
 	getCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", "", "Output format (yaml|json|table)")
@@ -431,6 +433,113 @@ func runGetAutoscalingPolicyBindings(cmd *cobra.Command, args []string) error {
 			fmt.Fprintf(w, "%s\t%s\t%s\n", binding.Namespace, binding.Name, age)
 		} else {
 			fmt.Fprintf(w, "%s\t%s\n", binding.Name, age)
+		}
+	}
+
+	return w.Flush()
+}
+
+var getModelRoutesCmd = &cobra.Command{
+	Use:     "model-routes",
+	Aliases: []string{"mroute", "model-route"},
+	Short:   "List model routes",
+	Long:    `List ModelRoute resources in the cluster.`,
+	RunE:    runGetModelRoutes,
+}
+
+var getModelServersCmd = &cobra.Command{
+	Use:     "model-servers",
+	Aliases: []string{"mserver", "model-server"},
+	Short:   "List model servers",
+	Long:    `List ModelServer resources in the cluster.`,
+	RunE:    runGetModelServers,
+}
+
+func runGetModelRoutes(cmd *cobra.Command, args []string) error {
+	client, err := getKthenaClient()
+	if err != nil {
+		return err
+	}
+
+	namespace := resolveGetNamespace()
+	ctx := context.Background()
+
+	routes, err := client.NetworkingV1alpha1().ModelRoutes(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to list ModelRoutes: %v", err)
+	}
+
+	if len(routes.Items) == 0 {
+		if getAllNamespaces {
+			fmt.Println("No ModelRoutes found across all namespaces.")
+		} else {
+			fmt.Printf("No ModelRoutes found in namespace %s.\n", namespace)
+		}
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	if getAllNamespaces {
+		fmt.Fprintln(w, "NAMESPACE\tNAME\tMODEL\tRULES\tAGE")
+	} else {
+		fmt.Fprintln(w, "NAME\tMODEL\tRULES\tAGE")
+	}
+
+	for _, route := range routes.Items {
+		age := time.Since(route.CreationTimestamp.Time).Truncate(time.Second)
+		model := route.Spec.ModelName
+		if model == "" {
+			model = "<lora>"
+		}
+		rules := len(route.Spec.Rules)
+		if getAllNamespaces {
+			fmt.Fprintf(w, "%s\t%s\t%s\t%d\t%s\n", route.Namespace, route.Name, model, rules, age)
+		} else {
+			fmt.Fprintf(w, "%s\t%s\t%d\t%s\n", route.Name, model, rules, age)
+		}
+	}
+
+	return w.Flush()
+}
+
+func runGetModelServers(cmd *cobra.Command, args []string) error {
+	client, err := getKthenaClient()
+	if err != nil {
+		return err
+	}
+
+	namespace := resolveGetNamespace()
+	ctx := context.Background()
+
+	servers, err := client.NetworkingV1alpha1().ModelServers(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to list ModelServers: %v", err)
+	}
+
+	if len(servers.Items) == 0 {
+		if getAllNamespaces {
+			fmt.Println("No ModelServers found across all namespaces.")
+		} else {
+			fmt.Printf("No ModelServers found in namespace %s.\n", namespace)
+		}
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	if getAllNamespaces {
+		fmt.Fprintln(w, "NAMESPACE\tNAME\tENGINE\tPORT\tAGE")
+	} else {
+		fmt.Fprintln(w, "NAME\tENGINE\tPORT\tAGE")
+	}
+
+	for _, server := range servers.Items {
+		age := time.Since(server.CreationTimestamp.Time).Truncate(time.Second)
+		engine := string(server.Spec.InferenceEngine)
+		port := server.Spec.WorkloadPort.Port
+		if getAllNamespaces {
+			fmt.Fprintf(w, "%s\t%s\t%s\t%d\t%s\n", server.Namespace, server.Name, engine, port, age)
+		} else {
+			fmt.Fprintf(w, "%s\t%s\t%d\t%s\n", server.Name, engine, port, age)
 		}
 	}
 

--- a/cli/kthena/cmd/get.go
+++ b/cli/kthena/cmd/get.go
@@ -489,7 +489,11 @@ func runGetModelRoutes(cmd *cobra.Command, args []string) error {
 		age := time.Since(route.CreationTimestamp.Time).Truncate(time.Second)
 		model := route.Spec.ModelName
 		if model == "" {
-			model = "<lora>"
+			if len(route.Spec.LoraAdapters) > 0 {
+				model = strings.Join(route.Spec.LoraAdapters, ",")
+			} else {
+				model = "<lora>"
+			}
 		}
 		rules := len(route.Spec.Rules)
 		if getAllNamespaces {

--- a/docs/kthena/docs/reference/kthena-cli/kthena_describe.md
+++ b/docs/kthena/docs/reference/kthena-cli/kthena_describe.md
@@ -29,6 +29,8 @@ Examples:
 * [kthena](kthena.md)	 - Kthena CLI for managing AI inference workloads
 * [kthena describe autoscaling-policy](kthena_describe_autoscaling-policy.md)	 - Show detailed information about an autoscaling policy
 * [kthena describe model-booster](kthena_describe_model-booster.md)	 - Show detailed information about a model booster
+* [kthena describe model-route](kthena_describe_model-route.md)	 - Show detailed information about a model route
+* [kthena describe model-server](kthena_describe_model-server.md)	 - Show detailed information about a model server
 * [kthena describe model-serving](kthena_describe_model-serving.md)	 - Show detailed information about a model serving workload
 * [kthena describe template](kthena_describe_template.md)	 - Show detailed information about a template
 

--- a/docs/kthena/docs/reference/kthena-cli/kthena_describe_model-route.md
+++ b/docs/kthena/docs/reference/kthena-cli/kthena_describe_model-route.md
@@ -1,0 +1,33 @@
+---
+title: Kthena CLI
+---
+## kthena describe model-route
+
+Show detailed information about a model route
+
+### Synopsis
+
+Show detailed information about a specific ModelRoute resource in the cluster.
+
+This will display the model route configuration including rules, target models, and rate limits.
+
+```
+kthena describe model-route [NAME] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for model-route
+```
+
+### Options inherited from parent commands
+
+```
+  -n, --namespace string   Kubernetes namespace (default: current context namespace)
+```
+
+### SEE ALSO
+
+* [kthena describe](kthena_describe.md)	 - Show detailed information about a specific resource
+

--- a/docs/kthena/docs/reference/kthena-cli/kthena_describe_model-server.md
+++ b/docs/kthena/docs/reference/kthena-cli/kthena_describe_model-server.md
@@ -1,0 +1,33 @@
+---
+title: Kthena CLI
+---
+## kthena describe model-server
+
+Show detailed information about a model server
+
+### Synopsis
+
+Show detailed information about a specific ModelServer resource in the cluster.
+
+This will display the model server configuration including inference engine, workload selector, and traffic policy.
+
+```
+kthena describe model-server [NAME] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for model-server
+```
+
+### Options inherited from parent commands
+
+```
+  -n, --namespace string   Kubernetes namespace (default: current context namespace)
+```
+
+### SEE ALSO
+
+* [kthena describe](kthena_describe.md)	 - Show detailed information about a specific resource
+

--- a/docs/kthena/docs/reference/kthena-cli/kthena_get.md
+++ b/docs/kthena/docs/reference/kthena-cli/kthena_get.md
@@ -34,6 +34,8 @@ Examples:
 * [kthena get autoscaling-policies](kthena_get_autoscaling-policies.md)	 - List autoscaling policies
 * [kthena get autoscaling-policy-bindings](kthena_get_autoscaling-policy-bindings.md)	 - List autoscaling policy bindings
 * [kthena get model-boosters](kthena_get_model-boosters.md)	 - List registered models
+* [kthena get model-routes](kthena_get_model-routes.md)	 - List model routes
+* [kthena get model-servers](kthena_get_model-servers.md)	 - List model servers
 * [kthena get model-servings](kthena_get_model-servings.md)	 - List model serving workloads
 * [kthena get template](kthena_get_template.md)	 - Get a specific template
 * [kthena get templates](kthena_get_templates.md)	 - List available manifest templates

--- a/docs/kthena/docs/reference/kthena-cli/kthena_get_model-routes.md
+++ b/docs/kthena/docs/reference/kthena-cli/kthena_get_model-routes.md
@@ -1,0 +1,33 @@
+---
+title: Kthena CLI
+---
+## kthena get model-routes
+
+List model routes
+
+### Synopsis
+
+List ModelRoute resources in the cluster.
+
+```
+kthena get model-routes [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for model-routes
+```
+
+### Options inherited from parent commands
+
+```
+  -A, --all-namespaces     List resources across all namespaces
+  -n, --namespace string   Kubernetes namespace (default: current context namespace)
+  -o, --output string      Output format (yaml|json|table)
+```
+
+### SEE ALSO
+
+* [kthena get](kthena_get.md)	 - Display one or many resources
+

--- a/docs/kthena/docs/reference/kthena-cli/kthena_get_model-servers.md
+++ b/docs/kthena/docs/reference/kthena-cli/kthena_get_model-servers.md
@@ -1,0 +1,33 @@
+---
+title: Kthena CLI
+---
+## kthena get model-servers
+
+List model servers
+
+### Synopsis
+
+List ModelServer resources in the cluster.
+
+```
+kthena get model-servers [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for model-servers
+```
+
+### Options inherited from parent commands
+
+```
+  -A, --all-namespaces     List resources across all namespaces
+  -n, --namespace string   Kubernetes namespace (default: current context namespace)
+  -o, --output string      Output format (yaml|json|table)
+```
+
+### SEE ALSO
+
+* [kthena get](kthena_get.md)	 - Display one or many resources
+


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
the kthena CLI had no commands to list or describe ModelRoute and ModelServer networking resources even though client-go interfaces for both already exist in `client-go/clientset/versioned/typed/networking/v1alpha1/`. ussers had to fall back to `kubectl` to inspect these resources. this PR adds four new commands: `kthena get model-routes` (shows NAME, MODEL, RULES, AGE), `kthena get model-servers` (shows NAME, ENGINE, PORT, AGE), `kthena describe model-route [NAME]`, and `kthena describe model-server [NAME]`. All commands support `-n` and `--all-namespaces` flags consistent with existing CLI commands.

**Which issue(s) this PR fixes**:
Fixes #980

**Special notes for your reviewer**:
it follows the exact same pattern as existing get/describe commands for workload resources. No changes have been done to  controllers, CRDs, or client-go.

**Does this PR introduce a user-facing change?**:
```release-note

```
