### PR TITLE
fix: reject empty parent in serving group names

### DIFF
--- a/pkg/model-serving-controller/utils/utils.go
+++ b/pkg/model-serving-controller/utils/utils.go
@@ -55,8 +55,8 @@ func GetNamespaceName(obj metav1.Object) types.NamespacedName {
 	}
 }
 
-// ServingGroupRegex is a regular expression that extracts the parent modelServing and ordinal from the Name of an ServingGroup
-var servingGroupRegex = regexp.MustCompile("(.*)-([0-9]+)$")
+// ServingGroupRegex is a regular expression that extracts the parent modelServing and ordinal from the Name of a ServingGroup.
+var servingGroupRegex = regexp.MustCompile("^(.+)-([0-9]+)$")
 
 // GetParentNameAndOrdinal gets the name of ServingGroup's parent modelServing and ServingGroup's ordinal as extracted from its Name.
 // For example, the Servinggroup name is vllm-sample-0, this function can be used to obtain the modelServing name corresponding to the ServingGroup,

--- a/pkg/model-serving-controller/utils/utils_test.go
+++ b/pkg/model-serving-controller/utils/utils_test.go
@@ -28,6 +28,54 @@ import (
 	workloadv1alpha1 "github.com/volcano-sh/kthena/pkg/apis/workload/v1alpha1"
 )
 
+func TestGetParentNameAndOrdinal(t *testing.T) {
+	tests := []struct {
+		name        string
+		groupName   string
+		wantParent  string
+		wantOrdinal int
+	}{
+		{
+			name:        "generated serving group name",
+			groupName:   "vllm-sample-0",
+			wantParent:  "vllm-sample",
+			wantOrdinal: 0,
+		},
+		{
+			name:        "parent name with numeric suffix",
+			groupName:   "model-7b-12",
+			wantParent:  "model-7b",
+			wantOrdinal: 12,
+		},
+		{
+			name:        "missing ordinal separator",
+			groupName:   "vllm-sample",
+			wantParent:  "",
+			wantOrdinal: -1,
+		},
+		{
+			name:        "empty ordinal",
+			groupName:   "vllm-sample-",
+			wantParent:  "",
+			wantOrdinal: -1,
+		},
+		{
+			name:        "empty parent",
+			groupName:   "-1",
+			wantParent:  "",
+			wantOrdinal: -1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parent, ordinal := GetParentNameAndOrdinal(tt.groupName)
+			assert.Equal(t, tt.wantParent, parent)
+			assert.Equal(t, tt.wantOrdinal, ordinal)
+		})
+	}
+}
+
 func TestGenerateEntryPod_WithAnnotations(t *testing.T) {
 	ms := &workloadv1alpha1.ModelServing{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
/kind bug

What this PR does / why we need it:

`GetParentNameAndOrdinal` currently accepts names like `-1` and returns an empty parent with ordinal `1`.

This tightens the generated ServingGroup/role name parser so it only accepts names with a non-empty parent before the final numeric ordinal, for example `vllm-sample-0`.

This also adds unit coverage for valid generated names and malformed inputs.

Verification:

```bash
go test ./pkg/model-serving-controller/utils
```
<img width="1024" height="52" alt="image" src="https://github.com/user-attachments/assets/d1dc9d2e-cc5d-4af0-b83d-294a5d34ab1b" />
