### PR TITLE
test: add unit tests for ModelRouteController and GatewayController

### DIFF
--- a/pkg/kthena-router/controller/gateway_controller_test.go
+++ b/pkg/kthena-router/controller/gateway_controller_test.go
@@ -1,0 +1,207 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayfake "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/fake"
+	gatewayinformers "sigs.k8s.io/gateway-api/pkg/client/informers/externalversions"
+
+	"github.com/volcano-sh/kthena/pkg/kthena-router/datastore"
+)
+
+func newTestGateway(name, namespace, gatewayClassName string) *gatewayv1.Gateway {
+	return &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: gatewayv1.ObjectName(gatewayClassName),
+			Listeners: []gatewayv1.Listener{
+				{
+					Name:     "http",
+					Port:     80,
+					Protocol: gatewayv1.HTTPProtocolType,
+				},
+			},
+		},
+	}
+}
+
+func TestGatewayController_Lifecycle(t *testing.T) {
+	gatewayClient := gatewayfake.NewSimpleClientset()
+	gatewayInformerFactory := gatewayinformers.NewSharedInformerFactory(gatewayClient, 0)
+	store := datastore.New()
+
+	controller := NewGatewayController(gatewayInformerFactory, store)
+
+	stop := make(chan struct{})
+	defer close(stop)
+	gatewayInformerFactory.Start(stop)
+
+	t.Run("GatewayCreate", func(t *testing.T) {
+		gw := newTestGateway("test-gateway", "default", DefaultGatewayClassName)
+
+		_, err := gatewayClient.GatewayV1().Gateways("default").Create(
+			context.Background(), gw, metav1.CreateOptions{})
+		assert.NoError(t, err)
+
+		if !waitForCacheSync(t, 5*time.Second, controller.gatewaySynced) {
+			t.Fatal("Failed to sync caches within timeout")
+		}
+
+		found := waitForObjectInCache(t, 2*time.Second, func() bool {
+			_, err := controller.gatewayLister.Gateways("default").Get("test-gateway")
+			return err == nil
+		})
+		assert.True(t, found, "Gateway should be in cache")
+
+		err = controller.syncHandler("default/test-gateway")
+		assert.NoError(t, err)
+
+		stored := store.GetGateway("default/test-gateway")
+		assert.NotNil(t, stored)
+		assert.Equal(t, "test-gateway", stored.Name)
+	})
+
+	t.Run("GatewayUpdate", func(t *testing.T) {
+		existing, err := gatewayClient.GatewayV1().Gateways("default").Get(
+			context.Background(), "test-gateway", metav1.GetOptions{})
+		assert.NoError(t, err)
+
+		updated := existing.DeepCopy()
+		updated.Spec.Listeners[0].Port = 8080
+
+		_, err = gatewayClient.GatewayV1().Gateways("default").Update(
+			context.Background(), updated, metav1.UpdateOptions{})
+		assert.NoError(t, err)
+
+		found := waitForObjectInCache(t, 2*time.Second, func() bool {
+			gw, err := controller.gatewayLister.Gateways("default").Get("test-gateway")
+			return err == nil && gw.Spec.Listeners[0].Port == 8080
+		})
+		assert.True(t, found, "Gateway update should be reflected in cache")
+
+		err = controller.syncHandler("default/test-gateway")
+		assert.NoError(t, err)
+
+		stored := store.GetGateway("default/test-gateway")
+		assert.NotNil(t, stored)
+		assert.Equal(t, gatewayv1.PortNumber(8080), stored.Spec.Listeners[0].Port)
+	})
+
+	t.Run("GatewayDelete", func(t *testing.T) {
+		err := gatewayClient.GatewayV1().Gateways("default").Delete(
+			context.Background(), "test-gateway", metav1.DeleteOptions{})
+		assert.NoError(t, err)
+
+		waitForObjectInCache(t, 2*time.Second, func() bool {
+			_, err := controller.gatewayLister.Gateways("default").Get("test-gateway")
+			return err != nil
+		})
+
+		err = controller.syncHandler("default/test-gateway")
+		assert.NoError(t, err)
+
+		stored := store.GetGateway("default/test-gateway")
+		assert.Nil(t, stored)
+	})
+}
+
+func TestGatewayController_GatewayClassFilter(t *testing.T) {
+	gatewayClient := gatewayfake.NewSimpleClientset()
+	gatewayInformerFactory := gatewayinformers.NewSharedInformerFactory(gatewayClient, 0)
+	store := datastore.New()
+
+	controller := NewGatewayController(gatewayInformerFactory, store)
+
+	stop := make(chan struct{})
+	defer close(stop)
+	gatewayInformerFactory.Start(stop)
+
+	if !waitForCacheSync(t, 5*time.Second, controller.gatewaySynced) {
+		t.Fatal("Failed to sync caches within timeout")
+	}
+
+	t.Run("NonKthenaGatewayNotStored", func(t *testing.T) {
+		gw := newTestGateway("other-gateway", "default", "other-gateway-class")
+
+		_, err := gatewayClient.GatewayV1().Gateways("default").Create(
+			context.Background(), gw, metav1.CreateOptions{})
+		assert.NoError(t, err)
+
+		// syncHandler still works but store should not be called for non-kthena gateways
+		// via the filter — directly calling syncHandler will still store it,
+		// but the event handler won't enqueue it
+		stored := store.GetGateway("default/other-gateway")
+		assert.Nil(t, stored, "Non-kthena gateway should not be in store via event handler")
+	})
+}
+
+func TestGatewayController_ErrorHandling(t *testing.T) {
+	gatewayClient := gatewayfake.NewSimpleClientset()
+	gatewayInformerFactory := gatewayinformers.NewSharedInformerFactory(gatewayClient, 0)
+	store := datastore.New()
+
+	controller := NewGatewayController(gatewayInformerFactory, store)
+
+	stop := make(chan struct{})
+	defer close(stop)
+	gatewayInformerFactory.Start(stop)
+
+	t.Run("InvalidKey", func(t *testing.T) {
+		err := controller.syncHandler("invalid/key/format")
+		assert.NoError(t, err)
+	})
+
+	t.Run("NonExistentGateway", func(t *testing.T) {
+		err := controller.syncHandler("default/non-existent")
+		assert.NoError(t, err)
+	})
+}
+
+func TestGatewayController_WorkQueueProcessing(t *testing.T) {
+	gatewayClient := gatewayfake.NewSimpleClientset()
+	gatewayInformerFactory := gatewayinformers.NewSharedInformerFactory(gatewayClient, 0)
+	store := datastore.New()
+
+	controller := NewGatewayController(gatewayInformerFactory, store)
+
+	stop := make(chan struct{})
+	defer close(stop)
+	gatewayInformerFactory.Start(stop)
+
+	t.Run("InitialSyncSignal", func(t *testing.T) {
+		assert.False(t, controller.HasSynced())
+		controller.workqueue.Add(initialSyncSignal)
+		controller.processNextWorkItem()
+		assert.True(t, controller.HasSynced())
+	})
+
+	t.Run("UnknownResourceType", func(t *testing.T) {
+		controller.workqueue.Add(12345)
+		result := controller.processNextWorkItem()
+		assert.True(t, result)
+	})
+}

--- a/pkg/kthena-router/controller/gateway_controller_test.go
+++ b/pkg/kthena-router/controller/gateway_controller_test.go
@@ -145,17 +145,23 @@ func TestGatewayController_GatewayClassFilter(t *testing.T) {
 	}
 
 	t.Run("NonKthenaGatewayNotStored", func(t *testing.T) {
-		gw := newTestGateway("other-gateway", "default", "other-gateway-class")
+		// we will first drain the workqueuee here
+		for controller.workqueue.Len() > 0 {
+			controller.processNextWorkItem()
+		}
 
+		gw := newTestGateway("other-gateway", "default", "other-gateway-class")
 		_, err := gatewayClient.GatewayV1().Gateways("default").Create(
 			context.Background(), gw, metav1.CreateOptions{})
 		assert.NoError(t, err)
 
-		// syncHandler still works but store should not be called for non-kthena gateways
-		// via the filter — directly calling syncHandler will still store it,
-		// but the event handler won't enqueue it
+		// wait and verify the non-kthena gateway was not enqueued
+		time.Sleep(100 * time.Millisecond)
+		assert.Equal(t, 0, controller.workqueue.Len(),
+			"Non-kthena gateway should not be enqueued by the filter")
+
 		stored := store.GetGateway("default/other-gateway")
-		assert.Nil(t, stored, "Non-kthena gateway should not be in store via event handler")
+		assert.Nil(t, stored, "Non-kthena gateway should not be in store")
 	})
 }
 

--- a/pkg/kthena-router/controller/gateway_controller_test.go
+++ b/pkg/kthena-router/controller/gateway_controller_test.go
@@ -61,6 +61,8 @@ func TestGatewayController_Lifecycle(t *testing.T) {
 	gatewayInformerFactory.Start(stop)
 
 	t.Run("GatewayCreate", func(t *testing.T) {
+		// Verifies that creating a kthena-router Gateway appears in the
+		// informer cache and gets synced into the datastore
 		gw := newTestGateway("test-gateway", "default", DefaultGatewayClassName)
 
 		_, err := gatewayClient.GatewayV1().Gateways("default").Create(
@@ -86,6 +88,8 @@ func TestGatewayController_Lifecycle(t *testing.T) {
 	})
 
 	t.Run("GatewayUpdate", func(t *testing.T) {
+		// Verifies that updating a Gateway spec is reflected in the
+		// informer cache and datastore after syncHandler is called
 		existing, err := gatewayClient.GatewayV1().Gateways("default").Get(
 			context.Background(), "test-gateway", metav1.GetOptions{})
 		assert.NoError(t, err)
@@ -112,14 +116,17 @@ func TestGatewayController_Lifecycle(t *testing.T) {
 	})
 
 	t.Run("GatewayDelete", func(t *testing.T) {
+		// Verifies that deleting a Gateway removes it from the informer
+		// cache and the datastore after syncHandler is called.
 		err := gatewayClient.GatewayV1().Gateways("default").Delete(
 			context.Background(), "test-gateway", metav1.DeleteOptions{})
 		assert.NoError(t, err)
 
-		waitForObjectInCache(t, 2*time.Second, func() bool {
+		found := waitForObjectInCache(t, 2*time.Second, func() bool {
 			_, err := controller.gatewayLister.Gateways("default").Get("test-gateway")
 			return err != nil
 		})
+		assert.True(t, found, "Gateway should be removed from cache")
 
 		err = controller.syncHandler("default/test-gateway")
 		assert.NoError(t, err)
@@ -145,7 +152,9 @@ func TestGatewayController_GatewayClassFilter(t *testing.T) {
 	}
 
 	t.Run("NonKthenaGatewayNotStored", func(t *testing.T) {
-		// we will first drain the workqueuee here
+		// Verifies that the FilteringResourceEventHandler only enqueues Gateways
+		// with DefaultGatewayClassName. A Gateway with a different class should
+		// not appear in the workqueue after the informer processes it.
 		for controller.workqueue.Len() > 0 {
 			controller.processNextWorkItem()
 		}
@@ -155,7 +164,7 @@ func TestGatewayController_GatewayClassFilter(t *testing.T) {
 			context.Background(), gw, metav1.CreateOptions{})
 		assert.NoError(t, err)
 
-		// wait and verify the non-kthena gateway was not enqueued
+		// Wait for informer to process the event, then check workqueue is empty.
 		time.Sleep(100 * time.Millisecond)
 		assert.Equal(t, 0, controller.workqueue.Len(),
 			"Non-kthena gateway should not be enqueued by the filter")
@@ -177,11 +186,13 @@ func TestGatewayController_ErrorHandling(t *testing.T) {
 	gatewayInformerFactory.Start(stop)
 
 	t.Run("InvalidKey", func(t *testing.T) {
+		// Verifies that a malformed key is handled gracefully without error.
 		err := controller.syncHandler("invalid/key/format")
 		assert.NoError(t, err)
 	})
 
 	t.Run("NonExistentGateway", func(t *testing.T) {
+		// Verifies that syncing a non-existent key is a no-op without error.
 		err := controller.syncHandler("default/non-existent")
 		assert.NoError(t, err)
 	})
@@ -199,6 +210,8 @@ func TestGatewayController_WorkQueueProcessing(t *testing.T) {
 	gatewayInformerFactory.Start(stop)
 
 	t.Run("InitialSyncSignal", func(t *testing.T) {
+		// Verifies that the initialSyncSignal sentinel marks the controller
+		// as synced via HasSynced().
 		assert.False(t, controller.HasSynced())
 		controller.workqueue.Add(initialSyncSignal)
 		controller.processNextWorkItem()
@@ -206,6 +219,8 @@ func TestGatewayController_WorkQueueProcessing(t *testing.T) {
 	})
 
 	t.Run("UnknownResourceType", func(t *testing.T) {
+		// Verifies that an unexpected workqueue item type is dropped
+		// without crashing the worker.
 		controller.workqueue.Add(12345)
 		result := controller.processNextWorkItem()
 		assert.True(t, result)

--- a/pkg/kthena-router/controller/gateway_controller_test.go
+++ b/pkg/kthena-router/controller/gateway_controller_test.go
@@ -164,12 +164,15 @@ func TestGatewayController_GatewayClassFilter(t *testing.T) {
 			context.Background(), gw, metav1.CreateOptions{})
 		assert.NoError(t, err)
 
-		// Wait for informer to process the event, then check workqueue is empty.
-		// Poll with a timeout instead of sleeping to deterministically verify
-		// the non-kthena gateway is never enqueued.
-		assert.Eventually(t, func() bool {
-			return controller.workqueue.Len() == 0
-		}, 1*time.Second, 10*time.Millisecond,
+		// Wait for the Gateway to appear in the informer cache first,
+		// then verify it is never enqueued.
+		waitForObjectInCache(t, 2*time.Second, func() bool {
+			_, err := controller.gatewayLister.Gateways("default").Get("other-gateway")
+			return err == nil
+		})
+		assert.Never(t, func() bool {
+			return controller.workqueue.Len() > 0
+		}, 500*time.Millisecond, 10*time.Millisecond,
 			"Non-kthena gateway should not be enqueued by the filter")
 
 		stored := store.GetGateway("default/other-gateway")

--- a/pkg/kthena-router/controller/gateway_controller_test.go
+++ b/pkg/kthena-router/controller/gateway_controller_test.go
@@ -165,8 +165,11 @@ func TestGatewayController_GatewayClassFilter(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Wait for informer to process the event, then check workqueue is empty.
-		time.Sleep(100 * time.Millisecond)
-		assert.Equal(t, 0, controller.workqueue.Len(),
+		// Poll with a timeout instead of sleeping to deterministically verify
+		// the non-kthena gateway is never enqueued.
+		assert.Eventually(t, func() bool {
+			return controller.workqueue.Len() == 0
+		}, 1*time.Second, 10*time.Millisecond,
 			"Non-kthena gateway should not be enqueued by the filter")
 
 		stored := store.GetGateway("default/other-gateway")

--- a/pkg/kthena-router/controller/modelroute_controller_test.go
+++ b/pkg/kthena-router/controller/modelroute_controller_test.go
@@ -93,7 +93,14 @@ func TestModelRouteController_Lifecycle(t *testing.T) {
 		assert.NoError(t, err)
 
 		updated := existing.DeepCopy()
-		updated.Spec.ModelName = "updated-model"
+		updated.Spec.Rules = []*aiv1alpha1.Rule{
+			{
+				Name: "rule-updated",
+				TargetModels: []*aiv1alpha1.TargetModel{
+					{ModelServerName: "updated-server"},
+				},
+			},
+		}
 
 		_, err = kthenaClient.NetworkingV1alpha1().ModelRoutes("default").Update(
 			context.Background(), updated, metav1.UpdateOptions{})
@@ -110,7 +117,7 @@ func TestModelRouteController_Lifecycle(t *testing.T) {
 
 		storedRoute := store.GetModelRoute("default/test-modelroute")
 		assert.NotNil(t, storedRoute)
-		assert.Equal(t, "updated-model", storedRoute.Spec.ModelName)
+		assert.Equal(t, "updated-server", storedRoute.Spec.Rules[0].TargetModels[0].ModelServerName)
 	})
 
 	// verifies that deleting a ModelRoute removes it from the informer

--- a/pkg/kthena-router/controller/modelroute_controller_test.go
+++ b/pkg/kthena-router/controller/modelroute_controller_test.go
@@ -41,6 +41,8 @@ func TestModelRouteController_Lifecycle(t *testing.T) {
 	defer close(stop)
 	kthenaInformerFactory.Start(stop)
 
+	//this block verifies that creating a ModelRoute via fake client causes it to
+	//appear in the informer cache and get synced into the datastore.
 	t.Run("ModelRouteCreate", func(t *testing.T) {
 		mr := &aiv1alpha1.ModelRoute{
 			ObjectMeta: metav1.ObjectMeta{
@@ -83,6 +85,8 @@ func TestModelRouteController_Lifecycle(t *testing.T) {
 		assert.Equal(t, "test-model", storedRoute.Spec.ModelName)
 	})
 
+	//this will verify that updating a ModelRoute's spec is reflected in the
+	//informer cache and the datastore after syncHandlerr is called.
 	t.Run("ModelRouteUpdate", func(t *testing.T) {
 		existing, err := kthenaClient.NetworkingV1alpha1().ModelRoutes("default").Get(
 			context.Background(), "test-modelroute", metav1.GetOptions{})
@@ -109,6 +113,8 @@ func TestModelRouteController_Lifecycle(t *testing.T) {
 		assert.Equal(t, "updated-model", storedRoute.Spec.ModelName)
 	})
 
+	//Verifies that deleting a ModelRoute removes it from the informer
+	//cache and datastore after syncHandler is called.
 	t.Run("ModelRouteDelete", func(t *testing.T) {
 		err := kthenaClient.NetworkingV1alpha1().ModelRoutes("default").Delete(
 			context.Background(), "test-modelroute", metav1.DeleteOptions{})
@@ -138,11 +144,14 @@ func TestModelRouteController_ErrorHandling(t *testing.T) {
 	defer close(stop)
 	kthenaInformerFactory.Start(stop)
 
+	//this will verify if a malformed key is handled without returning an error
 	t.Run("InvalidKey", func(t *testing.T) {
 		err := controller.syncHandler("invalid/key/format")
 		assert.NoError(t, err)
 	})
 
+	//this will verify that syncing a key for a resource that doesnt exist
+	// is a no-op and doesnt return an error
 	t.Run("NonExistentModelRoute", func(t *testing.T) {
 		err := controller.syncHandler("default/non-existent")
 		assert.NoError(t, err)
@@ -160,6 +169,8 @@ func TestModelRouteController_WorkQueueProcessing(t *testing.T) {
 	defer close(stop)
 	kthenaInformerFactory.Start(stop)
 
+	//verifies that processing the initialSyncSignal sentinel value
+	//marks the controller as synced via HasSynced()
 	t.Run("InitialSyncSignal", func(t *testing.T) {
 		assert.False(t, controller.HasSynced())
 		controller.workqueue.Add(initialSyncSignal)
@@ -167,6 +178,7 @@ func TestModelRouteController_WorkQueueProcessing(t *testing.T) {
 		assert.True(t, controller.HasSynced())
 	})
 
+	//verifies thqat an unexpected type in the workqueue is dropped without crashing the worker
 	t.Run("UnknownResourceType", func(t *testing.T) {
 		controller.workqueue.Add(12345)
 		result := controller.processNextWorkItem()

--- a/pkg/kthena-router/controller/modelroute_controller_test.go
+++ b/pkg/kthena-router/controller/modelroute_controller_test.go
@@ -1,0 +1,175 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	kthenafake "github.com/volcano-sh/kthena/client-go/clientset/versioned/fake"
+	informersv1alpha1 "github.com/volcano-sh/kthena/client-go/informers/externalversions"
+	aiv1alpha1 "github.com/volcano-sh/kthena/pkg/apis/networking/v1alpha1"
+	"github.com/volcano-sh/kthena/pkg/kthena-router/datastore"
+)
+
+func TestModelRouteController_Lifecycle(t *testing.T) {
+	kthenaClient := kthenafake.NewSimpleClientset()
+	kthenaInformerFactory := informersv1alpha1.NewSharedInformerFactory(kthenaClient, 0)
+	store := datastore.New()
+
+	controller := NewModelRouteController(kthenaInformerFactory, store)
+
+	stop := make(chan struct{})
+	defer close(stop)
+	kthenaInformerFactory.Start(stop)
+
+	t.Run("ModelRouteCreate", func(t *testing.T) {
+		mr := &aiv1alpha1.ModelRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "test-modelroute",
+			},
+			Spec: aiv1alpha1.ModelRouteSpec{
+				ModelName: "test-model",
+				Rules: []*aiv1alpha1.Rule{
+					{
+						Name: "rule-1",
+						TargetModels: []*aiv1alpha1.TargetModel{
+							{ModelServerName: "test-server"},
+						},
+					},
+				},
+			},
+		}
+
+		_, err := kthenaClient.NetworkingV1alpha1().ModelRoutes("default").Create(
+			context.Background(), mr, metav1.CreateOptions{})
+		assert.NoError(t, err)
+
+		if !waitForCacheSync(t, 5*time.Second, controller.modelRouteSynced) {
+			t.Fatal("Failed to sync caches within timeout")
+		}
+
+		found := waitForObjectInCache(t, 2*time.Second, func() bool {
+			_, err := controller.modelRouteLister.ModelRoutes("default").Get("test-modelroute")
+			return err == nil
+		})
+		assert.True(t, found, "ModelRoute should be in cache")
+
+		key := "default/test-modelroute"
+		err = controller.syncHandler(key)
+		assert.NoError(t, err)
+
+		storedRoute := store.GetModelRoute("default/test-modelroute")
+		assert.NotNil(t, storedRoute)
+		assert.Equal(t, "test-model", storedRoute.Spec.ModelName)
+	})
+
+	t.Run("ModelRouteUpdate", func(t *testing.T) {
+		existing, err := kthenaClient.NetworkingV1alpha1().ModelRoutes("default").Get(
+			context.Background(), "test-modelroute", metav1.GetOptions{})
+		assert.NoError(t, err)
+
+		updated := existing.DeepCopy()
+		updated.Spec.ModelName = "updated-model"
+
+		_, err = kthenaClient.NetworkingV1alpha1().ModelRoutes("default").Update(
+			context.Background(), updated, metav1.UpdateOptions{})
+		assert.NoError(t, err)
+
+		found := waitForObjectInCache(t, 2*time.Second, func() bool {
+			mr, err := controller.modelRouteLister.ModelRoutes("default").Get("test-modelroute")
+			return err == nil && mr.Spec.ModelName == "updated-model"
+		})
+		assert.True(t, found, "ModelRoute update should be reflected in cache")
+
+		err = controller.syncHandler("default/test-modelroute")
+		assert.NoError(t, err)
+
+		storedRoute := store.GetModelRoute("default/test-modelroute")
+		assert.NotNil(t, storedRoute)
+		assert.Equal(t, "updated-model", storedRoute.Spec.ModelName)
+	})
+
+	t.Run("ModelRouteDelete", func(t *testing.T) {
+		err := kthenaClient.NetworkingV1alpha1().ModelRoutes("default").Delete(
+			context.Background(), "test-modelroute", metav1.DeleteOptions{})
+		assert.NoError(t, err)
+
+		waitForObjectInCache(t, 2*time.Second, func() bool {
+			_, err := controller.modelRouteLister.ModelRoutes("default").Get("test-modelroute")
+			return err != nil
+		})
+
+		err = controller.syncHandler("default/test-modelroute")
+		assert.NoError(t, err)
+
+		storedRoute := store.GetModelRoute("default/test-modelroute")
+		assert.Nil(t, storedRoute)
+	})
+}
+
+func TestModelRouteController_ErrorHandling(t *testing.T) {
+	kthenaClient := kthenafake.NewSimpleClientset()
+	kthenaInformerFactory := informersv1alpha1.NewSharedInformerFactory(kthenaClient, 0)
+	store := datastore.New()
+
+	controller := NewModelRouteController(kthenaInformerFactory, store)
+
+	stop := make(chan struct{})
+	defer close(stop)
+	kthenaInformerFactory.Start(stop)
+
+	t.Run("InvalidKey", func(t *testing.T) {
+		err := controller.syncHandler("invalid/key/format")
+		assert.NoError(t, err)
+	})
+
+	t.Run("NonExistentModelRoute", func(t *testing.T) {
+		err := controller.syncHandler("default/non-existent")
+		assert.NoError(t, err)
+	})
+}
+
+func TestModelRouteController_WorkQueueProcessing(t *testing.T) {
+	kthenaClient := kthenafake.NewSimpleClientset()
+	kthenaInformerFactory := informersv1alpha1.NewSharedInformerFactory(kthenaClient, 0)
+	store := datastore.New()
+
+	controller := NewModelRouteController(kthenaInformerFactory, store)
+
+	stop := make(chan struct{})
+	defer close(stop)
+	kthenaInformerFactory.Start(stop)
+
+	t.Run("InitialSyncSignal", func(t *testing.T) {
+		assert.False(t, controller.HasSynced())
+		controller.workqueue.Add(initialSyncSignal)
+		controller.processNextWorkItem()
+		assert.True(t, controller.HasSynced())
+	})
+
+	t.Run("UnknownResourceType", func(t *testing.T) {
+		controller.workqueue.Add(12345)
+		result := controller.processNextWorkItem()
+		assert.True(t, result)
+	})
+}

--- a/pkg/kthena-router/controller/modelroute_controller_test.go
+++ b/pkg/kthena-router/controller/modelroute_controller_test.go
@@ -41,8 +41,8 @@ func TestModelRouteController_Lifecycle(t *testing.T) {
 	defer close(stop)
 	kthenaInformerFactory.Start(stop)
 
-	//this block verifies that creating a ModelRoute via fake client causes it to
-	//appear in the informer cache and get synced into the datastore.
+	// this block verifies that creating a ModelRoute via fake client causes it to
+	// appear in the informer cache and get synced into the datastore.
 	t.Run("ModelRouteCreate", func(t *testing.T) {
 		mr := &aiv1alpha1.ModelRoute{
 			ObjectMeta: metav1.ObjectMeta{
@@ -85,8 +85,8 @@ func TestModelRouteController_Lifecycle(t *testing.T) {
 		assert.Equal(t, "test-model", storedRoute.Spec.ModelName)
 	})
 
-	//this will verify that updating a ModelRoute's spec is reflected in the
-	//informer cache and the datastore after syncHandlerr is called.
+	// this will verify that updating a ModelRoute spec is reflected in the
+	// informer cache and the datastore after syncHandler is called.
 	t.Run("ModelRouteUpdate", func(t *testing.T) {
 		existing, err := kthenaClient.NetworkingV1alpha1().ModelRoutes("default").Get(
 			context.Background(), "test-modelroute", metav1.GetOptions{})
@@ -113,17 +113,18 @@ func TestModelRouteController_Lifecycle(t *testing.T) {
 		assert.Equal(t, "updated-model", storedRoute.Spec.ModelName)
 	})
 
-	//Verifies that deleting a ModelRoute removes it from the informer
-	//cache and datastore after syncHandler is called.
+	// verifies that deleting a ModelRoute removes it from the informer
+	// cache and datastore after syncHandler is called.
 	t.Run("ModelRouteDelete", func(t *testing.T) {
 		err := kthenaClient.NetworkingV1alpha1().ModelRoutes("default").Delete(
 			context.Background(), "test-modelroute", metav1.DeleteOptions{})
 		assert.NoError(t, err)
 
-		waitForObjectInCache(t, 2*time.Second, func() bool {
+		found := waitForObjectInCache(t, 2*time.Second, func() bool {
 			_, err := controller.modelRouteLister.ModelRoutes("default").Get("test-modelroute")
 			return err != nil
 		})
+		assert.True(t, found, "ModelRoute should be removed from cache")
 
 		err = controller.syncHandler("default/test-modelroute")
 		assert.NoError(t, err)
@@ -144,14 +145,14 @@ func TestModelRouteController_ErrorHandling(t *testing.T) {
 	defer close(stop)
 	kthenaInformerFactory.Start(stop)
 
-	//this will verify if a malformed key is handled without returning an error
+	// this will verify if a malformed key is handled without returning an error
 	t.Run("InvalidKey", func(t *testing.T) {
 		err := controller.syncHandler("invalid/key/format")
 		assert.NoError(t, err)
 	})
 
-	//this will verify that syncing a key for a resource that doesnt exist
-	// is a no-op and doesnt return an error
+	// this will verify that syncing a key for a resource that does not exist
+	// is a no-op and does not return an error
 	t.Run("NonExistentModelRoute", func(t *testing.T) {
 		err := controller.syncHandler("default/non-existent")
 		assert.NoError(t, err)
@@ -169,8 +170,8 @@ func TestModelRouteController_WorkQueueProcessing(t *testing.T) {
 	defer close(stop)
 	kthenaInformerFactory.Start(stop)
 
-	//verifies that processing the initialSyncSignal sentinel value
-	//marks the controller as synced via HasSynced()
+	// verifies that processing the initialSyncSignal sentinel value
+	// marks the controller as synced via HasSynced()
 	t.Run("InitialSyncSignal", func(t *testing.T) {
 		assert.False(t, controller.HasSynced())
 		controller.workqueue.Add(initialSyncSignal)
@@ -178,7 +179,7 @@ func TestModelRouteController_WorkQueueProcessing(t *testing.T) {
 		assert.True(t, controller.HasSynced())
 	})
 
-	//verifies thqat an unexpected type in the workqueue is dropped without crashing the worker
+	// verifies that an unexpected type in the workqueue is dropped without crashing the worker
 	t.Run("UnknownResourceType", func(t *testing.T) {
 		controller.workqueue.Add(12345)
 		result := controller.processNextWorkItem()

--- a/pkg/kthena-router/controller/modelroute_controller_test.go
+++ b/pkg/kthena-router/controller/modelroute_controller_test.go
@@ -108,7 +108,7 @@ func TestModelRouteController_Lifecycle(t *testing.T) {
 
 		found := waitForObjectInCache(t, 2*time.Second, func() bool {
 			mr, err := controller.modelRouteLister.ModelRoutes("default").Get("test-modelroute")
-			return err == nil && mr.Spec.ModelName == "updated-model"
+			return err == nil && len(mr.Spec.Rules) > 0 && mr.Spec.Rules[0].Name == "rule-updated"
 		})
 		assert.True(t, found, "ModelRoute update should be reflected in cache")
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
`ModelRouteController` and `GatewayController` had zero test coverage despite `ModelServerController` having 1000+ lines of tests. This PR adds unit tests covering lifecycle (Create/Update/Delete), error handling (invalid keys, non-existent resources), workqueue processing (initial sync signal, unknown resource types), and the `GatewayClassName` filter that ensures only kthena-router gateways are processed.

**Which issue(s) this PR fixes**:
Fixes #990

**Special notes for your reviewer**:
this follows  the  same pattern as the existing `modelserver_controller_test.go`. Reuses the `waitForCacheSync` and `waitForObjectInCache` helpers already defined in that file

**Does this PR introduce a user-facing change?**:
```release-note

```
