### PR TITLE
fix: use controller owner refs for modelbooster children

### DIFF
--- a/pkg/model-booster-controller/convert/model_route.go
+++ b/pkg/model-booster-controller/convert/model_route.go
@@ -36,12 +36,7 @@ func BuildModelRoute(model *workload.ModelBooster) *networking.ModelRoute {
 			Name:      routeName,
 			Namespace: model.Namespace,
 			OwnerReferences: []metav1.OwnerReference{
-				{
-					APIVersion: workload.GroupVersion.String(),
-					Kind:       workload.ModelKind.Kind,
-					Name:       model.Name,
-					UID:        model.UID,
-				},
+				utils.NewModelOwnerRef(model),
 			},
 		},
 		Spec: networking.ModelRouteSpec{

--- a/pkg/model-booster-controller/convert/model_serving.go
+++ b/pkg/model-booster-controller/convert/model_serving.go
@@ -167,12 +167,7 @@ func buildVllmDisaggregatedModelServing(model *workload.ModelBooster) (*workload
 			Namespace: model.Namespace,
 			Labels:    utils.GetModelControllerLabels(model, backend.Name, icUtils.Revision(backend)),
 			OwnerReferences: []metav1.OwnerReference{
-				{
-					APIVersion: workload.GroupVersion.String(),
-					Kind:       workload.ModelKind.Kind,
-					Name:       model.Name,
-					UID:        model.UID,
-				},
+				utils.NewModelOwnerRef(model),
 			},
 		},
 		"VOLUME_MOUNTS": []corev1.VolumeMount{{
@@ -278,12 +273,7 @@ func buildVllmModelServing(model *workload.ModelBooster) (*workload.ModelServing
 			Namespace: model.Namespace,
 			Labels:    utils.GetModelControllerLabels(model, backend.Name, icUtils.Revision(backend)),
 			OwnerReferences: []metav1.OwnerReference{
-				{
-					APIVersion: workload.GroupVersion.String(),
-					Kind:       workload.ModelKind.Kind,
-					Name:       model.Name,
-					UID:        model.UID,
-				},
+				utils.NewModelOwnerRef(model),
 			},
 		},
 		"MODEL_NAME":       model.Name,

--- a/pkg/model-booster-controller/convert/testdata/expected/disaggregated-model-serving-mooncake.yaml
+++ b/pkg/model-booster-controller/convert/testdata/expected/disaggregated-model-serving-mooncake.yaml
@@ -11,6 +11,8 @@ metadata:
   namespace: demo
   ownerReferences:
     - apiVersion: workload.serving.volcano.sh/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
       kind: ModelBooster
       name: ds-r1-qwen-7b-pd
       uid: randomUID

--- a/pkg/model-booster-controller/convert/testdata/expected/disaggregated-model-serving.yaml
+++ b/pkg/model-booster-controller/convert/testdata/expected/disaggregated-model-serving.yaml
@@ -11,6 +11,8 @@ metadata:
   namespace: demo
   ownerReferences:
     - apiVersion: workload.serving.volcano.sh/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
       kind: ModelBooster
       name: ds-r1-qwen-7b-pd
       uid: randomUID

--- a/pkg/model-booster-controller/convert/testdata/expected/model-route.yaml
+++ b/pkg/model-booster-controller/convert/testdata/expected/model-route.yaml
@@ -11,6 +11,8 @@ metadata:
     workload.serving.volcano.sh/revision: 8484fbf458
   ownerReferences:
     - apiVersion: workload.serving.volcano.sh/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
       kind: ModelBooster
       name: test-model
       uid: randomUID

--- a/pkg/model-booster-controller/convert/testdata/expected/model-serving.yaml
+++ b/pkg/model-booster-controller/convert/testdata/expected/model-serving.yaml
@@ -11,6 +11,8 @@ metadata:
   namespace: default
   ownerReferences:
     - apiVersion: workload.serving.volcano.sh/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
       kind: ModelBooster
       name: test-model
       uid: randomUID


### PR DESCRIPTION
/kind bug

ModelBooster-generated ModelServing and ModelRoute resources were hand-building ownerReferences without controller=true and blockOwnerDeletion=true.

Other ModelBooster child resources already use utils.NewModelOwnerRef, so this makes ownership metadata consistent and improves Kubernetes GC/controller ownership semantics.

Verification:
git diff --check
git diff --cached --check