### PR TITLE
fix: require bearer scheme for JWT auth

### DIFF
--- a/pkg/kthena-router/filters/auth/authentication.go
+++ b/pkg/kthena-router/filters/auth/authentication.go
@@ -37,14 +37,17 @@ import (
 
 // JWT token extraction constants
 const (
-	header = "Authorization"
-	prefix = "Bearer "
+	header       = "Authorization"
+	bearerScheme = "Bearer"
 )
 
 // extractTokenFromHeader extracts the Bearer token from the Authorization header
 func extractTokenFromHeader(req *http.Request) string {
-	value := req.Header.Get(header)
-	return strings.TrimPrefix(value, prefix)
+	fields := strings.Fields(req.Header.Get(header))
+	if len(fields) != 2 || !strings.EqualFold(fields[0], bearerScheme) {
+		return ""
+	}
+	return fields[1]
 }
 
 // JWTAuthenticator provides JWT token validation with automatic JWKS rotation support

--- a/pkg/kthena-router/filters/auth/authentication_test.go
+++ b/pkg/kthena-router/filters/auth/authentication_test.go
@@ -43,7 +43,7 @@ func TestExtractTokenFromHeader(t *testing.T) {
 		{
 			name:     "no bearer prefix",
 			header:   "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
-			expected: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
+			expected: "",
 		},
 		{
 			name:     "empty header",
@@ -53,6 +53,21 @@ func TestExtractTokenFromHeader(t *testing.T) {
 		{
 			name:     "bearer with space",
 			header:   "Bearer ",
+			expected: "",
+		},
+		{
+			name:     "lowercase bearer scheme",
+			header:   "bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
+			expected: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
+		},
+		{
+			name:     "bearer token with extra whitespace",
+			header:   "  Bearer   eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9  ",
+			expected: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
+		},
+		{
+			name:     "token with embedded whitespace",
+			header:   "Bearer token with space",
 			expected: "",
 		},
 	}
@@ -174,6 +189,19 @@ func TestJWTAuthenticatorMiddleware(t *testing.T) {
 		c.Request.Header.Set("Authorization", "Bearer ")
 
 		// Test that middleware returns 401 when empty token provided
+		middleware(c)
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+	})
+
+	t.Run("enabled authenticator with invalid authorization scheme", func(t *testing.T) {
+		validator := &JWTAuthenticator{enabled: true}
+		middleware := validator.Authenticate()
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest("GET", "/", nil)
+		c.Request.Header.Set("Authorization", "Basic some-token")
+
 		middleware(c)
 		assert.Equal(t, http.StatusUnauthorized, w.Code)
 	})


### PR DESCRIPTION
/kind bug

Require the `Authorization` header to use the Bearer scheme before extracting a JWT token.

Previously, an Authorization header without the `Bearer` prefix was treated as the token value. That allowed malformed schemes such as raw tokens or `Basic ...` values to reach JWT parsing instead of being rejected as an invalid auth header.

This change:
- Returns an empty token unless the header has exactly a Bearer scheme and token.
- Accepts the Bearer scheme case-insensitively.
- Handles extra whitespace around the scheme/token.
- Adds focused unit coverage for invalid schemes and malformed token values.

Verification:
go test ./pkg/kthena-router/filters/auth
<img width="1135" height="53" alt="image" src="https://github.com/user-attachments/assets/6d4caf67-bced-4f18-8254-7d3a28c12a89" />
