### PR TITLE
fix: find modelbooster owner by reference kind

### DIFF
--- a/pkg/model-booster-controller/controller/model_booster_controller.go
+++ b/pkg/model-booster-controller/controller/model_booster_controller.go
@@ -419,12 +419,7 @@ func (mc *ModelBoosterController) triggerModel(old any, new any) {
 		klog.Error("failed to parse old ModelServing")
 		return
 	}
-	if len(modelServing.OwnerReferences) > 0 {
-		// Find the owner of modelServing and reconcile the owner to change its status
-		if model, err := mc.modelBoosterLister.ModelBoosters(modelServing.Namespace).Get(modelServing.OwnerReferences[0].Name); err == nil {
-			mc.enqueueModelBooster(model)
-		}
-	}
+	mc.enqueueModelBoosterOwner(modelServing)
 }
 
 // deleteModelServing is called when a ModelServing is deleted. It will reconcile the ModelBooster. Recreate model serving.
@@ -435,11 +430,7 @@ func (mc *ModelBoosterController) deleteModelServing(obj any) {
 		return
 	}
 	klog.V(4).Infof("model serving: %s is deleted", klog.KObj(modelServing))
-	if len(modelServing.OwnerReferences) > 0 {
-		if model, err := mc.modelBoosterLister.ModelBoosters(modelServing.Namespace).Get(modelServing.OwnerReferences[0].Name); err == nil {
-			mc.enqueueModelBooster(model)
-		}
-	}
+	mc.enqueueModelBoosterOwner(modelServing)
 }
 
 // deleteModelRoute is called when a ModelRoute is deleted. It will reconcile the ModelBooster. Recreate model route.
@@ -450,11 +441,7 @@ func (mc *ModelBoosterController) deleteModelRoute(obj any) {
 		return
 	}
 	klog.V(4).Infof("model route: %s is deleted", klog.KObj(modelRoute))
-	if len(modelRoute.OwnerReferences) > 0 {
-		if model, err := mc.modelBoosterLister.ModelBoosters(modelRoute.Namespace).Get(modelRoute.OwnerReferences[0].Name); err == nil {
-			mc.enqueueModelBooster(model)
-		}
-	}
+	mc.enqueueModelBoosterOwner(modelRoute)
 }
 
 // deleteModelServer is called when a ModelServer is deleted. It will reconcile the ModelBooster. Recreate model server.
@@ -465,9 +452,34 @@ func (mc *ModelBoosterController) deleteModelServer(obj any) {
 		return
 	}
 	klog.V(4).Infof("model server: %s is deleted", klog.KObj(modelServer))
-	if len(modelServer.OwnerReferences) > 0 {
-		if model, err := mc.modelBoosterLister.ModelBoosters(modelServer.Namespace).Get(modelServer.OwnerReferences[0].Name); err == nil {
-			mc.enqueueModelBooster(model)
+	mc.enqueueModelBoosterOwner(modelServer)
+}
+
+func (mc *ModelBoosterController) enqueueModelBoosterOwner(obj metav1.Object) {
+	ownerName, ok := modelBoosterOwnerName(obj)
+	if !ok {
+		return
+	}
+	model, err := mc.modelBoosterLister.ModelBoosters(obj.GetNamespace()).Get(ownerName)
+	if err != nil {
+		klog.V(4).Infof("failed to get ModelBooster owner %s/%s: %v", obj.GetNamespace(), ownerName, err)
+		return
+	}
+	mc.enqueueModelBooster(model)
+}
+
+func modelBoosterOwnerName(obj metav1.Object) (string, bool) {
+	var modelOwnerName string
+	for _, ownerRef := range obj.GetOwnerReferences() {
+		if ownerRef.APIVersion != workload.GroupVersion.String() || ownerRef.Kind != workload.ModelKind.Kind || ownerRef.Name == "" {
+			continue
+		}
+		if ownerRef.Controller != nil && *ownerRef.Controller {
+			return ownerRef.Name, true
+		}
+		if modelOwnerName == "" {
+			modelOwnerName = ownerRef.Name
 		}
 	}
+	return modelOwnerName, modelOwnerName != ""
 }

--- a/pkg/model-booster-controller/controller/model_booster_controller_test.go
+++ b/pkg/model-booster-controller/controller/model_booster_controller_test.go
@@ -24,10 +24,14 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	kthenafake "github.com/volcano-sh/kthena/client-go/clientset/versioned/fake"
+	workloadLister "github.com/volcano-sh/kthena/client-go/listers/workload/v1alpha1"
+	networkingv1alpha1 "github.com/volcano-sh/kthena/pkg/apis/networking/v1alpha1"
 	workload "github.com/volcano-sh/kthena/pkg/apis/workload/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/yaml"
 )
 
@@ -203,6 +207,146 @@ func TestTriggerModel(t *testing.T) {
 	// invalid old
 	controller.triggerModel("invalid", modelServing)
 	assert.Equal(t, 0, controller.workQueue.Len())
+}
+
+func TestModelBoosterOwnerNameFindsOwnerByGVK(t *testing.T) {
+	controllerOwner := true
+	modelOwner := metav1.OwnerReference{
+		APIVersion: workload.GroupVersion.String(),
+		Kind:       workload.ModelKind.Kind,
+		Name:       "owner-model",
+		Controller: &controllerOwner,
+	}
+	nonControllerModelOwner := metav1.OwnerReference{
+		APIVersion: workload.GroupVersion.String(),
+		Kind:       workload.ModelKind.Kind,
+		Name:       "observer-model",
+	}
+	unrelatedOwner := metav1.OwnerReference{
+		APIVersion: "v1",
+		Kind:       "ConfigMap",
+		Name:       "config",
+	}
+
+	obj := &workload.ModelServing{
+		ObjectMeta: metav1.ObjectMeta{
+			OwnerReferences: []metav1.OwnerReference{unrelatedOwner, nonControllerModelOwner, modelOwner},
+		},
+	}
+
+	ownerName, ok := modelBoosterOwnerName(obj)
+	assert.True(t, ok)
+	assert.Equal(t, "owner-model", ownerName)
+}
+
+func TestChildResourceHandlersEnqueueModelBoosterOwner(t *testing.T) {
+	model := &workload.ModelBooster{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "owner-model",
+		},
+	}
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	assert.NoError(t, indexer.Add(model))
+	controller := newOwnerQueueController(indexer)
+	defer controller.workQueue.ShutDown()
+
+	controllerOwner := true
+	modelOwner := metav1.OwnerReference{
+		APIVersion: workload.GroupVersion.String(),
+		Kind:       workload.ModelKind.Kind,
+		Name:       model.Name,
+		Controller: &controllerOwner,
+	}
+	unrelatedOwner := metav1.OwnerReference{
+		APIVersion: "v1",
+		Kind:       "ConfigMap",
+		Name:       "config",
+	}
+	ownerRefs := []metav1.OwnerReference{unrelatedOwner, modelOwner}
+
+	cases := []struct {
+		name   string
+		invoke func()
+	}{
+		{
+			name: "model serving update",
+			invoke: func() {
+				controller.triggerModel(
+					&workload.ModelServing{ObjectMeta: metav1.ObjectMeta{Namespace: model.Namespace, Name: "serving"}},
+					&workload.ModelServing{ObjectMeta: metav1.ObjectMeta{Namespace: model.Namespace, Name: "serving", OwnerReferences: ownerRefs}},
+				)
+			},
+		},
+		{
+			name: "model serving delete",
+			invoke: func() {
+				controller.deleteModelServing(&workload.ModelServing{
+					ObjectMeta: metav1.ObjectMeta{Namespace: model.Namespace, Name: "serving", OwnerReferences: ownerRefs},
+				})
+			},
+		},
+		{
+			name: "model route delete",
+			invoke: func() {
+				controller.deleteModelRoute(&networkingv1alpha1.ModelRoute{
+					ObjectMeta: metav1.ObjectMeta{Namespace: model.Namespace, Name: "route", OwnerReferences: ownerRefs},
+				})
+			},
+		},
+		{
+			name: "model server delete",
+			invoke: func() {
+				controller.deleteModelServer(&networkingv1alpha1.ModelServer{
+					ObjectMeta: metav1.ObjectMeta{Namespace: model.Namespace, Name: "server", OwnerReferences: ownerRefs},
+				})
+			},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			drainWorkQueue(controller)
+			tt.invoke()
+			assert.Equal(t, 1, controller.workQueue.Len())
+		})
+	}
+}
+
+func TestChildResourceHandlersIgnoreNonModelBoosterOwners(t *testing.T) {
+	controller := newOwnerQueueController(cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{}))
+	defer controller.workQueue.ShutDown()
+
+	controller.deleteModelRoute(&networkingv1alpha1.ModelRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "route",
+			OwnerReferences: []metav1.OwnerReference{
+				{APIVersion: "v1", Kind: "ConfigMap", Name: "config"},
+			},
+		},
+	})
+
+	assert.Equal(t, 0, controller.workQueue.Len())
+}
+
+func newOwnerQueueController(indexer cache.Indexer) *ModelBoosterController {
+	return &ModelBoosterController{
+		modelBoosterLister: workloadLister.NewModelBoosterLister(indexer),
+		workQueue: workqueue.NewTypedRateLimitingQueueWithConfig(workqueue.DefaultTypedControllerRateLimiter[any](),
+			workqueue.TypedRateLimitingQueueConfig[any]{}),
+	}
+}
+
+func drainWorkQueue(controller *ModelBoosterController) {
+	for controller.workQueue.Len() > 0 {
+		item, shutdown := controller.workQueue.Get()
+		if shutdown {
+			return
+		}
+		controller.workQueue.Done(item)
+		controller.workQueue.Forget(item)
+	}
 }
 
 // Removed tests for LoRA adapter changes as the current API defines a single backend without loraAdapters


### PR DESCRIPTION
/kind bug

What this PR does / why we need it:

ModelBooster child handlers currently assume OwnerReferences[0] points to the owning ModelBooster.

OwnerReferences is a list, so the ModelBooster reference is not guaranteed to be first if another controller or tool adds additional owner refs. In that case, ModelServing/ModelRoute/ModelServer events may fail to enqueue the owning ModelBooster for reconciliation.

This change:
- finds the ModelBooster owner by APIVersion and Kind instead of list position
- prefers the controller owner reference when present
- reuses the lookup for ModelServing, ModelRoute, and ModelServer child handlers
- adds unit coverage for mixed ownerRefs and non-ModelBooster owners

Verification:

<img width="1136" height="94" alt="image" src="https://github.com/user-attachments/assets/8e1ad1d2-42af-4709-8140-bdeb14353f3b" />

Suggested test command:

go test ./pkg/model-booster-controller/controller
