### PR TITLE
Feat: Implemented e2e for  ModelServing Bin pack scale-down 

### DIFF
--- a/test/e2e/controller-manager/model_serving_test.go
+++ b/test/e2e/controller-manager/model_serving_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
-	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -859,6 +858,24 @@ func waitForRunningPodCount(t *testing.T, ctx context.Context, kubeClient *kuber
 		t.Logf("Running pod count: %d (expecting %d)", runningCount, expected)
 		return runningCount == expected
 	}, timeout, 5*time.Second, "Expected %d running pods for ModelServing %s", expected, msName)
+}
+
+// patchPodDeletionCost sets corev1.PodDeletionCost with retries to tolerate concurrent Pod updates (resourceVersion conflicts).
+func patchPodDeletionCost(t *testing.T, ctx context.Context, kubeClient *kubernetes.Clientset, podName, cost string) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		cur, err := kubeClient.CoreV1().Pods(testNamespace).Get(ctx, podName, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		upd := cur.DeepCopy()
+		if upd.Annotations == nil {
+			upd.Annotations = make(map[string]string)
+		}
+		upd.Annotations[corev1.PodDeletionCost] = cost
+		_, err = kubeClient.CoreV1().Pods(testNamespace).Update(ctx, upd, metav1.UpdateOptions{})
+		return err == nil
+	}, 90*time.Second, time.Second, "set PodDeletionCost on pod %s", podName)
 }
 
 // createRole is a helper function to create a Role with specified replicas and workers
@@ -1906,6 +1923,7 @@ func TestModelServingBinPackScaleDownServingGroup(t *testing.T) {
 	modelServing := createBasicModelServing("test-binpack-sg-scaledown", 4, 0)
 	t.Log("Creating ModelServing with 4 servingGroup replicas for bin pack scale down test")
 	createAndWaitForModelServing(t, ctx, kthenaClient, modelServing)
+	waitForRunningPodCount(t, ctx, kubeClient, modelServing.Name, 4, 3*time.Minute)
 
 	initialMS, err := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Get(ctx, modelServing.Name, metav1.GetOptions{})
 	require.NoError(t, err, "Failed to get initial ModelServing")
@@ -1932,14 +1950,7 @@ func TestModelServingBinPackScaleDownServingGroup(t *testing.T) {
 			maxOrdinal = ordinal
 		}
 
-		updatedPod := pod.DeepCopy()
-		if updatedPod.Annotations == nil {
-			updatedPod.Annotations = make(map[string]string)
-		}
-		updatedPod.Annotations[corev1.PodDeletionCost] = fmt.Sprintf("%d", cost)
-
-		_, err := kubeClient.CoreV1().Pods(testNamespace).Update(ctx, updatedPod, metav1.UpdateOptions{})
-		require.NoError(t, err, "Failed to update pod with deletion cost")
+		patchPodDeletionCost(t, ctx, kubeClient, pod.Name, fmt.Sprintf("%d", cost))
 	}
 
 	scaleDownMS := initialMS.DeepCopy()
@@ -1990,25 +2001,19 @@ func TestModelServingBinPackScaleDownRole(t *testing.T) {
 	require.NoError(t, err, "Failed to list pods")
 	require.NotEmpty(t, podList.Items, "Expected pods before role scale down")
 
-	maxRoleID := -1
+	maxRoleOrdinal := -1
 	for _, pod := range podList.Items {
 		roleIDStr := pod.Labels[workload.RoleIDKey]
 		require.NotEmpty(t, roleIDStr, "Pod should have role id label")
 
-		roleID, err := strconv.Atoi(roleIDStr)
-		require.NoError(t, err, "Role id label should be an integer")
-		if roleID > maxRoleID {
-			maxRoleID = roleID
+		_, roleOrdinal := controllerutils.GetParentNameAndOrdinal(roleIDStr)
+		require.GreaterOrEqual(t, roleOrdinal, 0, "Role id label should encode role-<ordinal>")
+
+		if roleOrdinal > maxRoleOrdinal {
+			maxRoleOrdinal = roleOrdinal
 		}
 
-		updatedPod := pod.DeepCopy()
-		if updatedPod.Annotations == nil {
-			updatedPod.Annotations = make(map[string]string)
-		}
-		updatedPod.Annotations[corev1.PodDeletionCost] = fmt.Sprintf("%d", roleID*100)
-
-		_, err = kubeClient.CoreV1().Pods(testNamespace).Update(ctx, updatedPod, metav1.UpdateOptions{})
-		require.NoError(t, err, "Failed to update pod with deletion cost")
+		patchPodDeletionCost(t, ctx, kubeClient, pod.Name, fmt.Sprintf("%d", roleOrdinal*100))
 	}
 
 	scaleDownMS, err := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Get(ctx, modelServing.Name, metav1.GetOptions{})
@@ -2033,9 +2038,9 @@ func TestModelServingBinPackScaleDownRole(t *testing.T) {
 		if pod.DeletionTimestamp != nil || pod.Status.Phase != corev1.PodRunning {
 			continue
 		}
-		remainingRoleID, err := strconv.Atoi(pod.Labels[workload.RoleIDKey])
-		require.NoError(t, err, "Remaining pod role id should be an integer")
-		assert.Equal(t, maxRoleID, remainingRoleID, "Pod with highest deletion cost should remain after bin pack scale down")
+		_, remainingOrdinal := controllerutils.GetParentNameAndOrdinal(pod.Labels[workload.RoleIDKey])
+		require.GreaterOrEqual(t, remainingOrdinal, 0, "Remaining pod role id should encode role-<ordinal>")
+		assert.Equal(t, maxRoleOrdinal, remainingOrdinal, "Pod with highest deletion cost should remain after bin pack scale down")
 	}
 
 	t.Log("Bin pack scale down Role test passed successfully")
@@ -2071,21 +2076,15 @@ func TestModelServingBinPackScaleDownCombined(t *testing.T) {
 			maxGroupOrdinal = ordinal
 		}
 
-		roleID := 0
+		roleOrdinal := 0
 		if roleIDStr := pod.Labels[workload.RoleIDKey]; roleIDStr != "" {
-			parsedRoleID, err := strconv.Atoi(roleIDStr)
-			require.NoError(t, err, "Role id label should be an integer")
-			roleID = parsedRoleID
+			_, roleOrdinal = controllerutils.GetParentNameAndOrdinal(roleIDStr)
+			require.GreaterOrEqual(t, roleOrdinal, 0, "Role id label should encode role-<ordinal>")
 		}
 
-		updatedPod := pod.DeepCopy()
-		if updatedPod.Annotations == nil {
-			updatedPod.Annotations = make(map[string]string)
-		}
-		updatedPod.Annotations[corev1.PodDeletionCost] = fmt.Sprintf("%d", int(ordinal)*100+roleID*10)
+		deletionCost := int(ordinal)*100 + roleOrdinal*10
 
-		_, err = kubeClient.CoreV1().Pods(testNamespace).Update(ctx, updatedPod, metav1.UpdateOptions{})
-		require.NoError(t, err, "Failed to update pod with deletion cost")
+		patchPodDeletionCost(t, ctx, kubeClient, pod.Name, fmt.Sprintf("%d", deletionCost))
 	}
 
 	scaleDownMS, err := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Get(ctx, modelServing.Name, metav1.GetOptions{})

--- a/test/e2e/controller-manager/model_serving_test.go
+++ b/test/e2e/controller-manager/model_serving_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -1896,4 +1897,223 @@ func TestModelServingRoleBasedRollingUpdate(t *testing.T) {
 	}, 2*time.Minute, 1*time.Second)
 
 	t.Log("ModelServing role-based rolling update test passed successfully")
+}
+
+// TestModelServingBinPackScaleDownServingGroup tests bin pack scale down at ServingGroup level
+func TestModelServingBinPackScaleDownServingGroup(t *testing.T) {
+	ctx, kthenaClient, kubeClient := setupControllerManagerE2ETest(t)
+
+	modelServing := createBasicModelServing("test-binpack-sg-scaledown", 4, 0)
+	t.Log("Creating ModelServing with 4 servingGroup replicas for bin pack scale down test")
+	createAndWaitForModelServing(t, ctx, kthenaClient, modelServing)
+
+	initialMS, err := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Get(ctx, modelServing.Name, metav1.GetOptions{})
+	require.NoError(t, err, "Failed to get initial ModelServing")
+	assert.Equal(t, int32(4), *initialMS.Spec.Replicas, "Initial ModelServing should have 4 replicas")
+
+	labelSelector := modelServingLabelSelector(modelServing.Name)
+	podList, err := kubeClient.CoreV1().Pods(testNamespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	require.NoError(t, err, "Failed to list pods")
+
+	// Match controller unit tests: higher PodDeletionCost protects the ServingGroup; lower cost is scaled away first.
+	maxOrdinal := -1
+	for _, pod := range podList.Items {
+		groupName := pod.Labels[workload.GroupNameLabelKey]
+		require.NotEmpty(t, groupName, "Pod should have GroupName label")
+
+		parentName, ordinal := controllerutils.GetParentNameAndOrdinal(groupName)
+		require.Equal(t, modelServing.Name, parentName, "Pod group name should belong to this ModelServing")
+		require.GreaterOrEqual(t, ordinal, 0, "ServingGroup ordinal should be parsed from group name")
+
+		cost := ordinal * 100
+		if ordinal > maxOrdinal {
+			maxOrdinal = ordinal
+		}
+
+		updatedPod := pod.DeepCopy()
+		if updatedPod.Annotations == nil {
+			updatedPod.Annotations = make(map[string]string)
+		}
+		updatedPod.Annotations[corev1.PodDeletionCost] = fmt.Sprintf("%d", cost)
+
+		_, err := kubeClient.CoreV1().Pods(testNamespace).Update(ctx, updatedPod, metav1.UpdateOptions{})
+		require.NoError(t, err, "Failed to update pod with deletion cost")
+	}
+
+	scaleDownMS := initialMS.DeepCopy()
+	scaleDownMS.Spec.Replicas = ptr.To(int32(1))
+
+	t.Log("Scaling down ModelServing from 4 to 1 servingGroup")
+	_, err = kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Update(ctx, scaleDownMS, metav1.UpdateOptions{})
+	require.NoError(t, err, "Failed to scale down ModelServing")
+
+	utils.WaitForModelServingReady(t, ctx, kthenaClient, testNamespace, modelServing.Name)
+	waitForRunningPodCount(t, ctx, kubeClient, modelServing.Name, 1, 2*time.Minute)
+
+	finalPods, err := kubeClient.CoreV1().Pods(testNamespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	require.NoError(t, err, "Failed to list pods after scale down")
+	require.NotEmpty(t, finalPods.Items, "Expected one remaining pod after bin pack scale down")
+
+	for _, pod := range finalPods.Items {
+		if pod.DeletionTimestamp != nil || pod.Status.Phase != corev1.PodRunning {
+			continue
+		}
+		groupName := pod.Labels[workload.GroupNameLabelKey]
+		_, ord := controllerutils.GetParentNameAndOrdinal(groupName)
+		assert.Equal(t, maxOrdinal, ord, "ServingGroup with highest deletion cost should remain")
+	}
+
+	t.Log("Bin pack scale down ServingGroup test passed successfully")
+}
+
+func TestModelServingBinPackScaleDownRole(t *testing.T) {
+	ctx, kthenaClient, kubeClient := setupControllerManagerE2ETest(t)
+
+	const (
+		initialRoleReplicas = int32(4)
+		targetRoleReplicas  = int32(1)
+	)
+
+	modelServing := createBasicModelServing("test-binpack-role-scaledown", 1, initialRoleReplicas)
+	t.Log("Creating ModelServing with 1 servingGroup and role replicas=4 for bin pack role scale down test")
+	createAndWaitForModelServing(t, ctx, kthenaClient, modelServing)
+	waitForRunningPodCount(t, ctx, kubeClient, modelServing.Name, int(initialRoleReplicas), 3*time.Minute)
+
+	labelSelector := modelServingLabelSelector(modelServing.Name)
+	podList, err := kubeClient.CoreV1().Pods(testNamespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	require.NoError(t, err, "Failed to list pods")
+	require.NotEmpty(t, podList.Items, "Expected pods before role scale down")
+
+	maxRoleID := -1
+	for _, pod := range podList.Items {
+		roleIDStr := pod.Labels[workload.RoleIDKey]
+		require.NotEmpty(t, roleIDStr, "Pod should have role id label")
+
+		roleID, err := strconv.Atoi(roleIDStr)
+		require.NoError(t, err, "Role id label should be an integer")
+		if roleID > maxRoleID {
+			maxRoleID = roleID
+		}
+
+		updatedPod := pod.DeepCopy()
+		if updatedPod.Annotations == nil {
+			updatedPod.Annotations = make(map[string]string)
+		}
+		updatedPod.Annotations[corev1.PodDeletionCost] = fmt.Sprintf("%d", roleID*100)
+
+		_, err = kubeClient.CoreV1().Pods(testNamespace).Update(ctx, updatedPod, metav1.UpdateOptions{})
+		require.NoError(t, err, "Failed to update pod with deletion cost")
+	}
+
+	scaleDownMS, err := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Get(ctx, modelServing.Name, metav1.GetOptions{})
+	require.NoError(t, err, "Failed to get ModelServing before scale down")
+	scaleDownMS = scaleDownMS.DeepCopy()
+	scaleDownMS.Spec.Template.Roles[0].Replicas = ptr.To(targetRoleReplicas)
+
+	t.Log("Scaling down role replicas from 4 to 1")
+	_, err = kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Update(ctx, scaleDownMS, metav1.UpdateOptions{})
+	require.NoError(t, err, "Failed to scale down role")
+
+	utils.WaitForModelServingReady(t, ctx, kthenaClient, testNamespace, modelServing.Name)
+	waitForRunningPodCount(t, ctx, kubeClient, modelServing.Name, int(targetRoleReplicas), 3*time.Minute)
+
+	finalPods, err := kubeClient.CoreV1().Pods(testNamespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	require.NoError(t, err, "Failed to list pods after scale down")
+	require.NotEmpty(t, finalPods.Items, "Expected remaining pod after role scale down")
+
+	for _, pod := range finalPods.Items {
+		if pod.DeletionTimestamp != nil || pod.Status.Phase != corev1.PodRunning {
+			continue
+		}
+		remainingRoleID, err := strconv.Atoi(pod.Labels[workload.RoleIDKey])
+		require.NoError(t, err, "Remaining pod role id should be an integer")
+		assert.Equal(t, maxRoleID, remainingRoleID, "Pod with highest deletion cost should remain after bin pack scale down")
+	}
+
+	t.Log("Bin pack scale down Role test passed successfully")
+}
+
+func TestModelServingBinPackScaleDownCombined(t *testing.T) {
+	ctx, kthenaClient, kubeClient := setupControllerManagerE2ETest(t)
+
+	prefillRole := createRole("prefill", 2, 0)
+	decodeRole := createRole("decode", 1, 0)
+	modelServing := createBasicModelServing("test-binpack-combined-scaledown", 2, 0, prefillRole, decodeRole)
+
+	t.Log("Creating ModelServing with 2 servingGroups and 2 roles for combined bin pack scale down test")
+	createAndWaitForModelServing(t, ctx, kthenaClient, modelServing)
+	waitForRunningPodCount(t, ctx, kubeClient, modelServing.Name, 6, 3*time.Minute)
+
+	labelSelector := modelServingLabelSelector(modelServing.Name)
+	podList, err := kubeClient.CoreV1().Pods(testNamespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	require.NoError(t, err, "Failed to list pods")
+	require.NotEmpty(t, podList.Items, "Expected pods before combined scale down")
+
+	maxGroupOrdinal := -1
+	for _, pod := range podList.Items {
+		groupName := pod.Labels[workload.GroupNameLabelKey]
+		require.NotEmpty(t, groupName, "Pod should have group name label")
+
+		parentName, ordinal := controllerutils.GetParentNameAndOrdinal(groupName)
+		require.Equal(t, modelServing.Name, parentName, "Pod should belong to test ModelServing")
+		require.GreaterOrEqual(t, ordinal, 0, "Group ordinal should be non-negative")
+		if ordinal > maxGroupOrdinal {
+			maxGroupOrdinal = ordinal
+		}
+
+		roleID := 0
+		if roleIDStr := pod.Labels[workload.RoleIDKey]; roleIDStr != "" {
+			parsedRoleID, err := strconv.Atoi(roleIDStr)
+			require.NoError(t, err, "Role id label should be an integer")
+			roleID = parsedRoleID
+		}
+
+		updatedPod := pod.DeepCopy()
+		if updatedPod.Annotations == nil {
+			updatedPod.Annotations = make(map[string]string)
+		}
+		updatedPod.Annotations[corev1.PodDeletionCost] = fmt.Sprintf("%d", int(ordinal)*100+roleID*10)
+
+		_, err = kubeClient.CoreV1().Pods(testNamespace).Update(ctx, updatedPod, metav1.UpdateOptions{})
+		require.NoError(t, err, "Failed to update pod with deletion cost")
+	}
+
+	scaleDownMS, err := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Get(ctx, modelServing.Name, metav1.GetOptions{})
+	require.NoError(t, err, "Failed to get ModelServing before combined scale down")
+	scaleDownMS = scaleDownMS.DeepCopy()
+	scaleDownMS.Spec.Replicas = ptr.To(int32(1))
+	scaleDownMS.Spec.Template.Roles[0].Replicas = ptr.To(int32(1))
+
+	t.Log("Scaling down combined dimensions (servingGroup 2->1 and prefill role 2->1)")
+	_, err = kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Update(ctx, scaleDownMS, metav1.UpdateOptions{})
+	require.NoError(t, err, "Failed to scale down combined dimensions")
+
+	utils.WaitForModelServingReady(t, ctx, kthenaClient, testNamespace, modelServing.Name)
+	waitForRunningPodCount(t, ctx, kubeClient, modelServing.Name, 2, 3*time.Minute)
+
+	finalPods, err := kubeClient.CoreV1().Pods(testNamespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	require.NoError(t, err, "Failed to list pods after combined scale down")
+
+	for _, pod := range finalPods.Items {
+		if pod.DeletionTimestamp != nil || pod.Status.Phase != corev1.PodRunning {
+			continue
+		}
+		groupName := pod.Labels[workload.GroupNameLabelKey]
+		_, ordinal := controllerutils.GetParentNameAndOrdinal(groupName)
+		assert.Equal(t, maxGroupOrdinal, ordinal, "Highest deletion-cost servingGroup should remain")
+	}
+
+	t.Log("Bin pack scale down combined test passed successfully")
 }

--- a/test/e2e/controller-manager/model_serving_test.go
+++ b/test/e2e/controller-manager/model_serving_test.go
@@ -18,8 +18,10 @@ package controller_manager
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"math/rand"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -29,6 +31,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
@@ -860,20 +863,23 @@ func waitForRunningPodCount(t *testing.T, ctx context.Context, kubeClient *kuber
 	}, timeout, 5*time.Second, "Expected %d running pods for ModelServing %s", expected, msName)
 }
 
-// patchPodDeletionCost sets corev1.PodDeletionCost with retries to tolerate concurrent Pod updates (resourceVersion conflicts).
-func patchPodDeletionCost(t *testing.T, ctx context.Context, kubeClient *kubernetes.Clientset, podName, cost string) {
+// patchPodDeletionCost sets corev1.PodDeletionCost with retries.
+// Patch is used instead of Update to reduce resourceVersion contention with concurrent Pod updates.
+func patchPodDeletionCost(t *testing.T, ctx context.Context, kubeClient *kubernetes.Clientset, podName string, cost int) {
 	t.Helper()
+	costStr := strconv.Itoa(cost)
+	patch := map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"annotations": map[string]string{
+				corev1.PodDeletionCost: costStr,
+			},
+		},
+	}
+	patchBytes, err := json.Marshal(patch)
+	require.NoError(t, err, "Failed to marshal patch for pod %s", podName)
+
 	require.Eventually(t, func() bool {
-		cur, err := kubeClient.CoreV1().Pods(testNamespace).Get(ctx, podName, metav1.GetOptions{})
-		if err != nil {
-			return false
-		}
-		upd := cur.DeepCopy()
-		if upd.Annotations == nil {
-			upd.Annotations = make(map[string]string)
-		}
-		upd.Annotations[corev1.PodDeletionCost] = cost
-		_, err = kubeClient.CoreV1().Pods(testNamespace).Update(ctx, upd, metav1.UpdateOptions{})
+		_, err = kubeClient.CoreV1().Pods(testNamespace).Patch(ctx, podName, types.MergePatchType, patchBytes, metav1.PatchOptions{})
 		return err == nil
 	}, 90*time.Second, time.Second, "set PodDeletionCost on pod %s", podName)
 }
@@ -1950,7 +1956,7 @@ func TestModelServingBinPackScaleDownServingGroup(t *testing.T) {
 			maxOrdinal = ordinal
 		}
 
-		patchPodDeletionCost(t, ctx, kubeClient, pod.Name, fmt.Sprintf("%d", cost))
+		patchPodDeletionCost(t, ctx, kubeClient, pod.Name, cost)
 	}
 
 	scaleDownMS := initialMS.DeepCopy()
@@ -2013,7 +2019,7 @@ func TestModelServingBinPackScaleDownRole(t *testing.T) {
 			maxRoleOrdinal = roleOrdinal
 		}
 
-		patchPodDeletionCost(t, ctx, kubeClient, pod.Name, fmt.Sprintf("%d", roleOrdinal*100))
+		patchPodDeletionCost(t, ctx, kubeClient, pod.Name, roleOrdinal*100)
 	}
 
 	scaleDownMS, err := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Get(ctx, modelServing.Name, metav1.GetOptions{})
@@ -2084,7 +2090,7 @@ func TestModelServingBinPackScaleDownCombined(t *testing.T) {
 
 		deletionCost := int(ordinal)*100 + roleOrdinal*10
 
-		patchPodDeletionCost(t, ctx, kubeClient, pod.Name, fmt.Sprintf("%d", deletionCost))
+		patchPodDeletionCost(t, ctx, kubeClient, pod.Name, deletionCost)
 	}
 
 	scaleDownMS, err := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Get(ctx, modelServing.Name, metav1.GetOptions{})


### PR DESCRIPTION
**What this PR does / why we need it**

Adds e2e tests for bin-pack scale-down in ModelServing. When scaling down, pods with lower `PodDeletionCost` should be removed first and higher-cost ones should survive — this is what the controller already does in production, and these tests verify it on a real cluster.

Three cases covered:
- **ServingGroup**:  4 groups, scale to 1, highest-cost group should be the one left
- **Role** : 4 replicas, scale to 1, highest-cost pod should be the one left
- **Combined**:  2 serving groups × 2 roles (prefill/decode), scale both down, assert the right group survives
**Which issue(s) this PR fixes**
Fixes #651 

**What type of Pull request is this**
  i think giving it a enhancement would be fine!
/kind enhancement

