### PR TITLE
fix: refresh router route indexes on update

### DIFF
--- a/pkg/kthena-router/datastore/store.go
+++ b/pkg/kthena-router/datastore/store.go
@@ -755,49 +755,24 @@ func (s *store) DeletePod(podName types.NamespacedName) error {
 func (s *store) AddOrUpdateModelRoute(mr *aiv1alpha1.ModelRoute) error {
 	s.routeMutex.Lock()
 	key := mr.Namespace + "/" + mr.Name
+	s.removeModelRouteIndexesLocked(key)
 	s.routeInfo[key] = &modelRouteInfo{
 		model: mr.Spec.ModelName,
 		loras: mr.Spec.LoraAdapters,
 	}
 
 	if mr.Spec.ModelName != "" {
-		// Check if this ModelRoute already exists in the slice
 		routes := s.routes[mr.Spec.ModelName]
-		found := false
-		for i, route := range routes {
-			if route.Namespace == mr.Namespace && route.Name == mr.Name {
-				routes[i] = mr // Update existing
-				sortModelRoutesInPlace(routes)
-				s.routes[mr.Spec.ModelName] = routes // Update the map
-				found = true
-				break
-			}
-		}
-		if !found {
-			routes = append(routes, mr)
-			sortModelRoutesInPlace(routes)
-			s.routes[mr.Spec.ModelName] = routes
-		}
+		routes = append(routes, mr)
+		sortModelRoutesInPlace(routes)
+		s.routes[mr.Spec.ModelName] = routes
 	}
 
 	for _, lora := range mr.Spec.LoraAdapters {
-		// Check if this ModelRoute already exists in the slice
 		loraRoutes := s.loraRoutes[lora]
-		found := false
-		for i, route := range loraRoutes {
-			if route.Namespace == mr.Namespace && route.Name == mr.Name {
-				loraRoutes[i] = mr // Update existing
-				sortModelRoutesInPlace(loraRoutes)
-				s.loraRoutes[lora] = loraRoutes // Update the map
-				found = true
-				break
-			}
-		}
-		if !found {
-			loraRoutes = append(loraRoutes, mr)
-			sortModelRoutesInPlace(loraRoutes)
-			s.loraRoutes[lora] = loraRoutes
-		}
+		loraRoutes = append(loraRoutes, mr)
+		sortModelRoutesInPlace(loraRoutes)
+		s.loraRoutes[lora] = loraRoutes
 	}
 
 	// Update gateway model routes mapping
@@ -825,6 +800,49 @@ func (s *store) AddOrUpdateModelRoute(mr *aiv1alpha1.ModelRoute) error {
 		ModelRoute: mr,
 	})
 	return nil
+}
+
+func (s *store) removeModelRouteIndexesLocked(key string) {
+	info := s.routeInfo[key]
+	if info != nil {
+		if info.model != "" {
+			s.routes[info.model] = removeModelRouteByKey(s.routes[info.model], key)
+			if len(s.routes[info.model]) == 0 {
+				delete(s.routes, info.model)
+			}
+		}
+
+		for _, lora := range info.loras {
+			s.loraRoutes[lora] = removeModelRouteByKey(s.loraRoutes[lora], key)
+			if len(s.loraRoutes[lora]) == 0 {
+				delete(s.loraRoutes, lora)
+			}
+		}
+	}
+
+	removeRouteKeyFromGatewayMap(s.gatewayModelRoutes, key)
+}
+
+func removeModelRouteByKey(routes []*aiv1alpha1.ModelRoute, key string) []*aiv1alpha1.ModelRoute {
+	if len(routes) == 0 {
+		return routes
+	}
+	filtered := routes[:0]
+	for _, route := range routes {
+		if route.Namespace+"/"+route.Name != key {
+			filtered = append(filtered, route)
+		}
+	}
+	return filtered
+}
+
+func removeRouteKeyFromGatewayMap(gatewayRoutes map[string]sets.Set[string], routeKey string) {
+	for gatewayKey, routeSet := range gatewayRoutes {
+		routeSet.Delete(routeKey)
+		if routeSet.IsEmpty() {
+			delete(gatewayRoutes, gatewayKey)
+		}
+	}
 }
 
 func sortModelRoutesInPlace(routes []*aiv1alpha1.ModelRoute) {
@@ -1516,6 +1534,10 @@ func (s *store) GetModelRoute(namespacedName string) *aiv1alpha1.ModelRoute {
 	s.routeMutex.RLock()
 	defer s.routeMutex.RUnlock()
 
+	return s.getModelRouteByKeyLocked(namespacedName)
+}
+
+func (s *store) getModelRouteByKeyLocked(namespacedName string) *aiv1alpha1.ModelRoute {
 	info, exists := s.routeInfo[namespacedName]
 	if !exists {
 		return nil
@@ -1708,6 +1730,7 @@ func (s *store) AddOrUpdateHTTPRoute(httpRoute *gatewayv1.HTTPRoute) error {
 	key := fmt.Sprintf("%s/%s", httpRoute.Namespace, httpRoute.Name)
 
 	s.httpRouteMutex.Lock()
+	removeRouteKeyFromGatewayMap(s.gatewayRoutes, key)
 	s.httpRoutes[key] = httpRoute
 
 	// Update gateway routes mapping
@@ -1794,19 +1817,8 @@ func (s *store) GetModelRoutesByGateway(gatewayKey string) []*aiv1alpha1.ModelRo
 	var result []*aiv1alpha1.ModelRoute
 	if routeSet, exists := s.gatewayModelRoutes[gatewayKey]; exists {
 		for routeKey := range routeSet {
-			// Find the ModelRoute in routes or loraRoutes
-			if info, ok := s.routeInfo[routeKey]; ok {
-				// Try to find from primary model routes
-				if info.model != "" {
-					if routes, exists := s.routes[info.model]; exists {
-						for _, route := range routes {
-							if route.Namespace+"/"+route.Name == routeKey {
-								result = append(result, route)
-								break
-							}
-						}
-					}
-				}
+			if route := s.getModelRouteByKeyLocked(routeKey); route != nil {
+				result = append(result, route)
 			}
 		}
 	}

--- a/pkg/kthena-router/datastore/store_test.go
+++ b/pkg/kthena-router/datastore/store_test.go
@@ -35,6 +35,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 // ptr is a helper function to get pointer to a value
@@ -807,6 +808,111 @@ func TestStoreDeleteModelRoute_ConcurrentAccess(t *testing.T) {
 		t.Errorf("Queue should not exist for key: %v", key)
 		return true
 	})
+}
+
+func TestStoreAddOrUpdateModelRouteRefreshesIndexes(t *testing.T) {
+	s := New().(*store)
+	gatewayKind := gatewayv1.Kind("Gateway")
+
+	route := &aiv1alpha1.ModelRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "test-route",
+		},
+		Spec: aiv1alpha1.ModelRouteSpec{
+			ModelName:    "base-model",
+			LoraAdapters: []string{"old-lora"},
+			ParentRefs: []gatewayv1.ParentReference{
+				{
+					Kind: &gatewayKind,
+					Name: gatewayv1.ObjectName("old-gateway"),
+				},
+			},
+		},
+	}
+	assert.NoError(t, s.AddOrUpdateModelRoute(route))
+
+	updated := route.DeepCopy()
+	updated.Spec.LoraAdapters = []string{"new-lora"}
+	updated.Spec.ParentRefs = []gatewayv1.ParentReference{
+		{
+			Kind: &gatewayKind,
+			Name: gatewayv1.ObjectName("new-gateway"),
+		},
+	}
+	assert.NoError(t, s.AddOrUpdateModelRoute(updated))
+
+	s.routeMutex.RLock()
+	assert.Empty(t, s.loraRoutes["old-lora"])
+	assert.Len(t, s.loraRoutes["new-lora"], 1)
+	assert.Nil(t, s.gatewayModelRoutes["default/old-gateway"])
+	assert.True(t, s.gatewayModelRoutes["default/new-gateway"].Contains("default/test-route"))
+	s.routeMutex.RUnlock()
+
+	assert.Empty(t, s.GetModelRoutesByGateway("default/old-gateway"))
+	assert.Len(t, s.GetModelRoutesByGateway("default/new-gateway"), 1)
+}
+
+func TestStoreGetModelRoutesByGatewayIncludesLoraOnlyRoutes(t *testing.T) {
+	s := New().(*store)
+	gatewayKind := gatewayv1.Kind("Gateway")
+
+	route := &aiv1alpha1.ModelRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "lora-route",
+		},
+		Spec: aiv1alpha1.ModelRouteSpec{
+			LoraAdapters: []string{"math-lora"},
+			ParentRefs: []gatewayv1.ParentReference{
+				{
+					Kind: &gatewayKind,
+					Name: gatewayv1.ObjectName("gateway"),
+				},
+			},
+		},
+	}
+	assert.NoError(t, s.AddOrUpdateModelRoute(route))
+
+	routes := s.GetModelRoutesByGateway("default/gateway")
+	assert.Len(t, routes, 1)
+	assert.Equal(t, "lora-route", routes[0].Name)
+}
+
+func TestStoreAddOrUpdateHTTPRouteRefreshesGatewayIndexes(t *testing.T) {
+	s := New().(*store)
+	gatewayKind := gatewayv1.Kind("Gateway")
+
+	route := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "test-route",
+		},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{
+					{
+						Kind: &gatewayKind,
+						Name: gatewayv1.ObjectName("old-gateway"),
+					},
+				},
+			},
+		},
+	}
+	assert.NoError(t, s.AddOrUpdateHTTPRoute(route))
+
+	updated := route.DeepCopy()
+	updated.Spec.ParentRefs = []gatewayv1.ParentReference{
+		{
+			Kind: &gatewayKind,
+			Name: gatewayv1.ObjectName("new-gateway"),
+		},
+	}
+	assert.NoError(t, s.AddOrUpdateHTTPRoute(updated))
+
+	assert.Empty(t, s.GetHTTPRoutesByGateway("default/old-gateway"))
+	assert.Len(t, s.GetHTTPRoutesByGateway("default/new-gateway"), 1)
+	assert.Equal(t, updated, s.GetHTTPRoute("default/test-route"))
 }
 
 // createComplexModelRoute creates a ModelRoute with multiple rules for different models


### PR DESCRIPTION
/kind bug

Refresh router route indexes when ModelRoute or HTTPRoute objects are updated.

Previously, updating a route could leave stale index entries behind:
- ModelRoute LoRA adapter changes could keep the route under old LoRA indexes.
- ModelRoute parentRef changes could keep the route attached to an old Gateway.
- HTTPRoute parentRef changes could keep the route attached to an old Gateway.
- GetModelRoutesByGateway skipped LoRA-only ModelRoutes because it only looked up routes through modelName indexes.

This updates the datastore to remove old index entries before re-indexing updated routes, and reuses the existing ModelRoute lookup path so gateway lookups include both base-model and LoRA-only routes.

Verification:
go test ./pkg/kthena-router/datastore
<img width="1440" height="241" alt="image" src="https://github.com/user-attachments/assets/ee9f1cda-2a23-44ab-8374-1a523083ae20" />
