### PR TITLE
fix(sglang): rebuild prefill/decode requests on every Proxy call

### DIFF
--- a/pkg/kthena-router/connectors/sglang.go
+++ b/pkg/kthena-router/connectors/sglang.go
@@ -48,11 +48,7 @@ const ConnectorTypeSGLang v1alpha1.KVConnectorType = "sglang"
 //
 //	https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/managers/scheduler.py
 type SGLangConnector struct {
-	prefillRequest  *http.Request
-	decodeRequest   *http.Request
-	bootstrapRoom   int64
-	lastPrefillAddr string
-	lastDecodeAddr  string
+	bootstrapRoom int64
 }
 
 // NewSGLangConnector creates a new SGLang connector with a unique bootstrap room id.
@@ -105,30 +101,28 @@ func (s *SGLangConnector) Proxy(c *gin.Context, reqBody map[string]interface{}, 
 	// Build the decode request first (before preparePrefillBody mutates reqBody).
 	// bootstrap_host = prefillHost so the decode receiver can find the prefill's
 	// bootstrap server and exchange ZMQ metadata.
-	if s.decodeRequest == nil || s.lastDecodeAddr != decodeAddr || s.lastPrefillAddr != prefillAddr {
-		decodeBody := cloneReqBody(reqBody)
-		decodeBody = addTokenUsage(c, decodeBody)
-		decodeBody["bootstrap_room"] = s.bootstrapRoom
-		decodeBody["bootstrap_host"] = prefillHost
-		s.decodeRequest, err = buildRequest(c.Request, decodeBody)
-		if err != nil {
-			return http.StatusInternalServerError, err
-		}
-		s.lastDecodeAddr = decodeAddr
+	//
+	// Both requests are rebuilt on every Proxy call: the request body is a
+	// one-shot bytes.Buffer wrapped in io.NopCloser, so it cannot be retried
+	// against a different upstream pod by the router's PD retry loop.
+	decodeBody := cloneReqBody(reqBody)
+	decodeBody = addTokenUsage(c, decodeBody)
+	decodeBody["bootstrap_room"] = s.bootstrapRoom
+	decodeBody["bootstrap_host"] = prefillHost
+	decodeRequest, err := buildRequest(c.Request, decodeBody)
+	if err != nil {
+		return http.StatusInternalServerError, err
 	}
 
 	// Build the prefill request: strip streaming, cap max_tokens, add bootstrap_room.
 	// The prefill sender uses bootstrap_room to track the ZMQ metadata sent by the
 	// decode receiver; it does not need bootstrap_host.
-	if s.prefillRequest == nil || s.lastPrefillAddr != prefillAddr {
-		prefillBody := cloneReqBody(reqBody)
-		preparePrefillBody(prefillBody)
-		prefillBody["bootstrap_room"] = s.bootstrapRoom
-		s.prefillRequest, err = buildRequest(req, prefillBody)
-		if err != nil {
-			return http.StatusInternalServerError, err
-		}
-		s.lastPrefillAddr = prefillAddr
+	prefillBody := cloneReqBody(reqBody)
+	preparePrefillBody(prefillBody)
+	prefillBody["bootstrap_room"] = s.bootstrapRoom
+	prefillRequest, err := buildRequest(req, prefillBody)
+	if err != nil {
+		return http.StatusInternalServerError, err
 	}
 
 	// --- Launch prefill and decode concurrently ---
@@ -153,13 +147,13 @@ func (s *SGLangConnector) Proxy(c *gin.Context, reqBody map[string]interface{}, 
 
 	go func() {
 		prefillCh <- prefillOutcome{
-			err: s.prefill(s.prefillRequest.WithContext(prefillCtx), prefillAddr),
+			err: s.prefill(prefillRequest.WithContext(prefillCtx), prefillAddr),
 		}
 	}()
 
 	// Run decode in the current goroutine so that streaming writes reach the
 	// gin.Context from the request-handling goroutine.
-	result, decodeErr := s.decode(c, s.decodeRequest, decodeAddr)
+	result, decodeErr := s.decode(c, decodeRequest, decodeAddr)
 
 	if decodeErr != nil {
 		// Decode failed: cancel the prefill context so the prefill goroutine is

--- a/pkg/kthena-router/connectors/sglang_test.go
+++ b/pkg/kthena-router/connectors/sglang_test.go
@@ -1,0 +1,135 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package connectors
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+// TestSGLangConnectorRetryBodyNotDrained checks that calling Proxy() twice on
+// the same connector instance — as proxyToPDDisaggregated does during PD
+// retries when the scheduler reselects the same prefill pod for a different
+// decode pod — sends a non-empty body to both backends on both attempts.
+func TestSGLangConnectorRetryBodyNotDrained(t *testing.T) {
+	var prefillCalls, decodeCalls int32
+	var prefillBodyLens [2]int64
+	var decodeBodyLens [2]int64
+
+	prefillServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		idx := atomic.AddInt32(&prefillCalls, 1) - 1
+		body, _ := io.ReadAll(r.Body)
+		if idx < 2 {
+			prefillBodyLens[idx] = int64(len(body))
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer prefillServer.Close()
+
+	decodeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		idx := atomic.AddInt32(&decodeCalls, 1) - 1
+		body, _ := io.ReadAll(r.Body)
+		if idx < 2 {
+			decodeBodyLens[idx] = int64(len(body))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"ok"}}],"usage":{"completion_tokens":1}}`))
+	}))
+	defer decodeServer.Close()
+
+	connector := NewSGLangConnector()
+
+	reqBody := map[string]interface{}{
+		"model":      "test-model",
+		"max_tokens": 100,
+		"messages": []interface{}{
+			map[string]interface{}{"role": "user", "content": "hello"},
+		},
+	}
+
+	makeCtx := func() *gin.Context {
+		req, _ := http.NewRequest("POST", "/v1/chat/completions", nil)
+		c, _ := gin.CreateTestContext(httptest.NewRecorder())
+		c.Request = req
+		return c
+	}
+
+	prefillAddr := prefillServer.Listener.Addr().String()
+	decodeAddr := decodeServer.Listener.Addr().String()
+
+	// First call — simulates retry iteration 0.
+	if _, err := connector.Proxy(makeCtx(), reqBody, prefillAddr, decodeAddr); err != nil {
+		t.Fatalf("first Proxy call failed: %v", err)
+	}
+	// Second call with the SAME prefill addr — simulates the scheduler reselecting
+	// the same prefill pod for a different decode pod on retry. This is the path
+	// where the previous (cached) request would have a drained body.
+	if _, err := connector.Proxy(makeCtx(), reqBody, prefillAddr, decodeAddr); err != nil {
+		t.Fatalf("second Proxy call failed: %v", err)
+	}
+
+	if prefillBodyLens[0] == 0 {
+		t.Error("first Proxy call sent empty body to prefill backend")
+	}
+	if prefillBodyLens[1] == 0 {
+		t.Error("second Proxy call sent empty body to prefill backend — request body was drained and reused")
+	}
+	if decodeBodyLens[0] == 0 {
+		t.Error("first Proxy call sent empty body to decode backend")
+	}
+	if decodeBodyLens[1] == 0 {
+		t.Error("second Proxy call sent empty body to decode backend — request body was drained and reused")
+	}
+}
+
+// TestSGLangConnectorReqBodyNotMutated checks that Proxy() does not mutate the
+// caller's reqBody map. proxyToPDDisaggregated passes the same modelRequest
+// across all retry iterations, so mutations would bleed between retries.
+func TestSGLangConnectorReqBodyNotMutated(t *testing.T) {
+	connector := NewSGLangConnector()
+
+	req, _ := http.NewRequest("POST", "/v1/chat/completions", nil)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = req
+
+	reqBody := map[string]interface{}{
+		"model":      "test-model",
+		"max_tokens": 100,
+		"messages": []interface{}{
+			map[string]interface{}{"role": "user", "content": "hello"},
+		},
+	}
+
+	keysBefore := make(map[string]struct{})
+	for k := range reqBody {
+		keysBefore[k] = struct{}{}
+	}
+
+	_, _ = connector.Proxy(c, reqBody, "127.0.0.1:1", "127.0.0.1:2")
+
+	for k := range reqBody {
+		if _, existed := keysBefore[k]; !existed {
+			t.Errorf("Proxy() mutated caller reqBody by adding key %q", k)
+		}
+	}
+}


### PR DESCRIPTION
 **What type of PR is this?**

  /kind bug

  **What this PR does / why we need it**:

  The SGLang connector was caching the prefill and decode `*http.Request` objects on the struct between `Proxy` calls, keyed by `lastPrefillAddr` / `lastDecodeAddr`. These requests wrap a `bytes.Buffer` body in `io.NopCloser` ; once the HTTP transport reads it, it's gone. Can't reuse it.

  The router's retry loop in `proxyToPDDisaggregated` calls `connector.Proxy(...)` multiple times on the same connector instance. In a typical PD setup with 1 prefill pool shared across multiple decode pods, the scheduler scores all decode pods against the same prefill pod set and picks the same best prefill pod for each iteration. So you end up with `PrefillPods = [P0, P0]` and `DecodePods = [D0, D1]`. When D0 fails and the router retries with D1, the prefill addr is still P0 , cache hit , and the drained
  request gets reused. Transport sends Content-Length N with 0 bytes. Prefill server rejects it, or the SGLang bootstrap handshake aborts with `KVTransferError: Aborted by AbortReq`. Worse, the decode side already wrote headers to the response stream, so the client can get HTTP 200 with an empty/truncated SSE response ; totally silent failure.

The fix is to rebuild both requests on every `Proxy` call and drop the dead caching fields from the struct. Same approach used in 067dfb5 for NIXL and d9f656a for HTTP.

  **Special notes for your reviewer**:

  This is the same body-reuse regression class that was just fixed for NIXL and HTTP connectors , the SGLang connector was added after those fixes landed and reintroduced the same pattern. The most common topology that triggers it is a single prefill pool with 2+ decode pods, which is pretty standard for SGLang PD deployments.

Added two regression tests in `sglang_test.go` that mirror the NIXL ones , one that calls `Proxy` twice with the same prefill addr on the same connector instance and checks both backends got a non-empty body each time, and one that checks the caller's `reqBody` map isn't mutated across calls.

<img width="1311" height="433" alt="Screenshot 2026-05-10 122946" src="https://github.com/user-attachments/assets/ce69f57a-4f1d-41c1-a05d-5c69024b0533" />


  **Does this PR introduce a user-facing change?**:

  ```release-note
  Fixed a bug in the SGLang PD connector where prefill/decode request bodies were cached and reused across retry attempts. In a typical PD setup with a shared prefill pool,
  retries after a decode pod failure would silently send an empty request body to the prefill backend, causing the entire request to fail or return a truncated response to the
   client.
