### PR TITLE
fix: skip nil debug config dump entries

### DIFF
--- a/pkg/kthena-router/debug/handlers.go
+++ b/pkg/kthena-router/debug/handlers.go
@@ -120,6 +120,9 @@ func (h *DebugHandler) ListModelRoutes(c *gin.Context) {
 
 	var responses []ModelRouteResponse
 	for namespacedName, mr := range modelRoutes {
+		if mr == nil {
+			continue
+		}
 		parts := strings.Split(namespacedName, "/")
 		if len(parts) != 2 {
 			continue
@@ -143,6 +146,9 @@ func (h *DebugHandler) ListModelServers(c *gin.Context) {
 
 	var responses []ModelServerResponse
 	for namespacedName, ms := range modelServers {
+		if ms == nil {
+			continue
+		}
 		response := ModelServerResponse{
 			Name:      namespacedName.Name,
 			Namespace: namespacedName.Namespace,
@@ -194,6 +200,9 @@ func (h *DebugHandler) ListPods(c *gin.Context) {
 
 	var responses []PodResponse
 	for namespacedName, podInfo := range pods {
+		if podInfo == nil {
+			continue
+		}
 		response := h.convertPodInfoToResponse(namespacedName, podInfo, false)
 		responses = append(responses, response)
 	}
@@ -207,6 +216,9 @@ func (h *DebugHandler) ListGateways(c *gin.Context) {
 
 	var responses []GatewayResponse
 	for _, gw := range gateways {
+		if gw == nil {
+			continue
+		}
 		response := GatewayResponse{
 			Name:      gw.Name,
 			Namespace: gw.Namespace,

--- a/pkg/kthena-router/debug/handlers_test.go
+++ b/pkg/kthena-router/debug/handlers_test.go
@@ -420,6 +420,20 @@ func TestListModelRoutes(t *testing.T) {
 				assert.Empty(t, response["modelroutes"])
 			},
 		},
+		{
+			name: "skips nil entries",
+			setup: func(m *MockStore) {
+				m.On("GetAllModelRoutes").Return(map[string]*aiv1alpha1.ModelRoute{
+					"default/nil-route": nil,
+				})
+			},
+			expectedStatus: http.StatusOK,
+			check: func(t *testing.T, body []byte) {
+				var response map[string][]ModelRouteResponse
+				require.NoError(t, json.Unmarshal(body, &response))
+				assert.Empty(t, response["modelroutes"])
+			},
+		},
 	}
 	runHandlerCases(t, cases, func(h *DebugHandler, c *gin.Context) { h.ListModelRoutes(c) })
 }
@@ -552,6 +566,20 @@ func TestListModelServers(t *testing.T) {
 				assert.Nil(t, servers[0].PrefillPods)
 			},
 		},
+		{
+			name: "skips nil entries",
+			setup: func(m *MockStore) {
+				m.On("GetAllModelServers").Return(map[types.NamespacedName]*aiv1alpha1.ModelServer{
+					{Namespace: "default", Name: "nil-server"}: nil,
+				})
+			},
+			expectedStatus: http.StatusOK,
+			check: func(t *testing.T, body []byte) {
+				var response map[string][]ModelServerResponse
+				require.NoError(t, json.Unmarshal(body, &response))
+				assert.Empty(t, response["modelservers"])
+			},
+		},
 	}
 	runHandlerCases(t, cases, func(h *DebugHandler, c *gin.Context) { h.ListModelServers(c) })
 }
@@ -634,6 +662,20 @@ func TestListPods(t *testing.T) {
 				assert.Equal(t, float64(2), pods[0].Metrics.RequestRunningNum)
 				assert.Equal(t, 1.5, pods[0].Metrics.TPOT)
 				assert.Equal(t, 0.2, pods[0].Metrics.TTFT)
+			},
+		},
+		{
+			name: "skips nil entries",
+			setup: func(m *MockStore) {
+				m.On("GetAllPods").Return(map[types.NamespacedName]*datastore.PodInfo{
+					{Namespace: "default", Name: "nil-pod"}: nil,
+				})
+			},
+			expectedStatus: http.StatusOK,
+			check: func(t *testing.T, body []byte) {
+				var response map[string][]PodResponse
+				require.NoError(t, json.Unmarshal(body, &response))
+				assert.Empty(t, response["pods"])
 			},
 		},
 	}
@@ -729,6 +771,20 @@ func TestListGateways(t *testing.T) {
 				require.Len(t, gateways, 1)
 				assert.Equal(t, "my-gateway", gateways[0].Name)
 				assert.Equal(t, "default", gateways[0].Namespace)
+			},
+		},
+		{
+			name: "skips nil entries",
+			setup: func(m *MockStore) {
+				m.On("GetAllGateways").Return([]*gatewayv1.Gateway{nil, gw, nil})
+			},
+			expectedStatus: http.StatusOK,
+			check: func(t *testing.T, body []byte) {
+				var response map[string][]GatewayResponse
+				require.NoError(t, json.Unmarshal(body, &response))
+				gateways := response["gateways"]
+				require.Len(t, gateways, 1)
+				assert.Equal(t, "my-gateway", gateways[0].Name)
 			},
 		},
 	}


### PR DESCRIPTION
/kind bug

What this PR does / why we need it:

Some debug config dump list handlers dereference store entries without nil checks. Other handlers already skip nil entries, so this makes the behavior consistent for ModelRoutes, ModelServers, Pods, and Gateways.

This prevents debug endpoints from panicking if the store returns a nil object entry.

Verification:

<img width="996" height="58" alt="image" src="https://github.com/user-attachments/assets/90c0e6c4-3505-470c-93ab-3c096c194f8e" />


```bash
go test ./pkg/kthena-router/debug
