### PR TITLE
fix: support ipv6 pod backend URLs

### DIFF
--- a/pkg/kthena-router/backend/metrics/metrics.go
+++ b/pkg/kthena-router/backend/metrics/metrics.go
@@ -18,7 +18,9 @@ package metrics
 
 import (
 	"fmt"
+	"net"
 	"net/http"
+	"strconv"
 	"time"
 
 	dto "github.com/prometheus/client_model/go"
@@ -33,6 +35,10 @@ var httpClient = &http.Client{
 
 func HTTPClient() *http.Client {
 	return httpClient
+}
+
+func PodEndpointURL(podIP string, port uint32, path string) string {
+	return "http://" + net.JoinHostPort(podIP, strconv.FormatUint(uint64(port), 10)) + path
 }
 
 // This function refers to aibrix(https://github.com/vllm-project/aibrix/blob/main/pkg/metrics/utils.go)

--- a/pkg/kthena-router/backend/metrics/metrics_test.go
+++ b/pkg/kthena-router/backend/metrics/metrics_test.go
@@ -1,0 +1,53 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import "testing"
+
+func TestPodEndpointURL(t *testing.T) {
+	tests := []struct {
+		name string
+		ip   string
+		port uint32
+		path string
+		want string
+	}{
+		{
+			name: "ipv4",
+			ip:   "10.244.0.12",
+			port: 8000,
+			path: "/metrics",
+			want: "http://10.244.0.12:8000/metrics",
+		},
+		{
+			name: "ipv6",
+			ip:   "fd00:10:244::12",
+			port: 8000,
+			path: "/v1/models",
+			want: "http://[fd00:10:244::12]:8000/v1/models",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := PodEndpointURL(tt.ip, tt.port, tt.path)
+			if got != tt.want {
+				t.Fatalf("PodEndpointURL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/kthena-router/backend/sglang/metrics.go
+++ b/pkg/kthena-router/backend/sglang/metrics.go
@@ -17,8 +17,6 @@ limitations under the License.
 package sglang
 
 import (
-	"fmt"
-
 	dto "github.com/prometheus/client_model/go"
 	corev1 "k8s.io/api/core/v1"
 
@@ -70,7 +68,7 @@ func NewSglangEngine() *sglangEngine {
 }
 
 func (engine *sglangEngine) GetPodMetrics(pod *corev1.Pod) (map[string]*dto.MetricFamily, error) {
-	url := fmt.Sprintf("http://%s:%d/metrics", pod.Status.PodIP, engine.MetricPort)
+	url := metrics.PodEndpointURL(pod.Status.PodIP, engine.MetricPort, "/metrics")
 	allMetrics, err := metrics.ParseMetricsURL(url)
 	if err != nil {
 		return nil, err

--- a/pkg/kthena-router/backend/vllm/metrics.go
+++ b/pkg/kthena-router/backend/vllm/metrics.go
@@ -17,8 +17,6 @@ limitations under the License.
 package vllm
 
 import (
-	"fmt"
-
 	dto "github.com/prometheus/client_model/go"
 	corev1 "k8s.io/api/core/v1"
 
@@ -69,7 +67,7 @@ func NewVllmEngine() *vllmEngine {
 }
 
 func (engine *vllmEngine) GetPodMetrics(pod *corev1.Pod) (map[string]*dto.MetricFamily, error) {
-	url := fmt.Sprintf("http://%s:%d/metrics", pod.Status.PodIP, engine.MetricPort)
+	url := metrics.PodEndpointURL(pod.Status.PodIP, engine.MetricPort, "/metrics")
 	allMetrics, err := metrics.ParseMetricsURL(url)
 	if err != nil {
 		return nil, err

--- a/pkg/kthena-router/backend/vllm/models.go
+++ b/pkg/kthena-router/backend/vllm/models.go
@@ -36,7 +36,7 @@ type ModelList struct {
 }
 
 func FetchPodModels(podIP string, port uint32) ([]string, error) {
-	url := fmt.Sprintf("http://%s:%d/v1/models", podIP, port)
+	url := metrics.PodEndpointURL(podIP, port, "/v1/models")
 	resp, err := metrics.HTTPClient().Get(url)
 	if err != nil {
 		return nil, err

--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"net"
 	"net/http"
 	"os"
 	"regexp"
@@ -944,7 +945,7 @@ func doRequest(
 	port int32,
 ) (*http.Response, error) {
 	// step 1: change request URL to prefill pod URL.
-	req.URL.Host = fmt.Sprintf("%s:%d", podIP, port)
+	req.URL.Host = net.JoinHostPort(podIP, strconv.Itoa(int(port)))
 
 	// step 2: use http.Transport to do request to prefill pod.
 	transport := http.DefaultTransport
@@ -1037,8 +1038,8 @@ func (r *Router) proxyToPDDisaggregated(
 		}
 
 		// Build addresses for prefill and decode pods
-		prefillAddr := fmt.Sprintf("%s:%d", ctx.PrefillPods[i].Pod.Status.PodIP, port)
-		decodeAddr := fmt.Sprintf("%s:%d", ctx.DecodePods[i].Pod.Status.PodIP, port)
+		prefillAddr := net.JoinHostPort(ctx.PrefillPods[i].Pod.Status.PodIP, strconv.Itoa(int(port)))
+		decodeAddr := net.JoinHostPort(ctx.DecodePods[i].Pod.Status.PodIP, strconv.Itoa(int(port)))
 
 		klog.V(4).Infof("Attempting PD disaggregated request: prefill=%s, decode=%s", prefillAddr, decodeAddr)
 


### PR DESCRIPTION
/kind bug

What this PR does / why we need it:

vLLM and SGLang backend code built pod URLs with `fmt.Sprintf("http://%s:%d/...", podIP, port)`. This works for IPv4, but creates invalid URLs for IPv6 pod IPs because IPv6 literals must be bracketed.

This PR adds a shared `PodEndpointURL` helper using `net.JoinHostPort` and uses it for:

- vLLM metrics endpoint
- vLLM model list endpoint
- SGLang metrics endpoint

This keeps router backend metric/model fetching working in IPv6 or dual-stack Kubernetes clusters.

Which issue(s) this PR fixes:

None

Verification:

```bash
git diff --check
```
<img width="1108" height="118" alt="image" src="https://github.com/user-attachments/assets/9696b379-de77-44d6-8072-71a6aa3d66ce" />
