### PR TITLE
docs: clarify that ENTRY_ADDRESS is auto-injected into worker pods

### DIFF
--- a/docs/kthena/docs/user-guide/multi-node-inference.md
+++ b/docs/kthena/docs/user-guide/multi-node-inference.md
@@ -176,6 +176,10 @@ spec:
                 sizeLimit: 15Gi
 ```
 
+:::tip
+`ENTRY_ADDRESS` is an environment variable that Kthena automatically injects into every worker pod. Its value is set to the headless service address of the corresponding entry pod (e.g., `llama-multinode-0-405b-0-0.default`). You do not need to define it yourself. When multiple Role replicas exist, each worker pod receives the correct entry address for its own replica, so Ray workers always connect to the right head node. See the [Labels and Environment Variables](../architecture/model-serving-controller.mdx#environment-variables) section for the full list of injected variables.
+:::
+
 ### Tensor and Pipeline Parallelism Configuration
 
 The multi‑node example configures tensor parallelism and pipeline parallelism through the command‑line arguments of the inference engine. In the `multi-node.yaml` manifest, the entry‑point container includes:

--- a/docs/kthena/versioned_docs/version-v0.1.0/user-guide/multi-node-inference.md
+++ b/docs/kthena/versioned_docs/version-v0.1.0/user-guide/multi-node-inference.md
@@ -177,6 +177,10 @@ spec:
                 sizeLimit: 15Gi
 ```
 
+:::tip
+`ENTRY_ADDRESS` is an environment variable that Kthena automatically injects into every worker pod. Its value is set to the headless service address of the corresponding entry pod (e.g., `llama-multinode-0-405b-0-0.default`). You do not need to define it yourself. When multiple Role replicas exist, each worker pod receives the correct entry address for its own replica, so Ray workers always connect to the right head node. See the [Labels and Environment Variables](../architecture/model-serving-controller.mdx#environment-variables) section for the full list of injected variables.
+:::
+
 ### Tensor and Pipeline Parallelism Configuration
 
 The multi‑node example configures tensor parallelism and pipeline parallelism through the command‑line arguments of the inference engine. In the `multi‑node.yaml` manifest, the entry‑point container includes:

--- a/docs/kthena/versioned_docs/version-v0.2.0/user-guide/multi-node-inference.md
+++ b/docs/kthena/versioned_docs/version-v0.2.0/user-guide/multi-node-inference.md
@@ -176,6 +176,10 @@ spec:
                 sizeLimit: 15Gi
 ```
 
+:::tip
+`ENTRY_ADDRESS` is an environment variable that Kthena automatically injects into every worker pod. Its value is set to the headless service address of the corresponding entry pod (e.g., `llama-multinode-0-405b-0-0.default`). You do not need to define it yourself. When multiple Role replicas exist, each worker pod receives the correct entry address for its own replica, so Ray workers always connect to the right head node. See the [Labels and Environment Variables](../architecture/model-serving-controller.mdx#environment-variables) section for the full list of injected variables.
+:::
+
 ### Tensor and Pipeline Parallelism Configuration
 
 The multi‑node example configures tensor parallelism and pipeline parallelism through the command‑line arguments of the inference engine. In the `multi-node.yaml` manifest, the entry‑point container includes:

--- a/docs/kthena/versioned_docs/version-v0.3.0/user-guide/multi-node-inference.md
+++ b/docs/kthena/versioned_docs/version-v0.3.0/user-guide/multi-node-inference.md
@@ -176,6 +176,10 @@ spec:
                 sizeLimit: 15Gi
 ```
 
+:::tip
+`ENTRY_ADDRESS` is an environment variable that Kthena automatically injects into every worker pod. Its value is set to the headless service address of the corresponding entry pod (e.g., `llama-multinode-0-405b-0-0.default`). You do not need to define it yourself. When multiple Role replicas exist, each worker pod receives the correct entry address for its own replica, so Ray workers always connect to the right head node. See the [Labels and Environment Variables](../architecture/model-serving-controller.mdx#environment-variables) section for the full list of injected variables.
+:::
+
 ### Tensor and Pipeline Parallelism Configuration
 
 The multi‑node example configures tensor parallelism and pipeline parallelism through the command‑line arguments of the inference engine. In the `multi-node.yaml` manifest, the entry‑point container includes:

--- a/docs/kthena/versioned_docs/version-v0.4.0/user-guide/multi-node-inference.md
+++ b/docs/kthena/versioned_docs/version-v0.4.0/user-guide/multi-node-inference.md
@@ -176,6 +176,10 @@ spec:
                 sizeLimit: 15Gi
 ```
 
+:::tip
+`ENTRY_ADDRESS` is an environment variable that Kthena automatically injects into every worker pod. Its value is set to the headless service address of the corresponding entry pod (e.g., `llama-multinode-0-405b-0-0.default`). You do not need to define it yourself. When multiple Role replicas exist, each worker pod receives the correct entry address for its own replica, so Ray workers always connect to the right head node. See the [Labels and Environment Variables](../architecture/model-serving-controller.mdx#environment-variables) section for the full list of injected variables.
+:::
+
 ### Tensor and Pipeline Parallelism Configuration
 
 The multi‑node example configures tensor parallelism and pipeline parallelism through the command‑line arguments of the inference engine. In the `multi-node.yaml` manifest, the entry‑point container includes:


### PR DESCRIPTION
## Summary

Fixes #487

The multi-node deployment example previously used an undefined `Leader_Node_Address` shell variable, which has since been replaced with `$(ENTRY_ADDRESS)`. However, the docs never explained that `ENTRY_ADDRESS` is an env var automatically injected by the controller -- leaving users confused about where it comes from and whether they need to define it themselves.

This adds a tip callout to the multi-node inference guide (all versioned docs + latest) explaining:
- `ENTRY_ADDRESS` is auto-injected by Kthena into every worker pod
- its value is the headless service address of the corresponding entry pod
- when multiple Role replicas exist, each worker gets the correct address for its own replica
- links to the Labels and Environment Variables reference for the full list

## Test plan

- [ ] Verify the docs site renders the `:::tip` callout correctly
- [ ] Confirm the cross-reference link to the architecture page resolves