### PR TITLE
fix: skip quota deduction when pod discovery fails

### DIFF
--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -263,7 +263,6 @@ func (r *Router) HandlerFunc() gin.HandlerFunc {
 		// Record input tokens immediately
 		metricsRecorder.RecordInputTokens(inputTokens)
 
-		// Store prompt string in context for deferred rate limiting after backend validation
 		c.Set("promptStr", promptStr)
 
 		requestID := uuid.New().String()
@@ -280,7 +279,33 @@ func (r *Router) HandlerFunc() gin.HandlerFunc {
 			return
 		}
 
-		// step 3.2: load balancing for Fairness scheduling enabled case
+		// step 3.2: Fairness scheduling enabled -- rate limit before entering the
+		// queue so that rejected requests do not occupy queue slots.
+		if err := r.loadRateLimiter.RateLimit(modelName, promptStr); err != nil {
+			var errorMsg string
+			var errorType string
+			var tokenType string
+			switch err.(type) {
+			case *ratelimit.InputRateLimitExceededError:
+				errorMsg = "input token rate limit exceeded"
+				errorType = "input_rate_limit"
+				tokenType = metrics.LimitTypeInputTokens
+			case *ratelimit.OutputRateLimitExceededError:
+				errorMsg = "output token rate limit exceeded"
+				errorType = "output_rate_limit"
+				tokenType = metrics.LimitTypeOutputTokens
+			default:
+				errorMsg = "token usage exceeds rate limit"
+				errorType = "rate_limit"
+				tokenType = metrics.LimitTypeRequests
+			}
+			accesslog.SetError(c, errorType, errorMsg)
+			metricsRecorder.RecordRateLimitExceeded(tokenType)
+			c.AbortWithStatusJSON(http.StatusTooManyRequests, errorMsg)
+			c.Set("finishReason", "rate_limit")
+			return
+		}
+
 		if err := r.handleFairnessScheduling(c, modelRequest, requestID, modelName); err != nil {
 			accesslog.SetError(c, "scheduling", err.Error())
 			c.Set("finishReason", "scheduling")
@@ -378,37 +403,41 @@ func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest) {
 
 	// Apply rate limiting after backend validation succeeds.
 	// This ensures quota is only consumed when a valid backend exists.
-	if promptStr, exists := c.Get("promptStr"); exists {
-		if ps, ok := promptStr.(string); ok {
-			if err := r.loadRateLimiter.RateLimit(modelName, ps); err != nil {
-				var errorMsg string
-				var errorType string
-				var tokenType string
-				switch err.(type) {
-				case *ratelimit.InputRateLimitExceededError:
-					errorMsg = "input token rate limit exceeded"
-					errorType = "input_rate_limit"
-					tokenType = metrics.LimitTypeInputTokens
-				case *ratelimit.OutputRateLimitExceededError:
-					errorMsg = "output token rate limit exceeded"
-					errorType = "output_rate_limit"
-					tokenType = metrics.LimitTypeOutputTokens
-				default:
-					errorMsg = "token usage exceeds rate limit"
-					errorType = "rate_limit"
-					tokenType = metrics.LimitTypeRequests
-				}
-				accesslog.SetError(c, errorType, errorMsg)
-
-				// Get metrics recorder from gin context for rate limit recording
-				if recorder, exists := c.Get("metricsRecorder"); exists {
-					if rec, ok := recorder.(*metrics.RequestMetricsRecorder); ok {
-						rec.RecordRateLimitExceeded(tokenType)
+	// When fairness scheduling is enabled, rate limiting is done before the
+	// queue (see HandlerFunc), so skip the duplicate check here.
+	if !EnableFairnessScheduling {
+		if promptStr, exists := c.Get("promptStr"); exists {
+			if ps, ok := promptStr.(string); ok {
+				if err := r.loadRateLimiter.RateLimit(modelName, ps); err != nil {
+					var errorMsg string
+					var errorType string
+					var tokenType string
+					switch err.(type) {
+					case *ratelimit.InputRateLimitExceededError:
+						errorMsg = "input token rate limit exceeded"
+						errorType = "input_rate_limit"
+						tokenType = metrics.LimitTypeInputTokens
+					case *ratelimit.OutputRateLimitExceededError:
+						errorMsg = "output token rate limit exceeded"
+						errorType = "output_rate_limit"
+						tokenType = metrics.LimitTypeOutputTokens
+					default:
+						errorMsg = "token usage exceeds rate limit"
+						errorType = "rate_limit"
+						tokenType = metrics.LimitTypeRequests
 					}
+					accesslog.SetError(c, errorType, errorMsg)
+
+					// Get metrics recorder from gin context for rate limit recording
+					if recorder, exists := c.Get("metricsRecorder"); exists {
+						if rec, ok := recorder.(*metrics.RequestMetricsRecorder); ok {
+							rec.RecordRateLimitExceeded(tokenType)
+						}
+					}
+					c.AbortWithStatusJSON(http.StatusTooManyRequests, errorMsg)
+					c.Set("finishReason", "rate_limit")
+					return
 				}
-				c.AbortWithStatusJSON(http.StatusTooManyRequests, errorMsg)
-				c.Set("finishReason", "rate_limit")
-				return
 			}
 		}
 	}

--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -210,7 +210,7 @@ func (r *Router) HandlerFunc() gin.HandlerFunc {
 			return
 		}
 
-		// step 2: Detection of rate limit
+		// step 2: Extract model name and prepare request metadata
 		modelName := modelRequest["model"].(string)
 
 		// Set model name in access log
@@ -263,33 +263,8 @@ func (r *Router) HandlerFunc() gin.HandlerFunc {
 		// Record input tokens immediately
 		metricsRecorder.RecordInputTokens(inputTokens)
 
-		// Apply rate limiting using the unified rate limiter
-		if err := r.loadRateLimiter.RateLimit(modelName, promptStr); err != nil {
-			var errorMsg string
-			var errorType string
-			var tokenType string
-			switch err.(type) {
-			case *ratelimit.InputRateLimitExceededError:
-				errorMsg = "input token rate limit exceeded"
-				errorType = "input_rate_limit"
-				tokenType = metrics.LimitTypeInputTokens
-			case *ratelimit.OutputRateLimitExceededError:
-				errorMsg = "output token rate limit exceeded"
-				errorType = "output_rate_limit"
-				tokenType = metrics.LimitTypeOutputTokens
-			default:
-				errorMsg = "token usage exceeds rate limit"
-				errorType = "rate_limit"
-				tokenType = metrics.LimitTypeRequests
-			}
-			accesslog.SetError(c, errorType, errorMsg)
-
-			// Record rate limit exceeded
-			metricsRecorder.RecordRateLimitExceeded(tokenType)
-			c.AbortWithStatusJSON(http.StatusTooManyRequests, errorMsg)
-			c.Set("finishReason", "rate_limit")
-			return
-		}
+		// Store prompt string in context for deferred rate limiting after backend validation
+		c.Set("promptStr", promptStr)
 
 		requestID := uuid.New().String()
 		if c.Request.Header.Get("x-request-id") == "" {
@@ -399,6 +374,43 @@ func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest) {
 		accesslog.SetError(c, "route_not_found", "route not found")
 		c.AbortWithStatusJSON(http.StatusNotFound, "route not found")
 		return
+	}
+
+	// Apply rate limiting after backend validation succeeds.
+	// This ensures quota is only consumed when a valid backend exists.
+	if promptStr, exists := c.Get("promptStr"); exists {
+		if ps, ok := promptStr.(string); ok {
+			if err := r.loadRateLimiter.RateLimit(modelName, ps); err != nil {
+				var errorMsg string
+				var errorType string
+				var tokenType string
+				switch err.(type) {
+				case *ratelimit.InputRateLimitExceededError:
+					errorMsg = "input token rate limit exceeded"
+					errorType = "input_rate_limit"
+					tokenType = metrics.LimitTypeInputTokens
+				case *ratelimit.OutputRateLimitExceededError:
+					errorMsg = "output token rate limit exceeded"
+					errorType = "output_rate_limit"
+					tokenType = metrics.LimitTypeOutputTokens
+				default:
+					errorMsg = "token usage exceeds rate limit"
+					errorType = "rate_limit"
+					tokenType = metrics.LimitTypeRequests
+				}
+				accesslog.SetError(c, errorType, errorMsg)
+
+				// Get metrics recorder from gin context for rate limit recording
+				if recorder, exists := c.Get("metricsRecorder"); exists {
+					if rec, ok := recorder.(*metrics.RequestMetricsRecorder); ok {
+						rec.RecordRateLimitExceeded(tokenType)
+					}
+				}
+				c.AbortWithStatusJSON(http.StatusTooManyRequests, errorMsg)
+				c.Set("finishReason", "rate_limit")
+				return
+			}
+		}
 	}
 
 	// Common scheduling logic for both ModelServer and InferencePool

--- a/pkg/kthena-router/router/router_test.go
+++ b/pkg/kthena-router/router/router_test.go
@@ -368,6 +368,66 @@ func TestParseModelRequestValidatesModelName(t *testing.T) {
 	}
 }
 
+// TestRouter_HandlerFunc_NoQuotaOnFailedPodDiscovery verifies that input token
+// quota is NOT consumed when pod discovery fails (issue #991).
+func TestRouter_HandlerFunc_NoQuotaOnFailedPodDiscovery(t *testing.T) {
+	router, store, backend := setupTestRouter(t, nil)
+	defer backend.Close()
+
+	// Set up a model route with a tight rate limit so quota drain is visible
+	inputLimit := uint32(20)
+	modelRoute := &aiv1alpha1.ModelRoute{
+		ObjectMeta: v1.ObjectMeta{Name: "mr-rate", Namespace: "default"},
+		Spec: aiv1alpha1.ModelRouteSpec{
+			ModelName: "rate-test-model",
+			RateLimit: &aiv1alpha1.RateLimit{
+				InputTokensPerUnit: &inputLimit,
+				Unit:               aiv1alpha1.Second,
+			},
+			Rules: []*aiv1alpha1.Rule{
+				{
+					TargetModels: []*aiv1alpha1.TargetModel{
+						{ModelServerName: "ms-missing"},
+					},
+				},
+			},
+		},
+	}
+
+	// Add model server with NO pods -- simulates missing backend
+	modelServer := &aiv1alpha1.ModelServer{
+		ObjectMeta: v1.ObjectMeta{Name: "ms-missing", Namespace: "default"},
+		Spec: aiv1alpha1.ModelServerSpec{
+			Model:           func(s string) *string { return &s }("rate-test-model-base"),
+			WorkloadPort:    aiv1alpha1.WorkloadPort{Port: 8080},
+			InferenceEngine: "vLLM",
+		},
+	}
+
+	store.AddOrUpdateModelRoute(modelRoute)
+	// Register model server with empty pod set -- no pods exist
+	store.AddOrUpdateModelServer(modelServer, sets.New[types.NamespacedName]())
+
+	// First request: should get 404 because no pods exist
+	w1 := httptest.NewRecorder()
+	c1, _ := gin.CreateTestContext(w1)
+	reqBody := `{"model": "rate-test-model", "messages": [{"role":"user","content":"one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen"}]}`
+	c1.Request, _ = http.NewRequest("POST", "/v1/chat/completions", bytes.NewBufferString(reqBody))
+	c1.Request.Header.Set("Content-Type", "application/json")
+	router.HandlerFunc()(c1)
+	assert.Equal(t, http.StatusNotFound, w1.Code, "first request should return 404 (no backend pods)")
+
+	// Second request: should also get 404, NOT 429
+	// Before the fix, this would return 429 because the first request consumed quota
+	w2 := httptest.NewRecorder()
+	c2, _ := gin.CreateTestContext(w2)
+	c2.Request, _ = http.NewRequest("POST", "/v1/chat/completions", bytes.NewBufferString(reqBody))
+	c2.Request.Header.Set("Content-Type", "application/json")
+	router.HandlerFunc()(c2)
+	assert.Equal(t, http.StatusNotFound, w2.Code, "second request should return 404, not 429 -- quota must not be consumed on failed pod discovery")
+	assert.NotEqual(t, http.StatusTooManyRequests, w2.Code, "quota should not be consumed when backend pod discovery fails")
+}
+
 func TestAccessLogConfigurationFromEnv(t *testing.T) {
 	// Save original environment variables
 	originalEnabled := os.Getenv("ACCESS_LOG_ENABLED")


### PR DESCRIPTION
## Summary

- Moved rate limiting from `HandlerFunc()` to `doLoadbalance()`, so it runs after backend/pod discovery instead of before
- Input token quota is now only consumed when a valid backend actually exists
- Added a regression test that reproduces the exact scenario from #991

The root cause was ordering -- `AllowN` on the rate limiter consumed tokens before pod discovery ran. When discovery failed (404), quota was already gone, so the next request hit 429 with zero inference.

The fix defers the `RateLimit()` call until after all backend resolution (model server match, pod lookup, inference pool lookup) has confirmed a valid target. The prompt string gets stashed in the gin context so `doLoadbalance` can pick it up.

Fixes #991

## Test plan

- [x] Existing router tests pass (10/10)
- [x] Rate limiter unit tests pass (47/47)
- [x] New `TestRouter_HandlerFunc_NoQuotaOnFailedPodDiscovery` covers the exact repro: model route with tight rate limit, model server with no pods, two sequential requests both return 404 (not 429)
- [x] Full `go build ./...` clean