### PR TITLE
fix: return request build marshal errors

### DIFF
--- a/pkg/kthena-router/connectors/connectors_test.go
+++ b/pkg/kthena-router/connectors/connectors_test.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/volcano-sh/kthena/pkg/apis/networking/v1alpha1"
-	"github.com/volcano-sh/kthena/pkg/kthena-router/common"
 )
 
 func TestHTTPConnector(t *testing.T) {
@@ -105,427 +104,64 @@ func parseRequestBody(req *http.Request) (map[string]interface{}, error) {
 }
 
 func TestHTTPConnectorProxy(t *testing.T) {
-	// Test non-streaming request
-	t.Run("NonStreamingRequest", func(t *testing.T) {
-		connector := NewHTTPConnector()
+	t.Run("StreamingRequestBuildsLocalRequests", func(t *testing.T) {
+		var prefillBody, decodeBody map[string]interface{}
 
-		// Create a proper test context with a valid HTTP request
-		req, _ := http.NewRequest("POST", "/v1/chat/completions", nil)
-		c, _ := gin.CreateTestContext(httptest.NewRecorder())
-		c.Request = req
-
-		reqBody := map[string]interface{}{
-			"model":      "test-model",
-			"max_tokens": 100,
-			"messages": []interface{}{
-				map[string]interface{}{
-					"role":    "user",
-					"content": "test message",
-				},
-			},
-		}
-
-		// The HTTP connector does support the Proxy method, but it will fail
-		// because the test addresses don't exist and the prefill/decode calls will fail
-		_, err := connector.Proxy(c, reqBody, "localhost:8000", "localhost:8001")
-		if err == nil {
-			t.Error("Expected HTTP connector Proxy to return error due to network/connection issues")
-		}
-
-		// Verify that prefill and decode requests were built
-		httpConn := connector.(*HTTPConnector)
-		if httpConn.prefillRequest == nil {
-			t.Error("Expected prefill request to be built")
-		}
-		if httpConn.decodeRequest == nil {
-			t.Error("Expected decode request to be built")
-		}
-
-		// Verify request body fields
-		if httpConn.prefillRequest != nil {
-			prefillBody, err := parseRequestBody(httpConn.prefillRequest)
+		prefillServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			var err error
+			prefillBody, err = parseRequestBody(r)
 			if err != nil {
 				t.Errorf("Failed to parse prefill request body: %v", err)
-			} else {
-				// Prefill request should have max_tokens set to 1
-				if maxTokens, ok := prefillBody["max_tokens"]; !ok {
-					t.Error("Expected prefill request to have max_tokens field")
-				} else if maxTokensFloat, ok := maxTokens.(float64); !ok || maxTokensFloat != 1.0 {
-					t.Errorf("Expected prefill request max_tokens to be 1, got %v", maxTokens)
-				}
-				// Prefill request should not have stream field
-				if _, hasStream := prefillBody["stream"]; hasStream {
-					t.Error("Expected prefill request to not have stream field")
-				}
-				// Prefill request should not have stream_options field
-				if _, hasStreamOptions := prefillBody["stream_options"]; hasStreamOptions {
-					t.Error("Expected prefill request to not have stream_options field")
-				}
-				// Should still have model and messages
-				if model, ok := prefillBody["model"]; !ok || model != "test-model" {
-					t.Errorf("Expected prefill request to have model 'test-model', got %v", model)
-				}
 			}
-		}
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer prefillServer.Close()
 
-		if httpConn.decodeRequest != nil {
-			decodeBody, err := parseRequestBody(httpConn.decodeRequest)
+		decodeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			var err error
+			decodeBody, err = parseRequestBody(r)
 			if err != nil {
 				t.Errorf("Failed to parse decode request body: %v", err)
-			} else {
-				// Decode request should have include_usage set for non-streaming requests
-				if includeUsage, ok := decodeBody["include_usage"]; !ok || includeUsage != true {
-					t.Errorf("Expected decode request include_usage to be true, got %v", includeUsage)
-				}
-				// Should preserve original max_tokens
-				if maxTokens, ok := decodeBody["max_tokens"]; !ok {
-					t.Error("Expected decode request to have max_tokens field")
-				} else if maxTokensFloat, ok := maxTokens.(float64); !ok || maxTokensFloat != 100.0 {
-					t.Errorf("Expected decode request max_tokens to be 100, got %v", maxTokens)
-				}
-				// Should still have model and messages
-				if model, ok := decodeBody["model"]; !ok || model != "test-model" {
-					t.Errorf("Expected decode request to have model 'test-model', got %v", model)
-				}
 			}
-		}
-	})
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"usage":{"completion_tokens":2}}`))
+		}))
+		defer decodeServer.Close()
 
-	// Test streaming request
-	t.Run("StreamingRequest", func(t *testing.T) {
-		connector := NewHTTPConnector()
-
-		// Create a proper test context with a valid HTTP request
 		req, _ := http.NewRequest("POST", "/v1/chat/completions", nil)
 		c, _ := gin.CreateTestContext(httptest.NewRecorder())
 		c.Request = req
 
-		reqBody := map[string]interface{}{
-			"model":      "test-model",
-			"stream":     true,
-			"max_tokens": 100,
-			"messages": []interface{}{
-				map[string]interface{}{
-					"role":    "user",
-					"content": "test message",
-				},
-			},
-		}
-
-		// The HTTP connector will fail due to network issues
-		_, err := connector.Proxy(c, reqBody, "localhost:8000", "localhost:8001")
-		if err == nil {
-			t.Error("Expected HTTP connector Proxy to return error due to network/connection issues")
-		}
-
-		// Verify that prefill and decode requests were built
-		httpConn := connector.(*HTTPConnector)
-		if httpConn.prefillRequest == nil {
-			t.Error("Expected prefill request to be built")
-		}
-		if httpConn.decodeRequest == nil {
-			t.Error("Expected decode request to be built")
-		}
-
-		// For streaming requests, verify that token usage context was set
-		if val, exists := c.Get(common.TokenUsageKey); !exists || val != true {
-			t.Error("Expected token usage to be set in context for streaming request")
-		}
-
-		// Verify request body fields for streaming request
-		if httpConn.prefillRequest != nil {
-			prefillBody, err := parseRequestBody(httpConn.prefillRequest)
-			if err != nil {
-				t.Errorf("Failed to parse prefill request body: %v", err)
-			} else {
-				// Prefill request should have max_tokens set to 1
-				if maxTokens, ok := prefillBody["max_tokens"]; !ok {
-					t.Error("Expected prefill request to have max_tokens field")
-				} else if maxTokensFloat, ok := maxTokens.(float64); !ok || maxTokensFloat != 1.0 {
-					t.Errorf("Expected prefill request max_tokens to be 1, got %v", maxTokens)
-				}
-				// Prefill request should not have stream field (removed for prefill)
-				if _, hasStream := prefillBody["stream"]; hasStream {
-					t.Error("Expected prefill request to not have stream field")
-				}
-				// Prefill request should not have stream_options field (removed for prefill)
-				if _, hasStreamOptions := prefillBody["stream_options"]; hasStreamOptions {
-					t.Error("Expected prefill request to not have stream_options field")
-				}
-			}
-		}
-
-		if httpConn.decodeRequest != nil {
-			decodeBody, err := parseRequestBody(httpConn.decodeRequest)
-			if err != nil {
-				t.Errorf("Failed to parse decode request body: %v", err)
-			} else {
-				// Decode request should preserve stream field
-				if stream, ok := decodeBody["stream"]; !ok || stream != true {
-					t.Errorf("Expected decode request stream to be true, got %v", stream)
-				}
-				// Decode request should have stream_options with include_usage added
-				if streamOptions, ok := decodeBody["stream_options"]; !ok {
-					t.Error("Expected decode request to have stream_options")
-				} else if opts, isMap := streamOptions.(map[string]interface{}); !isMap {
-					t.Error("Expected stream_options to be a map")
-				} else if includeUsage, ok := opts["include_usage"]; !ok || includeUsage != true {
-					t.Errorf("Expected stream_options include_usage to be true, got %v", includeUsage)
-				}
-				// Should preserve original max_tokens
-				if maxTokens, ok := decodeBody["max_tokens"]; !ok {
-					t.Error("Expected decode request to have max_tokens field")
-				} else if maxTokensFloat, ok := maxTokens.(float64); !ok || maxTokensFloat != 100.0 {
-					t.Errorf("Expected decode request max_tokens to be 100, got %v", maxTokens)
-				}
-			}
-		}
-	})
-
-	// Test streaming request with existing stream_options
-	t.Run("StreamingRequestWithStreamOptions", func(t *testing.T) {
-		connector := NewHTTPConnector()
-
-		// Create a proper test context with a valid HTTP request
-		req, _ := http.NewRequest("POST", "/v1/chat/completions", nil)
-		c, _ := gin.CreateTestContext(httptest.NewRecorder())
-		c.Request = req
-
-		reqBody := map[string]interface{}{
-			"model":  "test-model",
-			"stream": true,
-			"stream_options": map[string]interface{}{
-				"include_usage": true,
-			},
-			"max_tokens": 100,
-			"messages": []interface{}{
-				map[string]interface{}{
-					"role":    "user",
-					"content": "test message",
-				},
-			},
-		}
-
-		// The HTTP connector will fail due to network issues
-		_, err := connector.Proxy(c, reqBody, "localhost:8000", "localhost:8001")
-		if err == nil {
-			t.Error("Expected HTTP connector Proxy to return error due to network/connection issues")
-		}
-
-		// Verify that prefill and decode requests were built
-		httpConn := connector.(*HTTPConnector)
-		if httpConn.prefillRequest == nil {
-			t.Error("Expected prefill request to be built")
-		}
-		if httpConn.decodeRequest == nil {
-			t.Error("Expected decode request to be built")
-		}
-
-		// For streaming requests with existing stream_options, token usage should not be added to context
-		if val, exists := c.Get(common.TokenUsageKey); exists && val == true {
-			t.Error("Did not expect token usage to be set in context when stream_options already exists")
-		}
-
-		// Verify request body fields when stream_options already exists
-		if httpConn.decodeRequest != nil {
-			decodeBody, err := parseRequestBody(httpConn.decodeRequest)
-			if err != nil {
-				t.Errorf("Failed to parse decode request body: %v", err)
-			} else {
-				// Decode request should preserve existing stream_options
-				if streamOptions, ok := decodeBody["stream_options"]; !ok {
-					t.Error("Expected decode request to preserve existing stream_options")
-				} else if opts, isMap := streamOptions.(map[string]interface{}); !isMap {
-					t.Error("Expected stream_options to be a map")
-				} else if includeUsage, ok := opts["include_usage"]; !ok || includeUsage != true {
-					t.Errorf("Expected existing stream_options include_usage to be preserved as true, got %v", includeUsage)
-				}
-			}
-		}
-	})
-
-	// Test max_completion_tokens handling
-	t.Run("MaxCompletionTokensHandling", func(t *testing.T) {
-		connector := NewHTTPConnector()
-
-		// Create a proper test context with a valid HTTP request
-		req, _ := http.NewRequest("POST", "/v1/chat/completions", nil)
-		c, _ := gin.CreateTestContext(httptest.NewRecorder())
-		c.Request = req
-
-		reqBody := map[string]interface{}{
-			"model":                 "test-model",
-			"max_completion_tokens": 50,
-			"messages": []interface{}{
-				map[string]interface{}{
-					"role":    "user",
-					"content": "test message",
-				},
-			},
-		}
-
-		// The HTTP connector will fail due to network issues
-		_, err := connector.Proxy(c, reqBody, "localhost:8000", "localhost:8001")
-		if err == nil {
-			t.Error("Expected HTTP connector Proxy to return error due to network/connection issues")
-		}
-
-		// Verify that both prefill and decode requests were built
-		httpConn := connector.(*HTTPConnector)
-		if httpConn.prefillRequest == nil {
-			t.Error("Expected prefill request to be built")
-		}
-		if httpConn.decodeRequest == nil {
-			t.Error("Expected decode request to be built")
-		}
-
-		// Both requests should have content
-		if httpConn.prefillRequest.ContentLength == 0 {
-			t.Error("Expected prefill request to have a body")
-		}
-		if httpConn.decodeRequest.ContentLength == 0 {
-			t.Error("Expected decode request to have a body")
-		}
-
-		// Verify request body fields for max_completion_tokens handling
-		if httpConn.prefillRequest != nil {
-			prefillBody, err := parseRequestBody(httpConn.prefillRequest)
-			if err != nil {
-				t.Errorf("Failed to parse prefill request body: %v", err)
-			} else {
-				// Prefill request should have max_tokens set to 1
-				if maxTokens, ok := prefillBody["max_tokens"]; !ok {
-					t.Error("Expected prefill request to have max_tokens field")
-				} else if maxTokensFloat, ok := maxTokens.(float64); !ok || maxTokensFloat != 1.0 {
-					t.Errorf("Expected prefill request max_tokens to be 1, got %v", maxTokens)
-				}
-				// Prefill request should have max_completion_tokens set to 1
-				if maxCompletionTokens, ok := prefillBody["max_completion_tokens"]; !ok {
-					t.Error("Expected prefill request to have max_completion_tokens field")
-				} else if maxCompletionTokensFloat, ok := maxCompletionTokens.(float64); !ok || maxCompletionTokensFloat != 1.0 {
-					t.Errorf("Expected prefill request max_completion_tokens to be 1, got %v", maxCompletionTokens)
-				}
-			}
-		}
-
-		if httpConn.decodeRequest != nil {
-			decodeBody, err := parseRequestBody(httpConn.decodeRequest)
-			if err != nil {
-				t.Errorf("Failed to parse decode request body: %v", err)
-			} else {
-				// Decode request should preserve original max_completion_tokens
-				if maxCompletionTokens, ok := decodeBody["max_completion_tokens"]; !ok {
-					t.Error("Expected decode request to have max_completion_tokens field")
-				} else if maxCompletionTokensFloat, ok := maxCompletionTokens.(float64); !ok || maxCompletionTokensFloat != 50.0 {
-					t.Errorf("Expected decode request max_completion_tokens to be 50, got %v", maxCompletionTokens)
-				}
-				// Decode request should have include_usage for non-streaming
-				if includeUsage, ok := decodeBody["include_usage"]; !ok || includeUsage != true {
-					t.Errorf("Expected decode request include_usage to be true, got %v", includeUsage)
-				}
-			}
-		}
-	})
-
-	// Test request body modifications in detail
-	t.Run("RequestBodyModifications", func(t *testing.T) {
-		connector := NewHTTPConnector()
-
-		// Create a proper test context with a valid HTTP request
-		req, _ := http.NewRequest("POST", "/v1/chat/completions", nil)
-		c, _ := gin.CreateTestContext(httptest.NewRecorder())
-		c.Request = req
-
-		originalReqBody := map[string]interface{}{
+		_, err := NewHTTPConnector().Proxy(c, map[string]interface{}{
 			"model":      "test-model",
 			"stream":     true,
 			"max_tokens": 200,
 			"stream_options": map[string]interface{}{
 				"some_other_option": "value",
 			},
-			"messages": []interface{}{
-				map[string]interface{}{
-					"role":    "user",
-					"content": "test message",
-				},
-			},
+		}, prefillServer.Listener.Addr().String(), decodeServer.Listener.Addr().String())
+		if err != nil {
+			t.Fatalf("Expected proxy to succeed, got %v", err)
 		}
 
-		// Make a copy of the original to verify it gets modified
-		reqBodyCopy := make(map[string]interface{})
-		for k, v := range originalReqBody {
-			reqBodyCopy[k] = v
+		if prefillBody["max_tokens"] != float64(1) {
+			t.Errorf("Expected prefill max_tokens to be 1, got %v", prefillBody["max_tokens"])
 		}
-
-		// The HTTP connector will fail due to network issues
-		_, err := connector.Proxy(c, reqBodyCopy, "localhost:8000", "localhost:8001")
-		if err == nil {
-			t.Error("Expected HTTP connector Proxy to return error due to network/connection issues")
+		if _, ok := prefillBody["stream"]; ok {
+			t.Error("Expected prefill request to remove stream")
 		}
-
-		// Verify that the original request body was modified correctly
-		httpConn := connector.(*HTTPConnector)
-
-		// Check prefill request body
-		if httpConn.prefillRequest != nil {
-			prefillBody, err := parseRequestBody(httpConn.prefillRequest)
-			if err != nil {
-				t.Errorf("Failed to parse prefill request body: %v", err)
-			} else {
-				// Should have modified max_tokens to 1
-				if maxTokens, ok := prefillBody["max_tokens"]; !ok {
-					t.Error("Expected prefill request to have max_tokens field")
-				} else if maxTokensFloat, ok := maxTokens.(float64); !ok || maxTokensFloat != 1.0 {
-					t.Errorf("Expected prefill request max_tokens to be 1, got %v", maxTokens)
-				}
-
-				// Should have removed stream field
-				if _, hasStream := prefillBody["stream"]; hasStream {
-					t.Error("Expected prefill request to not have stream field")
-				}
-
-				// Should have removed stream_options field
-				if _, hasStreamOptions := prefillBody["stream_options"]; hasStreamOptions {
-					t.Error("Expected prefill request to not have stream_options field")
-				}
-			}
+		if _, ok := prefillBody["stream_options"]; ok {
+			t.Error("Expected prefill request to remove stream_options")
 		}
-
-		// Check decode request body
-		if httpConn.decodeRequest != nil {
-			decodeBody, err := parseRequestBody(httpConn.decodeRequest)
-			if err != nil {
-				t.Errorf("Failed to parse decode request body: %v", err)
-			} else {
-				// Should preserve stream field
-				if stream, ok := decodeBody["stream"]; !ok || stream != true {
-					t.Errorf("Expected decode request stream to be true, got %v", stream)
-				}
-
-				// Should preserve original max_tokens
-				if maxTokens, ok := decodeBody["max_tokens"]; !ok {
-					t.Error("Expected decode request to have max_tokens field")
-				} else if maxTokensFloat, ok := maxTokens.(float64); !ok || maxTokensFloat != 200.0 {
-					t.Errorf("Expected decode request max_tokens to be 200, got %v", maxTokens)
-				}
-
-				// Should have stream_options with include_usage added
-				if streamOptions, ok := decodeBody["stream_options"]; !ok {
-					t.Error("Expected decode request to have stream_options")
-				} else if opts, isMap := streamOptions.(map[string]interface{}); !isMap {
-					t.Error("Expected stream_options to be a map")
-				} else {
-					// Should have include_usage added
-					if includeUsage, ok := opts["include_usage"]; !ok || includeUsage != true {
-						t.Errorf("Expected stream_options include_usage to be true, got %v", includeUsage)
-					}
-					// Note: Original stream_options are replaced, not preserved
-					// This is the current behavior of buildDecodeRequest
-					if len(opts) != 1 {
-						t.Errorf("Expected stream_options to only contain include_usage, got %+v", opts)
-					}
-				}
-			}
+		if decodeBody["stream"] != true {
+			t.Errorf("Expected decode request stream to be true, got %v", decodeBody["stream"])
+		}
+		if decodeBody["max_tokens"] != float64(200) {
+			t.Errorf("Expected decode max_tokens to be 200, got %v", decodeBody["max_tokens"])
+		}
+		streamOptions, ok := decodeBody["stream_options"].(map[string]interface{})
+		if !ok || streamOptions["include_usage"] != true {
+			t.Errorf("Expected decode stream_options include_usage, got %+v", decodeBody["stream_options"])
 		}
 	})
 }

--- a/pkg/kthena-router/connectors/http.go
+++ b/pkg/kthena-router/connectors/http.go
@@ -27,10 +27,7 @@ import (
 
 // HTTPConnector implements simple HTTP-based KV transfer
 // Many kv connectors like LMCache, MoonCakeStore can use this
-type HTTPConnector struct {
-	prefillRequest *http.Request
-	decodeRequest  *http.Request
-}
+type HTTPConnector struct{}
 
 // NewHTTPConnector creates a new HTTP connector with default configuration
 func NewHTTPConnector() KVConnector {
@@ -71,10 +68,16 @@ func (h *HTTPConnector) Proxy(c *gin.Context, reqBody map[string]interface{}, pr
 	}
 
 	decodeBody := cloneReqBody(reqBody)
-	h.decodeRequest = BuildDecodeRequest(c, c.Request, decodeBody)
+	decodeRequest, err := BuildDecodeRequest(c, c.Request, decodeBody)
+	if err != nil {
+		return 0, err
+	}
 
 	prefillBody := cloneReqBody(reqBody)
-	h.prefillRequest = buildPrefillRequest(c.Request, prefillBody)
+	prefillRequest, err := buildPrefillRequest(c.Request, prefillBody)
+	if err != nil {
+		return 0, err
+	}
 
 	// Start prefill phase metrics and increment upstream request
 	if metricsRecorder != nil {
@@ -82,7 +85,7 @@ func (h *HTTPConnector) Proxy(c *gin.Context, reqBody map[string]interface{}, pr
 		metricsRecorder.IncActiveUpstreamRequests()
 	}
 
-	err := h.prefill(h.prefillRequest, prefillAddr)
+	err = h.prefill(prefillRequest, prefillAddr)
 
 	// End prefill phase metrics and handle upstream requests
 	if metricsRecorder != nil {
@@ -103,7 +106,7 @@ func (h *HTTPConnector) Proxy(c *gin.Context, reqBody map[string]interface{}, pr
 		return 0, err
 	}
 
-	result, decodeErr := h.decode(c, h.decodeRequest, decodeAddr)
+	result, decodeErr := h.decode(c, decodeRequest, decodeAddr)
 
 	// End decode phase metrics and decrement upstream request
 	if metricsRecorder != nil {

--- a/pkg/kthena-router/connectors/nixl.go
+++ b/pkg/kthena-router/connectors/nixl.go
@@ -33,9 +33,7 @@ import (
 
 // NIXLConnector implements high-performance distributed in-memory KV cache using NIXL
 type NIXLConnector struct {
-	name              string
-	prefillRequest    *http.Request
-	decodeRequestBody map[string]interface{}
+	name string
 }
 
 // NewNIXLConnector creates a new NIXL connector
@@ -62,9 +60,12 @@ func (n *NIXLConnector) Proxy(c *gin.Context, reqBody map[string]interface{}, pr
 
 	req := c.Request
 	prefillBody := cloneReqBody(reqBody)
-	n.prefillRequest = n.buildPrefillRequest(req, prefillBody)
+	prefillRequest, err := n.buildPrefillRequest(req, prefillBody)
+	if err != nil {
+		return 0, err
+	}
 	decodeBody := cloneReqBody(reqBody)
-	n.decodeRequestBody = addTokenUsage(c, decodeBody)
+	decodeRequestBody := addTokenUsage(c, decodeBody)
 
 	// Start prefill phase metrics and increment upstream request
 	if metricsRecorder != nil {
@@ -73,7 +74,7 @@ func (n *NIXLConnector) Proxy(c *gin.Context, reqBody map[string]interface{}, pr
 	}
 
 	// 1. send prefill request
-	kvTransferParams, err := n.prefill(n.prefillRequest, prefillAddr)
+	kvTransferParams, err := n.prefill(prefillRequest, prefillAddr)
 
 	// End prefill phase metrics and handle upstream requests
 	if metricsRecorder != nil {
@@ -95,7 +96,14 @@ func (n *NIXLConnector) Proxy(c *gin.Context, reqBody map[string]interface{}, pr
 	}
 
 	// 2. send decode request
-	decodeReq := n.buildDecodeRequest(c, n.decodeRequestBody, kvTransferParams)
+	decodeReq, err := n.buildDecodeRequest(c, decodeRequestBody, kvTransferParams)
+	if err != nil {
+		if metricsRecorder != nil {
+			metricsRecorder.FinishDecodePhase("500")
+			metricsRecorder.DecActiveUpstreamRequests()
+		}
+		return 0, err
+	}
 	result, decodeErr := n.decode(c, decodeReq, decodeAddr)
 
 	// End decode phase metrics and decrement upstream request
@@ -144,11 +152,11 @@ func (n *NIXLConnector) prefill(req *http.Request, prefillAddr string) (interfac
 	return kvTransferParams, nil
 }
 
-func (n *NIXLConnector) buildDecodeRequest(c *gin.Context, reqBody map[string]interface{}, kvTransferParams interface{}) *http.Request {
+func (n *NIXLConnector) buildDecodeRequest(c *gin.Context, reqBody map[string]interface{}, kvTransferParams interface{}) (*http.Request, error) {
 	reqBody["kv_transfer_params"] = kvTransferParams
 	body, err := json.Marshal(reqBody)
 	if err != nil {
-		return nil
+		return nil, fmt.Errorf("nixl connector: failed to marshal decode request body: %w", err)
 	}
 
 	// build request
@@ -157,7 +165,7 @@ func (n *NIXLConnector) buildDecodeRequest(c *gin.Context, reqBody map[string]in
 	reqCopy.Body = io.NopCloser(bytes.NewBuffer(body))
 	reqCopy.ContentLength = int64(len(body))
 
-	return reqCopy
+	return reqCopy, nil
 }
 
 // decode send decode request with streaming response
@@ -179,7 +187,7 @@ func cloneReqBody(reqBody map[string]interface{}) map[string]interface{} {
 	return clone
 }
 
-func (n *NIXLConnector) buildPrefillRequest(req *http.Request, reqBody map[string]interface{}) *http.Request {
+func (n *NIXLConnector) buildPrefillRequest(req *http.Request, reqBody map[string]interface{}) (*http.Request, error) {
 	// Prepare the body for a generic prefill request.
 	preparePrefillBody(reqBody)
 
@@ -191,8 +199,7 @@ func (n *NIXLConnector) buildPrefillRequest(req *http.Request, reqBody map[strin
 
 	body, err := json.Marshal(reqBody)
 	if err != nil {
-		klog.Errorf("Failed to marshal prefill request body: %v", err)
-		return nil
+		return nil, fmt.Errorf("nixl connector: failed to marshal prefill request body: %w", err)
 	}
 
 	prefillReq := req.Clone(req.Context())
@@ -200,5 +207,5 @@ func (n *NIXLConnector) buildPrefillRequest(req *http.Request, reqBody map[strin
 	prefillReq.Body = io.NopCloser(bytes.NewBuffer(body))
 	prefillReq.ContentLength = int64(len(body))
 
-	return prefillReq
+	return prefillReq, nil
 }

--- a/pkg/kthena-router/connectors/nixl_test.go
+++ b/pkg/kthena-router/connectors/nixl_test.go
@@ -18,10 +18,10 @@ package connectors
 
 import (
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -30,352 +30,215 @@ import (
 )
 
 func TestNIXLConnectorProxy(t *testing.T) {
-	// Test non-streaming request
-	t.Run("NonStreamingRequest", func(t *testing.T) {
-		connector := NewNIXLConnector()
+	t.Run("BuildsPrefillRequest", func(t *testing.T) {
+		connector := NewNIXLConnector().(*NIXLConnector)
+		req := httptest.NewRequest("POST", "/v1/chat/completions", nil)
 
-		// Create a proper test context with a valid HTTP request
-		req, _ := http.NewRequest("POST", "/v1/chat/completions", nil)
-		c, _ := gin.CreateTestContext(httptest.NewRecorder())
-		c.Request = req
-
-		reqBody := map[string]interface{}{
-			"model":      "test-model",
-			"max_tokens": 100,
+		prefillReq, err := connector.buildPrefillRequest(req, map[string]interface{}{
+			"model":                 "test-model",
+			"stream":                true,
+			"stream_options":        map[string]interface{}{"include_usage": true},
+			"max_tokens":            100,
+			"max_completion_tokens": 50,
 			"messages": []interface{}{
-				map[string]interface{}{
-					"role":    "user",
-					"content": "test message",
-				},
+				map[string]interface{}{"role": "user", "content": "test message"},
 			},
+		})
+		if err != nil {
+			t.Fatalf("buildPrefillRequest returned error: %v", err)
 		}
 
-		// The NIXL connector will fail due to network issues (prefill request)
-		_, err := connector.Proxy(c, reqBody, "localhost:8000", "localhost:8001")
-		if err == nil {
-			t.Error("Expected NIXL connector Proxy to return error due to network/connection issues")
+		prefillBody, err := parseRequestBody(prefillReq)
+		if err != nil {
+			t.Fatalf("Failed to parse prefill request body: %v", err)
 		}
 
-		// Verify that prefill request was built
-		nixlConn := connector.(*NIXLConnector)
-		if nixlConn.prefillRequest == nil {
-			t.Error("Expected prefill request to be built")
+		if maxTokens, ok := prefillBody["max_tokens"].(float64); !ok || maxTokens != 1 {
+			t.Errorf("Expected prefill max_tokens to be 1, got %v", prefillBody["max_tokens"])
+		}
+		if maxCompletionTokens, ok := prefillBody["max_completion_tokens"].(float64); !ok || maxCompletionTokens != 1 {
+			t.Errorf("Expected prefill max_completion_tokens to be 1, got %v", prefillBody["max_completion_tokens"])
+		}
+		if _, hasStream := prefillBody["stream"]; hasStream {
+			t.Error("Expected prefill request to remove stream")
+		}
+		if _, hasStreamOptions := prefillBody["stream_options"]; hasStreamOptions {
+			t.Error("Expected prefill request to remove stream_options")
+		}
+		if model := prefillBody["model"]; model != "test-model" {
+			t.Errorf("Expected prefill model to be preserved, got %v", model)
 		}
 
-		// Verify prefill request body
-		if nixlConn.prefillRequest != nil {
-			prefillBody, err := parseRequestBody(nixlConn.prefillRequest)
-			if err != nil {
-				t.Errorf("Failed to parse prefill request body: %v", err)
-			} else {
-				// Prefill request should have max_tokens set to 1
-				if maxTokens, ok := prefillBody["max_tokens"]; !ok {
-					t.Error("Expected prefill request to have max_tokens field")
-				} else if maxTokensFloat, ok := maxTokens.(float64); !ok || maxTokensFloat != 1.0 {
-					t.Errorf("Expected prefill request max_tokens to be 1, got %v", maxTokens)
-				}
-
-				// Prefill request should not have stream field
-				if _, hasStream := prefillBody["stream"]; hasStream {
-					t.Error("Expected prefill request to not have stream field")
-				}
-
-				// Prefill request should not have stream_options field
-				if _, hasStreamOptions := prefillBody["stream_options"]; hasStreamOptions {
-					t.Error("Expected prefill request to not have stream_options field")
-				}
-
-				// Should have kv_transfer_params for NIXL
-				if kvTransferParams, ok := prefillBody["kv_transfer_params"]; !ok {
-					t.Error("Expected prefill request to have kv_transfer_params field")
-				} else if params, isMap := kvTransferParams.(map[string]interface{}); !isMap {
-					t.Error("Expected kv_transfer_params to be a map")
-				} else {
-					// Verify NIXL-specific kv_transfer_params
-					if doRemoteDecode, ok := params["do_remote_decode"]; !ok || doRemoteDecode != true {
-						t.Errorf("Expected do_remote_decode to be true, got %v", doRemoteDecode)
-					}
-					if doRemotePrefill, ok := params["do_remote_prefill"]; !ok || doRemotePrefill != false {
-						t.Errorf("Expected do_remote_prefill to be false, got %v", doRemotePrefill)
-					}
-				}
-
-				// Should still have model and messages
-				if model, ok := prefillBody["model"]; !ok || model != "test-model" {
-					t.Errorf("Expected prefill request to have model 'test-model', got %v", model)
-				}
-			}
+		params, ok := prefillBody["kv_transfer_params"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("Expected kv_transfer_params to be a map, got %T", prefillBody["kv_transfer_params"])
 		}
-
-		// Verify decode request body was prepared (but not executed due to prefill failure)
-		if nixlConn.decodeRequestBody == nil {
-			t.Error("Expected decode request body to be prepared")
-		} else {
-			fmt.Println("Decode request body:", nixlConn.decodeRequestBody)
-			// Decode request should have include_usage set for non-streaming requests
-			if includeUsage, ok := nixlConn.decodeRequestBody["include_usage"]; !ok || includeUsage != true {
-				t.Errorf("Expected decode request body include_usage to be true, got %v", includeUsage)
-			}
-			// Should preserve original max_tokens
-			if maxTokens, ok := nixlConn.decodeRequestBody["max_tokens"]; !ok {
-				t.Error("Expected decode request body to have max_tokens field")
-			} else if maxTokens, ok := maxTokens.(int); !ok || maxTokens != 100 {
-				t.Errorf("Expected decode request body max_tokens to be 100, got %v", maxTokens)
-			}
+		if params["do_remote_decode"] != true {
+			t.Errorf("Expected do_remote_decode to be true, got %v", params["do_remote_decode"])
+		}
+		if params["do_remote_prefill"] != false {
+			t.Errorf("Expected do_remote_prefill to be false, got %v", params["do_remote_prefill"])
 		}
 	})
 
-	// Test streaming request
-	t.Run("StreamingRequest", func(t *testing.T) {
-		connector := NewNIXLConnector()
-
-		// Create a proper test context with a valid HTTP request
-		req, _ := http.NewRequest("POST", "/v1/chat/completions", nil)
+	t.Run("BuildsNonStreamingDecodeRequest", func(t *testing.T) {
+		connector := NewNIXLConnector().(*NIXLConnector)
+		req := httptest.NewRequest("POST", "/v1/chat/completions", nil)
 		c, _ := gin.CreateTestContext(httptest.NewRecorder())
 		c.Request = req
 
-		reqBody := map[string]interface{}{
+		decodeBody := addTokenUsage(c, map[string]interface{}{
+			"model":      "test-model",
+			"max_tokens": 100,
+		})
+
+		decodeReq, err := connector.buildDecodeRequest(c, decodeBody, map[string]interface{}{"cache": "ready"})
+		if err != nil {
+			t.Fatalf("buildDecodeRequest returned error: %v", err)
+		}
+
+		parsedBody, err := parseRequestBody(decodeReq)
+		if err != nil {
+			t.Fatalf("Failed to parse decode request body: %v", err)
+		}
+		if parsedBody["include_usage"] != true {
+			t.Errorf("Expected non-streaming decode request to include usage, got %v", parsedBody["include_usage"])
+		}
+		if maxTokens, ok := parsedBody["max_tokens"].(float64); !ok || maxTokens != 100 {
+			t.Errorf("Expected decode max_tokens to stay 100, got %v", parsedBody["max_tokens"])
+		}
+		if params, ok := parsedBody["kv_transfer_params"].(map[string]interface{}); !ok || params["cache"] != "ready" {
+			t.Errorf("Expected decode kv_transfer_params to be attached, got %v", parsedBody["kv_transfer_params"])
+		}
+	})
+
+	t.Run("BuildsStreamingDecodeRequest", func(t *testing.T) {
+		connector := NewNIXLConnector().(*NIXLConnector)
+		req := httptest.NewRequest("POST", "/v1/chat/completions", nil)
+		c, _ := gin.CreateTestContext(httptest.NewRecorder())
+		c.Request = req
+
+		decodeBody := addTokenUsage(c, map[string]interface{}{
 			"model":      "test-model",
 			"stream":     true,
 			"max_tokens": 100,
-			"messages": []interface{}{
-				map[string]interface{}{
-					"role":    "user",
-					"content": "test message",
-				},
-			},
-		}
-
-		// The NIXL connector will fail due to network issues
-		_, err := connector.Proxy(c, reqBody, "localhost:8000", "localhost:8001")
-		if err == nil {
-			t.Error("Expected NIXL connector Proxy to return error due to network/connection issues")
-		}
-
-		// Verify that prefill request was built
-		nixlConn := connector.(*NIXLConnector)
-		if nixlConn.prefillRequest == nil {
-			t.Error("Expected prefill request to be built")
-		}
-
-		// For streaming requests, verify that token usage context was set
+		})
 		if val, exists := c.Get(common.TokenUsageKey); !exists || val != true {
 			t.Error("Expected token usage to be set in context for streaming request")
 		}
 
-		// Verify prefill request body for streaming request
-		if nixlConn.prefillRequest != nil {
-			prefillBody, err := parseRequestBody(nixlConn.prefillRequest)
-			if err != nil {
-				t.Errorf("Failed to parse prefill request body: %v", err)
-			} else {
-				// Prefill request should have max_tokens set to 1
-				if maxTokens, ok := prefillBody["max_tokens"]; !ok {
-					t.Error("Expected prefill request to have max_tokens field")
-				} else if maxTokensFloat, ok := maxTokens.(float64); !ok || maxTokensFloat != 1.0 {
-					t.Errorf("Expected prefill request max_tokens to be 1, got %v", maxTokens)
-				}
-
-				// Prefill request should not have stream field (removed for prefill)
-				if _, hasStream := prefillBody["stream"]; hasStream {
-					t.Error("Expected prefill request to not have stream field")
-				}
-
-				// Prefill request should not have stream_options field (removed for prefill)
-				if _, hasStreamOptions := prefillBody["stream_options"]; hasStreamOptions {
-					t.Error("Expected prefill request to not have stream_options field")
-				}
-
-				// Should have NIXL-specific kv_transfer_params
-				if kvTransferParams, ok := prefillBody["kv_transfer_params"]; !ok {
-					t.Error("Expected prefill request to have kv_transfer_params field")
-				} else if params, isMap := kvTransferParams.(map[string]interface{}); !isMap {
-					t.Error("Expected kv_transfer_params to be a map")
-				} else {
-					if doRemoteDecode, ok := params["do_remote_decode"]; !ok || doRemoteDecode != true {
-						t.Errorf("Expected do_remote_decode to be true, got %v", doRemoteDecode)
-					}
-				}
-			}
+		decodeReq, err := connector.buildDecodeRequest(c, decodeBody, nil)
+		if err != nil {
+			t.Fatalf("buildDecodeRequest returned error: %v", err)
 		}
-
-		// Verify decode request body
-		if nixlConn.decodeRequestBody != nil {
-			// Decode request should preserve stream field
-			if stream, ok := nixlConn.decodeRequestBody["stream"]; !ok || stream != true {
-				t.Errorf("Expected decode request body stream to be true, got %v", stream)
-			}
-			// Decode request should have stream_options with include_usage added
-			if streamOptions, ok := nixlConn.decodeRequestBody["stream_options"]; !ok {
-				t.Error("Expected decode request body to have stream_options")
-			} else if opts, isMap := streamOptions.(map[string]interface{}); !isMap {
-				t.Error("Expected stream_options to be a map")
-			} else if includeUsage, ok := opts["include_usage"]; !ok || includeUsage != true {
-				t.Errorf("Expected stream_options include_usage to be true, got %v", includeUsage)
-			}
+		parsedBody, err := parseRequestBody(decodeReq)
+		if err != nil {
+			t.Fatalf("Failed to parse decode request body: %v", err)
+		}
+		if parsedBody["stream"] != true {
+			t.Errorf("Expected decode stream to stay true, got %v", parsedBody["stream"])
+		}
+		streamOptions, ok := parsedBody["stream_options"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("Expected stream_options to be a map, got %T", parsedBody["stream_options"])
+		}
+		if streamOptions["include_usage"] != true {
+			t.Errorf("Expected stream_options include_usage to be true, got %v", streamOptions["include_usage"])
 		}
 	})
 
-	// Test streaming request with existing stream_options
-	t.Run("StreamingRequestWithStreamOptions", func(t *testing.T) {
-		connector := NewNIXLConnector()
-
-		// Create a proper test context with a valid HTTP request
-		req, _ := http.NewRequest("POST", "/v1/chat/completions", nil)
+	t.Run("KeepsExistingStreamOptions", func(t *testing.T) {
+		connector := NewNIXLConnector().(*NIXLConnector)
+		req := httptest.NewRequest("POST", "/v1/chat/completions", nil)
 		c, _ := gin.CreateTestContext(httptest.NewRecorder())
 		c.Request = req
 
-		reqBody := map[string]interface{}{
-			"model":  "test-model",
-			"stream": true,
-			"stream_options": map[string]interface{}{
-				"include_usage": true,
-			},
-			"max_tokens": 100,
-			"messages": []interface{}{
-				map[string]interface{}{
-					"role":    "user",
-					"content": "test message",
-				},
-			},
-		}
-
-		// The NIXL connector will fail due to network issues
-		_, err := connector.Proxy(c, reqBody, "localhost:8000", "localhost:8001")
-		if err == nil {
-			t.Error("Expected NIXL connector Proxy to return error due to network/connection issues")
-		}
-
-		// For streaming requests with existing stream_options, token usage should not be added to context
+		decodeBody := addTokenUsage(c, map[string]interface{}{
+			"model":          "test-model",
+			"stream":         true,
+			"stream_options": map[string]interface{}{"include_usage": true},
+		})
 		if val, exists := c.Get(common.TokenUsageKey); exists && val == true {
-			t.Error("Did not expect token usage to be set in context when stream_options already exists")
+			t.Error("Did not expect token usage to be set when stream_options already requests usage")
 		}
 
-		// Verify decode request body preserves existing stream_options
-		nixlConn := connector.(*NIXLConnector)
-		if nixlConn.decodeRequestBody != nil {
-			if streamOptions, ok := nixlConn.decodeRequestBody["stream_options"]; !ok {
-				t.Error("Expected decode request body to preserve existing stream_options")
-			} else if opts, isMap := streamOptions.(map[string]interface{}); !isMap {
-				t.Error("Expected stream_options to be a map")
-			} else if includeUsage, ok := opts["include_usage"]; !ok || includeUsage != true {
-				t.Errorf("Expected existing stream_options include_usage to be preserved as true, got %v", includeUsage)
-			}
+		decodeReq, err := connector.buildDecodeRequest(c, decodeBody, nil)
+		if err != nil {
+			t.Fatalf("buildDecodeRequest returned error: %v", err)
 		}
-	})
-
-	// Test max_completion_tokens handling
-	t.Run("MaxCompletionTokensHandling", func(t *testing.T) {
-		connector := NewNIXLConnector()
-
-		// Create a proper test context with a valid HTTP request
-		req, _ := http.NewRequest("POST", "/v1/chat/completions", nil)
-		c, _ := gin.CreateTestContext(httptest.NewRecorder())
-		c.Request = req
-
-		reqBody := map[string]interface{}{
-			"model":                 "test-model",
-			"max_completion_tokens": 50,
-			"messages": []interface{}{
-				map[string]interface{}{
-					"role":    "user",
-					"content": "test message",
-				},
-			},
+		parsedBody, err := parseRequestBody(decodeReq)
+		if err != nil {
+			t.Fatalf("Failed to parse decode request body: %v", err)
 		}
-
-		// The NIXL connector will fail due to network issues
-		_, err := connector.Proxy(c, reqBody, "localhost:8000", "localhost:8001")
-		if err == nil {
-			t.Error("Expected NIXL connector Proxy to return error due to network/connection issues")
+		streamOptions, ok := parsedBody["stream_options"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("Expected stream_options to be a map, got %T", parsedBody["stream_options"])
 		}
-
-		// Verify prefill request handling of max_completion_tokens
-		nixlConn := connector.(*NIXLConnector)
-		if nixlConn.prefillRequest != nil {
-			prefillBody, err := parseRequestBody(nixlConn.prefillRequest)
-			if err != nil {
-				t.Errorf("Failed to parse prefill request body: %v", err)
-			} else {
-				// Prefill request should have max_tokens set to 1
-				if maxTokens, ok := prefillBody["max_tokens"]; !ok {
-					t.Error("Expected prefill request to have max_tokens field")
-				} else if maxTokensFloat, ok := maxTokens.(float64); !ok || maxTokensFloat != 1.0 {
-					t.Errorf("Expected prefill request max_tokens to be 1, got %v", maxTokens)
-				}
-				// Prefill request should have max_completion_tokens set to 1
-				if maxCompletionTokens, ok := prefillBody["max_completion_tokens"]; !ok {
-					t.Error("Expected prefill request to have max_completion_tokens field")
-				} else if maxCompletionTokensFloat, ok := maxCompletionTokens.(float64); !ok || maxCompletionTokensFloat != 1.0 {
-					t.Errorf("Expected prefill request max_completion_tokens to be 1, got %v", maxCompletionTokens)
-				}
-			}
-		}
-
-		// Verify decode request preserves original max_completion_tokens
-		if nixlConn.decodeRequestBody != nil {
-			if maxCompletionTokens, ok := nixlConn.decodeRequestBody["max_completion_tokens"]; !ok {
-				t.Error("Expected decode request body to have max_completion_tokens field")
-			} else if maxCompletionTokens, ok := maxCompletionTokens.(int); !ok || maxCompletionTokens != 50 {
-				t.Errorf("Expected decode request body max_completion_tokens to be 50, got %v", maxCompletionTokens)
-			}
+		if streamOptions["include_usage"] != true {
+			t.Errorf("Expected existing stream_options include_usage to be preserved, got %v", streamOptions["include_usage"])
 		}
 	})
+}
 
-	// Test NIXL-specific kv_transfer_params structure
-	t.Run("KVTransferParamsStructure", func(t *testing.T) {
-		connector := NewNIXLConnector()
+func TestNIXLConnectorBuildPrefillRequestMarshalError(t *testing.T) {
+	connector := NewNIXLConnector().(*NIXLConnector)
+	req := httptest.NewRequest("POST", "/v1/chat/completions", nil)
 
-		// Create a proper test context with a valid HTTP request
-		req, _ := http.NewRequest("POST", "/v1/chat/completions", nil)
-		c, _ := gin.CreateTestContext(httptest.NewRecorder())
-		c.Request = req
-
-		reqBody := map[string]interface{}{
-			"model": "test-model",
-			"messages": []interface{}{
-				map[string]interface{}{
-					"role":    "user",
-					"content": "test message",
-				},
-			},
-		}
-
-		// The NIXL connector will fail due to network issues
-		_, err := connector.Proxy(c, reqBody, "localhost:8000", "localhost:8001")
-		if err == nil {
-			t.Error("Expected NIXL connector Proxy to return error due to network/connection issues")
-		}
-
-		// Verify detailed kv_transfer_params structure in prefill request
-		nixlConn := connector.(*NIXLConnector)
-		if nixlConn.prefillRequest != nil {
-			prefillBody, err := parseRequestBody(nixlConn.prefillRequest)
-			if err != nil {
-				t.Errorf("Failed to parse prefill request body: %v", err)
-			} else {
-				if kvTransferParams, ok := prefillBody["kv_transfer_params"]; !ok {
-					t.Error("Expected prefill request to have kv_transfer_params field")
-				} else if params, isMap := kvTransferParams.(map[string]interface{}); !isMap {
-					t.Error("Expected kv_transfer_params to be a map")
-				} else {
-					// Verify all expected NIXL kv_transfer_params fields
-					expectedFields := map[string]interface{}{
-						"do_remote_decode":  true,
-						"do_remote_prefill": false,
-					}
-
-					for field, expectedValue := range expectedFields {
-						if actualValue, ok := params[field]; !ok {
-							t.Errorf("Expected kv_transfer_params to have field '%s'", field)
-						} else if actualValue != expectedValue {
-							t.Errorf("Expected kv_transfer_params['%s'] to be %v, got %v", field, expectedValue, actualValue)
-						}
-					}
-				}
-			}
-		}
+	result, err := connector.buildPrefillRequest(req, map[string]interface{}{
+		"model":       "test-model",
+		"bad_payload": make(chan struct{}),
 	})
+
+	if err == nil {
+		t.Fatal("Expected marshal error")
+	}
+	if result != nil {
+		t.Fatal("Expected nil request on marshal error")
+	}
+	if got := err.Error(); !strings.Contains(got, "failed to marshal prefill request body") {
+		t.Fatalf("Expected prefill marshal error, got %q", got)
+	}
+}
+
+func TestNIXLConnectorBuildDecodeRequestMarshalError(t *testing.T) {
+	connector := NewNIXLConnector().(*NIXLConnector)
+	req, _ := http.NewRequest("POST", "/v1/chat/completions", nil)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = req
+
+	result, err := connector.buildDecodeRequest(c, map[string]interface{}{
+		"model":       "test-model",
+		"bad_payload": func() {},
+	}, nil)
+
+	if err == nil {
+		t.Fatal("Expected marshal error")
+	}
+	if result != nil {
+		t.Fatal("Expected nil request on marshal error")
+	}
+	if got := err.Error(); !strings.Contains(got, "failed to marshal decode request body") {
+		t.Fatalf("Expected decode marshal error, got %q", got)
+	}
+}
+
+func TestNIXLConnectorProxyReturnsMarshalError(t *testing.T) {
+	connector := NewNIXLConnector()
+	req, _ := http.NewRequest("POST", "/v1/chat/completions", nil)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = req
+
+	_, err := connector.Proxy(c, map[string]interface{}{
+		"model":       "test-model",
+		"bad_payload": make(chan struct{}),
+	}, "127.0.0.1:1", "127.0.0.1:2")
+
+	if err == nil {
+		t.Fatal("Expected marshal error")
+	}
+	if got := err.Error(); !strings.Contains(got, "failed to marshal prefill request body") {
+		t.Fatalf("Expected prefill marshal error, got %q", got)
+	}
 }
 
 // TestNIXLConnectorRetryBodyNotDrained checks that calling Proxy() twice on the

--- a/pkg/kthena-router/connectors/transport.go
+++ b/pkg/kthena-router/connectors/transport.go
@@ -89,13 +89,13 @@ func preparePrefillBody(reqBody map[string]interface{}) {
 	}
 }
 
-func buildPrefillRequest(req *http.Request, modelRequest map[string]interface{}) *http.Request {
+func buildPrefillRequest(req *http.Request, modelRequest map[string]interface{}) (*http.Request, error) {
 	// In PD disaggregated mode, we need to send a prefill request to the prefill pod with non stream mode.
 	preparePrefillBody(modelRequest)
 
 	body, err := json.Marshal(modelRequest)
 	if err != nil {
-		return nil
+		return nil, fmt.Errorf("http connector: failed to marshal prefill request body: %w", err)
 	}
 
 	// build request
@@ -104,14 +104,14 @@ func buildPrefillRequest(req *http.Request, modelRequest map[string]interface{})
 	reqCopy.Body = io.NopCloser(bytes.NewBuffer(body))
 	reqCopy.ContentLength = int64(len(body))
 
-	return reqCopy
+	return reqCopy, nil
 }
 
-func BuildDecodeRequest(c *gin.Context, req *http.Request, modelRequest map[string]interface{}) *http.Request {
+func BuildDecodeRequest(c *gin.Context, req *http.Request, modelRequest map[string]interface{}) (*http.Request, error) {
 	modelRequest = addTokenUsage(c, modelRequest)
 	body, err := json.Marshal(modelRequest)
 	if err != nil {
-		return nil
+		return nil, fmt.Errorf("http connector: failed to marshal decode request body: %w", err)
 	}
 
 	reqCopy := req.Clone(req.Context())
@@ -119,7 +119,7 @@ func BuildDecodeRequest(c *gin.Context, req *http.Request, modelRequest map[stri
 	reqCopy.Body = io.NopCloser(bytes.NewBuffer(body))
 	reqCopy.ContentLength = int64(len(body))
 
-	return reqCopy
+	return reqCopy, nil
 }
 
 // addTokenUsage adds token usage to the request body if it is not already present

--- a/pkg/kthena-router/connectors/transport_test.go
+++ b/pkg/kthena-router/connectors/transport_test.go
@@ -257,13 +257,15 @@ func TestBuildPrefillRequest(t *testing.T) {
 			// Create a test HTTP request
 			originalReq := httptest.NewRequest("POST", "/test", nil)
 
-			result := buildPrefillRequest(originalReq, tt.modelRequest)
+			result, err := buildPrefillRequest(originalReq, tt.modelRequest)
 
 			if tt.expectNil {
+				require.Error(t, err)
 				assert.Nil(t, result)
 				return
 			}
 
+			require.NoError(t, err)
 			require.NotNil(t, result)
 
 			// Verify the request body was modified correctly
@@ -290,6 +292,18 @@ func TestBuildPrefillRequest(t *testing.T) {
 			assert.Equal(t, "http", result.URL.Scheme)
 		})
 	}
+}
+
+func TestBuildPrefillRequestMarshalError(t *testing.T) {
+	originalReq := httptest.NewRequest("POST", "/test", nil)
+	result, err := buildPrefillRequest(originalReq, map[string]interface{}{
+		"model":       "test-model",
+		"bad_payload": make(chan struct{}),
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "failed to marshal prefill request body")
 }
 
 func TestBuildDecodeRequest(t *testing.T) {
@@ -338,7 +352,8 @@ func TestBuildDecodeRequest(t *testing.T) {
 			// Create a test HTTP request
 			originalReq := httptest.NewRequest("POST", "/test", nil)
 
-			result := BuildDecodeRequest(c, originalReq, tt.modelRequest)
+			result, err := BuildDecodeRequest(c, originalReq, tt.modelRequest)
+			require.NoError(t, err)
 			require.NotNil(t, result)
 
 			// Verify the request body was modified correctly
@@ -371,6 +386,38 @@ func TestBuildDecodeRequest(t *testing.T) {
 			assert.Equal(t, "http", result.URL.Scheme)
 		})
 	}
+}
+
+func TestBuildDecodeRequestMarshalError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	originalReq := httptest.NewRequest("POST", "/test", nil)
+
+	result, err := BuildDecodeRequest(c, originalReq, map[string]interface{}{
+		"model":       "test-model",
+		"bad_payload": func() {},
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "failed to marshal decode request body")
+}
+
+func TestHTTPConnectorProxyReturnsMarshalError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	req := httptest.NewRequest("POST", "/v1/chat/completions", nil)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = req
+
+	connector := NewHTTPConnector()
+	_, err := connector.Proxy(c, map[string]interface{}{
+		"model":       "test-model",
+		"bad_payload": make(chan struct{}),
+	}, "127.0.0.1:1", "127.0.0.1:2")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to marshal decode request body")
 }
 
 func TestHandleNonStreamingResponse(t *testing.T) {

--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -720,6 +720,7 @@ func (r *Router) proxyModelEndpoint(
 ) error {
 	// Mark start of upstream processing
 	accesslog.MarkUpstreamStart(c)
+	defer accesslog.MarkUpstreamEnd(c)
 
 	// Get metrics recorder from context
 	var metricsRecorder *metrics.RequestMetricsRecorder
@@ -731,7 +732,10 @@ func (r *Router) proxyModelEndpoint(
 
 	// proxy to pd aggregated pod
 	if ctx.BestPods != nil {
-		decodeRequest := connectors.BuildDecodeRequest(c, req, modelRequest)
+		decodeRequest, err := connectors.BuildDecodeRequest(c, req, modelRequest)
+		if err != nil {
+			return fmt.Errorf("failed to build decode request: %w", err)
+		}
 		// build request
 		stream := isStreaming(modelRequest)
 		userID := ""
@@ -739,7 +743,7 @@ func (r *Router) proxyModelEndpoint(
 			userID = v
 		}
 		modelName := ctx.Model
-		err := r.proxy(c, decodeRequest, ctx, stream, port, func(resp handlers.OpenAIResponse) {
+		err = r.proxy(c, decodeRequest, ctx, stream, port, func(resp handlers.OpenAIResponse) {
 			if resp.Usage.TotalTokens <= 0 {
 				return
 			}
@@ -763,8 +767,6 @@ func (r *Router) proxyModelEndpoint(
 			_ = r.store.UpdateTokenCount(userID, modelName, float64(resp.Usage.PromptTokens), float64(resp.Usage.CompletionTokens))
 		})
 
-		// Mark end of upstream processing
-		accesslog.MarkUpstreamEnd(c)
 		return err
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fixes request builders in the HTTP and NIXL connector paths so marshal failures are returned as errors instead of silently returning a nil `*http.Request`.

Without this, callers can continue with a nil request and later panic while mutating it during prefill/decode proxying.

**Which issue(s) this PR fixes**:
Fixes #985 

**Special notes for your reviewer**:

This follows the safer pattern already used by the SGLang connector, where request builders return `(*http.Request, error)`.

Added regression tests for marshal failures in both helper-level and connector `Proxy` paths.

**Does this PR introduce a user-facing change?**

```release-note
NONE
