### PR TITLE
fix(scheduler): treat zero TTFT/TPOT as uninitialized in least-latency plugin

### DIFF
--- a/pkg/kthena-router/scheduler/plugins/least_latency.go
+++ b/pkg/kthena-router/scheduler/plugins/least_latency.go
@@ -78,10 +78,17 @@ func (l *LeastLatency) Score(ctx *framework.Context, pods []*datastore.PodInfo) 
 	// 2. Second pass: Compute scores using linear normalization
 	// Note: If all pods have identical latency (max == min), all pods get MaxScore
 	for _, info := range pods {
-		scoreTTFT := MaxScore
-		scoreTPOT := MaxScore
 		ttft := info.GetTTFT()
 		tpot := info.GetTPOT()
+		// Pods with no observed latency yet (zero default) are uninitialized — assign a
+		// neutral mid-range score so they receive some traffic via other plugins without
+		// monopolizing dispatch ahead of warm, measured replicas.
+		if ttft <= 0 || tpot <= 0 {
+			scoreResults[info] = int(MaxScore / 2)
+			continue
+		}
+		scoreTTFT := MaxScore
+		scoreTPOT := MaxScore
 		// Only compute normalized score if there's variance in latency values
 		if maxTTFT > minTTFT {
 			scoreTTFT = MaxScore * (maxTTFT - ttft) / (maxTTFT - minTTFT)
@@ -104,8 +111,8 @@ func calculateMinMaxMetrics(pods []*datastore.PodInfo) (minTTFT, maxTTFT, minTPO
 	for _, info := range pods {
 		ttft := info.GetTTFT()
 		tpot := info.GetTPOT()
-		// Skip pods with invalid values
-		if ttft < 0 || tpot < 0 {
+		// Skip pods with no observed data (zero is the uninitialized default, not a valid measurement)
+		if ttft <= 0 || tpot <= 0 {
 			continue
 		}
 


### PR DESCRIPTION
## **What type of PR is this?**

/kind bug

## **What this PR does / why we need it**:

So while I was going through the router code to understand how scheduling works (for the benchmark project), I found a bug in the least-latency scoring plugin that's been there since the plugin was added.

Basically when a new pod starts up, its TTFT and TPOT fields are just 0.0 by default since nothing has been measured yet. The metrics scraper already knows this and skips zero values when updating PodInfo. But the scoring plugin doesn't know that - it treats 0 as a real latency value, which means the new pod looks like it has the lowest latency of anyone and gets a perfect score of 100.

So what ends up happening is during a rolling update or scale-out, the fresh cold pod gets all the traffic while the warm pods just sit there doing nothing. Which is exactly what the plugin is supposed to prevent. I noticed this specifically because I was looking at how the min/max normalization works and realized that zero being included in the min would skew every other score.

The fix is small - just change < 0 to <= 0 in calculateMinMaxMetrics so zero values are excluded from the min/max calculation, and in the scoring loop give uninitialized pods a neutral score of 50 instead of accidentally giving them 100. That way new pods still get some traffic through the other plugins but don't monopolize dispatch.

### **Does this PR introduce a user-facing change?**:

```release-note
Fixed least-latency scheduling plugin incorrectly routing all traffic to cold/new pods during rolling updates. New pods with no latency data yet now get a neutral score instead of the highest score.
```
