### PR TITLE
fix: replace fmt.Printf with klog and fix error string formatting

### DIFF
--- a/pkg/kthena-router/backend/metrics/metrics.go
+++ b/pkg/kthena-router/backend/metrics/metrics.go
@@ -24,6 +24,7 @@ import (
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
 	"github.com/prometheus/common/model"
+	"k8s.io/klog/v2"
 )
 
 var httpClient = &http.Client{
@@ -38,18 +39,18 @@ func HTTPClient() *http.Client {
 func ParseMetricsURL(url string) (map[string]*dto.MetricFamily, error) {
 	resp, err := httpClient.Get(url)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to fetch metrics from %s: %v", url, err)
+		return nil, fmt.Errorf("failed to fetch metrics from %s: %v", url, err)
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
-			fmt.Printf("failed to close response body: %v", err)
+			klog.Errorf("failed to close response body: %v", err)
 		}
 	}()
 
 	parser := expfmt.NewTextParser(model.UTF8Validation)
 	allMetrics, err := parser.TextToMetricFamilies(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("Error parsing metric families: %v\n", err)
+		return nil, fmt.Errorf("error parsing metric families: %v", err)
 	}
 	return allMetrics, nil
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Replace `fmt.Printf` with `klog.Errorf` in `ParseMetricsURL` and fix error strings to be lowercase without trailing newlines
