### PR TITLE
fix: reject empty router model requests

### DIFF
--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -476,7 +476,7 @@ func ParseModelRequest(c *gin.Context) (ModelRequest, error) {
 	}
 
 	modelName, ok := modelRequest["model"].(string)
-	if !ok {
+	if !ok || strings.TrimSpace(modelName) == "" {
 		c.AbortWithStatusJSON(http.StatusNotFound, "model not found")
 		return nil, fmt.Errorf("model not found")
 	}

--- a/pkg/kthena-router/router/router_test.go
+++ b/pkg/kthena-router/router/router_test.go
@@ -315,6 +315,59 @@ func TestRouter_HandlerFunc_ScheduleFailure(t *testing.T) {
 	assert.Contains(t, w.Body.String(), "can't schedule to target pod")
 }
 
+func TestParseModelRequestValidatesModelName(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    string
+		wantErr bool
+	}{
+		{
+			name:    "valid model",
+			body:    `{"model": "test-model", "prompt": "hello"}`,
+			wantErr: false,
+		},
+		{
+			name:    "missing model",
+			body:    `{"prompt": "hello"}`,
+			wantErr: true,
+		},
+		{
+			name:    "non-string model",
+			body:    `{"model": 123, "prompt": "hello"}`,
+			wantErr: true,
+		},
+		{
+			name:    "empty model",
+			body:    `{"model": "", "prompt": "hello"}`,
+			wantErr: true,
+		},
+		{
+			name:    "whitespace model",
+			body:    `{"model": "  ", "prompt": "hello"}`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request, _ = http.NewRequest("POST", "/v1/chat/completions", bytes.NewBufferString(tt.body))
+
+			got, err := ParseModelRequest(c)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Nil(t, got)
+				assert.Equal(t, http.StatusNotFound, w.Code)
+				assert.Contains(t, w.Body.String(), "model not found")
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, "test-model", got["model"])
+		})
+	}
+}
+
 func TestAccessLogConfigurationFromEnv(t *testing.T) {
 	// Save original environment variables
 	originalEnabled := os.Getenv("ACCESS_LOG_ENABLED")


### PR DESCRIPTION
/kind bug

Reject empty or whitespace-only `model` values in router requests.

`ParseModelRequest` already rejected missing or non-string `model` fields, but accepted `""` or `"  "`. Those requests then continued into routing/scheduling with an unusable model name.

This change treats blank model names as `model not found` and adds focused unit coverage for:
- valid model
- missing model
- non-string model
- empty model
- whitespace-only model

Verification:
go test ./pkg/kthena-router/router


<img width="1020" height="53" alt="image" src="https://github.com/user-attachments/assets/2c659bf1-15f0-4bfb-9cfc-858303b7c402" />

