### PR TITLE
test/e2e: fix flaky TestKthenaRouterValidatingWebhook caused by webhook race after pod restart

### DIFF
--- a/test/e2e/router/shared.go
+++ b/test/e2e/router/shared.go
@@ -1769,6 +1769,7 @@ func TestRouterConfigUpdateShared(t *testing.T, testCtx *routercontext.RouterTes
 	restartedMetricsURL := fmt.Sprintf("http://127.0.0.1:%s/metrics", restartedRouterPort)
 
 	// Verify routing works after config update and restart.
+	WaitForKthenaRouterValidatingWebhook(t, ctx, testCtx.KthenaClient, kthenaNamespace)
 	t.Run("VerifyUpdatedConfig", func(t *testing.T) {
 		resp := utils.CheckChatCompletionsWithURL(t, restartedRouterURL, modelRoute.Spec.ModelName, messages)
 		assert.Equal(t, 200, resp.StatusCode, "Routing should work after config update and restart")

--- a/test/e2e/router/shared.go
+++ b/test/e2e/router/shared.go
@@ -95,6 +95,14 @@ func matchLabels(metricLabels []*dto.LabelPair, wantLabels map[string]string) bo
 	return true
 }
 
+// WaitForKthenaRouterValidatingWebhook polls until a DryRun ModelRoute create reaches the
+// validating webhook (avoids flaky tests while cert-manager / deployment finishes).
+//
+// The validating webhook is served by the kthena-router pod itself, not a separate
+// deployment. TestRouterConfigUpdate deliberately restarts the kthena-router pod before
+// this test runs. Kubernetes can mark the pod Ready before the webhook handler is fully
+// initialised, so we retry all transient connection errors until the webhook is stable.
+
 func ensureRedis(t *testing.T, kubeClient kubernetes.Interface, namespace string) func() {
 	t.Helper()
 	ctx := context.Background()
@@ -1770,6 +1778,7 @@ func TestRouterConfigUpdateShared(t *testing.T, testCtx *routercontext.RouterTes
 
 	// Verify routing works after config update and restart.
 	WaitForKthenaRouterValidatingWebhook(t, ctx, testCtx.KthenaClient, kthenaNamespace)
+
 	t.Run("VerifyUpdatedConfig", func(t *testing.T) {
 		resp := utils.CheckChatCompletionsWithURL(t, restartedRouterURL, modelRoute.Spec.ModelName, messages)
 		assert.Equal(t, 200, resp.StatusCode, "Routing should work after config update and restart")

--- a/test/e2e/router/shared.go
+++ b/test/e2e/router/shared.go
@@ -30,6 +30,7 @@ import (
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	clientset "github.com/volcano-sh/kthena/client-go/clientset/versioned"
 	networkingv1alpha1 "github.com/volcano-sh/kthena/pkg/apis/networking/v1alpha1"
 	workloadv1alpha1 "github.com/volcano-sh/kthena/pkg/apis/workload/v1alpha1"
 	backendmetrics "github.com/volcano-sh/kthena/pkg/kthena-router/backend/metrics"
@@ -44,6 +45,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
@@ -102,6 +104,55 @@ func matchLabels(metricLabels []*dto.LabelPair, wantLabels map[string]string) bo
 // deployment. TestRouterConfigUpdate deliberately restarts the kthena-router pod before
 // this test runs. Kubernetes can mark the pod Ready before the webhook handler is fully
 // initialised, so we retry all transient connection errors until the webhook is stable.
+func WaitForKthenaRouterValidatingWebhook(t *testing.T, ctx context.Context, kthenaClient *clientset.Clientset, namespace string) {
+	t.Helper()
+	t.Log("Waiting for kthena-router validating webhook to accept requests")
+
+	weight100 := uint32(100)
+	waitCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+
+	err := wait.PollUntilContextCancel(waitCtx, 2*time.Second, true, func(ctx context.Context) (bool, error) {
+		probe := &networkingv1alpha1.ModelRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      "webhook-ready-probe-" + utils.RandomString(5),
+			},
+			Spec: networkingv1alpha1.ModelRouteSpec{
+				ModelName: "probe-model",
+				Rules: []*networkingv1alpha1.Rule{
+					{
+						Name: "default",
+						TargetModels: []*networkingv1alpha1.TargetModel{
+							{ModelServerName: routercontext.ModelServer1_5bName, Weight: &weight100},
+						},
+					},
+				},
+			},
+		}
+		_, err := kthenaClient.NetworkingV1alpha1().ModelRoutes(namespace).Create(ctx, probe, metav1.CreateOptions{DryRun: []string{"All"}})
+		if err != nil {
+			errStr := err.Error()
+			// CHANGE 1: added EOF, connection reset by peer, no endpoints available.
+			// EOF is the primary failure mode — the router pod accepts the TCP
+			// connection but drops it mid-TLS handshake during partial startup after
+			// TestRouterConfigUpdate restarts the pod. Without EOF here the test
+			// dies instantly with no retry on the most common failure case.
+			if strings.Contains(errStr, "connect: connection refused") ||
+				strings.Contains(errStr, "i/o timeout") ||
+				strings.Contains(errStr, "context deadline exceeded") ||
+				strings.Contains(errStr, "EOF") ||
+				strings.Contains(errStr, "connection reset by peer") ||
+				strings.Contains(errStr, "no endpoints available") {
+				t.Logf("Router validating webhook not ready yet, retrying: %v", err)
+				return false, nil
+			}
+			return false, err
+		}
+		return true, nil
+	})
+	require.NoError(t, err, "kthena-router validating webhook did not become ready in time")
+}
 
 func ensureRedis(t *testing.T, kubeClient kubernetes.Interface, namespace string) func() {
 	t.Helper()

--- a/test/e2e/router/webhook_test.go
+++ b/test/e2e/router/webhook_test.go
@@ -18,74 +18,18 @@ package router
 
 import (
 	"context"
-	"strings"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	clientset "github.com/volcano-sh/kthena/client-go/clientset/versioned"
 	networkingv1alpha1 "github.com/volcano-sh/kthena/pkg/apis/networking/v1alpha1"
 	routercontext "github.com/volcano-sh/kthena/test/e2e/router/context"
 	"github.com/volcano-sh/kthena/test/e2e/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
 )
 
-// waitForKthenaRouterValidatingWebhook polls until a DryRun ModelRoute create reaches the
-// validating webhook (avoids flaky tests while cert-manager / deployment finishes).
 //
-// The validating webhook is served by the kthena-router pod itself, not a separate
-// deployment. TestRouterConfigUpdate deliberately restarts the kthena-router pod before
-// this test runs. Kubernetes can mark the pod Ready before the webhook handler is fully
-// initialised, so we retry all transient connection errors until the webhook is stable.
-func WaitForKthenaRouterValidatingWebhook(t *testing.T, ctx context.Context, kthenaClient *clientset.Clientset, namespace string) {
-	t.Helper()
-	t.Log("Waiting for kthena-router validating webhook to accept requests")
-
-	weight100 := uint32(100)
-	waitCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
-	defer cancel()
-
-	err := wait.PollUntilContextCancel(waitCtx, 2*time.Second, true, func(ctx context.Context) (bool, error) {
-		probe := &networkingv1alpha1.ModelRoute{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: namespace,
-				Name:      "webhook-ready-probe-" + utils.RandomString(5),
-			},
-			Spec: networkingv1alpha1.ModelRouteSpec{
-				ModelName: "probe-model",
-				Rules: []*networkingv1alpha1.Rule{
-					{
-						Name: "default",
-						TargetModels: []*networkingv1alpha1.TargetModel{
-							{ModelServerName: routercontext.ModelServer1_5bName, Weight: &weight100},
-						},
-					},
-				},
-			},
-		}
-		_, err := kthenaClient.NetworkingV1alpha1().ModelRoutes(namespace).Create(ctx, probe, metav1.CreateOptions{DryRun: []string{"All"}})
-		if err != nil {
-			errStr := err.Error()
-			// We retry on transient connection errors that occur when the router pod
-			// is restarting. EOF is a common failure mode where the pod accepts
-			// the TCP connection but drops it during the TLS handshake.
-			if strings.Contains(errStr, "connect: connection refused") ||
-				strings.Contains(errStr, "i/o timeout") ||
-				strings.Contains(errStr, "context deadline exceeded") ||
-				strings.Contains(errStr, "EOF") ||
-				strings.Contains(errStr, "connection reset by peer") ||
-				strings.Contains(errStr, "no endpoints available") {
-				t.Logf("Router validating webhook not ready yet, retrying: %v", err)
-				return false, nil
-			}
-			return false, err
-		}
-		return true, nil
-	})
-	require.NoError(t, err, "kthena-router validating webhook did not become ready in time")
-}
+// The validating webhook is served by the kthena-router pod itself, not a separate// deployment. TestRouter
 
 // TestKthenaRouterValidatingWebhook ensures the networking chart's ValidatingWebhookConfiguration
 // targets the real API group and the router webhook rejects invalid ModelRoute specs.

--- a/test/e2e/router/webhook_test.go
+++ b/test/e2e/router/webhook_test.go
@@ -34,7 +34,12 @@ import (
 
 // waitForKthenaRouterValidatingWebhook polls until a DryRun ModelRoute create reaches the
 // validating webhook (avoids flaky tests while cert-manager / deployment finishes).
-func waitForKthenaRouterValidatingWebhook(t *testing.T, ctx context.Context, kthenaClient *clientset.Clientset, namespace string) {
+//
+// The validating webhook is served by the kthena-router pod itself, not a separate
+// deployment. TestRouterConfigUpdate deliberately restarts the kthena-router pod before
+// this test runs. Kubernetes can mark the pod Ready before the webhook handler is fully
+// initialised, so we retry all transient connection errors until the webhook is stable.
+func WaitForKthenaRouterValidatingWebhook(t *testing.T, ctx context.Context, kthenaClient *clientset.Clientset, namespace string) {
 	t.Helper()
 	t.Log("Waiting for kthena-router validating webhook to accept requests")
 
@@ -63,9 +68,17 @@ func waitForKthenaRouterValidatingWebhook(t *testing.T, ctx context.Context, kth
 		_, err := kthenaClient.NetworkingV1alpha1().ModelRoutes(namespace).Create(ctx, probe, metav1.CreateOptions{DryRun: []string{"All"}})
 		if err != nil {
 			errStr := err.Error()
+			// CHANGE 1: added EOF, connection reset by peer, no endpoints available.
+			// EOF is the primary failure mode — the router pod accepts the TCP
+			// connection but drops it mid-TLS handshake during partial startup after
+			// TestRouterConfigUpdate restarts the pod. Without EOF here the test
+			// dies instantly with no retry on the most common failure case.
 			if strings.Contains(errStr, "connect: connection refused") ||
 				strings.Contains(errStr, "i/o timeout") ||
-				strings.Contains(errStr, "context deadline exceeded") {
+				strings.Contains(errStr, "context deadline exceeded") ||
+				strings.Contains(errStr, "EOF") ||
+				strings.Contains(errStr, "connection reset by peer") ||
+				strings.Contains(errStr, "no endpoints available") {
 				t.Logf("Router validating webhook not ready yet, retrying: %v", err)
 				return false, nil
 			}
@@ -81,7 +94,7 @@ func waitForKthenaRouterValidatingWebhook(t *testing.T, ctx context.Context, kth
 // Invalid case uses an empty string in loraAdapters (CRD CEL allows non-empty list; webhook rejects item).
 func TestKthenaRouterValidatingWebhook(t *testing.T) {
 	ctx := context.Background()
-	waitForKthenaRouterValidatingWebhook(t, ctx, testCtx.KthenaClient, testNamespace)
+	WaitForKthenaRouterValidatingWebhook(t, ctx, testCtx.KthenaClient, testNamespace)
 
 	weight100 := uint32(100)
 	validRoute := &networkingv1alpha1.ModelRoute{

--- a/test/e2e/router/webhook_test.go
+++ b/test/e2e/router/webhook_test.go
@@ -68,11 +68,9 @@ func WaitForKthenaRouterValidatingWebhook(t *testing.T, ctx context.Context, kth
 		_, err := kthenaClient.NetworkingV1alpha1().ModelRoutes(namespace).Create(ctx, probe, metav1.CreateOptions{DryRun: []string{"All"}})
 		if err != nil {
 			errStr := err.Error()
-			// CHANGE 1: added EOF, connection reset by peer, no endpoints available.
-			// EOF is the primary failure mode — the router pod accepts the TCP
-			// connection but drops it mid-TLS handshake during partial startup after
-			// TestRouterConfigUpdate restarts the pod. Without EOF here the test
-			// dies instantly with no retry on the most common failure case.
+			// We retry on transient connection errors that occur when the router pod
+			// is restarting. EOF is a common failure mode where the pod accepts
+			// the TCP connection but drops it during the TLS handshake.
 			if strings.Contains(errStr, "connect: connection refused") ||
 				strings.Contains(errStr, "i/o timeout") ||
 				strings.Contains(errStr, "context deadline exceeded") ||


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
`TestKthenaRouterValidatingWebhook` was intermittently failing in CI due to a race
condition between `TestRouterConfigUpdate` and `TestKthenaRouterValidatingWebhook`.

`TestRouterConfigUpdate` deliberately deletes and restarts the `kthena-router` pod to
verify config reload behaviour and always runs immediately before
`TestKthenaRouterValidatingWebhook`. The validating webhook is not a separate deployment
— it is served by the same `kthena-router` pod. After the restart Kubernetes marks the
pod `Ready` before the webhook HTTP handler is fully initialised, so the next test starts
in an unstable window and hits transient connection errors.

Two minimal fixes:
1. Add `EOF`, `connection reset by peer`, and `no endpoints available` to the retryable
   error list in `waitForKthenaRouterValidatingWebhook`. `EOF` is the primary failure
   mode — without it the test exits instantly on the most common error with no retry.
2. Call `waitForKthenaRouterValidatingWebhook` at the end of `TestRouterConfigUpdate`
   after the pod restart so the webhook is stable before the next test starts, fixing
   the problem at its source rather than defending against its symptoms.

**Which issue(s) this PR fixes**:
Fixes #1050 
