### PR TITLE
fix: reject invalid token tracker weights

### DIFF
--- a/pkg/kthena-router/datastore/store.go
+++ b/pkg/kthena-router/datastore/store.go
@@ -95,18 +95,18 @@ func createTokenTracker() TokenTracker {
 		outputWeight := defaultOutputTokenWeight
 
 		if inputWeightStr != "" {
-			if w, err := strconv.ParseFloat(inputWeightStr, 64); err == nil {
+			if w, err := strconv.ParseFloat(inputWeightStr, 64); err == nil && isValidTokenWeight(w) {
 				inputWeight = w
 			} else {
-				klog.Warningf("Invalid FAIRNESS_INPUT_TOKEN_WEIGHT: %v, using default", err)
+				klog.Warningf("Invalid FAIRNESS_INPUT_TOKEN_WEIGHT: %q, using default", inputWeightStr)
 			}
 		}
 
 		if outputWeightStr != "" {
-			if w, err := strconv.ParseFloat(outputWeightStr, 64); err == nil {
+			if w, err := strconv.ParseFloat(outputWeightStr, 64); err == nil && isValidTokenWeight(w) {
 				outputWeight = w
 			} else {
-				klog.Warningf("Invalid FAIRNESS_OUTPUT_TOKEN_WEIGHT: %v, using default", err)
+				klog.Warningf("Invalid FAIRNESS_OUTPUT_TOKEN_WEIGHT: %q, using default", outputWeightStr)
 			}
 		}
 

--- a/pkg/kthena-router/datastore/store_test.go
+++ b/pkg/kthena-router/datastore/store_test.go
@@ -133,6 +133,30 @@ func TestCreateFairnessQueueConfig_RejectsInvalidWeights(t *testing.T) {
 	}
 }
 
+func TestCreateTokenTrackerRejectsInvalidWeights(t *testing.T) {
+	t.Setenv("FAIRNESS_INPUT_TOKEN_WEIGHT", "NaN")
+	t.Setenv("FAIRNESS_OUTPUT_TOKEN_WEIGHT", strconv.FormatFloat(math.Inf(1), 'f', -1, 64))
+
+	tracker := createTokenTracker().(*InMemorySlidingWindowTokenTracker)
+	if tracker.inputTokenWeight != defaultInputTokenWeight {
+		t.Fatalf("Expected default input token weight %v, got %v", defaultInputTokenWeight, tracker.inputTokenWeight)
+	}
+	if tracker.outputTokenWeight != defaultOutputTokenWeight {
+		t.Fatalf("Expected default output token weight %v, got %v", defaultOutputTokenWeight, tracker.outputTokenWeight)
+	}
+
+	t.Setenv("FAIRNESS_INPUT_TOKEN_WEIGHT", "1.5")
+	t.Setenv("FAIRNESS_OUTPUT_TOKEN_WEIGHT", "-2")
+
+	tracker = createTokenTracker().(*InMemorySlidingWindowTokenTracker)
+	if tracker.inputTokenWeight != 1.5 {
+		t.Fatalf("Expected configured input token weight 1.5, got %v", tracker.inputTokenWeight)
+	}
+	if tracker.outputTokenWeight != defaultOutputTokenWeight {
+		t.Fatalf("Expected default output token weight for negative value, got %v", tracker.outputTokenWeight)
+	}
+}
+
 func Test_updateHistogramMetrics(t *testing.T) {
 	sum1 := float64(2)
 	count1 := uint64(2)

--- a/pkg/kthena-router/datastore/token_tracker.go
+++ b/pkg/kthena-router/datastore/token_tracker.go
@@ -18,6 +18,7 @@ package datastore
 
 import (
 	"fmt"
+	"math"
 	"sync"
 	"time"
 
@@ -84,13 +85,17 @@ func WithWindowSize(size time.Duration) TokenTrackerOption {
 // WithTokenWeights overrides the default token weights
 func WithTokenWeights(inputWeight, outputWeight float64) TokenTrackerOption {
 	return func(t *InMemorySlidingWindowTokenTracker) {
-		if inputWeight < 0 || outputWeight < 0 {
-			klog.Warningf("Invalid token weights: input=%v, output=%v. Weights must be non-negative", inputWeight, outputWeight)
+		if !isValidTokenWeight(inputWeight) || !isValidTokenWeight(outputWeight) {
+			klog.Warningf("Invalid token weights: input=%v, output=%v. Weights must be finite and non-negative", inputWeight, outputWeight)
 			return
 		}
 		t.inputTokenWeight = inputWeight
 		t.outputTokenWeight = outputWeight
 	}
+}
+
+func isValidTokenWeight(value float64) bool {
+	return !math.IsNaN(value) && !math.IsInf(value, 0) && value >= 0
 }
 
 // NewInMemorySlidingWindowTokenTracker creates a new tracker with optional configuration

--- a/pkg/kthena-router/datastore/token_tracker_test.go
+++ b/pkg/kthena-router/datastore/token_tracker_test.go
@@ -16,6 +16,7 @@ limitations under the License.
 package datastore
 
 import (
+	"math"
 	"sync"
 	"testing"
 	"time"
@@ -119,6 +120,20 @@ func TestTokenWeightsConfiguration(t *testing.T) {
 			name:             "negative weights (should be ignored)",
 			inputWeight:      -1.0,
 			outputWeight:     -2.0,
+			wantInputWeight:  defaultInputTokenWeight,
+			wantOutputWeight: defaultOutputTokenWeight,
+		},
+		{
+			name:             "nan input weight (should be ignored)",
+			inputWeight:      math.NaN(),
+			outputWeight:     3.0,
+			wantInputWeight:  defaultInputTokenWeight,
+			wantOutputWeight: defaultOutputTokenWeight,
+		},
+		{
+			name:             "infinite output weight (should be ignored)",
+			inputWeight:      1.5,
+			outputWeight:     math.Inf(1),
 			wantInputWeight:  defaultInputTokenWeight,
 			wantOutputWeight: defaultOutputTokenWeight,
 		},


### PR DESCRIPTION
/kind bug

Validate token tracker weights before applying them.

Previously `FAIRNESS_INPUT_TOKEN_WEIGHT`, `FAIRNESS_OUTPUT_TOKEN_WEIGHT`, and `WithTokenWeights` rejected negative values but still accepted non-finite values like `NaN` and `Inf`. That could poison token accounting and fairness/rate-limit calculations with non-finite totals.

This change requires token weights to be finite and non-negative. Invalid env values fall back to defaults, while valid values are still applied.

Verification:
go test ./pkg/kthena-router/datastore

<img width="1465" height="80" alt="image" src="https://github.com/user-attachments/assets/e32e5291-ef69-4f4c-a5bb-291515db9ba5" />

