### PR TITLE
fix: honor default gateway parent refs

### DIFF
--- a/pkg/kthena-router/controller/constants.go
+++ b/pkg/kthena-router/controller/constants.go
@@ -23,6 +23,8 @@ const (
 	DefaultGatewayClassName = "kthena-router"
 	// ControllerName is the controller name for kthena-router GatewayClass
 	ControllerName = "volcano.sh/kthena-router"
+
+	gatewayAPIGroupName = "gateway.networking.k8s.io"
 )
 
 // this is the signal used to indicate that the controllers has reconciled all the initial resources.

--- a/pkg/kthena-router/controller/httproute_controller.go
+++ b/pkg/kthena-router/controller/httproute_controller.go
@@ -167,14 +167,10 @@ func (c *HTTPRouteController) syncHandler(key string) error {
 	// Check all parentRefs - process immediately if any matches, retry only if no match and a Gateway is pending
 	var gatewayPending bool
 	for _, parentRef := range httpRoute.Spec.ParentRefs {
-		if parentRef.Kind == nil || *parentRef.Kind != "Gateway" {
+		if !isGatewayParentRef(parentRef) {
 			continue
 		}
-		gatewayNamespace := httpRoute.Namespace
-		if parentRef.Namespace != nil {
-			gatewayNamespace = string(*parentRef.Namespace)
-		}
-		gatewayKey := fmt.Sprintf("%s/%s", gatewayNamespace, string(parentRef.Name))
+		gatewayNamespace, gatewayKey := gatewayParentRefNamespaceAndKey(httpRoute.Namespace, parentRef)
 		gw := c.store.GetGateway(gatewayKey)
 		if gw == nil {
 			if _, err := c.gatewayLister.Gateways(gatewayNamespace).Get(string(parentRef.Name)); err == nil {
@@ -216,16 +212,29 @@ func (c *HTTPRouteController) enqueueHTTPRoutesForGateway(obj interface{}) {
 	}
 	for _, route := range routes {
 		for _, parentRef := range route.Spec.ParentRefs {
-			if parentRef.Kind != nil && *parentRef.Kind == "Gateway" {
-				ns := route.Namespace
-				if parentRef.Namespace != nil {
-					ns = string(*parentRef.Namespace)
-				}
-				if fmt.Sprintf("%s/%s", ns, string(parentRef.Name)) == gatewayKey {
-					c.workqueue.Add(fmt.Sprintf("%s/%s", route.Namespace, route.Name))
-					break
-				}
+			if !isGatewayParentRef(parentRef) {
+				continue
+			}
+			_, parentKey := gatewayParentRefNamespaceAndKey(route.Namespace, parentRef)
+			if parentKey == gatewayKey {
+				c.workqueue.Add(fmt.Sprintf("%s/%s", route.Namespace, route.Name))
+				break
 			}
 		}
 	}
+}
+
+func isGatewayParentRef(parentRef gatewayv1.ParentReference) bool {
+	if parentRef.Group != nil && *parentRef.Group != "" && *parentRef.Group != gatewayv1.Group(gatewayAPIGroupName) {
+		return false
+	}
+	return parentRef.Kind == nil || *parentRef.Kind == "" || *parentRef.Kind == gatewayv1.Kind("Gateway")
+}
+
+func gatewayParentRefNamespaceAndKey(defaultNamespace string, parentRef gatewayv1.ParentReference) (string, string) {
+	namespace := defaultNamespace
+	if parentRef.Namespace != nil {
+		namespace = string(*parentRef.Namespace)
+	}
+	return namespace, fmt.Sprintf("%s/%s", namespace, string(parentRef.Name))
 }

--- a/pkg/kthena-router/controller/httproute_controller_test.go
+++ b/pkg/kthena-router/controller/httproute_controller_test.go
@@ -45,6 +45,8 @@ func TestHTTPRouteController_EnqueueHTTPRoutesForGateway(t *testing.T) {
 
 	ctx := context.Background()
 	ns := "default"
+	emptyGroup := gatewayv1.Group("")
+	emptyKind := gatewayv1.Kind("")
 	gw := &gatewayv1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "gateway-1"},
 		Spec: gatewayv1.GatewaySpec{
@@ -59,7 +61,7 @@ func TestHTTPRouteController_EnqueueHTTPRoutesForGateway(t *testing.T) {
 		Spec: gatewayv1.HTTPRouteSpec{
 			CommonRouteSpec: gatewayv1.CommonRouteSpec{
 				ParentRefs: []gatewayv1.ParentReference{
-					{Kind: ptr(gatewayv1.Kind("Gateway")), Name: gatewayv1.ObjectName("gateway-1")},
+					{Name: gatewayv1.ObjectName("gateway-1")},
 				},
 			},
 		},
@@ -93,6 +95,19 @@ func TestHTTPRouteController_EnqueueHTTPRoutesForGateway(t *testing.T) {
 	_, err = gatewayClient.GatewayV1().HTTPRoutes("other-ns").Create(ctx, httpRoute3, metav1.CreateOptions{})
 	assert.NoError(t, err)
 
+	httpRoute4 := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "route-4"},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{
+					{Group: &emptyGroup, Kind: &emptyKind, Name: gatewayv1.ObjectName("gateway-1")},
+				},
+			},
+		},
+	}
+	_, err = gatewayClient.GatewayV1().HTTPRoutes(ns).Create(ctx, httpRoute4, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
 	gatewayInformer := gatewayInformerFactory.Gateway().V1().Gateways()
 	if !cache.WaitForCacheSync(stop, gatewayInformer.Informer().HasSynced) {
 		t.Fatal("gateway cache sync timeout")
@@ -110,7 +125,7 @@ func TestHTTPRouteController_EnqueueHTTPRoutesForGateway(t *testing.T) {
 
 	ctrl.enqueueHTTPRoutesForGateway(gw)
 	time.Sleep(50 * time.Millisecond)
-	assert.Equal(t, 2, ctrl.workqueue.Len(), "route-1 and route-3 reference gateway-1, route-2 does not")
+	assert.Equal(t, 3, ctrl.workqueue.Len(), "route-1, route-3, and route-4 reference gateway-1, route-2 does not")
 }
 
 func TestHTTPRouteController_EnqueueHTTPRoutesForGateway_NoMatchingRoutes(t *testing.T) {
@@ -147,6 +162,21 @@ func TestHTTPRouteController_EnqueueHTTPRoutesForGateway_NoMatchingRoutes(t *tes
 	_, err = gatewayClient.GatewayV1().HTTPRoutes(ns).Create(ctx, httpRoute, metav1.CreateOptions{})
 	assert.NoError(t, err)
 
+	serviceGroup := gatewayv1.Group("core")
+	serviceKind := gatewayv1.Kind("Service")
+	httpRoute2 := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "route-2"},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{
+					{Group: &serviceGroup, Kind: &serviceKind, Name: gatewayv1.ObjectName("gateway-1")},
+				},
+			},
+		},
+	}
+	_, err = gatewayClient.GatewayV1().HTTPRoutes(ns).Create(ctx, httpRoute2, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
 	if !cache.WaitForCacheSync(stop, gatewayInformerFactory.Gateway().V1().HTTPRoutes().Informer().HasSynced) {
 		t.Fatal("cache sync timeout")
 	}
@@ -159,7 +189,7 @@ func TestHTTPRouteController_EnqueueHTTPRoutesForGateway_NoMatchingRoutes(t *tes
 
 	ctrl.enqueueHTTPRoutesForGateway(gw)
 	time.Sleep(50 * time.Millisecond)
-	assert.Equal(t, 0, ctrl.workqueue.Len(), "no HTTPRoutes reference gateway-1")
+	assert.Equal(t, 0, ctrl.workqueue.Len(), "no HTTPRoutes reference gateway-1 as a Gateway parent")
 }
 
 // TestHTTPRouteController_MultipleParentRefs_FirstPending verifies that when the first parentRef
@@ -187,7 +217,7 @@ func TestHTTPRouteController_MultipleParentRefs_FirstPending(t *testing.T) {
 			CommonRouteSpec: gatewayv1.CommonRouteSpec{
 				ParentRefs: []gatewayv1.ParentReference{
 					{Kind: ptr(gatewayv1.Kind("Gateway")), Name: gatewayv1.ObjectName("gateway-1")},
-					{Kind: ptr(gatewayv1.Kind("Gateway")), Name: gatewayv1.ObjectName("gateway-2")},
+					{Name: gatewayv1.ObjectName("gateway-2")},
 				},
 			},
 		},

--- a/pkg/kthena-router/controller/httproute_controller_test.go
+++ b/pkg/kthena-router/controller/httproute_controller_test.go
@@ -19,9 +19,9 @@ package controller
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -39,11 +39,6 @@ func TestHTTPRouteController_EnqueueHTTPRoutesForGateway(t *testing.T) {
 	store := datastore.New()
 
 	ctrl := NewHTTPRouteController(gatewayInformerFactory, store)
-	stop := make(chan struct{})
-	defer close(stop)
-	gatewayInformerFactory.Start(stop)
-
-	ctx := context.Background()
 	ns := "default"
 	emptyGroup := gatewayv1.Group("")
 	emptyKind := gatewayv1.Kind("")
@@ -53,8 +48,6 @@ func TestHTTPRouteController_EnqueueHTTPRoutesForGateway(t *testing.T) {
 			GatewayClassName: gatewayv1.ObjectName(DefaultGatewayClassName),
 		},
 	}
-	_, err := gatewayClient.GatewayV1().Gateways(ns).Create(ctx, gw, metav1.CreateOptions{})
-	assert.NoError(t, err)
 
 	httpRoute := &gatewayv1.HTTPRoute{
 		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "route-1"},
@@ -66,8 +59,6 @@ func TestHTTPRouteController_EnqueueHTTPRoutesForGateway(t *testing.T) {
 			},
 		},
 	}
-	_, err = gatewayClient.GatewayV1().HTTPRoutes(ns).Create(ctx, httpRoute, metav1.CreateOptions{})
-	assert.NoError(t, err)
 
 	httpRoute2 := &gatewayv1.HTTPRoute{
 		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "route-2"},
@@ -79,8 +70,6 @@ func TestHTTPRouteController_EnqueueHTTPRoutesForGateway(t *testing.T) {
 			},
 		},
 	}
-	_, err = gatewayClient.GatewayV1().HTTPRoutes(ns).Create(ctx, httpRoute2, metav1.CreateOptions{})
-	assert.NoError(t, err)
 
 	httpRoute3 := &gatewayv1.HTTPRoute{
 		ObjectMeta: metav1.ObjectMeta{Namespace: "other-ns", Name: "route-3"},
@@ -92,8 +81,6 @@ func TestHTTPRouteController_EnqueueHTTPRoutesForGateway(t *testing.T) {
 			},
 		},
 	}
-	_, err = gatewayClient.GatewayV1().HTTPRoutes("other-ns").Create(ctx, httpRoute3, metav1.CreateOptions{})
-	assert.NoError(t, err)
 
 	httpRoute4 := &gatewayv1.HTTPRoute{
 		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "route-4"},
@@ -105,27 +92,15 @@ func TestHTTPRouteController_EnqueueHTTPRoutesForGateway(t *testing.T) {
 			},
 		},
 	}
-	_, err = gatewayClient.GatewayV1().HTTPRoutes(ns).Create(ctx, httpRoute4, metav1.CreateOptions{})
-	assert.NoError(t, err)
 
-	gatewayInformer := gatewayInformerFactory.Gateway().V1().Gateways()
-	if !cache.WaitForCacheSync(stop, gatewayInformer.Informer().HasSynced) {
-		t.Fatal("gateway cache sync timeout")
-	}
-	httpRouteInformer := gatewayInformerFactory.Gateway().V1().HTTPRoutes()
-	if !cache.WaitForCacheSync(stop, httpRouteInformer.Informer().HasSynced) {
-		t.Fatal("httproute cache sync timeout")
-	}
-
-	time.Sleep(200 * time.Millisecond)
-	for ctrl.workqueue.Len() > 0 {
-		obj, _ := ctrl.workqueue.Get()
-		ctrl.workqueue.Done(obj)
-	}
-
+	addHTTPRoutesToInformer(t, gatewayInformerFactory, httpRoute, httpRoute2, httpRoute3, httpRoute4)
 	ctrl.enqueueHTTPRoutesForGateway(gw)
-	time.Sleep(50 * time.Millisecond)
-	assert.Equal(t, 3, ctrl.workqueue.Len(), "route-1, route-3, and route-4 reference gateway-1, route-2 does not")
+
+	assert.ElementsMatch(t, []string{
+		"default/route-1",
+		"other-ns/route-3",
+		"default/route-4",
+	}, drainHTTPRouteQueue(ctrl), "route-1, route-3, and route-4 reference gateway-1, route-2 does not")
 }
 
 func TestHTTPRouteController_EnqueueHTTPRoutesForGateway_NoMatchingRoutes(t *testing.T) {
@@ -134,11 +109,6 @@ func TestHTTPRouteController_EnqueueHTTPRoutesForGateway_NoMatchingRoutes(t *tes
 	store := datastore.New()
 
 	ctrl := NewHTTPRouteController(gatewayInformerFactory, store)
-	stop := make(chan struct{})
-	defer close(stop)
-	gatewayInformerFactory.Start(stop)
-
-	ctx := context.Background()
 	ns := "default"
 	gw := &gatewayv1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "gateway-1"},
@@ -146,8 +116,6 @@ func TestHTTPRouteController_EnqueueHTTPRoutesForGateway_NoMatchingRoutes(t *tes
 			GatewayClassName: gatewayv1.ObjectName(DefaultGatewayClassName),
 		},
 	}
-	_, err := gatewayClient.GatewayV1().Gateways(ns).Create(ctx, gw, metav1.CreateOptions{})
-	assert.NoError(t, err)
 
 	httpRoute := &gatewayv1.HTTPRoute{
 		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "route-1"},
@@ -159,8 +127,6 @@ func TestHTTPRouteController_EnqueueHTTPRoutesForGateway_NoMatchingRoutes(t *tes
 			},
 		},
 	}
-	_, err = gatewayClient.GatewayV1().HTTPRoutes(ns).Create(ctx, httpRoute, metav1.CreateOptions{})
-	assert.NoError(t, err)
 
 	serviceGroup := gatewayv1.Group("core")
 	serviceKind := gatewayv1.Kind("Service")
@@ -174,22 +140,10 @@ func TestHTTPRouteController_EnqueueHTTPRoutesForGateway_NoMatchingRoutes(t *tes
 			},
 		},
 	}
-	_, err = gatewayClient.GatewayV1().HTTPRoutes(ns).Create(ctx, httpRoute2, metav1.CreateOptions{})
-	assert.NoError(t, err)
 
-	if !cache.WaitForCacheSync(stop, gatewayInformerFactory.Gateway().V1().HTTPRoutes().Informer().HasSynced) {
-		t.Fatal("cache sync timeout")
-	}
-
-	time.Sleep(200 * time.Millisecond)
-	for ctrl.workqueue.Len() > 0 {
-		obj, _ := ctrl.workqueue.Get()
-		ctrl.workqueue.Done(obj)
-	}
-
+	addHTTPRoutesToInformer(t, gatewayInformerFactory, httpRoute, httpRoute2)
 	ctrl.enqueueHTTPRoutesForGateway(gw)
-	time.Sleep(50 * time.Millisecond)
-	assert.Equal(t, 0, ctrl.workqueue.Len(), "no HTTPRoutes reference gateway-1 as a Gateway parent")
+	assert.Empty(t, drainHTTPRouteQueue(ctrl), "no HTTPRoutes reference gateway-1 as a Gateway parent")
 }
 
 // TestHTTPRouteController_MultipleParentRefs_FirstPending verifies that when the first parentRef
@@ -237,4 +191,26 @@ func TestHTTPRouteController_MultipleParentRefs_FirstPending(t *testing.T) {
 	err = ctrl.syncHandler(ns + "/route-multi")
 	assert.NoError(t, err)
 	assert.NotNil(t, store.GetHTTPRoute(ns+"/route-multi"))
+}
+
+func addHTTPRoutesToInformer(t *testing.T, factory gatewayinformers.SharedInformerFactory, routes ...*gatewayv1.HTTPRoute) {
+	t.Helper()
+
+	store := factory.Gateway().V1().HTTPRoutes().Informer().GetStore()
+	for _, route := range routes {
+		require.NoError(t, store.Add(route))
+	}
+}
+
+func drainHTTPRouteQueue(ctrl *HTTPRouteController) []string {
+	keys := []string{}
+	for ctrl.workqueue.Len() > 0 {
+		obj, _ := ctrl.workqueue.Get()
+		if key, ok := obj.(string); ok {
+			keys = append(keys, key)
+		}
+		ctrl.workqueue.Done(obj)
+		ctrl.workqueue.Forget(obj)
+	}
+	return keys
 }

--- a/pkg/kthena-router/datastore/store.go
+++ b/pkg/kthena-router/datastore/store.go
@@ -755,6 +755,23 @@ func (s *store) DeletePod(podName types.NamespacedName) error {
 }
 
 // Model routing methods
+const gatewayAPIGroupName = "gateway.networking.k8s.io"
+
+func isGatewayParentRef(parentRef gatewayv1.ParentReference) bool {
+	if parentRef.Group != nil && *parentRef.Group != "" && *parentRef.Group != gatewayv1.Group(gatewayAPIGroupName) {
+		return false
+	}
+	return parentRef.Kind == nil || *parentRef.Kind == "" || *parentRef.Kind == gatewayv1.Kind("Gateway")
+}
+
+func gatewayParentRefKey(defaultNamespace string, parentRef gatewayv1.ParentReference) string {
+	namespace := defaultNamespace
+	if parentRef.Namespace != nil {
+		namespace = string(*parentRef.Namespace)
+	}
+	return fmt.Sprintf("%s/%s", namespace, string(parentRef.Name))
+}
+
 func (s *store) AddOrUpdateModelRoute(mr *aiv1alpha1.ModelRoute) error {
 	s.routeMutex.Lock()
 	key := mr.Namespace + "/" + mr.Name
@@ -805,19 +822,15 @@ func (s *store) AddOrUpdateModelRoute(mr *aiv1alpha1.ModelRoute) error {
 
 	// Update gateway model routes mapping
 	for _, parentRef := range mr.Spec.ParentRefs {
-		if parentRef.Kind != nil && *parentRef.Kind == "Gateway" {
-			gatewayName := string(parentRef.Name)
-			gatewayNamespace := mr.Namespace
-			if parentRef.Namespace != nil {
-				gatewayNamespace = string(*parentRef.Namespace)
-			}
-			gatewayKey := fmt.Sprintf("%s/%s", gatewayNamespace, gatewayName)
-
-			if s.gatewayModelRoutes[gatewayKey] == nil {
-				s.gatewayModelRoutes[gatewayKey] = sets.New[string]()
-			}
-			s.gatewayModelRoutes[gatewayKey].Insert(key)
+		if !isGatewayParentRef(parentRef) {
+			continue
 		}
+		gatewayKey := gatewayParentRefKey(mr.Namespace, parentRef)
+
+		if s.gatewayModelRoutes[gatewayKey] == nil {
+			s.gatewayModelRoutes[gatewayKey] = sets.New[string]()
+		}
+		s.gatewayModelRoutes[gatewayKey].Insert(key)
 	}
 
 	s.routeMutex.Unlock()
@@ -896,19 +909,15 @@ func (s *store) DeleteModelRoute(namespacedName string) error {
 	// Remove from gateway model routes mapping
 	if deletedRoute != nil {
 		for _, parentRef := range deletedRoute.Spec.ParentRefs {
-			if parentRef.Kind != nil && *parentRef.Kind == "Gateway" {
-				gatewayName := string(parentRef.Name)
-				gatewayNamespace := deletedRoute.Namespace
-				if parentRef.Namespace != nil {
-					gatewayNamespace = string(*parentRef.Namespace)
-				}
-				gatewayKey := fmt.Sprintf("%s/%s", gatewayNamespace, gatewayName)
+			if !isGatewayParentRef(parentRef) {
+				continue
+			}
+			gatewayKey := gatewayParentRefKey(deletedRoute.Namespace, parentRef)
 
-				if routeSet, exists := s.gatewayModelRoutes[gatewayKey]; exists {
-					routeSet.Delete(namespacedName)
-					if routeSet.IsEmpty() {
-						delete(s.gatewayModelRoutes, gatewayKey)
-					}
+			if routeSet, exists := s.gatewayModelRoutes[gatewayKey]; exists {
+				routeSet.Delete(namespacedName)
+				if routeSet.IsEmpty() {
+					delete(s.gatewayModelRoutes, gatewayKey)
 				}
 			}
 		}
@@ -1011,15 +1020,12 @@ func (s *store) matchesSpecificGateway(mr *aiv1alpha1.ModelRoute, gatewayKey str
 	}
 
 	for _, parentRef := range mr.Spec.ParentRefs {
-		// Get namespace from parentRef, default to ModelRoute's namespace
-		namespace := mr.Namespace
-		if parentRef.Namespace != nil {
-			namespace = string(*parentRef.Namespace)
+		if !isGatewayParentRef(parentRef) {
+			continue
 		}
 
-		// Get name from parentRef
-		name := string(parentRef.Name)
-		key := fmt.Sprintf("%s/%s", namespace, name)
+		// Get namespace from parentRef, default to ModelRoute's namespace
+		key := gatewayParentRefKey(mr.Namespace, parentRef)
 
 		// Check if this parentRef matches the specified gateway
 		if key == gatewayKey {
@@ -1732,19 +1738,15 @@ func (s *store) AddOrUpdateHTTPRoute(httpRoute *gatewayv1.HTTPRoute) error {
 
 	// Update gateway routes mapping
 	for _, parentRef := range httpRoute.Spec.ParentRefs {
-		if parentRef.Kind != nil && *parentRef.Kind == "Gateway" {
-			gatewayName := string(parentRef.Name)
-			gatewayNamespace := httpRoute.Namespace
-			if parentRef.Namespace != nil {
-				gatewayNamespace = string(*parentRef.Namespace)
-			}
-			gatewayKey := fmt.Sprintf("%s/%s", gatewayNamespace, gatewayName)
-
-			if s.gatewayRoutes[gatewayKey] == nil {
-				s.gatewayRoutes[gatewayKey] = sets.New[string]()
-			}
-			s.gatewayRoutes[gatewayKey].Insert(key)
+		if !isGatewayParentRef(parentRef) {
+			continue
 		}
+		gatewayKey := gatewayParentRefKey(httpRoute.Namespace, parentRef)
+
+		if s.gatewayRoutes[gatewayKey] == nil {
+			s.gatewayRoutes[gatewayKey] = sets.New[string]()
+		}
+		s.gatewayRoutes[gatewayKey].Insert(key)
 	}
 
 	s.httpRouteMutex.Unlock()

--- a/pkg/kthena-router/datastore/store_test.go
+++ b/pkg/kthena-router/datastore/store_test.go
@@ -1945,6 +1945,64 @@ func TestMatchModelServer_GatewayScoped(t *testing.T) {
 			expectedError:  false,
 		},
 		{
+			name: "route matches gateway defaults when group and kind are omitted",
+			setupStore: func() *store {
+				s := newStore()
+				s.AddOrUpdateGateway(&gatewayv1.Gateway{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "my-gateway"},
+					Spec:       gatewayv1.GatewaySpec{Listeners: []gatewayv1.Listener{{Name: "http"}}},
+				})
+				s.AddOrUpdateModelRoute(&aiv1alpha1.ModelRoute{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "route-a"},
+					Spec: aiv1alpha1.ModelRouteSpec{
+						ModelName:  "llama3",
+						ParentRefs: []gatewayv1.ParentReference{{Name: "my-gateway"}},
+						Rules: []*aiv1alpha1.Rule{
+							{Name: "r", TargetModels: []*aiv1alpha1.TargetModel{{ModelServerName: "llama3-server", Weight: ptr(uint32(100))}}},
+						},
+					},
+				})
+				return s
+			},
+			modelName:      "llama3",
+			gatewayKey:     "default/my-gateway",
+			request:        &http.Request{URL: &url.URL{Path: "/v1/chat/completions"}},
+			expectedServer: types.NamespacedName{Namespace: "default", Name: "llama3-server"},
+			expectedError:  false,
+		},
+		{
+			name: "route matches gateway defaults when group and kind are empty",
+			setupStore: func() *store {
+				emptyGroup := gatewayv1.Group("")
+				emptyKind := gatewayv1.Kind("")
+				s := newStore()
+				s.AddOrUpdateGateway(&gatewayv1.Gateway{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "my-gateway"},
+					Spec:       gatewayv1.GatewaySpec{Listeners: []gatewayv1.Listener{{Name: "http"}}},
+				})
+				s.AddOrUpdateModelRoute(&aiv1alpha1.ModelRoute{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "route-a"},
+					Spec: aiv1alpha1.ModelRouteSpec{
+						ModelName: "llama3",
+						ParentRefs: []gatewayv1.ParentReference{{
+							Group: &emptyGroup,
+							Kind:  &emptyKind,
+							Name:  "my-gateway",
+						}},
+						Rules: []*aiv1alpha1.Rule{
+							{Name: "r", TargetModels: []*aiv1alpha1.TargetModel{{ModelServerName: "llama3-server", Weight: ptr(uint32(100))}}},
+						},
+					},
+				})
+				return s
+			},
+			modelName:      "llama3",
+			gatewayKey:     "default/my-gateway",
+			request:        &http.Request{URL: &url.URL{Path: "/v1/chat/completions"}},
+			expectedServer: types.NamespacedName{Namespace: "default", Name: "llama3-server"},
+			expectedError:  false,
+		},
+		{
 			name: "route skipped for different gateway",
 			setupStore: func() *store {
 				s := newStore()
@@ -1970,6 +2028,37 @@ func TestMatchModelServer_GatewayScoped(t *testing.T) {
 			},
 			modelName:     "llama3",
 			gatewayKey:    "default/gateway-b",
+			request:       &http.Request{URL: &url.URL{Path: "/v1/chat/completions"}},
+			expectedError: true,
+		},
+		{
+			name: "route skips explicit non-gateway parent ref",
+			setupStore: func() *store {
+				serviceGroup := gatewayv1.Group("core")
+				serviceKind := gatewayv1.Kind("Service")
+				s := newStore()
+				s.AddOrUpdateGateway(&gatewayv1.Gateway{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "backend"},
+					Spec:       gatewayv1.GatewaySpec{Listeners: []gatewayv1.Listener{{Name: "http"}}},
+				})
+				s.AddOrUpdateModelRoute(&aiv1alpha1.ModelRoute{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "route-a"},
+					Spec: aiv1alpha1.ModelRouteSpec{
+						ModelName: "llama3",
+						ParentRefs: []gatewayv1.ParentReference{{
+							Group: &serviceGroup,
+							Kind:  &serviceKind,
+							Name:  "backend",
+						}},
+						Rules: []*aiv1alpha1.Rule{
+							{Name: "r", TargetModels: []*aiv1alpha1.TargetModel{{ModelServerName: "llama3-server", Weight: ptr(uint32(100))}}},
+						},
+					},
+				})
+				return s
+			},
+			modelName:     "llama3",
+			gatewayKey:    "default/backend",
 			request:       &http.Request{URL: &url.URL{Path: "/v1/chat/completions"}},
 			expectedError: true,
 		},
@@ -2118,7 +2207,7 @@ func TestMatchModelServer_GatewayScoped(t *testing.T) {
 			expectedError:  false,
 		},
 		{
-			name: "multiple routes — only matching gateway selected",
+			name: "multiple routes - only matching gateway selected",
 			setupStore: func() *store {
 				s := newStore()
 				s.AddOrUpdateGateway(&gatewayv1.Gateway{
@@ -2174,6 +2263,204 @@ func TestMatchModelServer_GatewayScoped(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expectedIsLora, isLora)
 			assert.Equal(t, tt.expectedServer, server)
+		})
+	}
+}
+
+func TestStoreIndexesHTTPRouteGatewayParentRefDefaults(t *testing.T) {
+	emptyGroup := gatewayv1.Group("")
+	emptyKind := gatewayv1.Kind("")
+	gatewayGroup := gatewayv1.Group(gatewayAPIGroupName)
+	gatewayKind := gatewayv1.Kind("Gateway")
+	otherNamespace := gatewayv1.Namespace("other")
+	serviceGroup := gatewayv1.Group("core")
+	serviceKind := gatewayv1.Kind("Service")
+
+	tests := []struct {
+		name        string
+		parentRef   gatewayv1.ParentReference
+		gatewayKey  string
+		wantIndexed bool
+	}{
+		{
+			name:        "omitted group and kind use Gateway defaults",
+			parentRef:   gatewayv1.ParentReference{Name: "gateway"},
+			gatewayKey:  "default/gateway",
+			wantIndexed: true,
+		},
+		{
+			name: "empty group and kind use Gateway defaults",
+			parentRef: gatewayv1.ParentReference{
+				Group: &emptyGroup,
+				Kind:  &emptyKind,
+				Name:  "gateway",
+			},
+			gatewayKey:  "default/gateway",
+			wantIndexed: true,
+		},
+		{
+			name: "explicit Gateway group and kind",
+			parentRef: gatewayv1.ParentReference{
+				Group: &gatewayGroup,
+				Kind:  &gatewayKind,
+				Name:  "gateway",
+			},
+			gatewayKey:  "default/gateway",
+			wantIndexed: true,
+		},
+		{
+			name: "parent namespace overrides route namespace",
+			parentRef: gatewayv1.ParentReference{
+				Name:      "gateway",
+				Namespace: &otherNamespace,
+			},
+			gatewayKey:  "other/gateway",
+			wantIndexed: true,
+		},
+		{
+			name: "explicit non-Gateway group is ignored",
+			parentRef: gatewayv1.ParentReference{
+				Group: &serviceGroup,
+				Name:  "gateway",
+			},
+			gatewayKey:  "default/gateway",
+			wantIndexed: false,
+		},
+		{
+			name: "explicit non-Gateway kind is ignored",
+			parentRef: gatewayv1.ParentReference{
+				Kind: &serviceKind,
+				Name: "gateway",
+			},
+			gatewayKey:  "default/gateway",
+			wantIndexed: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newStore()
+			httpRoute := &gatewayv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "route",
+				},
+				Spec: gatewayv1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{
+						ParentRefs: []gatewayv1.ParentReference{tt.parentRef},
+					},
+				},
+			}
+
+			assert.NoError(t, s.AddOrUpdateHTTPRoute(httpRoute))
+
+			routes := s.GetHTTPRoutesByGateway(tt.gatewayKey)
+			if tt.wantIndexed {
+				assert.Len(t, routes, 1)
+				assert.Equal(t, "route", routes[0].Name)
+				return
+			}
+			assert.Empty(t, routes)
+		})
+	}
+}
+
+func TestStoreIndexesModelRouteGatewayParentRefDefaults(t *testing.T) {
+	emptyGroup := gatewayv1.Group("")
+	emptyKind := gatewayv1.Kind("")
+	gatewayGroup := gatewayv1.Group(gatewayAPIGroupName)
+	gatewayKind := gatewayv1.Kind("Gateway")
+	otherNamespace := gatewayv1.Namespace("other")
+	serviceGroup := gatewayv1.Group("core")
+	serviceKind := gatewayv1.Kind("Service")
+
+	tests := []struct {
+		name        string
+		parentRef   gatewayv1.ParentReference
+		gatewayKey  string
+		wantIndexed bool
+	}{
+		{
+			name:        "omitted group and kind use Gateway defaults",
+			parentRef:   gatewayv1.ParentReference{Name: "gateway"},
+			gatewayKey:  "default/gateway",
+			wantIndexed: true,
+		},
+		{
+			name: "empty group and kind use Gateway defaults",
+			parentRef: gatewayv1.ParentReference{
+				Group: &emptyGroup,
+				Kind:  &emptyKind,
+				Name:  "gateway",
+			},
+			gatewayKey:  "default/gateway",
+			wantIndexed: true,
+		},
+		{
+			name: "explicit Gateway group and kind",
+			parentRef: gatewayv1.ParentReference{
+				Group: &gatewayGroup,
+				Kind:  &gatewayKind,
+				Name:  "gateway",
+			},
+			gatewayKey:  "default/gateway",
+			wantIndexed: true,
+		},
+		{
+			name: "parent namespace overrides route namespace",
+			parentRef: gatewayv1.ParentReference{
+				Name:      "gateway",
+				Namespace: &otherNamespace,
+			},
+			gatewayKey:  "other/gateway",
+			wantIndexed: true,
+		},
+		{
+			name: "explicit non-Gateway group is ignored",
+			parentRef: gatewayv1.ParentReference{
+				Group: &serviceGroup,
+				Name:  "gateway",
+			},
+			gatewayKey:  "default/gateway",
+			wantIndexed: false,
+		},
+		{
+			name: "explicit non-Gateway kind is ignored",
+			parentRef: gatewayv1.ParentReference{
+				Kind: &serviceKind,
+				Name: "gateway",
+			},
+			gatewayKey:  "default/gateway",
+			wantIndexed: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newStore()
+			modelRoute := &aiv1alpha1.ModelRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "route",
+				},
+				Spec: aiv1alpha1.ModelRouteSpec{
+					ModelName:  "model",
+					ParentRefs: []gatewayv1.ParentReference{tt.parentRef},
+					Rules: []*aiv1alpha1.Rule{
+						{
+							TargetModels: []*aiv1alpha1.TargetModel{
+								{ModelServerName: "model-server", Weight: ptr(uint32(100))},
+							},
+						},
+					},
+				},
+			}
+
+			assert.NoError(t, s.AddOrUpdateModelRoute(modelRoute))
+
+			routeSet, ok := s.gatewayModelRoutes[tt.gatewayKey]
+			indexed := ok && routeSet.Contains("default/route")
+			assert.Equal(t, tt.wantIndexed, indexed)
 		})
 	}
 }


### PR DESCRIPTION
/kind bug

What this PR does / why we need it:

This PR fixes router handling for `ParentReference` defaults.

`HTTPRouteSpec.ParentRefs` uses the Gateway API `ParentReference` type. According to that type definition, when `group` and `kind` are omitted, they default to:

- `group: gateway.networking.k8s.io`
- `kind: Gateway`

Reference: https://pkg.go.dev/sigs.k8s.io/gateway-api/apis/v1#ParentReference

So this route parentRef:

```yaml
parentRefs:
- name: default