### PR TITLE
fix: tolerate SSE usage line variants

### DIFF
--- a/pkg/kthena-router/connectors/transport_test.go
+++ b/pkg/kthena-router/connectors/transport_test.go
@@ -446,24 +446,53 @@ func TestHandleStreamingResponse(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	tests := []struct {
-		name         string
-		responseBody string
-		tokenUsage   bool
+		name             string
+		responseBody     string
+		tokenUsage       bool
+		wantOutputTokens int
+		wantResponseBody string
 	}{
 		{
-			name:         "streaming response with usage",
-			responseBody: "data: {\"id\":\"test\",\"object\":\"text_completion\",\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":20,\"total_tokens\":30}}\n\ndata: [DONE]\n\n",
-			tokenUsage:   false,
+			name:             "streaming response with usage",
+			responseBody:     "data: {\"id\":\"test\",\"object\":\"text_completion\",\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":20,\"total_tokens\":30}}\n\ndata: [DONE]\n\n",
+			tokenUsage:       false,
+			wantOutputTokens: 20,
+			wantResponseBody: "data: {\"id\":\"test\",\"object\":\"text_completion\",\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":20,\"total_tokens\":30}}\n\ndata: [DONE]\n\n",
 		},
 		{
-			name:         "streaming response with token usage filtering",
-			responseBody: "data: {\"id\":\"test\",\"object\":\"text_completion\",\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":20,\"total_tokens\":30}}\n\ndata: [DONE]\n\n",
-			tokenUsage:   true,
+			name:             "streaming response with usage and no optional space after data colon",
+			responseBody:     "data:{\"id\":\"test\",\"object\":\"text_completion\",\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":20,\"total_tokens\":30}}\n\ndata:[DONE]\n\n",
+			tokenUsage:       false,
+			wantOutputTokens: 20,
+			wantResponseBody: "data:{\"id\":\"test\",\"object\":\"text_completion\",\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":20,\"total_tokens\":30}}\n\ndata:[DONE]\n\n",
 		},
 		{
-			name:         "streaming response without usage",
-			responseBody: "data: {\"id\":\"test\",\"object\":\"text_completion\"}\n\ndata: [DONE]\n\n",
-			tokenUsage:   false,
+			name:             "streaming response with token usage filtering",
+			responseBody:     "data: {\"id\":\"test\",\"object\":\"text_completion\",\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":20,\"total_tokens\":30}}\n\ndata: [DONE]\n\n",
+			tokenUsage:       true,
+			wantOutputTokens: 20,
+			wantResponseBody: "\ndata: [DONE]\n\n",
+		},
+		{
+			name:             "streaming response filters no-space data usage line",
+			responseBody:     "data:{\"id\":\"test\",\"object\":\"text_completion\",\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":20,\"total_tokens\":30}}\n\ndata:[DONE]\n\n",
+			tokenUsage:       true,
+			wantOutputTokens: 20,
+			wantResponseBody: "\ndata:[DONE]\n\n",
+		},
+		{
+			name:             "streaming response with invalid leading whitespace before data field",
+			responseBody:     "\tdata: {\"id\":\"test\",\"object\":\"text_completion\",\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":20,\"total_tokens\":30}}\n\ndata: [DONE]\n\n",
+			tokenUsage:       false,
+			wantOutputTokens: 0,
+			wantResponseBody: "\tdata: {\"id\":\"test\",\"object\":\"text_completion\",\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":20,\"total_tokens\":30}}\n\ndata: [DONE]\n\n",
+		},
+		{
+			name:             "streaming response without usage",
+			responseBody:     "data: {\"id\":\"test\",\"object\":\"text_completion\"}\n\ndata: [DONE]\n\n",
+			tokenUsage:       false,
+			wantOutputTokens: 0,
+			wantResponseBody: "data: {\"id\":\"test\",\"object\":\"text_completion\"}\n\ndata: [DONE]\n\n",
 		},
 	}
 
@@ -487,10 +516,12 @@ func TestHandleStreamingResponse(t *testing.T) {
 			}
 			resp.Header.Set("Content-Type", "text/event-stream")
 
-			_, err := handleStreamingResponse(c, resp)
+			gotOutputTokens, err := handleStreamingResponse(c, resp)
 
 			// Should not return error
 			assert.NoError(t, err)
+			assert.Equal(t, tt.wantOutputTokens, gotOutputTokens)
+			assert.Equal(t, tt.wantResponseBody, w.Body.String())
 		})
 	}
 }

--- a/pkg/kthena-router/handlers/response.go
+++ b/pkg/kthena-router/handlers/response.go
@@ -71,7 +71,10 @@ func ParseStreamRespForUsage(
 	responseText string,
 ) OpenAIResponse {
 	var response OpenAIResponse
-	line := strings.TrimSpace(responseText)
+	// SSE data fields allow both "data: <value>" and "data:<value>".
+	// Do not trim leading whitespace before the prefix check; that would
+	// accept invalid field names such as " data:".
+	line := strings.TrimRight(responseText, "\r\n")
 	if !strings.HasPrefix(line, streamingRespPrefix) {
 		return response
 	}

--- a/pkg/kthena-router/handlers/response.go
+++ b/pkg/kthena-router/handlers/response.go
@@ -52,8 +52,8 @@ func ParseOpenAIResponseBody(resp []byte) (*OpenAIResponse, error) {
 }
 
 const (
-	streamingRespPrefix = "data: "
-	streamingEndMsg     = "data: [DONE]"
+	streamingRespPrefix = "data:"
+	streamingEndMsg     = "[DONE]"
 )
 
 // Example message if "stream_options": {"include_usage": "true"} is included in the request:
@@ -71,10 +71,14 @@ func ParseStreamRespForUsage(
 	responseText string,
 ) OpenAIResponse {
 	var response OpenAIResponse
-	if !strings.HasPrefix(responseText, streamingRespPrefix) || strings.HasPrefix(responseText, streamingEndMsg) {
+	line := strings.TrimSpace(responseText)
+	if !strings.HasPrefix(line, streamingRespPrefix) {
 		return response
 	}
-	content := strings.TrimPrefix(responseText, streamingRespPrefix)
+	content := strings.TrimSpace(strings.TrimPrefix(line, streamingRespPrefix))
+	if content == "" || content == streamingEndMsg {
+		return response
+	}
 
 	byteSlice := []byte(content)
 	if err := json.Unmarshal(byteSlice, &response); err != nil {

--- a/pkg/kthena-router/handlers/response_test.go
+++ b/pkg/kthena-router/handlers/response_test.go
@@ -91,18 +91,18 @@ func TestParseStreamRespForUsage(t *testing.T) {
 			want:         validUsageResponse,
 		},
 		{
-			name:         "valid stream without space after prefix",
+			name:         "valid stream without optional space after colon",
 			responseText: "data:" + usageChunk,
 			want:         validUsageResponse,
 		},
 		{
-			name:         "valid stream with leading and trailing whitespace",
-			responseText: "\tdata: " + usageChunk + "\r\n",
+			name:         "valid stream with trailing line terminator",
+			responseText: "data: " + usageChunk + "\r\n",
 			want:         validUsageResponse,
 		},
 		{
-			name:         "valid stream with tab after prefix",
-			responseText: "data:\t" + usageChunk,
+			name:         "valid stream with json whitespace after colon",
+			responseText: "data:\t " + usageChunk + " ",
 			want:         validUsageResponse,
 		},
 		{
@@ -111,8 +111,8 @@ func TestParseStreamRespForUsage(t *testing.T) {
 			want:         OpenAIResponse{},
 		},
 		{
-			name:         "stream [DONE] with whitespace",
-			responseText: " data: [DONE]\r\n",
+			name:         "stream [DONE] with trailing line terminator",
+			responseText: "data: [DONE]\r\n",
 			want:         OpenAIResponse{},
 		},
 		{
@@ -123,6 +123,26 @@ func TestParseStreamRespForUsage(t *testing.T) {
 		{
 			name:         "empty data payload",
 			responseText: "data:   ",
+			want:         OpenAIResponse{},
+		},
+		{
+			name:         "leading whitespace before data field is not accepted",
+			responseText: "\tdata: " + usageChunk,
+			want:         OpenAIResponse{},
+		},
+		{
+			name:         "space before colon is not a data field",
+			responseText: "data : " + usageChunk,
+			want:         OpenAIResponse{},
+		},
+		{
+			name:         "other sse field is ignored",
+			responseText: "event: message",
+			want:         OpenAIResponse{},
+		},
+		{
+			name:         "data field without colon is ignored",
+			responseText: "data " + usageChunk,
 			want:         OpenAIResponse{},
 		},
 		{

--- a/pkg/kthena-router/handlers/response_test.go
+++ b/pkg/kthena-router/handlers/response_test.go
@@ -67,6 +67,18 @@ func TestParseOpenAIResponseBody(t *testing.T) {
 }
 
 func TestParseStreamRespForUsage(t *testing.T) {
+	validUsageResponse := OpenAIResponse{
+		ID:      "test-id",
+		Object:  "text_completion",
+		Created: 1739400043,
+		Model:   "tweet-summary-0",
+		Usage: Usage{
+			PromptTokens:     7,
+			CompletionTokens: 10,
+			TotalTokens:      17,
+		},
+	}
+
 	tests := []struct {
 		name         string
 		responseText string
@@ -75,22 +87,32 @@ func TestParseStreamRespForUsage(t *testing.T) {
 		{
 			name:         "valid stream with usage",
 			responseText: `data: {"id":"test-id","object":"text_completion","created":1739400043,"model":"tweet-summary-0","choices":[],"usage":{"prompt_tokens":7,"total_tokens":17,"completion_tokens":10}}`,
-			want: OpenAIResponse{
-				ID:      "test-id",
-				Object:  "text_completion",
-				Created: 1739400043,
-				Model:   "tweet-summary-0",
-				Usage: Usage{
-					PromptTokens:     7,
-					CompletionTokens: 10,
-					TotalTokens:      17,
-				},
-			},
+			want:         validUsageResponse,
 		},
 		{
 			name:         "stream [DONE]",
 			responseText: `data: [DONE]`,
 			want:         OpenAIResponse{},
+		},
+		{
+			name:         "stream [DONE] with whitespace",
+			responseText: " data: [DONE]\r\n",
+			want:         OpenAIResponse{},
+		},
+		{
+			name:         "stream [DONE] without space after prefix",
+			responseText: `data:[DONE]`,
+			want:         OpenAIResponse{},
+		},
+		{
+			name:         "valid stream without space after prefix",
+			responseText: `data:{"id":"test-id","object":"text_completion","created":1739400043,"model":"tweet-summary-0","choices":[],"usage":{"prompt_tokens":7,"total_tokens":17,"completion_tokens":10}}`,
+			want:         validUsageResponse,
+		},
+		{
+			name:         "valid stream with CRLF",
+			responseText: "data: {\"id\":\"test-id\",\"object\":\"text_completion\",\"created\":1739400043,\"model\":\"tweet-summary-0\",\"choices\":[],\"usage\":{\"prompt_tokens\":7,\"total_tokens\":17,\"completion_tokens\":10}}\r\n",
+			want:         validUsageResponse,
 		},
 		{
 			name:         "no data: prefix",

--- a/pkg/kthena-router/handlers/response_test.go
+++ b/pkg/kthena-router/handlers/response_test.go
@@ -67,6 +67,7 @@ func TestParseOpenAIResponseBody(t *testing.T) {
 }
 
 func TestParseStreamRespForUsage(t *testing.T) {
+	usageChunk := `{"id":"test-id","object":"text_completion","created":1739400043,"model":"tweet-summary-0","choices":[],"usage":{"prompt_tokens":7,"total_tokens":17,"completion_tokens":10}}`
 	validUsageResponse := OpenAIResponse{
 		ID:      "test-id",
 		Object:  "text_completion",
@@ -86,7 +87,22 @@ func TestParseStreamRespForUsage(t *testing.T) {
 	}{
 		{
 			name:         "valid stream with usage",
-			responseText: `data: {"id":"test-id","object":"text_completion","created":1739400043,"model":"tweet-summary-0","choices":[],"usage":{"prompt_tokens":7,"total_tokens":17,"completion_tokens":10}}`,
+			responseText: "data: " + usageChunk,
+			want:         validUsageResponse,
+		},
+		{
+			name:         "valid stream without space after prefix",
+			responseText: "data:" + usageChunk,
+			want:         validUsageResponse,
+		},
+		{
+			name:         "valid stream with leading and trailing whitespace",
+			responseText: "\tdata: " + usageChunk + "\r\n",
+			want:         validUsageResponse,
+		},
+		{
+			name:         "valid stream with tab after prefix",
+			responseText: "data:\t" + usageChunk,
 			want:         validUsageResponse,
 		},
 		{
@@ -105,14 +121,9 @@ func TestParseStreamRespForUsage(t *testing.T) {
 			want:         OpenAIResponse{},
 		},
 		{
-			name:         "valid stream without space after prefix",
-			responseText: `data:{"id":"test-id","object":"text_completion","created":1739400043,"model":"tweet-summary-0","choices":[],"usage":{"prompt_tokens":7,"total_tokens":17,"completion_tokens":10}}`,
-			want:         validUsageResponse,
-		},
-		{
-			name:         "valid stream with CRLF",
-			responseText: "data: {\"id\":\"test-id\",\"object\":\"text_completion\",\"created\":1739400043,\"model\":\"tweet-summary-0\",\"choices\":[],\"usage\":{\"prompt_tokens\":7,\"total_tokens\":17,\"completion_tokens\":10}}\r\n",
-			want:         validUsageResponse,
+			name:         "empty data payload",
+			responseText: "data:   ",
+			want:         OpenAIResponse{},
 		},
 		{
 			name:         "no data: prefix",
@@ -122,6 +133,11 @@ func TestParseStreamRespForUsage(t *testing.T) {
 		{
 			name:         "invalid json",
 			responseText: `data: {"id":"test-id",`,
+			want:         OpenAIResponse{},
+		},
+		{
+			name:         "non-json data payload",
+			responseText: `data: not-json`,
 			want:         OpenAIResponse{},
 		},
 	}


### PR DESCRIPTION
What type of PR is this?

/kind bug

What this PR does / why we need it:

Makes streaming usage parsing more tolerant of normal SSE line variants.

The router now trims whitespace, accepts both `data: {...}` and `data:{...}`, ignores empty `data:` payloads, and safely skips `[DONE]` markers even when the line has trailing CRLF/whitespace.

This helps usage parsing work with providers that format SSE chunks slightly differently.

Which issue(s) this PR fixes:

None

Special notes for your reviewer:

Small parsing-only change with focused unit coverage.

Verification:

<img width="1442" height="140" alt="image" src="https://github.com/user-attachments/assets/f52786c9-a9d2-492d-9f39-038efb182888" />


```bash
go test ./pkg/kthena-router/handlers
