### PR TITLE
feat: support /v1/models endpoint

### DIFF
--- a/pkg/kthena-router/datastore/store.go
+++ b/pkg/kthena-router/datastore/store.go
@@ -233,6 +233,10 @@ type Store interface {
 	GetHTTPRoutesByGateway(gatewayKey string) []*gatewayv1.HTTPRoute
 	GetModelRoutesByGateway(gatewayKey string) []*aiv1alpha1.ModelRoute
 
+	// GetModelNames returns all model names registered via ModelRoutes,
+	// including both base model names and LoRA adapter names.
+	GetModelNames() []string
+
 	// Debug interface methods
 	GetAllModelRoutes() map[string]*aiv1alpha1.ModelRoute
 	GetAllModelServers() map[types.NamespacedName]*aiv1alpha1.ModelServer
@@ -1481,6 +1485,28 @@ func (s *store) GetAllModelRoutes() map[string]*aiv1alpha1.ModelRoute {
 		}
 	}
 	return result
+}
+
+// GetModelNames returns all model names registered via ModelRoutes,
+// including both base model names and LoRA adapter names.
+func (s *store) GetModelNames() []string {
+	s.routeMutex.RLock()
+	defer s.routeMutex.RUnlock()
+
+	seen := make(map[string]struct{})
+	for name := range s.routes {
+		seen[name] = struct{}{}
+	}
+	for name := range s.loraRoutes {
+		seen[name] = struct{}{}
+	}
+
+	names := make([]string, 0, len(seen))
+	for name := range seen {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
 }
 
 // GetAllModelServers returns all ModelServers in the store

--- a/pkg/kthena-router/datastore/store.go
+++ b/pkg/kthena-router/datastore/store.go
@@ -1493,16 +1493,11 @@ func (s *store) GetModelNames() []string {
 	s.routeMutex.RLock()
 	defer s.routeMutex.RUnlock()
 
-	seen := make(map[string]struct{})
+	names := make([]string, 0, len(s.routes)+len(s.loraRoutes))
 	for name := range s.routes {
-		seen[name] = struct{}{}
+		names = append(names, name)
 	}
 	for name := range s.loraRoutes {
-		seen[name] = struct{}{}
-	}
-
-	names := make([]string, 0, len(seen))
-	for name := range seen {
 		names = append(names, name)
 	}
 	sort.Strings(names)

--- a/pkg/kthena-router/debug/handlers_test.go
+++ b/pkg/kthena-router/debug/handlers_test.go
@@ -326,6 +326,14 @@ func (m *MockStore) GetAllInferencePools() []*inferencev1.InferencePool {
 	return args.Get(0).([]*inferencev1.InferencePool)
 }
 
+func (m *MockStore) GetModelNames() []string {
+	args := m.Called()
+	if args.Get(0) == nil {
+		return nil
+	}
+	return args.Get(0).([]string)
+}
+
 func newTestContext(params gin.Params) (*gin.Context, *httptest.ResponseRecorder) {
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)

--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -206,7 +206,7 @@ func (r *Router) HandlerFunc() gin.HandlerFunc {
 		// Handle /v1/models endpoint (OpenAI-compatible model listing)
 		if c.Request.Method == http.MethodGet &&
 			(c.Request.URL.Path == "/v1/models" || c.Request.URL.Path == "/models") {
-			r.ListModelsHandlerFunc()(c)
+			r.ListModels(c)
 			return
 		}
 
@@ -817,39 +817,37 @@ func (r *Router) GetModelServer(modelName string, req *http.Request) (*v1alpha1.
 	return modelServer, nil
 }
 
-// ListModelsHandlerFunc returns a handler that implements the OpenAI-compatible
-// GET /v1/models endpoint. It returns all model names registered via ModelRoutes.
-func (r *Router) ListModelsHandlerFunc() gin.HandlerFunc {
-	return func(c *gin.Context) {
-		modelNames := r.store.GetModelNames()
+type modelObject struct {
+	ID      string `json:"id"`
+	Object  string `json:"object"`
+	Created int64  `json:"created"`
+	OwnedBy string `json:"owned_by"`
+}
 
-		type modelObject struct {
-			ID      string `json:"id"`
-			Object  string `json:"object"`
-			Created int64  `json:"created"`
-			OwnedBy string `json:"owned_by"`
-		}
+type modelsResponse struct {
+	Object string        `json:"object"`
+	Data   []modelObject `json:"data"`
+}
 
-		type modelsResponse struct {
-			Object string        `json:"object"`
-			Data   []modelObject `json:"data"`
-		}
+// ListModels implements the OpenAI-compatible GET /v1/models endpoint.
+// It returns all model names registered via ModelRoutes.
+func (r *Router) ListModels(c *gin.Context) {
+	modelNames := r.store.GetModelNames()
 
-		data := make([]modelObject, 0, len(modelNames))
-		for _, name := range modelNames {
-			data = append(data, modelObject{
-				ID:      name,
-				Object:  "model",
-				Created: 0,
-				OwnedBy: "kthena",
-			})
-		}
-
-		c.JSON(http.StatusOK, modelsResponse{
-			Object: "list",
-			Data:   data,
+	data := make([]modelObject, 0, len(modelNames))
+	for _, name := range modelNames {
+		data = append(data, modelObject{
+			ID:      name,
+			Object:  "model",
+			Created: 0,
+			OwnedBy: "kthena",
 		})
 	}
+
+	c.JSON(http.StatusOK, modelsResponse{
+		Object: "list",
+		Data:   data,
+	})
 }
 
 func (r *Router) Auth() gin.HandlerFunc {

--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -203,6 +203,13 @@ type ModelRequest map[string]interface{}
 
 func (r *Router) HandlerFunc() gin.HandlerFunc {
 	return func(c *gin.Context) {
+		// Handle /v1/models endpoint (OpenAI-compatible model listing)
+		if c.Request.Method == http.MethodGet &&
+			(c.Request.URL.Path == "/v1/models" || c.Request.URL.Path == "/models") {
+			r.ListModelsHandlerFunc()(c)
+			return
+		}
+
 		// Step 1: Parse and validate request
 		modelRequest, err := ParseModelRequest(c)
 		if err != nil {
@@ -808,6 +815,41 @@ func (r *Router) GetModelServer(modelName string, req *http.Request) (*v1alpha1.
 	}
 
 	return modelServer, nil
+}
+
+// ListModelsHandlerFunc returns a handler that implements the OpenAI-compatible
+// GET /v1/models endpoint. It returns all model names registered via ModelRoutes.
+func (r *Router) ListModelsHandlerFunc() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		modelNames := r.store.GetModelNames()
+
+		type modelObject struct {
+			ID      string `json:"id"`
+			Object  string `json:"object"`
+			Created int64  `json:"created"`
+			OwnedBy string `json:"owned_by"`
+		}
+
+		type modelsResponse struct {
+			Object string        `json:"object"`
+			Data   []modelObject `json:"data"`
+		}
+
+		data := make([]modelObject, 0, len(modelNames))
+		for _, name := range modelNames {
+			data = append(data, modelObject{
+				ID:      name,
+				Object:  "model",
+				Created: 0,
+				OwnedBy: "kthena",
+			})
+		}
+
+		c.JSON(http.StatusOK, modelsResponse{
+			Object: "list",
+			Data:   data,
+		})
+	}
 }
 
 func (r *Router) Auth() gin.HandlerFunc {

--- a/pkg/kthena-router/router/router_test.go
+++ b/pkg/kthena-router/router/router_test.go
@@ -539,6 +539,97 @@ func TestProxy_RetryBodyNotDrained(t *testing.T) {
 	}
 }
 
+func TestRouter_HandlerFunc_ListModels(t *testing.T) {
+	router, store, backend := setupTestRouter(t, nil)
+	defer backend.Close()
+
+	backendURL, _ := url.Parse(backend.URL)
+	backendIP := backendURL.Hostname()
+	backendPort, _ := strconv.Atoi(backendURL.Port())
+
+	modelServer := &aiv1alpha1.ModelServer{
+		ObjectMeta: v1.ObjectMeta{Name: "ms-1", Namespace: "default"},
+		Spec: aiv1alpha1.ModelServerSpec{
+			Model:        func(s string) *string { return &s }("base-model"),
+			WorkloadPort: aiv1alpha1.WorkloadPort{Port: int32(backendPort)},
+		},
+	}
+	pod1 := &corev1.Pod{
+		ObjectMeta: v1.ObjectMeta{Name: "pod-1", Namespace: "default"},
+		Status:     corev1.PodStatus{PodIP: backendIP, Phase: corev1.PodRunning},
+	}
+	modelRoute1 := &aiv1alpha1.ModelRoute{
+		ObjectMeta: v1.ObjectMeta{Name: "mr-1", Namespace: "default"},
+		Spec: aiv1alpha1.ModelRouteSpec{
+			ModelName: "model-alpha",
+			Rules: []*aiv1alpha1.Rule{
+				{TargetModels: []*aiv1alpha1.TargetModel{{ModelServerName: "ms-1"}}},
+			},
+		},
+	}
+	modelRoute2 := &aiv1alpha1.ModelRoute{
+		ObjectMeta: v1.ObjectMeta{Name: "mr-2", Namespace: "default"},
+		Spec: aiv1alpha1.ModelRouteSpec{
+			ModelName: "model-beta",
+			Rules: []*aiv1alpha1.Rule{
+				{TargetModels: []*aiv1alpha1.TargetModel{{ModelServerName: "ms-1"}}},
+			},
+		},
+	}
+
+	store.AddOrUpdateModelServer(modelServer, sets.New(types.NamespacedName{Name: "pod-1", Namespace: "default"}))
+	store.AddOrUpdatePod(pod1, []*aiv1alpha1.ModelServer{modelServer})
+	store.AddOrUpdateModelRoute(modelRoute1)
+	store.AddOrUpdateModelRoute(modelRoute2)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request, _ = http.NewRequest("GET", "/v1/models", nil)
+
+	router.HandlerFunc()(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp struct {
+		Object string `json:"object"`
+		Data   []struct {
+			ID      string `json:"id"`
+			Object  string `json:"object"`
+			OwnedBy string `json:"owned_by"`
+		} `json:"data"`
+	}
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.NoError(t, err)
+	assert.Equal(t, "list", resp.Object)
+	assert.Len(t, resp.Data, 2)
+	assert.Equal(t, "model-alpha", resp.Data[0].ID)
+	assert.Equal(t, "model-beta", resp.Data[1].ID)
+	assert.Equal(t, "model", resp.Data[0].Object)
+	assert.Equal(t, "kthena", resp.Data[0].OwnedBy)
+}
+
+func TestRouter_HandlerFunc_ListModels_Empty(t *testing.T) {
+	router, _, backend := setupTestRouter(t, nil)
+	defer backend.Close()
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request, _ = http.NewRequest("GET", "/v1/models", nil)
+
+	router.HandlerFunc()(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp struct {
+		Object string        `json:"object"`
+		Data   []interface{} `json:"data"`
+	}
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.NoError(t, err)
+	assert.Equal(t, "list", resp.Object)
+	assert.Empty(t, resp.Data)
+}
+
 // Helper function to parse boolean (same logic as strconv.ParseBool but simpler for test)
 func parseBool(str string) (bool, error) {
 	switch str {


### PR DESCRIPTION
## Summary

Implements the OpenAI-compatible `GET /v1/models` endpoint that was missing from the kthena router, causing 400 errors when clients tried to list available models.

Fixes #958

## What changed

- Added `GetModelNames()` to the datastore `Store` interface -- returns sorted list of all model names from both base model routes and LoRA adapter routes
- Added `ListModelsHandlerFunc()` on `Router` that returns the standard OpenAI `/v1/models` response format
- Intercepts `GET /v1/models` (and `/models` for gateway mode) at the top of `HandlerFunc()` before the JSON body parser runs, so GET requests without a body don't blow up
- Added the `GetModelNames` mock method to the debug test's `MockStore` so the interface stays satisfied
- Two new tests: one with models registered, one with an empty store

## Response format

```json
{
  "object": "list",
  "data": [
    {
      "id": "my-model",
      "object": "model",
      "created": 0,
      "owned_by": "kthena"
    }
  ]
}
```

Works in both default server mode and Gateway API mode since the check lives inside `HandlerFunc()`.

## Test plan

- [x] `TestRouter_HandlerFunc_ListModels` -- verifies response shape, sorted model names, correct fields
- [x] `TestRouter_HandlerFunc_ListModels_Empty` -- verifies empty store returns `{"object":"list","data":[]}`
- [x] Full `go test ./pkg/kthena-router/...` passes (all 24 packages)
- [x] `go build ./...` clean