### PR TITLE
fix(autoscaler/metric_collector): Use the target-referenced namespace first

### DIFF
--- a/pkg/autoscaler/autoscaler/metric_collector.go
+++ b/pkg/autoscaler/autoscaler/metric_collector.go
@@ -49,11 +49,15 @@ type MetricCollector struct {
 }
 
 func NewMetricCollector(target *v1alpha1.Target, binding *v1alpha1.AutoscalingPolicyBinding, metricTargets map[string]float64) *MetricCollector {
+	namespace := target.TargetRef.Namespace
+	if namespace == "" {
+		namespace = binding.Namespace
+	}
 	return &MetricCollector{
 		PastHistograms: datastructure.NewSnapshotSlidingWindow[map[string]HistogramInfo](util.SecondToTimestamp(util.SloQuantileSlidingWindowSeconds), util.SecondToTimestamp(util.SloQuantileDataKeepSeconds)),
 		Target:         target,
 		Scope: Scope{
-			Namespace:      binding.Namespace,
+			Namespace:      namespace,
 			OwnedBindingId: binding.UID,
 		},
 		MetricTargets:   metricTargets,


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`MetricCollector` hardcodes `binding.Namespace` , So when the `Target` and `AutoscalingPolicyBinding` are not in the same namespace, `MetricCollector` uses `binding.Namespace` to list pods, which queries the wrong namespace and fails to collect metrics.

This PR aligns `NewMetricCollector` with the `autoscale_controller`: use `target.TargetRef.Namespace` first, fall back to `binding.Namespace` when it is empty.

**Special notes for your reviewer**:

- The controller already has the same fallback logic in `autoscale_controller.go`:
  ```go
  // pkg/autoscaler/controller/autoscale_controller.go L175-L178
  namespaceScope := targetRef.Namespace
  if namespaceScope == "" {
      namespaceScope = defaultNamespace
  }
  ```

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
