### PR TITLE
fix: correct rate limit token consumption in e2e tests

### DIFF
--- a/test/e2e/router/shared.go
+++ b/test/e2e/router/shared.go
@@ -690,8 +690,10 @@ func TestModelRouteWithRateLimitShared(t *testing.T, testCtx *routercontext.Rout
 
 		// First request: use CheckChatCompletions to handle router reconciliation
 		resp := utils.CheckChatCompletions(t, createdModelRoute.Spec.ModelName, standardMessage)
-		tokensConsumed := resp.Attempts * tokensPerRequest
-		t.Logf("Router reconciliation complete (consumed %d tokens in %d attempts)", tokensConsumed, resp.Attempts)
+		// CheckChatCompletions retries on transient failures (e.g., 404 before route is ready),
+		// but only the final successful request counts toward rate limit quota.
+		tokensConsumed := tokensPerRequest
+		t.Logf("Router reconciliation complete (consumed %d tokens, %d attempts including retries)", tokensConsumed, resp.Attempts)
 
 		// Calculate remaining quota
 		remainingQuota := inputTokenLimit - tokensConsumed
@@ -720,7 +722,7 @@ func TestModelRouteWithRateLimitShared(t *testing.T, testCtx *routercontext.Rout
 		assert.Contains(t, strings.ToLower(string(responseBody)), "rate limit",
 			"Rate limit error response must contain descriptive message")
 
-		t.Logf("Input token rate limit enforced after %d total requests", resp.Attempts+expectedSuccessfulRequests)
+		t.Logf("Input token rate limit enforced after %d quota-consuming requests", 1+expectedSuccessfulRequests)
 	})
 
 	// Test 2 Verify rate limit window accuracy and persistence
@@ -752,7 +754,9 @@ func TestModelRouteWithRateLimitShared(t *testing.T, testCtx *routercontext.Rout
 
 		// First request: handle reconciliation and track tokens
 		resp := utils.CheckChatCompletions(t, createdModelRoute.Spec.ModelName, standardMessage)
-		tokensConsumed := resp.Attempts * tokensPerRequest
+		// Only the final successful request counts toward rate limit quota.
+		tokensConsumed := tokensPerRequest
+		t.Logf("Router reconciliation complete (consumed %d tokens, %d attempts including retries)", tokensConsumed, resp.Attempts)
 
 		// Exhaust remaining quota
 		remainingQuota := inputTokenLimit - tokensConsumed
@@ -821,7 +825,9 @@ func TestModelRouteWithRateLimitShared(t *testing.T, testCtx *routercontext.Rout
 
 		// First request: handle reconciliation and track tokens
 		resp := utils.CheckChatCompletions(t, createdModelRoute.Spec.ModelName, standardMessage)
-		tokensConsumed := resp.Attempts * tokensPerRequest
+		// Only the final successful request counts toward rate limit quota.
+		tokensConsumed := tokensPerRequest
+		t.Logf("Router reconciliation complete (consumed %d tokens, %d attempts including retries)", tokensConsumed, resp.Attempts)
 
 		// Consume remaining quota
 		remainingQuota := inputTokenLimit - tokensConsumed


### PR DESCRIPTION
## Problem

The E2E test `TestModelRouteWithRateLimit/VerifyRateLimitWindowAccuracy` is flaky and fails intermittently in CI (GitHub Actions) while passing consistently in local environments.

**CI failure:**
```
Error Trace: test/e2e/router/shared.go:769
Error:      Not equal:
            expected: 429
            actual  : 200
Messages:   Rate limit should be active after exhausting quota
```

Related CI run: https://github.com/volcano-sh/kthena/actions/runs/25626660594/job/75222917196

Fixes #987

## Root Cause

`CheckChatCompletions` retries with exponential backoff on transient failures (e.g. 404 before ModelRoute is fully reconciled). The test incorrectly uses `resp.Attempts` to calculate token consumption:

```go
tokensConsumed := resp.Attempts * tokensPerRequest
```

However, **404 retries do not consume rate limit quota** — when the ModelRoute is not yet in the datastore, the rate limiter does not exist either, and the request is rejected before any token deduction occurs.

In CI (resource-constrained Kind clusters), this timing window is larger, causing `Attempts > 1`. The test then overestimates consumed tokens and sends too few follow-up requests, expecting rate limiting to be active when there is still quota remaining.

## Why This Fix

The key insight is understanding the **request lifecycle** in the router:

```
HandlerFunc() execution order:
1. ParseModelRequest          → extract model name from JSON body
2. RateLimit()                → consume tokens from rate limiter (if exists)
3. doLoadbalance()            → route matching + pod discovery
   └── MatchModelServer()     → 404 "route not found" if route not in datastore
```

When the ModelRoute is still being reconciled, it is **not yet in the datastore** (step 3 fails). The rate limiter is registered via the same `AddOrUpdateModelRoute` callback, so it also **does not exist** at this point. This means the 404 retry consumes **zero tokens** — the request is rejected in `MatchModelServer()` before ever reaching `RateLimit()`.

`CheckChatCompletions` is designed as a robust helper that hides retry complexity from callers. Its `Attempts` field reflects internal retry count (including failed attempts), not actual backend-quota-consuming requests. Using `resp.Attempts` for quota calculation conflates two different things:
- **Transport-level retries**: 404s due to timing, not counted by rate limiter
- **Application-level quota consumption**: only successful 200s that pass through `RateLimit()`

Therefore, `tokensConsumed` should reflect the latter — exactly one successful request — regardless of how many transport-level retries occurred.

## Changes

In `TestModelRouteWithRateLimitShared`, three subtests calculate token consumption after the initial `CheckChatCompletions` call:

**Before:**
```go
resp := utils.CheckChatCompletions(t, createdModelRoute.Spec.ModelName, standardMessage)
tokensConsumed := resp.Attempts * tokensPerRequest
```

**After:**
```go
resp := utils.CheckChatCompletions(t, createdModelRoute.Spec.ModelName, standardMessage)
// Only the final successful request counts toward rate limit quota.
tokensConsumed := tokensPerRequest
```

Also updated the log message to clarify "quota-consuming requests" instead of "total requests" for accuracy.

## Verification

- Local E2E tests continue to pass
- The fix eliminates the dependency on transient retry behavior during ModelRoute reconciliation