### PR TITLE
test: add unit tests for vllm metrics

### DIFF
--- a/pkg/kthena-router/backend/vllm/metrics_test.go
+++ b/pkg/kthena-router/backend/vllm/metrics_test.go
@@ -1,0 +1,225 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vllm
+
+import (
+	"testing"
+
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/volcano-sh/kthena/pkg/kthena-router/utils"
+)
+
+// this creates a mock gauge metric family for testing gauge/counter metrics.
+func gaugeMetricFamily(value float64) *dto.MetricFamily {
+	v := value
+	return &dto.MetricFamily{
+		Metric: []*dto.Metric{
+			{Gauge: &dto.Gauge{Value: &v}},
+		},
+	}
+}
+
+// this creates a mock histogram metric family for testing histogram metrics.
+func histogramMetricFamily(sum float64, count uint64) *dto.MetricFamily {
+	s, c := sum, count
+	return &dto.MetricFamily{
+		Metric: []*dto.Metric{
+			{Histogram: &dto.Histogram{SampleSum: &s, SampleCount: &c}},
+		},
+	}
+}
+
+// this will test the extraction and mapping of gauge/counter metrics.
+func TestGetCountMetricsInfo(t *testing.T) {
+	engine := NewVllmEngine()
+
+	tests := []struct {
+		name       string
+		allMetrics map[string]*dto.MetricFamily
+		want       map[string]float64
+	}{
+		{
+			name: "all known counter/gauge metrics present",
+			allMetrics: map[string]*dto.MetricFamily{
+				GPUCacheUsage:     gaugeMetricFamily(0.75),
+				RequestWaitingNum: gaugeMetricFamily(3.0),
+				RequestRunningNum: gaugeMetricFamily(5.0),
+			},
+			want: map[string]float64{
+				utils.GPUCacheUsage:     0.75,
+				utils.RequestWaitingNum: 3.0,
+				utils.RequestRunningNum: 5.0,
+			},
+		},
+		{
+			name:       "empty input returns empty map",
+			allMetrics: map[string]*dto.MetricFamily{},
+			want:       map[string]float64{},
+		},
+		{
+			name: "unknown metrics are ignored",
+			allMetrics: map[string]*dto.MetricFamily{
+				"some:unknown:metric": gaugeMetricFamily(99.0),
+			},
+			want: map[string]float64{},
+		},
+		{
+			name: "partial metrics — only gpu cache present",
+			allMetrics: map[string]*dto.MetricFamily{
+				GPUCacheUsage: gaugeMetricFamily(0.5),
+			},
+			want: map[string]float64{
+				utils.GPUCacheUsage: 0.5,
+			},
+		},
+		{
+			name: "zero values stored correctly",
+			allMetrics: map[string]*dto.MetricFamily{
+				GPUCacheUsage:     gaugeMetricFamily(0.0),
+				RequestWaitingNum: gaugeMetricFamily(0.0),
+				RequestRunningNum: gaugeMetricFamily(0.0),
+			},
+			want: map[string]float64{
+				utils.GPUCacheUsage:     0.0,
+				utils.RequestWaitingNum: 0.0,
+				utils.RequestRunningNum: 0.0,
+			},
+		},
+		{
+			name: "name mapping correctness",
+			allMetrics: map[string]*dto.MetricFamily{
+				RequestRunningNum: gaugeMetricFamily(7.0),
+			},
+			want: map[string]float64{
+				utils.RequestRunningNum: 7.0,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := engine.GetCountMetricsInfo(tt.allMetrics)
+			if len(got) != len(tt.want) {
+				t.Errorf("got %d keys, want %d keys", len(got), len(tt.want))
+			}
+			for k, wantVal := range tt.want {
+				if gotVal, ok := got[k]; !ok {
+					t.Errorf("missing key %q in result", k)
+				} else if gotVal != wantVal {
+					t.Errorf("key %q: got %v, want %v", k, gotVal, wantVal)
+				}
+			}
+		})
+	}
+}
+
+// this will test histogram metric processing and rolling-average calculations
+func TestGetHistogramPodMetrics(t *testing.T) {
+	engine := NewVllmEngine()
+
+	tests := []struct {
+		name              string
+		allMetrics        map[string]*dto.MetricFamily
+		previousHistogram map[string]*dto.Histogram
+		wantMetrics       map[string]float64
+		wantHistogramKeys []string
+	}{
+		{
+			name: "no previous histogram — zero latency (fair initial chance)",
+			allMetrics: map[string]*dto.MetricFamily{
+				TPOT: histogramMetricFamily(10.0, 5),
+				TTFT: histogramMetricFamily(20.0, 8),
+			},
+			previousHistogram: map[string]*dto.Histogram{},
+			wantMetrics: map[string]float64{
+				utils.TPOT: 0.0,
+				utils.TTFT: 0.0,
+			},
+			wantHistogramKeys: []string{utils.TPOT, utils.TTFT},
+		},
+		{
+			name: "with previous — correct delta avg",
+			allMetrics: map[string]*dto.MetricFamily{
+				TPOT: histogramMetricFamily(20.0, 10),
+			},
+			previousHistogram: map[string]*dto.Histogram{
+				utils.TPOT: func() *dto.Histogram {
+					s, c := 10.0, uint64(5)
+					return &dto.Histogram{SampleSum: &s, SampleCount: &c}
+				}(),
+			},
+			wantMetrics: map[string]float64{
+				utils.TPOT: 2.0,
+			},
+			wantHistogramKeys: []string{utils.TPOT},
+		},
+		{
+			name:              "empty input",
+			allMetrics:        map[string]*dto.MetricFamily{},
+			previousHistogram: map[string]*dto.Histogram{},
+			wantMetrics:       map[string]float64{},
+			wantHistogramKeys: []string{},
+		},
+		{
+			name: "unknown metrics ignored",
+			allMetrics: map[string]*dto.MetricFamily{
+				"vllm:unknown_histogram": histogramMetricFamily(5.0, 2),
+			},
+			previousHistogram: map[string]*dto.Histogram{},
+			wantMetrics:       map[string]float64{},
+			wantHistogramKeys: []string{},
+		},
+		{
+			name: "stored histogram matches current scrape",
+			allMetrics: map[string]*dto.MetricFamily{
+				TTFT: histogramMetricFamily(30.0, 15),
+			},
+			previousHistogram: map[string]*dto.Histogram{},
+			wantMetrics: map[string]float64{
+				utils.TTFT: 0.0,
+			},
+			wantHistogramKeys: []string{utils.TTFT},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotMetrics, gotHistograms := engine.GetHistogramPodMetrics(tt.allMetrics, tt.previousHistogram)
+
+			if len(gotMetrics) != len(tt.wantMetrics) {
+				t.Errorf("got %d metric keys, want %d", len(gotMetrics), len(tt.wantMetrics))
+			}
+			for k, wantVal := range tt.wantMetrics {
+				if gotVal, ok := gotMetrics[k]; !ok {
+					t.Errorf("missing metric key %q", k)
+				} else if gotVal != wantVal {
+					t.Errorf("metric %q: got %v, want %v", k, gotVal, wantVal)
+				}
+			}
+
+			for _, k := range tt.wantHistogramKeys {
+				if _, ok := gotHistograms[k]; !ok {
+					t.Errorf("missing histogram key %q", k)
+				}
+			}
+			if len(gotHistograms) != len(tt.wantHistogramKeys) {
+				t.Errorf("got %d histogram keys, want %d", len(gotHistograms), len(tt.wantHistogramKeys))
+			}
+		})
+	}
+}

--- a/pkg/kthena-router/backend/vllm/metrics_test.go
+++ b/pkg/kthena-router/backend/vllm/metrics_test.go
@@ -56,12 +56,12 @@ func TestGetCountMetricsInfo(t *testing.T) {
 		{
 			name: "all known counter/gauge metrics present",
 			allMetrics: map[string]*dto.MetricFamily{
-				GPUCacheUsage:     gaugeMetricFamily(0.75),
+				KVCacheUsage:     gaugeMetricFamily(0.75),
 				RequestWaitingNum: gaugeMetricFamily(3.0),
 				RequestRunningNum: gaugeMetricFamily(5.0),
 			},
 			want: map[string]float64{
-				utils.GPUCacheUsage:     0.75,
+				utils.KVCacheUsage:     0.75,
 				utils.RequestWaitingNum: 3.0,
 				utils.RequestRunningNum: 5.0,
 			},
@@ -81,21 +81,21 @@ func TestGetCountMetricsInfo(t *testing.T) {
 		{
 			name: "partial metrics — only gpu cache present",
 			allMetrics: map[string]*dto.MetricFamily{
-				GPUCacheUsage: gaugeMetricFamily(0.5),
+				KVCacheUsage: gaugeMetricFamily(0.5),
 			},
 			want: map[string]float64{
-				utils.GPUCacheUsage: 0.5,
+				utils.KVCacheUsage: 0.5,
 			},
 		},
 		{
 			name: "zero values stored correctly",
 			allMetrics: map[string]*dto.MetricFamily{
-				GPUCacheUsage:     gaugeMetricFamily(0.0),
+				KVCacheUsage:     gaugeMetricFamily(0.0),
 				RequestWaitingNum: gaugeMetricFamily(0.0),
 				RequestRunningNum: gaugeMetricFamily(0.0),
 			},
 			want: map[string]float64{
-				utils.GPUCacheUsage:     0.0,
+				utils.KVCacheUsage:     0.0,
 				utils.RequestWaitingNum: 0.0,
 				utils.RequestRunningNum: 0.0,
 			},
@@ -141,7 +141,7 @@ func TestGetHistogramPodMetrics(t *testing.T) {
 		{
 			name: "no previous histogram — zero latency (fair initial chance)",
 			allMetrics: map[string]*dto.MetricFamily{
-				TPOT: histogramMetricFamily(10.0, 5),
+				ITL: histogramMetricFamily(10.0, 5),
 				TTFT: histogramMetricFamily(20.0, 8),
 			},
 			previousHistogram: map[string]*dto.Histogram{},
@@ -154,7 +154,7 @@ func TestGetHistogramPodMetrics(t *testing.T) {
 		{
 			name: "with previous — correct delta avg",
 			allMetrics: map[string]*dto.MetricFamily{
-				TPOT: histogramMetricFamily(20.0, 10),
+				ITL: histogramMetricFamily(20.0, 10),
 			},
 			previousHistogram: map[string]*dto.Histogram{
 				utils.TPOT: func() *dto.Histogram {

--- a/pkg/kthena-router/backend/vllm/metrics_test.go
+++ b/pkg/kthena-router/backend/vllm/metrics_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/volcano-sh/kthena/pkg/kthena-router/utils"
 )
 
-// this creates a mock gauge metric family for testing gauge/counter metrics.
+// gaugeMetricFamily creates a mock gauge metric family for testing gauge/counter metrics.
 func gaugeMetricFamily(value float64) *dto.MetricFamily {
 	v := value
 	return &dto.MetricFamily{
@@ -34,7 +34,7 @@ func gaugeMetricFamily(value float64) *dto.MetricFamily {
 	}
 }
 
-// this creates a mock histogram metric family for testing histogram metrics.
+// histogramMetricFamily creates a mock histogram metric family for testing histogram metrics.
 func histogramMetricFamily(sum float64, count uint64) *dto.MetricFamily {
 	s, c := sum, count
 	return &dto.MetricFamily{
@@ -44,7 +44,7 @@ func histogramMetricFamily(sum float64, count uint64) *dto.MetricFamily {
 	}
 }
 
-// this will test the extraction and mapping of gauge/counter metrics.
+// TestGetCountMetricsInfo will test the extraction and mapping of gauge/counter metrics.
 func TestGetCountMetricsInfo(t *testing.T) {
 	engine := NewVllmEngine()
 
@@ -128,7 +128,7 @@ func TestGetCountMetricsInfo(t *testing.T) {
 	}
 }
 
-// this will test histogram metric processing and rolling-average calculations
+// TestGetHistogramPodMetrics will test histogram metric processing and rolling-average calculations
 func TestGetHistogramPodMetrics(t *testing.T) {
 	engine := NewVllmEngine()
 

--- a/pkg/kthena-router/backend/vllm/metrics_test.go
+++ b/pkg/kthena-router/backend/vllm/metrics_test.go
@@ -20,31 +20,31 @@ import (
 	"testing"
 
 	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/volcano-sh/kthena/pkg/kthena-router/utils"
 )
 
 // gaugeMetricFamily creates a mock gauge metric family for testing gauge/counter metrics.
 func gaugeMetricFamily(value float64) *dto.MetricFamily {
-	v := value
 	return &dto.MetricFamily{
 		Metric: []*dto.Metric{
-			{Gauge: &dto.Gauge{Value: &v}},
+			{Gauge: &dto.Gauge{Value: &value}},
 		},
 	}
 }
 
 // histogramMetricFamily creates a mock histogram metric family for testing histogram metrics.
 func histogramMetricFamily(sum float64, count uint64) *dto.MetricFamily {
-	s, c := sum, count
 	return &dto.MetricFamily{
 		Metric: []*dto.Metric{
-			{Histogram: &dto.Histogram{SampleSum: &s, SampleCount: &c}},
+			{Histogram: &dto.Histogram{SampleSum: &sum, SampleCount: &count}},
 		},
 	}
 }
 
-// TestGetCountMetricsInfo will test the extraction and mapping of gauge/counter metrics.
+// TestGetCountMetricsInfo tests extraction and mapping of gauge/counter metrics.
 func TestGetCountMetricsInfo(t *testing.T) {
 	engine := NewVllmEngine()
 
@@ -114,21 +114,20 @@ func TestGetCountMetricsInfo(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := engine.GetCountMetricsInfo(tt.allMetrics)
-			if len(got) != len(tt.want) {
-				t.Errorf("got %d keys, want %d keys", len(got), len(tt.want))
-			}
+
+			require.Len(t, got, len(tt.want))
+
 			for k, wantVal := range tt.want {
-				if gotVal, ok := got[k]; !ok {
-					t.Errorf("missing key %q in result", k)
-				} else if gotVal != wantVal {
-					t.Errorf("key %q: got %v, want %v", k, gotVal, wantVal)
-				}
+				gotVal, ok := got[k]
+				require.True(t, ok, "missing key %q in result", k)
+				assert.Equal(t, wantVal, gotVal)
 			}
 		})
 	}
 }
 
-// TestGetHistogramPodMetrics will test histogram metric processing and rolling-average calculations
+// TestGetHistogramPodMetrics tests histogram metric processing
+// and rolling-average calculations.
 func TestGetHistogramPodMetrics(t *testing.T) {
 	engine := NewVllmEngine()
 
@@ -201,24 +200,20 @@ func TestGetHistogramPodMetrics(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			gotMetrics, gotHistograms := engine.GetHistogramPodMetrics(tt.allMetrics, tt.previousHistogram)
 
-			if len(gotMetrics) != len(tt.wantMetrics) {
-				t.Errorf("got %d metric keys, want %d", len(gotMetrics), len(tt.wantMetrics))
-			}
+			require.Len(t, gotMetrics, len(tt.wantMetrics))
+
 			for k, wantVal := range tt.wantMetrics {
-				if gotVal, ok := gotMetrics[k]; !ok {
-					t.Errorf("missing metric key %q", k)
-				} else if gotVal != wantVal {
-					t.Errorf("metric %q: got %v, want %v", k, gotVal, wantVal)
-				}
+				gotVal, ok := gotMetrics[k]
+				require.True(t, ok, "missing metric key %q", k)
+				assert.Equal(t, wantVal, gotVal)
 			}
 
+			require.Len(t, gotHistograms, len(tt.wantHistogramKeys))
+
 			for _, k := range tt.wantHistogramKeys {
-				if _, ok := gotHistograms[k]; !ok {
-					t.Errorf("missing histogram key %q", k)
-				}
-			}
-			if len(gotHistograms) != len(tt.wantHistogramKeys) {
-				t.Errorf("got %d histogram keys, want %d", len(gotHistograms), len(tt.wantHistogramKeys))
+				h, ok := gotHistograms[k]
+				require.True(t, ok, "missing histogram key %q", k)
+				assert.NotNil(t, h)
 			}
 		})
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

adding  unit tests for vLLM metrics processing in kthena-router.
The tests will validate:
* Gauge/counter metric extraction
* Histogram metric handling
* Rolling-average latency calculations
* Empty and unknown metric handling
* Histogram snapshot storage behavior

will improve reliability and help prevent regressions in the metrics processing logic.
PR only adds test coverage and does not modify existing runtime behavior.

**Which issue(s) this PR fixes**:
Fixes #1022

**Special notes for your reviewer**:



