### PR TITLE
fix: reject whitespace in webhook image validation

### DIFF
--- a/pkg/model-booster-controller/webhook/model_validator.go
+++ b/pkg/model-booster-controller/webhook/model_validator.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"unicode"
 
 	registryv1alpha1 "github.com/volcano-sh/kthena/pkg/apis/workload/v1alpha1"
 	admissionv1 "k8s.io/api/admission/v1"
@@ -197,13 +198,13 @@ func validateImageField(image string) error {
 		return nil
 	}
 
-	// Simple validation: check if image contains at least one character and no spaces
+	// Simple validation: check if image contains at least one character and no whitespace.
 	if strings.TrimSpace(image) == "" {
 		return fmt.Errorf("image cannot be empty or whitespace only")
 	}
 
-	if strings.Contains(image, " ") {
-		return fmt.Errorf("image cannot contain spaces")
+	if strings.IndexFunc(image, unicode.IsSpace) >= 0 {
+		return fmt.Errorf("image cannot contain whitespace")
 	}
 
 	// Basic format check: should contain at least one character

--- a/pkg/model-booster-controller/webhook/model_validator_test.go
+++ b/pkg/model-booster-controller/webhook/model_validator_test.go
@@ -114,3 +114,13 @@ func TestValidateModel_NoErrors(t *testing.T) {
 	assert.True(t, valid)
 	assert.Empty(t, errorMsg)
 }
+
+func TestValidateImageFieldRejectsWhitespace(t *testing.T) {
+	assert.NoError(t, validateImageField("registry.example.com/model-worker:v1"))
+
+	for _, image := range []string{"model worker:v1", "model\tworker:v1", "model\nworker:v1", "\t\n"} {
+		t.Run(image, func(t *testing.T) {
+			assert.Error(t, validateImageField(image))
+		})
+	}
+}

--- a/pkg/model-serving-controller/webhook/validator.go
+++ b/pkg/model-serving-controller/webhook/validator.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"unicode"
 
 	admissionv1 "k8s.io/api/admission/v1"
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
@@ -357,13 +358,13 @@ func validateImageField(image string) error {
 		return nil
 	}
 
-	// Simple validation: check if image contains at least one character and no spaces
+	// Simple validation: check if image contains at least one character and no whitespace.
 	if strings.TrimSpace(image) == "" {
 		return fmt.Errorf("image cannot be empty or whitespace only")
 	}
 
-	if strings.Contains(image, " ") {
-		return fmt.Errorf("image cannot contain spaces")
+	if strings.IndexFunc(image, unicode.IsSpace) >= 0 {
+		return fmt.Errorf("image cannot contain whitespace")
 	}
 
 	return nil

--- a/pkg/model-serving-controller/webhook/validator_test.go
+++ b/pkg/model-serving-controller/webhook/validator_test.go
@@ -1077,6 +1077,16 @@ func TestValidateRoleNames(t *testing.T) {
 	}
 }
 
+func TestValidateImageFieldRejectsWhitespace(t *testing.T) {
+	assert.NoError(t, validateImageField("registry.example.com/model-serving:v1"))
+
+	for _, image := range []string{"model serving:v1", "model\tserving:v1", "model\nserving:v1", "\t\n"} {
+		t.Run(image, func(t *testing.T) {
+			assert.Error(t, validateImageField(image))
+		})
+	}
+}
+
 func TestValidateRecoveryPolicyAndRolloutStrategy(t *testing.T) {
 	replicas := int32(3)
 


### PR DESCRIPTION
/kind bug

Use strings.Cut when parsing cache URIs so only the first `://` separator is treated as the URI prefix separator.

This avoids truncating cache paths that themselves contain `://`.

Fixes : #1026 

Verification:

<img width="1453" height="147" alt="image" src="https://github.com/user-attachments/assets/40f4910b-ae34-4a92-bcc0-c23fbbfe8d03" />

go test ./pkg/model-booster-controller/convert
