### PR TITLE
fix: use server worker config for vllm serving

### DIFF
--- a/pkg/model-booster-controller/convert/model_serving.go
+++ b/pkg/model-booster-controller/convert/model_serving.go
@@ -214,8 +214,7 @@ func buildVllmDisaggregatedModelServing(model *workload.ModelBooster) (*workload
 func buildVllmModelServing(model *workload.ModelBooster) (*workload.ModelServing, error) {
 	backend := &model.Spec.Backend
 	workersMap := mapWorkers(backend.Workers)
-	serverWorker := workersMap[workload.ModelWorkerTypeServer]
-	if serverWorker == nil {
+	if workersMap[workload.ModelWorkerTypeServer] == nil {
 		return nil, fmt.Errorf("server worker not found in backend: %s", backend.Name)
 	}
 	cacheVolume, err := buildCacheVolume(backend)
@@ -223,7 +222,8 @@ func buildVllmModelServing(model *workload.ModelBooster) (*workload.ModelServing
 		return nil, err
 	}
 	modelDownloadPath := GetCachePath(backend.CacheURI) + GetMountPath(backend.ModelURI)
-	commands, err := buildCommands(backend, &serverWorker.Config, modelDownloadPath, workersMap)
+	serverWorkerConfig := workersMap[workload.ModelWorkerTypeServer].Config
+	commands, err := buildCommands(backend, &serverWorkerConfig, modelDownloadPath, workersMap)
 	if err != nil {
 		return nil, err
 	}
@@ -292,7 +292,7 @@ func buildVllmModelServing(model *workload.ModelBooster) (*workload.ModelServing
 		"BACKEND_TYPE":     strings.ToLower(string(backend.Type)),
 		"ENGINE_ENV":       engineEnv,
 		"WORKER_ENV":       backend.Env,
-		"SERVER_REPLICAS":  serverWorker.Replicas,
+		"SERVER_REPLICAS":  workersMap[workload.ModelWorkerTypeServer].Replicas,
 		"SERVER_ENTRY_TEMPLATE_METADATA": &metav1.ObjectMeta{
 			Labels: utils.GetModelControllerLabels(model, backend.Name, icUtils.Revision(backend)),
 		},
@@ -325,10 +325,10 @@ func buildVllmModelServing(model *workload.ModelBooster) (*workload.ModelServing
 		"MODEL_SERVING_RUNTIME_METRICS_PATH": env.GetEnvValueOrDefault[string](backend, env.RuntimeMetricsPath, "/metrics"),
 		"MODEL_SERVING_RUNTIME_ENGINE":       strings.ToLower(string(backend.Type)),
 		"MODEL_SERVING_RUNTIME_POD":          "$(POD_NAME).$(NAMESPACE)",
-		"ENGINE_SERVER_RESOURCES":            serverWorker.Resources,
-		"ENGINE_SERVER_IMAGE":                serverWorker.Image,
+		"ENGINE_SERVER_RESOURCES":            workersMap[workload.ModelWorkerTypeServer].Resources,
+		"ENGINE_SERVER_IMAGE":                workersMap[workload.ModelWorkerTypeServer].Image,
 		"ENGINE_SERVER_COMMAND":              commands,
-		"WORKER_REPLICAS":                    serverWorker.Pods - 1,
+		"WORKER_REPLICAS":                    workersMap[workload.ModelWorkerTypeServer].Pods - 1,
 		"SCHEDULER_NAME":                     backend.SchedulerName,
 	}
 	return loadModelServingTemplate(VllmTemplatePath, &data)

--- a/pkg/model-booster-controller/convert/model_serving.go
+++ b/pkg/model-booster-controller/convert/model_serving.go
@@ -214,7 +214,8 @@ func buildVllmDisaggregatedModelServing(model *workload.ModelBooster) (*workload
 func buildVllmModelServing(model *workload.ModelBooster) (*workload.ModelServing, error) {
 	backend := &model.Spec.Backend
 	workersMap := mapWorkers(backend.Workers)
-	if workersMap[workload.ModelWorkerTypeServer] == nil {
+	serverWorker := workersMap[workload.ModelWorkerTypeServer]
+	if serverWorker == nil {
 		return nil, fmt.Errorf("server worker not found in backend: %s", backend.Name)
 	}
 	cacheVolume, err := buildCacheVolume(backend)
@@ -222,8 +223,7 @@ func buildVllmModelServing(model *workload.ModelBooster) (*workload.ModelServing
 		return nil, err
 	}
 	modelDownloadPath := GetCachePath(backend.CacheURI) + GetMountPath(backend.ModelURI)
-	// only one worker in such circumstance so get the first worker's config as commands
-	commands, err := buildCommands(backend, &backend.Workers[0].Config, modelDownloadPath, workersMap)
+	commands, err := buildCommands(backend, &serverWorker.Config, modelDownloadPath, workersMap)
 	if err != nil {
 		return nil, err
 	}
@@ -292,7 +292,7 @@ func buildVllmModelServing(model *workload.ModelBooster) (*workload.ModelServing
 		"BACKEND_TYPE":     strings.ToLower(string(backend.Type)),
 		"ENGINE_ENV":       engineEnv,
 		"WORKER_ENV":       backend.Env,
-		"SERVER_REPLICAS":  workersMap[workload.ModelWorkerTypeServer].Replicas,
+		"SERVER_REPLICAS":  serverWorker.Replicas,
 		"SERVER_ENTRY_TEMPLATE_METADATA": &metav1.ObjectMeta{
 			Labels: utils.GetModelControllerLabels(model, backend.Name, icUtils.Revision(backend)),
 		},
@@ -325,10 +325,10 @@ func buildVllmModelServing(model *workload.ModelBooster) (*workload.ModelServing
 		"MODEL_SERVING_RUNTIME_METRICS_PATH": env.GetEnvValueOrDefault[string](backend, env.RuntimeMetricsPath, "/metrics"),
 		"MODEL_SERVING_RUNTIME_ENGINE":       strings.ToLower(string(backend.Type)),
 		"MODEL_SERVING_RUNTIME_POD":          "$(POD_NAME).$(NAMESPACE)",
-		"ENGINE_SERVER_RESOURCES":            workersMap[workload.ModelWorkerTypeServer].Resources,
-		"ENGINE_SERVER_IMAGE":                workersMap[workload.ModelWorkerTypeServer].Image,
+		"ENGINE_SERVER_RESOURCES":            serverWorker.Resources,
+		"ENGINE_SERVER_IMAGE":                serverWorker.Image,
 		"ENGINE_SERVER_COMMAND":              commands,
-		"WORKER_REPLICAS":                    workersMap[workload.ModelWorkerTypeServer].Pods - 1,
+		"WORKER_REPLICAS":                    serverWorker.Pods - 1,
 		"SCHEDULER_NAME":                     backend.SchedulerName,
 	}
 	return loadModelServingTemplate(VllmTemplatePath, &data)

--- a/pkg/model-booster-controller/convert/model_serving_test.go
+++ b/pkg/model-booster-controller/convert/model_serving_test.go
@@ -25,6 +25,7 @@ import (
 	workload "github.com/volcano-sh/kthena/pkg/apis/workload/v1alpha1"
 	"github.com/volcano-sh/kthena/pkg/model-booster-controller/env"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/utils/ptr"
 )
 
@@ -199,11 +200,28 @@ func TestBuildModelServingSkipEngineDependencyInstall(t *testing.T) {
 func TestBuildVllmModelServingUsesServerWorkerConfig(t *testing.T) {
 	model := loadYaml[workload.ModelBooster](t, "testdata/input/model.yaml")
 	serverWorker := model.Spec.Backend.Workers[0]
-	serverWorker.Pods = 1
+	serverWorker.Image = "vllm-server:server"
+	serverWorker.Replicas = 2
+	serverWorker.Pods = 3
+	serverWorker.Resources = corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("2"),
+			corev1.ResourceMemory: resource.MustParse("4Gi"),
+		},
+	}
 	serverWorker.Config.Raw = []byte(`{"served-model-name":"server-model","max-model-len":222}`)
 
 	prefillWorker := serverWorker
 	prefillWorker.Type = workload.ModelWorkerTypePrefill
+	prefillWorker.Image = "vllm-server:prefill"
+	prefillWorker.Replicas = 9
+	prefillWorker.Pods = 7
+	prefillWorker.Resources = corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("8"),
+			corev1.ResourceMemory: resource.MustParse("16Gi"),
+		},
+	}
 	prefillWorker.Config.Raw = []byte(`{"served-model-name":"prefill-model","max-model-len":111}`)
 
 	model.Spec.Backend.Workers = []workload.ModelWorker{prefillWorker, serverWorker}
@@ -211,25 +229,81 @@ func TestBuildVllmModelServingUsesServerWorkerConfig(t *testing.T) {
 	serving, err := BuildModelServing(model)
 	assert.NoError(t, err)
 
-	command := engineCommand(t, serving)
+	role := modelServingRole(t, serving, "leader")
+	if role.Replicas == nil {
+		t.Fatal("leader role replicas not set")
+	}
+	if serving.Spec.Template.GangPolicy == nil {
+		t.Fatal("leader gang policy not set")
+	}
+	assert.Equal(t, int32(2), *role.Replicas)
+	assert.Equal(t, int32(2), serving.Spec.Template.GangPolicy.MinRoleReplicas["leader"])
+	assert.Equal(t, int32(2), role.WorkerReplicas)
+
+	engine := entryContainer(t, role, "engine")
+	assert.Equal(t, "vllm-server:server", engine.Image)
+	assert.Equal(t, serverWorker.Resources, engine.Resources)
+
+	command := strings.Join(engine.Command, " ")
 	assert.Contains(t, command, "--served-model-name server-model")
 	assert.Contains(t, command, "--max-model-len 222")
+	assert.Contains(t, command, "--ray_cluster_size=3")
 	assert.NotContains(t, command, "prefill-model")
 	assert.NotContains(t, command, "--max-model-len 111")
+
+	worker := workerContainer(t, role)
+	assert.Equal(t, "vllm-server:server", worker.Image)
+	assert.Equal(t, serverWorker.Resources, worker.Resources)
 }
 
-func engineCommand(t *testing.T, serving *workload.ModelServing) string {
+func TestBuildVllmModelServingRequiresServerWorker(t *testing.T) {
+	model := loadYaml[workload.ModelBooster](t, "testdata/input/model.yaml")
+	prefillWorker := model.Spec.Backend.Workers[0]
+	prefillWorker.Type = workload.ModelWorkerTypePrefill
+	model.Spec.Backend.Workers = []workload.ModelWorker{prefillWorker}
+
+	serving, err := BuildModelServing(model)
+
+	assert.Nil(t, serving)
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "server worker not found")
+	}
+}
+
+func modelServingRole(t *testing.T, serving *workload.ModelServing, name string) workload.Role {
 	t.Helper()
 
 	for _, role := range serving.Spec.Template.Roles {
-		for _, container := range role.EntryTemplate.Spec.Containers {
-			if container.Name == "engine" {
-				return strings.Join(container.Command, " ")
-			}
+		if role.Name == name {
+			return role
 		}
 	}
-	t.Fatal("engine container not found")
-	return ""
+	t.Fatalf("role %q not found", name)
+	return workload.Role{}
+}
+
+func entryContainer(t *testing.T, role workload.Role, name string) corev1.Container {
+	t.Helper()
+
+	for _, container := range role.EntryTemplate.Spec.Containers {
+		if container.Name == name {
+			return container
+		}
+	}
+	t.Fatalf("entry container %q not found", name)
+	return corev1.Container{}
+}
+
+func workerContainer(t *testing.T, role workload.Role) corev1.Container {
+	t.Helper()
+
+	if role.WorkerTemplate == nil {
+		t.Fatal("worker template not found")
+	}
+	if len(role.WorkerTemplate.Spec.Containers) == 0 {
+		t.Fatal("worker container not found")
+	}
+	return role.WorkerTemplate.Spec.Containers[0]
 }
 
 func TestBuildCacheVolume(t *testing.T) {

--- a/pkg/model-booster-controller/convert/model_serving_test.go
+++ b/pkg/model-booster-controller/convert/model_serving_test.go
@@ -196,6 +196,42 @@ func TestBuildModelServingSkipEngineDependencyInstall(t *testing.T) {
 	}
 }
 
+func TestBuildVllmModelServingUsesServerWorkerConfig(t *testing.T) {
+	model := loadYaml[workload.ModelBooster](t, "testdata/input/model.yaml")
+	serverWorker := model.Spec.Backend.Workers[0]
+	serverWorker.Pods = 1
+	serverWorker.Config.Raw = []byte(`{"served-model-name":"server-model","max-model-len":222}`)
+
+	prefillWorker := serverWorker
+	prefillWorker.Type = workload.ModelWorkerTypePrefill
+	prefillWorker.Config.Raw = []byte(`{"served-model-name":"prefill-model","max-model-len":111}`)
+
+	model.Spec.Backend.Workers = []workload.ModelWorker{prefillWorker, serverWorker}
+
+	serving, err := BuildModelServing(model)
+	assert.NoError(t, err)
+
+	command := engineCommand(t, serving)
+	assert.Contains(t, command, "--served-model-name server-model")
+	assert.Contains(t, command, "--max-model-len 222")
+	assert.NotContains(t, command, "prefill-model")
+	assert.NotContains(t, command, "--max-model-len 111")
+}
+
+func engineCommand(t *testing.T, serving *workload.ModelServing) string {
+	t.Helper()
+
+	for _, role := range serving.Spec.Template.Roles {
+		for _, container := range role.EntryTemplate.Spec.Containers {
+			if container.Name == "engine" {
+				return strings.Join(container.Command, " ")
+			}
+		}
+	}
+	t.Fatal("engine container not found")
+	return ""
+}
+
 func TestBuildCacheVolume(t *testing.T) {
 	tests := []struct {
 		name         string


### PR DESCRIPTION
/kind bug

What this PR does / why we need it:

For regular VLLM backends, BuildModelServing checks that a server worker exists, but it built the engine command from backend.Workers[0]. If the server worker is not the first item in the workers list, the generated ModelServing can use another worker's config for the VLLM command.

This change:
- stores the resolved server worker once
- uses that server worker for command generation
- also uses it consistently for server replicas, image, resources, and worker replicas
- adds regression coverage where a non-server worker appears before the server worker

Verification:

go test ./pkg/model-booster-controller/convert
<img width="1128" height="52" alt="image" src="https://github.com/user-attachments/assets/b36ab890-7137-4828-a16a-0d1fa3d4c845" />
