### PR TITLE
fix: treat prometheus counters as rates in autoscaling signals

### DIFF
--- a/pkg/autoscaler/autoscaler/metric_collector.go
+++ b/pkg/autoscaler/autoscaler/metric_collector.go
@@ -64,9 +64,7 @@ func NewMetricCollector(target *v1alpha1.Target, binding *v1alpha1.AutoscalingPo
 type HistogramInfo struct {
 	PodStartTime    *metav1.Time
 	HistogramMap    map[string]*histogram.Snapshot
-	// CounterMap stores cumulative counter values observed at the last scrape for this pod
 	CounterMap      map[string]float64
-	// ScrapeTimestamp is the timestamp (milliseconds) when the counters/histograms were scraped
 	ScrapeTimestamp int64
 }
 
@@ -154,7 +152,6 @@ func (collector *MetricCollector) fetchMetricsFromPods(ctx context.Context, pods
 				pastScrapeTimestamp = 0
 			} else {
 				pastHistogramMap = pastValue.HistogramMap
-				// CounterMap and ScrapeTimestamp may be missing on older snapshots
 				if pastValue.CounterMap == nil {
 					pastCounterMap = make(map[string]float64)
 				} else {
@@ -190,9 +187,9 @@ func (collector *MetricCollector) fetchMetricsFromPods(ctx context.Context, pods
 			result := string(bodyStr)
 			collector.processPrometheusString(result, pastHistogramMap, pastCounterMap, currentHistogramMap, currentCounterMap, pastScrapeTimestamp, instanceInfo.MetricsMap)
 			(*currentHistograms)[pod.Name] = HistogramInfo{
-				PodStartTime: pod.Status.StartTime,
-				HistogramMap: currentHistogramMap,
-				CounterMap:   currentCounterMap,
+				PodStartTime:    pod.Status.StartTime,
+				HistogramMap:    currentHistogramMap,
+				CounterMap:      currentCounterMap,
 				ScrapeTimestamp: util.GetCurrentTimestamp(),
 			}
 		}()
@@ -229,13 +226,11 @@ func (collector *MetricCollector) processPrometheusString(metricStr string, past
 			cur := metric.GetCounter().GetValue()
 			currentCounters[mf.GetName()] = cur
 
-			// compute rate = (cur - prev) / elapsed_seconds
 			rate := 0.0
 			now := util.GetCurrentTimestamp()
 			if pastCounters != nil && pastScrapeTimestamp > 0 {
 				if prev, ok := pastCounters[mf.GetName()]; ok {
 					if cur < prev {
-						// counter reset
 						rate = 0
 					} else {
 						elapsedSec := float64(now-pastScrapeTimestamp) / 1000.0

--- a/pkg/autoscaler/autoscaler/metric_collector.go
+++ b/pkg/autoscaler/autoscaler/metric_collector.go
@@ -62,8 +62,12 @@ func NewMetricCollector(target *v1alpha1.Target, binding *v1alpha1.AutoscalingPo
 }
 
 type HistogramInfo struct {
-	PodStartTime *metav1.Time
-	HistogramMap map[string]*histogram.Snapshot
+	PodStartTime    *metav1.Time
+	HistogramMap    map[string]*histogram.Snapshot
+	// CounterMap stores cumulative counter values observed at the last scrape for this pod
+	CounterMap      map[string]float64
+	// ScrapeTimestamp is the timestamp (milliseconds) when the counters/histograms were scraped
+	ScrapeTimestamp int64
 }
 
 type Scope struct {
@@ -130,7 +134,7 @@ func (collector *MetricCollector) UpdateMetrics(ctx context.Context, podLister l
 
 func (collector *MetricCollector) fetchMetricsFromPods(ctx context.Context, pods []*corev1.Pod, currentHistograms *map[string]HistogramInfo) InstanceInfo {
 	instanceInfo := InstanceInfo{true, false, make(algorithm.Metrics)}
-	pastHistograms, ok := collector.PastHistograms.GetLastUnfreshSnapshot()
+	pastHistograms, _, ok := collector.PastHistograms.GetLastUnfreshSnapshotWithTimestamp()
 	if !ok {
 		pastHistograms = make(map[string]HistogramInfo)
 	}
@@ -142,13 +146,25 @@ func (collector *MetricCollector) fetchMetricsFromPods(ctx context.Context, pods
 
 			pastValue, ok := pastHistograms[pod.Name]
 			var pastHistogramMap map[string]*histogram.Snapshot
+			var pastCounterMap map[string]float64
+			var pastScrapeTimestamp int64
 			if !ok || pod.Status.StartTime == nil || pastValue.PodStartTime == nil || !pod.Status.StartTime.Equal(pastValue.PodStartTime) {
 				pastHistogramMap = make(map[string]*histogram.Snapshot)
+				pastCounterMap = make(map[string]float64)
+				pastScrapeTimestamp = 0
 			} else {
 				pastHistogramMap = pastValue.HistogramMap
+				// CounterMap and ScrapeTimestamp may be missing on older snapshots
+				if pastValue.CounterMap == nil {
+					pastCounterMap = make(map[string]float64)
+				} else {
+					pastCounterMap = pastValue.CounterMap
+				}
+				pastScrapeTimestamp = pastValue.ScrapeTimestamp
 			}
 
 			currentHistogramMap := make(map[string]*histogram.Snapshot)
+			currentCounterMap := make(map[string]float64)
 			ip := pod.Status.PodIP
 			podCtx, cancel := context.WithTimeout(ctx, util.AutoscaleCtxTimeoutSeconds*time.Second)
 			defer cancel()
@@ -172,17 +188,19 @@ func (collector *MetricCollector) fetchMetricsFromPods(ctx context.Context, pods
 				return
 			}
 			result := string(bodyStr)
-			collector.processPrometheusString(result, pastHistogramMap, currentHistogramMap, instanceInfo.MetricsMap)
+			collector.processPrometheusString(result, pastHistogramMap, pastCounterMap, currentHistogramMap, currentCounterMap, pastScrapeTimestamp, instanceInfo.MetricsMap)
 			(*currentHistograms)[pod.Name] = HistogramInfo{
 				PodStartTime: pod.Status.StartTime,
 				HistogramMap: currentHistogramMap,
+				CounterMap:   currentCounterMap,
+				ScrapeTimestamp: util.GetCurrentTimestamp(),
 			}
 		}()
 	}
 	return instanceInfo
 }
 
-func (collector *MetricCollector) processPrometheusString(metricStr string, pastHistograms map[string]*histogram.Snapshot, currentHistograms map[string]*histogram.Snapshot, instanceMetricMap algorithm.Metrics) {
+func (collector *MetricCollector) processPrometheusString(metricStr string, pastHistograms map[string]*histogram.Snapshot, pastCounters map[string]float64, currentHistograms map[string]*histogram.Snapshot, currentCounters map[string]float64, pastScrapeTimestamp int64, instanceMetricMap algorithm.Metrics) {
 	reader := strings.NewReader(metricStr)
 	decoder := expfmt.NewDecoder(reader, expfmt.NewFormat(expfmt.TypeTextPlain))
 	for {
@@ -208,7 +226,26 @@ func (collector *MetricCollector) processPrometheusString(metricStr string, past
 		metric := mf.Metric[0]
 		switch mf.GetType() {
 		case io_prometheus_client.MetricType_COUNTER:
-			addMetric(instanceMetricMap, mf.GetName(), metric.GetCounter().GetValue())
+			cur := metric.GetCounter().GetValue()
+			currentCounters[mf.GetName()] = cur
+
+			// compute rate = (cur - prev) / elapsed_seconds
+			rate := 0.0
+			now := util.GetCurrentTimestamp()
+			if pastCounters != nil && pastScrapeTimestamp > 0 {
+				if prev, ok := pastCounters[mf.GetName()]; ok {
+					if cur < prev {
+						// counter reset
+						rate = 0
+					} else {
+						elapsedSec := float64(now-pastScrapeTimestamp) / 1000.0
+						if elapsedSec > 0 {
+							rate = (cur - prev) / elapsedSec
+						}
+					}
+				}
+			}
+			addMetric(instanceMetricMap, mf.GetName(), rate)
 		case io_prometheus_client.MetricType_GAUGE:
 			addMetric(instanceMetricMap, mf.GetName(), metric.GetGauge().GetValue())
 		case io_prometheus_client.MetricType_HISTOGRAM:

--- a/pkg/autoscaler/autoscaler/metric_collector.go
+++ b/pkg/autoscaler/autoscaler/metric_collector.go
@@ -47,6 +47,7 @@ import (
 
 type MetricCollector struct {
 	PastHistograms *datastructure.SnapshotSlidingWindow[map[string]HistogramInfo]
+	PastCounters   *datastructure.SnapshotSlidingWindow[map[string]CounterInfo]
 	Target         *v1alpha1.Target
 	Scope          Scope
 	MetricTargets  map[string]float64
@@ -61,6 +62,7 @@ func NewMetricCollector(target *v1alpha1.Target, policy *v1alpha1.AutoscalingPol
 	}
 	return &MetricCollector{
 		PastHistograms: datastructure.NewSnapshotSlidingWindow[map[string]HistogramInfo](util.SecondToTimestamp(util.SloQuantileSlidingWindowSeconds), util.SecondToTimestamp(util.SloQuantileDataKeepSeconds)),
+		PastCounters:   datastructure.NewSnapshotSlidingWindow[map[string]CounterInfo](util.SecondToTimestamp(util.SloQuantileSlidingWindowSeconds), util.SecondToTimestamp(util.SloQuantileDataKeepSeconds)),
 		Target:         target,
 		Scope: Scope{
 			Namespace:     namespace,
@@ -74,6 +76,12 @@ func NewMetricCollector(target *v1alpha1.Target, policy *v1alpha1.AutoscalingPol
 type HistogramInfo struct {
 	PodStartTime *metav1.Time
 	HistogramMap map[string]*histogram.Snapshot
+}
+
+type CounterInfo struct {
+	PodStartTime     *metav1.Time
+	CounterMap       map[string]float64
+	ScrapeTimestamps map[string]int64
 }
 
 type Scope struct {
@@ -105,11 +113,12 @@ func (collector *MetricCollector) UpdateMetrics(
 ) (unreadyInstancesCount int32, readyInstancesMetric algorithm.Metrics, externalMetrics algorithm.Metrics, err error) {
 	readyInstancesMetric = make(algorithm.Metrics)
 
-	pastHistograms, ok := collector.PastHistograms.GetLastUnfreshSnapshot()
-	if !ok {
-		pastHistograms = make(map[string]HistogramInfo)
-	}
+	pastHistograms, _ := collector.PastHistograms.GetLastUnfreshSnapshot()
+
 	currentHistograms := make(map[string]HistogramInfo)
+
+	pastCounters, _ := collector.PastCounters.GetLastSnapshot()
+	currentCounters := make(map[string]CounterInfo)
 
 	// Group pod metrics by identical PodMetricSource (uri/port/selector) so we
 	// scrape each pod endpoint once per reconcile and extract every required
@@ -117,7 +126,10 @@ func (collector *MetricCollector) UpdateMetrics(
 	podGroups, externalMetrics := collector.planMetricSources(ctx, targetMetricSources)
 
 	for _, g := range podGroups {
-		values, anyUnready, failed, collectErr := collector.collectPodMetricsGroup(ctx, podLister, g.podSource, g.specs, pastHistograms, currentHistograms)
+		values, anyUnready, failed, collectErr := collector.collectPodMetricsGroup(ctx, podLister, g.podSource, g.specs,
+			pastHistograms, currentHistograms,
+			pastCounters, currentCounters,
+		)
 		if collectErr != nil {
 			klog.Warningf("collect pod metrics for target %s failed: %v", collector.Target.TargetRef.Name, collectErr)
 			continue
@@ -136,6 +148,7 @@ func (collector *MetricCollector) UpdateMetrics(
 	}
 
 	collector.PastHistograms.Append(currentHistograms)
+	collector.PastCounters.Append(currentCounters)
 	return
 }
 
@@ -232,6 +245,8 @@ func (collector *MetricCollector) collectPodMetricsGroup(
 	specs []podMetricSpec,
 	pastHistograms map[string]HistogramInfo,
 	currentHistograms map[string]HistogramInfo,
+	pastCounters map[string]CounterInfo,
+	currentCounters map[string]CounterInfo,
 ) (values map[string]float64, anyUnready bool, failed bool, err error) {
 	values = make(map[string]float64, len(specs))
 	pods, err := util.GetMetricPods(podLister, collector.Scope.Namespace, collector.Target, podSource)
@@ -250,10 +265,16 @@ func (collector *MetricCollector) collectPodMetricsGroup(
 	// Multiple policy keys may target the same scrape metric name.
 	wanted := groupPolicyKeysByScrapeName(specs)
 
+	missingBaselines := make(map[string]bool)
+
 	for _, pod := range pods {
-		if err = collector.collectPodMetrics(ctx, pod, podSource, wanted, values, pastHistograms, currentHistograms); err != nil {
+		if err = collector.collectPodMetrics(ctx, pod, podSource, wanted, values, pastHistograms, currentHistograms, pastCounters, currentCounters, missingBaselines); err != nil {
 			return nil, false, false, err
 		}
+	}
+
+	for policyKey := range missingBaselines {
+		delete(values, policyKey)
 	}
 	return
 }
@@ -283,7 +304,7 @@ func groupPolicyKeysByScrapeName(specs []podMetricSpec) map[string][]string {
 }
 
 // collectPodMetrics scrapes a single pod and accumulates its metric values into
-// values, refreshing the pod's histogram snapshots in currentHistograms.
+// values, refreshing the pod's snapshots.
 func (collector *MetricCollector) collectPodMetrics(
 	ctx context.Context,
 	pod *corev1.Pod,
@@ -292,18 +313,33 @@ func (collector *MetricCollector) collectPodMetrics(
 	values map[string]float64,
 	pastHistograms map[string]HistogramInfo,
 	currentHistograms map[string]HistogramInfo,
+	pastCounters map[string]CounterInfo,
+	currentCounters map[string]CounterInfo,
+	missingBaselines map[string]bool,
 ) error {
 	pastHistogramMap := pastHistogramMapForPod(pod, pastHistograms)
+	pastCounterMap, pastScrapeTimestamps := pastCounterMapForPod(pod, pastCounters)
 
 	currentHistogramMap := currentHistograms[pod.Name].HistogramMap
 	if currentHistogramMap == nil {
 		currentHistogramMap = make(map[string]*histogram.Snapshot)
 	}
 
+	currentCounterMap := currentCounters[pod.Name].CounterMap
+	if currentCounterMap == nil {
+		currentCounterMap = make(map[string]float64)
+	}
+
+	currentScrapeTimestamps := currentCounters[pod.Name].ScrapeTimestamps
+	if currentScrapeTimestamps == nil {
+		currentScrapeTimestamps = make(map[string]int64)
+	}
+
 	body, err := collector.scrapePod(ctx, pod, podSource)
 	if err != nil {
 		return err
 	}
+	scrapeTime := util.GetCurrentTimestamp()
 
 	families, err := parsePrometheusFamilies(body, wanted)
 	if err != nil {
@@ -320,8 +356,42 @@ func (collector *MetricCollector) collectPodMetrics(
 			if extractErr != nil {
 				return extractErr
 			}
-			if gotValue {
-				values[policyKey] += v
+
+			if mf.GetType() == io_prometheus_client.MetricType_HISTOGRAM {
+				if pastHistogramMap[policyKey] == nil {
+					missingBaselines[policyKey] = true
+					if snapshot != nil {
+						currentHistogramMap[policyKey] = snapshot
+					}
+					continue
+				}
+			}
+
+			if mf.GetType() == io_prometheus_client.MetricType_COUNTER {
+				if !gotValue {
+					continue
+				}
+				currentCounterMap[policyKey] = v
+				currentScrapeTimestamps[policyKey] = scrapeTime
+
+				prev, ok := pastCounterMap[policyKey]
+				pastScrapeTimestamp, okTimestamp := pastScrapeTimestamps[policyKey]
+				if !ok || !okTimestamp || pastScrapeTimestamp <= 0 || v < prev {
+					missingBaselines[policyKey] = true
+					continue
+				}
+
+				elapsedSec := float64(scrapeTime-pastScrapeTimestamp) / 1000.0
+				if elapsedSec <= 0 {
+					missingBaselines[policyKey] = true
+					continue
+				}
+
+				values[policyKey] += (v - prev) / elapsedSec
+			} else {
+				if gotValue {
+					values[policyKey] += v
+				}
 			}
 			if snapshot != nil {
 				currentHistogramMap[policyKey] = snapshot
@@ -333,17 +403,37 @@ func (collector *MetricCollector) collectPodMetrics(
 		PodStartTime: pod.Status.StartTime,
 		HistogramMap: currentHistogramMap,
 	}
+
+	currentCounters[pod.Name] = CounterInfo{
+		PodStartTime:     pod.Status.StartTime,
+		CounterMap:       currentCounterMap,
+		ScrapeTimestamps: currentScrapeTimestamps,
+	}
 	return nil
 }
 
-// pastHistogramMapForPod returns the previous histogram snapshots for pod, but
-// only when the pod has not restarted since they were recorded.
 func pastHistogramMapForPod(pod *corev1.Pod, pastHistograms map[string]HistogramInfo) map[string]*histogram.Snapshot {
 	pastValue, ok := pastHistograms[pod.Name]
 	if ok && pod.Status.StartTime != nil && pastValue.PodStartTime != nil && pod.Status.StartTime.Equal(pastValue.PodStartTime) {
 		return pastValue.HistogramMap
 	}
 	return map[string]*histogram.Snapshot{}
+}
+
+func pastCounterMapForPod(pod *corev1.Pod, pastCounters map[string]CounterInfo) (map[string]float64, map[string]int64) {
+	pastValue, ok := pastCounters[pod.Name]
+	if ok && pod.Status.StartTime != nil && pastValue.PodStartTime != nil && pod.Status.StartTime.Equal(pastValue.PodStartTime) {
+		pastMap := pastValue.CounterMap
+		if pastMap == nil {
+			pastMap = make(map[string]float64)
+		}
+		pastTimestamps := pastValue.ScrapeTimestamps
+		if pastTimestamps == nil {
+			pastTimestamps = make(map[string]int64)
+		}
+		return pastMap, pastTimestamps
+	}
+	return map[string]float64{}, map[string]int64{}
 }
 
 func (collector *MetricCollector) scrapePod(ctx context.Context, pod *corev1.Pod, podSource *v1alpha1.PodMetricSource) (string, error) {

--- a/pkg/autoscaler/autoscaler/metric_collector_test.go
+++ b/pkg/autoscaler/autoscaler/metric_collector_test.go
@@ -18,6 +18,7 @@ package autoscaler
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -29,6 +30,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	workload "github.com/volcano-sh/kthena/pkg/apis/workload/v1alpha1"
 	"github.com/volcano-sh/kthena/pkg/autoscaler/util"
@@ -334,4 +336,122 @@ not a valid prometheus metric line
 	})
 
 	require.Error(t, err)
+}
+func TestCollectCounterMetric(t *testing.T) {
+	type want struct {
+		rate           float64
+		currentCounter float64
+	}
+
+	cases := []struct {
+		name         string
+		firstScrape  float64
+		secondScrape float64
+		elapsedMs    int64
+		podRestarted bool
+		want         want
+	}{
+		{
+			name:         "counter delta rate calculation",
+			firstScrape:  10,
+			secondScrape: 30,
+			elapsedMs:    2000,
+			want:         want{rate: 10.0, currentCounter: 30.0},
+		},
+		{
+			name:         "counter reset handles rate of 0",
+			firstScrape:  30,
+			secondScrape: 10,
+			elapsedMs:    2000,
+			want:         want{rate: 0.0, currentCounter: 10.0},
+		},
+		{
+			name:         "pod restart resets baseline",
+			firstScrape:  10,
+			secondScrape: 30,
+			elapsedMs:    2000,
+			podRestarted: true,
+			want:         want{rate: 0.0, currentCounter: 30.0},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			var scrapeCount int
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				if scrapeCount == 0 {
+					fmt.Fprintf(w, "# HELP my_counter A test counter\n# TYPE my_counter counter\nmy_counter %g\n", tc.firstScrape)
+				} else {
+					fmt.Fprintf(w, "# HELP my_counter A test counter\n# TYPE my_counter counter\nmy_counter %g\n", tc.secondScrape)
+				}
+				scrapeCount++
+			}))
+			defer srv.Close()
+
+			urlParts := strings.Split(strings.TrimPrefix(srv.URL, "http://"), ":")
+			require.Len(t, urlParts, 2)
+			ip := urlParts[0]
+			var port int32
+			_, err := fmt.Sscanf(urlParts[1], "%d", &port)
+			require.NoError(t, err)
+
+			collector := newTestCollector()
+			pod := &corev1.Pod{}
+			pod.Name = "pod-1"
+			pod.Status.PodIP = ip
+			pod.Status.StartTime = &metav1.Time{Time: time.Now().Add(-10 * time.Minute)}
+
+			podSource := &workload.PodMetricSource{
+				Uri:  "/metrics",
+				Port: port,
+			}
+
+			wanted := map[string][]string{
+				"my_counter": {"my_policy_key"},
+			}
+
+			values := make(map[string]float64)
+			pastHistograms := make(map[string]HistogramInfo)
+			currentHistograms := make(map[string]HistogramInfo)
+			pastCounters := make(map[string]CounterInfo)
+			currentCounters := make(map[string]CounterInfo)
+			missingBaselines := make(map[string]bool)
+
+			err = collector.collectPodMetrics(context.Background(), pod, podSource, wanted, values, pastHistograms, currentHistograms, pastCounters, currentCounters, missingBaselines)
+			require.NoError(t, err)
+
+			_, ok := values["my_policy_key"]
+			assert.False(t, ok)
+			info, ok := currentCounters[pod.Name]
+			require.True(t, ok)
+			assert.Equal(t, tc.firstScrape, info.CounterMap["my_policy_key"])
+
+			t1 := info.ScrapeTimestamps["my_policy_key"]
+			info.ScrapeTimestamps["my_policy_key"] = t1 - tc.elapsedMs
+			if tc.podRestarted {
+				// Change start time to simulate restart
+				pod.Status.StartTime = &metav1.Time{Time: time.Now()}
+			}
+			pastCounters[pod.Name] = info
+
+			values = make(map[string]float64)
+			currentHistograms = make(map[string]HistogramInfo)
+			currentCounters = make(map[string]CounterInfo)
+			missingBaselines = make(map[string]bool)
+			err = collector.collectPodMetrics(context.Background(), pod, podSource, wanted, values, pastHistograms, currentHistograms, pastCounters, currentCounters, missingBaselines)
+			require.NoError(t, err)
+
+			if tc.want.rate > 0 {
+				assert.InDelta(t, tc.want.rate, values["my_policy_key"], 1e-2)
+			} else {
+				_, ok := values["my_policy_key"]
+				assert.False(t, ok)
+			}
+			info2, ok := currentCounters[pod.Name]
+			require.True(t, ok)
+			assert.Equal(t, tc.want.currentCounter, info2.CounterMap["my_policy_key"])
+		})
+	}
 }

--- a/pkg/autoscaler/datastructure/sliding_window.go
+++ b/pkg/autoscaler/datastructure/sliding_window.go
@@ -234,3 +234,19 @@ func (window *SnapshotSlidingWindow[T]) GetLastUnfreshSnapshot() (value T, ok bo
 	}
 	return front.value, true
 }
+
+func (window *SnapshotSlidingWindow[T]) GetLastUnfreshSnapshotWithTimestamp() (value T, timestamp int64, ok bool) {
+	if window.freshMilliseconds == 0 {
+		return value, 0, false
+	}
+	currentTimestamp := window.getCurrentTimestamp()
+	window.expire(currentTimestamp)
+	if window.pool.Len() == 0 {
+		return value, 0, false
+	}
+	front := window.pool.Front()
+	if isFresh(window.freshMilliseconds, currentTimestamp, front.timestamp) {
+		return value, 0, false
+	}
+	return front.value, front.timestamp, true
+}

--- a/pkg/autoscaler/datastructure/sliding_window.go
+++ b/pkg/autoscaler/datastructure/sliding_window.go
@@ -234,3 +234,12 @@ func (window *SnapshotSlidingWindow[T]) GetLastUnfreshSnapshot() (value T, ok bo
 	}
 	return front.value, true
 }
+
+func (window *SnapshotSlidingWindow[T]) GetLastSnapshot() (value T, ok bool) {
+	currentTimestamp := window.getCurrentTimestamp()
+	window.expire(currentTimestamp)
+	if window.pool.Len() == 0 {
+		return value, false
+	}
+	return window.pool.Back().value, true
+}

--- a/pkg/autoscaler/datastructure/sliding_window_test.go
+++ b/pkg/autoscaler/datastructure/sliding_window_test.go
@@ -332,3 +332,30 @@ func Test_snapshotSlidingWindowWithZeroTTL(t *testing.T) {
 	_, ok = window.GetLastUnfreshSnapshot()
 	assert.False(ok)
 }
+
+func Test_snapshotSlidingWindowGetLastSnapshot(t *testing.T) {
+	assert := assert.New(t)
+
+	window := NewSnapshotSlidingWindow[string](10000, 15000)
+
+	_, ok := window.GetLastSnapshot()
+	assert.False(ok)
+
+	window.getCurrentTimestamp = dateFunc(1)
+	window.Append("foo")
+
+	last, ok := window.GetLastSnapshot()
+	assert.True(ok)
+	assert.Equal("foo", last)
+
+	window.getCurrentTimestamp = dateFunc(3)
+	window.Append("bar")
+
+	last, ok = window.GetLastSnapshot()
+	assert.True(ok)
+	assert.Equal("bar", last)
+
+	window.getCurrentTimestamp = dateFunc(19)
+	_, ok = window.GetLastSnapshot()
+	assert.False(ok)
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind enhancement
**What this PR does / why we need it**:

Prometheus counter metrics are monotonically increasing cumulative values. 
The autoscaler was treating these raw cumulative values as instantaneous load 
signals, causing two critical failures:

1. **Scale-up runaway**: A pod that handled 50 total requests since startup would 
   trigger scaling to 5 replicas (ceil(50 / target)), regardless of current traffic.

2. **No scale-down**: Even after traffic stops, the counter value persists at 50, 
   preventing the autoscaler from ever scaling back down.

The fix: Track per-pod counter snapshots across scrape cycles and compute the 
*rate of change* (delta/elapsed_seconds) instead of the raw cumulative value. 
This correctly reflects instantaneous demand and enables both scale-up and scale-down.

**Implementation Details**:

- Added `CounterMap` and `ScrapeTimestamp` fields to `HistogramInfo` to maintain 
  per-pod/metric baseline state across scrape cycles.
- New rate calculation in metric collection:
```
rate = (current_value - previous_value) / elapsed_seconds
```

- Counter resets (current < previous) detected and handled by clamping rate to 0.
- First scrape returns rate=0 until baseline is established.
- Added `GetLastUnfreshSnapshotWithTimestamp()` to `SnapshotSlidingWindow` 
  to expose precise per-pod scrape timestamps (more accurate than window-level timestamps).
- Backward compatibility: Nil `CounterMap` guards protect in-memory snapshots 
  created before this change.

**Which issue(s) this PR fixes**:
Fixes #1037 

**Special notes for your reviewer**:

- **Why per-pod timestamps?** The sliding-window-level timestamp is too coarse; 
  per-pod scrape times give us the actual elapsed duration for each counter, 
  improving rate precision when scrape intervals vary.

- **Counter reset handling**: If a pod restarts, its counter resets to 0. 
  Detecting `current < previous` avoids reporting a massive negative rate; 
  returning 0 is safe and gives the pod a grace period to re-accumulate load signals.

- **Backward compatibility**: Any in-memory snapshots from before this change 
  will have `CounterMap == nil`. These are safely handled with a nil-check guard.

- **Testing recommendation**: Add bench tests for rate calculation under 
  varying scrape intervals and counter reset scenarios.

**Does this PR introduce a user-facing change?**:
Yes. Autoscaling behavior for counter-based metrics will change—scaling will now 
respond to instantaneous rate of change rather than cumulative totals, enabling 
proper scale-down behavior.

```release-note
Fix autoscaler counter metric handling: Prometheus counter metrics are now 
correctly treated as rates (delta/elapsed_seconds) instead of raw cumulative 
values. This fixes runaway scale-up and enables proper scale-down when traffic stops.
```