### PR TITLE
fix: randomize webhook certificate serial numbers

### DIFF
--- a/pkg/webhook/cert/generator.go
+++ b/pkg/webhook/cert/generator.go
@@ -151,11 +151,5 @@ func GenerateSelfSignedCertificate(dnsNames []string) (*CertBundle, error) {
 
 func generateSerialNumber() (*big.Int, error) {
 	limit := new(big.Int).Lsh(big.NewInt(1), CertSerialNumberBits)
-	limit.Sub(limit, big.NewInt(1))
-
-	serialNumber, err := rand.Int(rand.Reader, limit)
-	if err != nil {
-		return nil, err
-	}
-	return serialNumber.Add(serialNumber, big.NewInt(1)), nil
+	return rand.Int(rand.Reader, limit)
 }

--- a/pkg/webhook/cert/generator.go
+++ b/pkg/webhook/cert/generator.go
@@ -35,6 +35,8 @@ const (
 	RSAKeySize = 2048
 	// CertValidityYears is the number of years the certificate is valid
 	CertValidityYears = 10
+	// CertSerialNumberBits is the entropy used for generated certificate serial numbers.
+	CertSerialNumberBits = 128
 )
 
 // CertBundle contains the certificate, key, and CA certificate
@@ -61,8 +63,12 @@ func GenerateSelfSignedCertificate(dnsNames []string) (*CertBundle, error) {
 		return nil, fmt.Errorf("failed to generate CA key: %w", err)
 	}
 
+	caSerialNumber, err := generateSerialNumber()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate CA serial number: %w", err)
+	}
 	caTemplate := &x509.Certificate{
-		SerialNumber: big.NewInt(1),
+		SerialNumber: caSerialNumber,
 		Subject: pkix.Name{
 			CommonName:   "kthena-webhook-ca",
 			Organization: []string{"Volcano"},
@@ -85,8 +91,12 @@ func GenerateSelfSignedCertificate(dnsNames []string) (*CertBundle, error) {
 		return nil, fmt.Errorf("failed to generate server key: %w", err)
 	}
 
+	serverSerialNumber, err := generateSerialNumber()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate server serial number: %w", err)
+	}
 	serverTemplate := &x509.Certificate{
-		SerialNumber: big.NewInt(2),
+		SerialNumber: serverSerialNumber,
 		Subject: pkix.Name{
 			CommonName:   dnsNames[0],
 			Organization: []string{"Volcano"},
@@ -137,4 +147,15 @@ func GenerateSelfSignedCertificate(dnsNames []string) (*CertBundle, error) {
 		KeyPEM:  serverKeyPEM.Bytes(),
 		CAPEM:   caCertPEM.Bytes(),
 	}, nil
+}
+
+func generateSerialNumber() (*big.Int, error) {
+	limit := new(big.Int).Lsh(big.NewInt(1), CertSerialNumberBits)
+	limit.Sub(limit, big.NewInt(1))
+
+	serialNumber, err := rand.Int(rand.Reader, limit)
+	if err != nil {
+		return nil, err
+	}
+	return serialNumber.Add(serialNumber, big.NewInt(1)), nil
 }

--- a/pkg/webhook/cert/generator_test.go
+++ b/pkg/webhook/cert/generator_test.go
@@ -19,6 +19,7 @@ package cert
 import (
 	"crypto/x509"
 	"encoding/pem"
+	"math/big"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -44,6 +45,7 @@ func TestGenerateSelfSignedCertificate(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, caCert.IsCA)
 	assert.Equal(t, "kthena-webhook-ca", caCert.Subject.CommonName)
+	assert.Positive(t, caCert.SerialNumber.Sign())
 
 	// Verify server certificate
 	certBlock, _ := pem.Decode(bundle.CertPEM)
@@ -55,6 +57,7 @@ func TestGenerateSelfSignedCertificate(t *testing.T) {
 	assert.False(t, serverCert.IsCA)
 	assert.Equal(t, dnsNames, serverCert.DNSNames)
 	assert.Equal(t, dnsNames[0], serverCert.Subject.CommonName)
+	assert.Positive(t, serverCert.SerialNumber.Sign())
 
 	// Verify server key
 	keyBlock, _ := pem.Decode(bundle.KeyPEM)
@@ -108,6 +111,40 @@ func TestGenerateSelfSignedCertificate_MultipleDNSNames(t *testing.T) {
 
 	assert.Equal(t, dnsNames, serverCert.DNSNames)
 	assert.Equal(t, dnsNames[0], serverCert.Subject.CommonName)
+}
+
+func TestGenerateSelfSignedCertificate_RandomSerialNumbers(t *testing.T) {
+	dnsNames := []string{"webhook.default.svc"}
+
+	first, err := GenerateSelfSignedCertificate(dnsNames)
+	require.NoError(t, err)
+	second, err := GenerateSelfSignedCertificate(dnsNames)
+	require.NoError(t, err)
+
+	firstCABlock, _ := pem.Decode(first.CAPEM)
+	firstCertBlock, _ := pem.Decode(first.CertPEM)
+	secondCABlock, _ := pem.Decode(second.CAPEM)
+	secondCertBlock, _ := pem.Decode(second.CertPEM)
+	require.NotNil(t, firstCABlock)
+	require.NotNil(t, firstCertBlock)
+	require.NotNil(t, secondCABlock)
+	require.NotNil(t, secondCertBlock)
+
+	firstCA, err := x509.ParseCertificate(firstCABlock.Bytes)
+	require.NoError(t, err)
+	firstServer, err := x509.ParseCertificate(firstCertBlock.Bytes)
+	require.NoError(t, err)
+	secondCA, err := x509.ParseCertificate(secondCABlock.Bytes)
+	require.NoError(t, err)
+	secondServer, err := x509.ParseCertificate(secondCertBlock.Bytes)
+	require.NoError(t, err)
+
+	assert.Positive(t, firstCA.SerialNumber.Sign())
+	assert.Positive(t, firstServer.SerialNumber.Sign())
+	assert.NotEqual(t, big.NewInt(1), firstCA.SerialNumber)
+	assert.NotEqual(t, big.NewInt(2), firstServer.SerialNumber)
+	assert.NotEqual(t, firstCA.SerialNumber, secondCA.SerialNumber)
+	assert.NotEqual(t, firstServer.SerialNumber, secondServer.SerialNumber)
 }
 
 func TestGenerateSelfSignedCertificate_EmptyDNSNames(t *testing.T) {

--- a/pkg/webhook/cert/generator_test.go
+++ b/pkg/webhook/cert/generator_test.go
@@ -147,6 +147,15 @@ func TestGenerateSelfSignedCertificate_RandomSerialNumbers(t *testing.T) {
 	assert.NotEqual(t, firstServer.SerialNumber, secondServer.SerialNumber)
 }
 
+func TestGenerateSerialNumber(t *testing.T) {
+	for i := 0; i < 32; i++ {
+		serialNumber, err := generateSerialNumber()
+		require.NoError(t, err)
+		assert.Positive(t, serialNumber.Sign())
+		assert.LessOrEqual(t, serialNumber.BitLen(), CertSerialNumberBits)
+	}
+}
+
 func TestGenerateSelfSignedCertificate_EmptyDNSNames(t *testing.T) {
 	dnsNames := []string{}
 


### PR DESCRIPTION
/kind bug

Webhook self-signed certificate generation used fixed certificate serial numbers:
- CA certificate: 1
- server certificate: 2

Certificate serial numbers should be positive and unique per issuer. Reusing deterministic serial numbers for regenerated webhook certificates is weak certificate hygiene and can cause avoidable ambiguity for consumers that cache or inspect certificates.

This change:
- generates positive 128-bit random serial numbers for CA and server certificates
- returns clear errors if serial generation fails
- adds tests that verify generated certificates use positive randomized serials

Verification:
git diff --check
git diff --cached --check

Suggested test:
go test ./pkg/webhook/cert

<img width="872" height="49" alt="image" src="https://github.com/user-attachments/assets/50f30237-35a5-47ac-a675-81a7a2d0a043" />
