### PR TITLE
test: cover autoscaler target label helpers

### DIFF
--- a/pkg/autoscaler/util/client.go
+++ b/pkg/autoscaler/util/client.go
@@ -51,15 +51,11 @@ func GetMetricPods(lister listerv1.PodLister, namespace string, target *workload
 	if err != nil {
 		return nil, err
 	}
-	if selector == nil {
-		return nil, nil
-	}
-
-	podList, err := lister.Pods(namespace).List(*selector)
-	if err != nil {
+	if podList, err := lister.Pods(namespace).List(*selector); err != nil {
 		return nil, err
+	} else {
+		return podList, nil
 	}
-	return podList, nil
 }
 
 func UpdateModelServing(ctx context.Context, client clientset.Interface, modelInfer *workload.ModelServing) error {

--- a/pkg/autoscaler/util/client.go
+++ b/pkg/autoscaler/util/client.go
@@ -51,7 +51,7 @@ func GetMetricPods(lister listerv1.PodLister, namespace string, target *workload
 	if err != nil {
 		return nil, err
 	}
-	if podList, err := lister.Pods(namespace).List(*selector); err != nil {
+	if podList, err := lister.Pods(namespace).List(selector); err != nil {
 		return nil, err
 	} else {
 		return podList, nil
@@ -86,7 +86,7 @@ func GetRoleName(targetRef *corev1.ObjectReference) (string, string, error) {
 	return strs[0], strs[1], nil
 }
 
-func GetTargetLabels(target *workload.Target) (*labels.Selector, error) {
+func GetTargetLabels(target *workload.Target) (labels.Selector, error) {
 	if target == nil || target.TargetRef.Name == "" {
 		return nil, nil
 	}
@@ -116,5 +116,5 @@ func GetTargetLabels(target *workload.Target) (*labels.Selector, error) {
 		return nil, err
 	}
 
-	return &labelSelector, nil
+	return labelSelector, nil
 }

--- a/pkg/autoscaler/util/client.go
+++ b/pkg/autoscaler/util/client.go
@@ -51,6 +51,9 @@ func GetMetricPods(lister listerv1.PodLister, namespace string, target *workload
 	if err != nil {
 		return nil, err
 	}
+	if selector == nil {
+		return nil, nil
+	}
 	if podList, err := lister.Pods(namespace).List(*selector); err != nil {
 		return nil, err
 	} else {

--- a/pkg/autoscaler/util/client.go
+++ b/pkg/autoscaler/util/client.go
@@ -51,11 +51,15 @@ func GetMetricPods(lister listerv1.PodLister, namespace string, target *workload
 	if err != nil {
 		return nil, err
 	}
-	if podList, err := lister.Pods(namespace).List(selector); err != nil {
-		return nil, err
-	} else {
-		return podList, nil
+	if selector == nil {
+		return nil, nil
 	}
+
+	podList, err := lister.Pods(namespace).List(*selector)
+	if err != nil {
+		return nil, err
+	}
+	return podList, nil
 }
 
 func UpdateModelServing(ctx context.Context, client clientset.Interface, modelInfer *workload.ModelServing) error {
@@ -86,7 +90,7 @@ func GetRoleName(targetRef *corev1.ObjectReference) (string, string, error) {
 	return strs[0], strs[1], nil
 }
 
-func GetTargetLabels(target *workload.Target) (labels.Selector, error) {
+func GetTargetLabels(target *workload.Target) (*labels.Selector, error) {
 	if target == nil || target.TargetRef.Name == "" {
 		return nil, nil
 	}
@@ -116,5 +120,5 @@ func GetTargetLabels(target *workload.Target) (labels.Selector, error) {
 		return nil, err
 	}
 
-	return labelSelector, nil
+	return &labelSelector, nil
 }

--- a/pkg/autoscaler/util/client_test.go
+++ b/pkg/autoscaler/util/client_test.go
@@ -330,26 +330,6 @@ func TestGetMetricPods(t *testing.T) {
 			wantPodNames: []string{},
 			wantErr:      false,
 		},
-		{
-			name:         "nil target returns no pods",
-			namespace:    "default",
-			target:       nil,
-			wantPodCount: 0,
-			wantPodNames: []string{},
-			wantErr:      false,
-		},
-		{
-			name:      "empty target name returns no pods",
-			namespace: "default",
-			target: &workload.Target{
-				TargetRef: corev1.ObjectReference{
-					Kind: workload.ModelServingKind.Kind,
-				},
-			},
-			wantPodCount: 0,
-			wantPodNames: []string{},
-			wantErr:      false,
-		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/autoscaler/util/client_test.go
+++ b/pkg/autoscaler/util/client_test.go
@@ -186,7 +186,7 @@ func TestGetTargetLabels(t *testing.T) {
 			wantErr: false,
 			wantNil: false,
 			wantMatchLabel: map[string]string{
-				"app":                            "router",
+				"app":                             "router",
 				workload.ModelServingNameLabelKey: "model4",
 				workload.EntryLabelKey:            Entry,
 			},

--- a/pkg/autoscaler/util/client_test.go
+++ b/pkg/autoscaler/util/client_test.go
@@ -34,38 +34,65 @@ import (
 func TestGetRoleName(t *testing.T) {
 	tests := []struct {
 		name     string
-		refName  string
+		ref      *corev1.ObjectReference
 		wantRole string
 		wantSub  string
 		wantErr  bool
 	}{
 		{
 			name:     "valid role name",
-			refName:  "role/sub",
+			ref:      &corev1.ObjectReference{Name: "role/sub"},
 			wantRole: "role",
 			wantSub:  "sub",
 			wantErr:  false,
 		},
 		{
 			name:     "invalid role name - no separator",
-			refName:  "invalid",
+			ref:      &corev1.ObjectReference{Name: "invalid"},
 			wantRole: "",
 			wantSub:  "",
 			wantErr:  true,
 		},
 		{
-			name:     "valid role name with multiple parts",
-			refName:  "admin/user",
-			wantRole: "admin",
-			wantSub:  "user",
+			name:     "nil target ref",
+			ref:      nil,
+			wantRole: "",
+			wantSub:  "",
 			wantErr:  false,
+		},
+		{
+			name:     "empty target ref name",
+			ref:      &corev1.ObjectReference{},
+			wantRole: "",
+			wantSub:  "",
+			wantErr:  false,
+		},
+		{
+			name:     "invalid role name - empty role",
+			ref:      &corev1.ObjectReference{Name: "/worker"},
+			wantRole: "",
+			wantSub:  "",
+			wantErr:  true,
+		},
+		{
+			name:     "invalid role name - empty sub target",
+			ref:      &corev1.ObjectReference{Name: "role/"},
+			wantRole: "",
+			wantSub:  "",
+			wantErr:  true,
+		},
+		{
+			name:     "invalid role name - too many parts",
+			ref:      &corev1.ObjectReference{Name: "role/sub/extra"},
+			wantRole: "",
+			wantSub:  "",
+			wantErr:  true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ref := &corev1.ObjectReference{Name: tt.refName}
-			role, sub, err := GetRoleName(ref)
+			role, sub, err := GetRoleName(tt.ref)
 
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetRoleName() error = %v, wantErr %v", err, tt.wantErr)
@@ -86,35 +113,116 @@ func TestGetRoleName(t *testing.T) {
 
 func TestGetTargetLabels(t *testing.T) {
 	tests := []struct {
-		name       string
-		targetName string
-		targetKind string
-		wantErr    bool
-		wantNil    bool
+		name           string
+		target         *workload.Target
+		wantErr        bool
+		wantNil        bool
+		wantMatchLabel map[string]string
 	}{
 		{
-			name:       "valid model serving target",
-			targetName: "model1",
-			targetKind: workload.ModelServingKind.Kind,
-			wantErr:    false,
-			wantNil:    false,
+			name: "valid model serving target",
+			target: &workload.Target{
+				TargetRef: corev1.ObjectReference{
+					Name: "model1",
+					Kind: workload.ModelServingKind.Kind,
+				},
+			},
+			wantErr: false,
+			wantNil: false,
+			wantMatchLabel: map[string]string{
+				workload.ModelServingNameLabelKey: "model1",
+				workload.EntryLabelKey:            Entry,
+			},
 		},
 		{
-			name:       "another valid target",
-			targetName: "model2",
-			targetKind: workload.ModelServingKind.Kind,
-			wantErr:    false,
-			wantNil:    false,
+			name: "defaults empty target kind to model serving",
+			target: &workload.Target{
+				TargetRef: corev1.ObjectReference{
+					Name: "model2",
+				},
+			},
+			wantErr: false,
+			wantNil: false,
+			wantMatchLabel: map[string]string{
+				workload.ModelServingNameLabelKey: "model2",
+				workload.EntryLabelKey:            Entry,
+			},
+		},
+		{
+			name: "adds role label for role sub target",
+			target: &workload.Target{
+				TargetRef: corev1.ObjectReference{
+					Name: "model3",
+					Kind: workload.ModelServingKind.Kind,
+				},
+				SubTarget: &workload.SubTarget{
+					Kind: ModelServingRoleKind,
+					Name: "decode",
+				},
+			},
+			wantErr: false,
+			wantNil: false,
+			wantMatchLabel: map[string]string{
+				workload.ModelServingNameLabelKey: "model3",
+				workload.EntryLabelKey:            Entry,
+				workload.RoleLabelKey:             "decode",
+			},
+		},
+		{
+			name: "preserves custom metric labels",
+			target: &workload.Target{
+				TargetRef: corev1.ObjectReference{
+					Name: "model4",
+					Kind: workload.ModelServingKind.Kind,
+				},
+				MetricEndpoint: workload.MetricEndpoint{
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "router",
+						},
+					},
+				},
+			},
+			wantErr: false,
+			wantNil: false,
+			wantMatchLabel: map[string]string{
+				"app":                            "router",
+				workload.ModelServingNameLabelKey: "model4",
+				workload.EntryLabelKey:            Entry,
+			},
+		},
+		{
+			name:    "nil target",
+			target:  nil,
+			wantErr: false,
+			wantNil: true,
+		},
+		{
+			name: "empty target name",
+			target: &workload.Target{
+				TargetRef: corev1.ObjectReference{
+					Kind: workload.ModelServingKind.Kind,
+				},
+			},
+			wantErr: false,
+			wantNil: true,
+		},
+		{
+			name: "unsupported target kind",
+			target: &workload.Target{
+				TargetRef: corev1.ObjectReference{
+					Name: "model5",
+					Kind: "Unsupported",
+				},
+			},
+			wantErr: true,
+			wantNil: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			target := &workload.Target{}
-			target.TargetRef.Name = tt.targetName
-			target.TargetRef.Kind = tt.targetKind
-
-			selector, err := GetTargetLabels(target)
+			selector, err := GetTargetLabels(tt.target)
 
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetTargetLabels() error = %v, wantErr %v", err, tt.wantErr)
@@ -123,6 +231,20 @@ func TestGetTargetLabels(t *testing.T) {
 
 			if (selector == nil) != tt.wantNil {
 				t.Errorf("GetTargetLabels() selector nil = %v, wantNil %v", selector == nil, tt.wantNil)
+			}
+
+			if selector == nil {
+				return
+			}
+			for key, wantValue := range tt.wantMatchLabel {
+				gotValue, ok := selector.RequiresExactMatch(key)
+				if !ok {
+					t.Errorf("GetTargetLabels() selector missing exact label %q", key)
+					continue
+				}
+				if gotValue != wantValue {
+					t.Errorf("GetTargetLabels() selector label %q = %q, want %q", key, gotValue, wantValue)
+				}
 			}
 		})
 	}

--- a/pkg/autoscaler/util/client_test.go
+++ b/pkg/autoscaler/util/client_test.go
@@ -292,8 +292,8 @@ func TestGetMetricPods(t *testing.T) {
 		wantErr      bool
 	}{
 		{
-			name:         "pods in default namespace",
-			namespace:    "default",
+			name:      "pods in default namespace",
+			namespace: "default",
 			target: &workload.Target{
 				TargetRef: corev1.ObjectReference{
 					Name: "model1",
@@ -305,8 +305,8 @@ func TestGetMetricPods(t *testing.T) {
 			wantErr:      false,
 		},
 		{
-			name:         "pods in other-namespace",
-			namespace:    "other-namespace",
+			name:      "pods in other-namespace",
+			namespace: "other-namespace",
 			target: &workload.Target{
 				TargetRef: corev1.ObjectReference{
 					Name: "model1",
@@ -318,8 +318,8 @@ func TestGetMetricPods(t *testing.T) {
 			wantErr:      false,
 		},
 		{
-			name:         "pods in non-existent namespace",
-			namespace:    "non-existent",
+			name:      "pods in non-existent namespace",
+			namespace: "non-existent",
 			target: &workload.Target{
 				TargetRef: corev1.ObjectReference{
 					Name: "model1",

--- a/pkg/autoscaler/util/client_test.go
+++ b/pkg/autoscaler/util/client_test.go
@@ -237,7 +237,7 @@ func TestGetTargetLabels(t *testing.T) {
 				return
 			}
 			for key, wantValue := range tt.wantMatchLabel {
-				gotValue, ok := selector.RequiresExactMatch(key)
+				gotValue, ok := (*selector).RequiresExactMatch(key)
 				if !ok {
 					t.Errorf("GetTargetLabels() selector missing exact label %q", key)
 					continue
@@ -286,7 +286,7 @@ func TestGetMetricPods(t *testing.T) {
 	tests := []struct {
 		name         string
 		namespace    string
-		targetName   string
+		target       *workload.Target
 		wantPodCount int
 		wantPodNames []string
 		wantErr      bool
@@ -294,7 +294,12 @@ func TestGetMetricPods(t *testing.T) {
 		{
 			name:         "pods in default namespace",
 			namespace:    "default",
-			targetName:   "model1",
+			target: &workload.Target{
+				TargetRef: corev1.ObjectReference{
+					Name: "model1",
+					Kind: workload.ModelServingKind.Kind,
+				},
+			},
 			wantPodCount: 1,
 			wantPodNames: []string{"pod1"},
 			wantErr:      false,
@@ -302,7 +307,12 @@ func TestGetMetricPods(t *testing.T) {
 		{
 			name:         "pods in other-namespace",
 			namespace:    "other-namespace",
-			targetName:   "model1",
+			target: &workload.Target{
+				TargetRef: corev1.ObjectReference{
+					Name: "model1",
+					Kind: workload.ModelServingKind.Kind,
+				},
+			},
 			wantPodCount: 1,
 			wantPodNames: []string{"pod2"},
 			wantErr:      false,
@@ -310,7 +320,32 @@ func TestGetMetricPods(t *testing.T) {
 		{
 			name:         "pods in non-existent namespace",
 			namespace:    "non-existent",
-			targetName:   "model1",
+			target: &workload.Target{
+				TargetRef: corev1.ObjectReference{
+					Name: "model1",
+					Kind: workload.ModelServingKind.Kind,
+				},
+			},
+			wantPodCount: 0,
+			wantPodNames: []string{},
+			wantErr:      false,
+		},
+		{
+			name:         "nil target returns no pods",
+			namespace:    "default",
+			target:       nil,
+			wantPodCount: 0,
+			wantPodNames: []string{},
+			wantErr:      false,
+		},
+		{
+			name:      "empty target name returns no pods",
+			namespace: "default",
+			target: &workload.Target{
+				TargetRef: corev1.ObjectReference{
+					Kind: workload.ModelServingKind.Kind,
+				},
+			},
 			wantPodCount: 0,
 			wantPodNames: []string{},
 			wantErr:      false,
@@ -319,11 +354,7 @@ func TestGetMetricPods(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			target := &workload.Target{}
-			target.TargetRef.Name = tt.targetName
-			target.TargetRef.Kind = workload.ModelServingKind.Kind
-
-			pods, err := GetMetricPods(podLister, tt.namespace, target)
+			pods, err := GetMetricPods(podLister, tt.namespace, tt.target)
 
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetMetricPods() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/autoscaler/util/client_test.go
+++ b/pkg/autoscaler/util/client_test.go
@@ -330,6 +330,26 @@ func TestGetMetricPods(t *testing.T) {
 			wantPodNames: []string{},
 			wantErr:      false,
 		},
+		{
+			name:         "nil target returns no pods",
+			namespace:    "default",
+			target:       nil,
+			wantPodCount: 0,
+			wantPodNames: []string{},
+			wantErr:      false,
+		},
+		{
+			name:      "empty target name returns no pods",
+			namespace: "default",
+			target: &workload.Target{
+				TargetRef: corev1.ObjectReference{
+					Kind: workload.ModelServingKind.Kind,
+				},
+			},
+			wantPodCount: 0,
+			wantPodNames: []string{},
+			wantErr:      false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Expands unit coverage for autoscaler target helper functions.

This adds edge-case coverage for `GetRoleName` and `GetTargetLabels`, including nil/empty target refs, malformed role refs, default target kind behavior, role sub-target labels, preserved custom metric labels, and unsupported target kinds.

These helpers are used to resolve autoscaling metric targets, so the added coverage makes selector behavior safer to maintain.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

Test-only change.

**Verification**
<img width="1419" height="74" alt="image" src="https://github.com/user-attachments/assets/ce5f8434-127d-44bb-b7fe-1eb6ad9bf0cc" />

Test command:

```bash
go test ./pkg/autoscaler/util
