### PR TITLE
fix(router): retry sends empty body to fallback pods in aggregated proxy path

### DIFF
--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -694,16 +694,16 @@ func (r *Router) proxy(
 	// request across loop iterations sends an empty body to subsequent pods.
 	var bodyBytes []byte
 	if req.Body != nil {
-		var err error
-		bodyBytes, err = io.ReadAll(req.Body)
+		b, err := io.ReadAll(req.Body)
 		req.Body.Close()
 		if err != nil {
 			return fmt.Errorf("failed to read request body: %w", err)
 		}
+		bodyBytes = b
 	}
 
 	for i := 0; i < len(ctx.BestPods); i++ {
-		req.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+		req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
 
 		// Increment upstream request count with both modelServer and modelRoute
 		r.metrics.IncActiveUpstreamRequests(modelServerName, modelRouteName)

--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -689,7 +689,22 @@ func (r *Router) proxy(
 		}
 	}
 
+	// Capture body bytes once so each retry attempt gets a fresh reader.
+	// transport.RoundTrip drains req.Body on every call, so reusing the same
+	// request across loop iterations sends an empty body to subsequent pods.
+	var bodyBytes []byte
+	if req.Body != nil {
+		var err error
+		bodyBytes, err = io.ReadAll(req.Body)
+		req.Body.Close()
+		if err != nil {
+			return fmt.Errorf("failed to read request body: %w", err)
+		}
+	}
+
 	for i := 0; i < len(ctx.BestPods); i++ {
+		req.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+
 		// Increment upstream request count with both modelServer and modelRoute
 		r.metrics.IncActiveUpstreamRequests(modelServerName, modelRouteName)
 
@@ -898,6 +913,7 @@ func doRequest(
 		return nil, err
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		resp.Body.Close()
 		return nil, fmt.Errorf("http resp error, http code is %d", resp.StatusCode)
 	}
 	return resp, nil

--- a/pkg/kthena-router/router/router_test.go
+++ b/pkg/kthena-router/router/router_test.go
@@ -452,6 +452,93 @@ func TestAccessLogConfigurationFromEnv(t *testing.T) {
 	}
 }
 
+// TestProxy_RetryBodyNotDrained verifies that when the first pod returns a non-2xx
+// response, the retry attempt to the next pod carries the full request body.
+// Before the fix, transport.RoundTrip drained the body on the first attempt, so
+// every subsequent pod received an empty POST body.
+func TestProxy_RetryBodyNotDrained(t *testing.T) {
+	var receivedBodies []string
+
+	// Single backend: returns 503 on the first call, 200 on the second.
+	// Both pods in the test point to this same server so we can observe both attempts.
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		receivedBodies = append(receivedBodies, string(body))
+		if len(receivedBodies) == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"id":"retry-ok"}`)
+	}))
+	defer backend.Close()
+
+	backendURL, _ := url.Parse(backend.URL)
+	backendIP := backendURL.Hostname()
+	backendPort, _ := strconv.Atoi(backendURL.Port())
+
+	store := datastore.New()
+	router := NewRouter(store, "../scheduler/testdata/configmap.yaml")
+
+	modelServer := &aiv1alpha1.ModelServer{
+		ObjectMeta: v1.ObjectMeta{Name: "ms-retry", Namespace: "default"},
+		Spec: aiv1alpha1.ModelServerSpec{
+			Model:           func(s string) *string { return &s }("base-model"),
+			WorkloadPort:    aiv1alpha1.WorkloadPort{Port: int32(backendPort)},
+			InferenceEngine: "vLLM",
+		},
+	}
+	pod1 := &corev1.Pod{
+		ObjectMeta: v1.ObjectMeta{Name: "pod-retry-1", Namespace: "default"},
+		Status:     corev1.PodStatus{PodIP: backendIP, Phase: corev1.PodRunning},
+	}
+	pod2 := &corev1.Pod{
+		ObjectMeta: v1.ObjectMeta{Name: "pod-retry-2", Namespace: "default"},
+		Status:     corev1.PodStatus{PodIP: backendIP, Phase: corev1.PodRunning},
+	}
+	modelRoute := &aiv1alpha1.ModelRoute{
+		ObjectMeta: v1.ObjectMeta{Name: "mr-retry", Namespace: "default"},
+		Spec: aiv1alpha1.ModelRouteSpec{
+			ModelName: "retry-model",
+			Rules: []*aiv1alpha1.Rule{
+				{TargetModels: []*aiv1alpha1.TargetModel{{ModelServerName: "ms-retry"}}},
+			},
+		},
+	}
+
+	store.AddOrUpdateModelServer(modelServer, sets.New(
+		types.NamespacedName{Name: "pod-retry-1", Namespace: "default"},
+		types.NamespacedName{Name: "pod-retry-2", Namespace: "default"},
+	))
+	store.AddOrUpdatePod(pod1, []*aiv1alpha1.ModelServer{modelServer})
+	store.AddOrUpdatePod(pod2, []*aiv1alpha1.ModelServer{modelServer})
+	store.AddOrUpdateModelRoute(modelRoute)
+
+	// Give pod-2 a non-zero waiting count so pod-1 scores higher and is always
+	// BestPods[0]. This guarantees the 503 is hit first, forcing a retry to pod-2.
+	podInfo2 := store.GetPodInfo(types.NamespacedName{Name: "pod-retry-2", Namespace: "default"})
+	assert.NotNil(t, podInfo2)
+	podInfo2.RequestWaitingNum = 1
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	reqBody := `{"model": "retry-model", "prompt": "test prompt for retry path"}`
+	c.Request, _ = http.NewRequest("POST", "/v1/chat/completions", bytes.NewBufferString(reqBody))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	router.HandlerFunc()(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	if assert.Len(t, receivedBodies, 2, "expected exactly 2 backend attempts (first 503, then retry)") {
+		// The router rewrites model name to the ModelServer's base model before dispatch,
+		// so check for the prompt which passes through unchanged.
+		assert.Contains(t, receivedBodies[0], "test prompt for retry path", "first attempt body was missing")
+		// Regression assertion: before the fix, transport.RoundTrip drained the body on the
+		// first attempt, so this would be an empty string.
+		assert.Contains(t, receivedBodies[1], "test prompt for retry path", "retry attempt sent empty body (body reuse regression)")
+	}
+}
+
 // Helper function to parse boolean (same logic as strconv.ParseBool but simpler for test)
 func parseBool(str string) (bool, error) {
 	switch str {


### PR DESCRIPTION
## **What type of PR is this?**

/kind bug

## **What this PR does / why we need it**:

So while I was reading through the router code for the benchmark work, I noticed that `proxy()` in `router.go` loops over `BestPods` to retry failed requests across backends. The problem is it reuses the same `*http.Request` for every iteration. The request body is a `bytes.Buffer` wrapped in `io.NopCloser`, and once `transport.RoundTrip` reads it on the first attempt, it's gone. Any retry after that sends an empty body to the next pod, so the fallback never actually works in cases where the first pod accepted the connection but still failed (like returning a non-2xx).

I also noticed `doRequest` was returning an error on non-2xx responses without closing `resp.Body`, which leaks connections from the default transport pool underload.

The fix for the first one is pretty simple - I just read the body bytes once before the loop starts, then reset `req.Body` at the top of each iteration. For the second one, just close the body before returning the error.

Worth noting this is the same class of bug that was just fixed in the SGLang connector in `918496a` - that commit even has a comment calling this out, but the aggregated HTTP path didn't get the same treatment.

 ### **Special notes for your reviewer**:

The only behavioral change is in the retry path, which only kicks in when the first pod actually fails. Happy path is untouched. The body read at the top of  `proxy()` is safe because `BuildDecodeRequest` already reconstructs the body from `modelRequest` before this point, so we're not double-reading anything unexpected.
  
Also the `resp.Body.Close()` fix in `doRequest` is a one-liner but worth checking - just making sure it doesn't affect anything else downstream since `proxyRequest` never sees a non-2xx response anyway.

 ### **Does this PR introduce a user-facing change?**:

  ```release-note
Fixed a bug where retry attempts in the aggregated proxy path would send empty request bodies to fallback pods after the first backend failed. Also fixed a connection leak when upstream pods returned non-2xx responses.
