### PR TITLE
Fix ModelBooster status update conflicts and e2e cleanup race

### DIFF
--- a/pkg/model-booster-controller/controller/model_booster_controller.go
+++ b/pkg/model-booster-controller/controller/model_booster_controller.go
@@ -268,7 +268,7 @@ func (mc *ModelBoosterController) updateModelBoosterStatus(ctx context.Context, 
 			return err
 		}
 		updated := latest.DeepCopy()
-		updated.Status.Conditions = modelBooster.Status.Conditions
+		modelBooster.Status.DeepCopyInto(&updated.Status)
 
 		updated.Status.ObservedGeneration = updated.Generation
 
@@ -288,7 +288,7 @@ func (mc *ModelBoosterController) updateModelBoosterStatus(ctx context.Context, 
 		return err
 	}
 
-	*modelBooster = *finalModel
+	finalModel.DeepCopyInto(modelBooster)
 
 	//Cleanup the LoRA cache ONLY after confirmed API success.
 	mc.cleanupOutdatedLoraUpdateCache(modelBooster)

--- a/pkg/model-booster-controller/controller/model_booster_controller.go
+++ b/pkg/model-booster-controller/controller/model_booster_controller.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	listerv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -256,13 +257,40 @@ func (mc *ModelBoosterController) isModelServingActive(model *workload.ModelBoos
 
 // updateModelBoosterStatus updates model status.
 func (mc *ModelBoosterController) updateModelBoosterStatus(ctx context.Context, modelBooster *workload.ModelBooster) error {
-	modelBooster.Status.ObservedGeneration = modelBooster.Generation
-	if _, err := mc.client.WorkloadV1alpha1().ModelBoosters(modelBooster.Namespace).UpdateStatus(ctx, modelBooster, metav1.UpdateOptions{}); err != nil {
-		klog.Errorf("update modelBooster status failed: %v", err)
+	var finalModel *workload.ModelBooster
+
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		// getting live updates from the api server as a sudden update in model can cause multiple gen of modelBooster to be created and we want to make sure we are updating the latest one.
+		latest, err := mc.client.WorkloadV1alpha1().
+			ModelBoosters(modelBooster.Namespace).
+			Get(ctx, modelBooster.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		updated := latest.DeepCopy()
+		updated.Status.Conditions = modelBooster.Status.Conditions
+
+		updated.Status.ObservedGeneration = updated.Generation
+
+		res, err := mc.client.WorkloadV1alpha1().
+			ModelBoosters(updated.Namespace).
+			UpdateStatus(ctx, updated, metav1.UpdateOptions{})
+		if err != nil {
+			return err
+		}
+
+		finalModel = res
+		return nil
+	})
+
+	if err != nil {
+		klog.Errorf("update modelBooster status failed after retries: %v", err)
 		return err
 	}
 
-	// Clean up outdated cache entries for this modelBooster
+	*modelBooster = *finalModel
+
+	//Cleanup the LoRA cache ONLY after confirmed API success.
 	mc.cleanupOutdatedLoraUpdateCache(modelBooster)
 	return nil
 }

--- a/test/e2e/controller-manager/model_serving_test.go
+++ b/test/e2e/controller-manager/model_serving_test.go
@@ -712,7 +712,7 @@ func TestModelServingRollingUpdateMaxUnavailable(t *testing.T) {
 	maxObservedUnavailable := int32(0)
 	var mu sync.Mutex
 
-	watcherCtx, watcherCancel := context.WithCancel(watchContext)
+	watcherCtx, watcherCancel := context.WithTimeout(context.Background(), 8*time.Minute)
 	defer watcherCancel()
 
 	go func() {

--- a/test/e2e/controller-manager/test_suite_test.go
+++ b/test/e2e/controller-manager/test_suite_test.go
@@ -137,30 +137,3 @@ func waitForControllerManagerToStop(kubeClient *kubernetes.Clientset, namespace 
 		return len(pods.Items) == 0, nil
 	})
 }
-
-
-function RetryOnConflict(retryFunc):
-    maxRetries = 5
-    attempts = 0
-
-    loop:
-        err = retryFunc()
-
-        if err == nil:
-            return success
-
-        if err is NOT a conflict error (HTTP 409 / "object has been modified"):
-            return err  // unretryable, bail immediately
-
-        attempts++
-
-        if attempts >= maxRetries:
-            return err  // gave up
-
-        backoff(attempts)  // exponential or fixed sleep
-        
-        // re-fetch the latest object before retrying
-        // so you're applying changes on top of current state
-        refreshObject()
-
-    end loop

--- a/test/e2e/controller-manager/test_suite_test.go
+++ b/test/e2e/controller-manager/test_suite_test.go
@@ -74,13 +74,12 @@ func TestMain(m *testing.M) {
 	// Run tests
 	code := m.Run()
 
-	// Cleanup test namespace
-	if err := utils.DeleteTestNamespaceAndWait(kubeClient, testNamespace, 2*time.Minute); err != nil {
-		fmt.Printf("Warning: Failed to delete test namespace %s: %v\n", testNamespace, err)
-	}
-
 	if err := framework.UninstallKthena(config.Namespace); err != nil {
 		fmt.Printf("Failed to uninstall kthena: %v\n", err)
+	}
+
+	if err := waitForControllerManagerToStop(kubeClient, kthenaNamespace, 2*time.Minute); err != nil {
+		fmt.Printf("Warning: controller-manager did not fully stop before namespace deletion: %v\n", err)
 	}
 
 	os.Exit(code)
@@ -124,3 +123,44 @@ func waitForWebhookReady(t *testing.T, ctx context.Context, kthenaClient *client
 	})
 	require.NoError(t, err, "Webhook did not become ready in time")
 }
+
+func waitForControllerManagerToStop(kubeClient *kubernetes.Clientset, namespace string, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	labelSelector := "app.kubernetes.io/component=kthena-controller-manager"
+	return wait.PollUntilContextCancel(ctx, 2*time.Second, true, func(ctx context.Context) (bool, error) {
+		pods, err := kubeClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
+		if err != nil {
+			return false, err
+		}
+		return len(pods.Items) == 0, nil
+	})
+}
+
+
+function RetryOnConflict(retryFunc):
+    maxRetries = 5
+    attempts = 0
+
+    loop:
+        err = retryFunc()
+
+        if err == nil:
+            return success
+
+        if err is NOT a conflict error (HTTP 409 / "object has been modified"):
+            return err  // unretryable, bail immediately
+
+        attempts++
+
+        if attempts >= maxRetries:
+            return err  // gave up
+
+        backoff(attempts)  // exponential or fixed sleep
+        
+        // re-fetch the latest object before retrying
+        // so you're applying changes on top of current state
+        refreshObject()
+
+    end loop


### PR DESCRIPTION
**What type of PR is this?**

/kind bug  
/kind cleanup

**What this PR does / why we need it**:

This PR fixes a race condition in `ModelBooster` status updates.

Previously, the controller updated status using the existing in-memory `ModelBooster` object, which could become stale if the resource changed during reconciliation. This could cause Kubernetes conflict errors during status updates.

This change updates the status flow to fetch the latest `ModelBooster` from the API server, apply the intended status fields, and retry on conflicts using `RetryOnConflict`. It also updates `ObservedGeneration` from the latest object and cleans up the LoRA cache only after the status update succeeds.

The e2e cleanup flow is also improved by uninstalling Kthena first, waiting for the controller-manager pod to stop, and using a bounded timeout for the rolling update watcher.

**Which issue(s) this PR fixes**:

Fixes #1038

**Does this PR introduce a user-facing change?**:

```release-note
NONE