### PR TITLE
fix: set least-request args default value when maxWaitingRequests is empty

### DIFF
--- a/pkg/kthena-router/scheduler/plugins/least_request.go
+++ b/pkg/kthena-router/scheduler/plugins/least_request.go
@@ -42,7 +42,7 @@ type LeastRequestArgs struct {
 
 func NewLeastRequest(pluginArg runtime.RawExtension) *LeastRequest {
 	var leastRequestArgs LeastRequestArgs
-	if yaml.Unmarshal(pluginArg.Raw, &leastRequestArgs) != nil {
+	if pluginArg.Raw == nil || yaml.Unmarshal(pluginArg.Raw, &leastRequestArgs) != nil {
 		klog.Errorf("Unmarshal LeastRequestArgs error, setting default value")
 		leastRequestArgs = LeastRequestArgs{
 			10,


### PR DESCRIPTION
fix: set least-request args default value when maxWaitingRequests is not set in router conf file

like:
`
scheduler:  
  pluginConfig:
    - name: least-request
`






