### PR TITLE
fix(router): return mid-stream and copy errors from proxyRequest

### DIFF
--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -716,6 +716,9 @@ func (r *Router) proxy(
 
 		if err != nil {
 			klog.Errorf(" pod request error: %v", err)
+			if c.Writer.Written() {
+				return err
+			}
 			continue
 		}
 		// record in prefix cache
@@ -845,6 +848,7 @@ func proxyRequest(
 		// Stream response: read and forward each event (line) one by one, and parse usage if present
 		c.Status(resp.StatusCode)
 		reader := bufio.NewReader(resp.Body)
+		var streamErr error
 		c.Stream(func(w io.Writer) bool {
 			line, err := reader.ReadBytes('\n')
 			if len(line) > 0 {
@@ -869,11 +873,13 @@ func proxyRequest(
 			if err != nil {
 				if err != io.EOF {
 					klog.Errorf("error reading stream body: %v", err)
+					streamErr = err
 				}
 				return false
 			}
 			return true
 		})
+		return streamErr
 	} else {
 		// Non-stream: efficiently stream response while capturing for parsing
 		var buf bytes.Buffer
@@ -882,7 +888,7 @@ func proxyRequest(
 		_, err := io.Copy(c.Writer, ttee)
 		if err != nil {
 			klog.Errorf("copy response to downstream failed: %v", err)
-			return nil
+			return err
 		}
 
 		// Parse usage if present

--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -845,6 +845,7 @@ func proxyRequest(
 		// Stream response: read and forward each event (line) one by one, and parse usage if present
 		c.Status(resp.StatusCode)
 		reader := bufio.NewReader(resp.Body)
+		var streamErr error
 		c.Stream(func(w io.Writer) bool {
 			line, err := reader.ReadBytes('\n')
 			if len(line) > 0 {
@@ -869,11 +870,13 @@ func proxyRequest(
 			if err != nil {
 				if err != io.EOF {
 					klog.Errorf("error reading stream body: %v", err)
+					streamErr = err
 				}
 				return false
 			}
 			return true
 		})
+		return streamErr
 	} else {
 		// Non-stream: efficiently stream response while capturing for parsing
 		var buf bytes.Buffer
@@ -882,7 +885,7 @@ func proxyRequest(
 		_, err := io.Copy(c.Writer, ttee)
 		if err != nil {
 			klog.Errorf("copy response to downstream failed: %v", err)
-			return nil
+			return err
 		}
 
 		// Parse usage if present


### PR DESCRIPTION
### **What type of PR is this?**

/kind bug

## **What this PR does / why we need it**:

So I was going through the router code to understand how requests get dispatched, and I found something that felt off in proxyRequest in `pkg/kthena-router/router/router.go`.

When a streaming response from a backend pod breaks mid-way (like if the pod gets killed during a rolling update), the stream read error was being logged but then just... ignored. The function returned nil like nothing went wrong. Same thing for non-streaming responses - if io.Copy failed while copying the response body, it would log the error and return nil.
  
The problem with that is the retry loop in proxy() only tries the next pod if it gets a non-nil error back. So when a pod dies mid-response, we never retry to a healthy pod, we don't record any error in metrics, and we still call RunPostHooks which writes the dead pod into the prefix cache as if it handled the request successfully. That last part is pretty bad because future requests with similar prompts will keep getting scored toward a pod that's already gone.
  
The fix is pretty simple honestly. For streaming I added a streamErr variable that captures any non-EOF error inside the c.Stream closure and returns it after the stream finishes. For non-streaming I just changed return nil to return err in the io.Copy error path.

Now mid-stream failures and copy failures actually surface as errors, so the retry logic works as intended, metrics reflect what actually happened, and the prefixcache doesn't get poisoned with dead pod entries.

## **Does this PR introduce a user-facing change?**:

```release-note
Fixed a bug where broken streaming or non-streaming responses from backend pods were silently treated as successful requests. Mid-stream upstream failures now correctly surface as errors, enabling retries to healthy pods and accurate error metrics.
```
