### PR TITLE
fix: honor filters in pd scheduling

### DIFF
--- a/pkg/kthena-router/scheduler/scheduler_impl.go
+++ b/pkg/kthena-router/scheduler/scheduler_impl.go
@@ -106,6 +106,8 @@ func (s *SchedulerImpl) Schedule(ctx *framework.Context, pods []*datastore.PodIn
 	}
 
 	if ctx.PDGroup != nil {
+		filteredPods := podInfoKeySet(pods)
+
 		// Use optimized PDGroup scheduling with pre-categorized pods from store
 		klog.V(4).Info("Using optimized PD disaggregated scheduling")
 
@@ -114,6 +116,7 @@ func (s *SchedulerImpl) Schedule(ctx *framework.Context, pods []*datastore.PodIn
 		if err != nil {
 			return fmt.Errorf("failed to get decode pods: %v", err)
 		}
+		decodePods = filterPodInfosByKeySet(decodePods, filteredPods)
 
 		if len(decodePods) == 0 {
 			return fmt.Errorf("no decode pod found")
@@ -136,6 +139,12 @@ func (s *SchedulerImpl) Schedule(ctx *framework.Context, pods []*datastore.PodIn
 				})
 			if err != nil || len(selectedPods) == 0 {
 				klog.V(4).InfoS("prefill pods for decode group not found", "decode instance", klog.KObj(decodePod.Pod), "error", err)
+				continue
+			}
+			selectedPods = filterPodInfosByKeySet(selectedPods, filteredPods)
+			if len(selectedPods) == 0 {
+				klog.V(4).InfoS("prefill pods for decode group were filtered out",
+					"decode instance", klog.KObj(decodePod.Pod))
 				continue
 			}
 
@@ -162,6 +171,35 @@ func (s *SchedulerImpl) Schedule(ctx *framework.Context, pods []*datastore.PodIn
 	ctx.BestPods = TopNPodInfos(scores, topN)
 
 	return nil
+}
+
+func podInfoKeySet(pods []*datastore.PodInfo) map[types.NamespacedName]struct{} {
+	res := make(map[types.NamespacedName]struct{}, len(pods))
+	for _, pod := range pods {
+		if pod == nil || pod.Pod == nil {
+			continue
+		}
+		res[types.NamespacedName{Namespace: pod.Pod.Namespace, Name: pod.Pod.Name}] = struct{}{}
+	}
+	return res
+}
+
+func filterPodInfosByKeySet(pods []*datastore.PodInfo, allowed map[types.NamespacedName]struct{}) []*datastore.PodInfo {
+	if len(pods) == 0 || len(allowed) == 0 {
+		return nil
+	}
+
+	filtered := pods[:0]
+	for _, pod := range pods {
+		if pod == nil || pod.Pod == nil {
+			continue
+		}
+		key := types.NamespacedName{Namespace: pod.Pod.Namespace, Name: pod.Pod.Name}
+		if _, ok := allowed[key]; ok {
+			filtered = append(filtered, pod)
+		}
+	}
+	return filtered
 }
 
 func (s *SchedulerImpl) RunFilterPlugins(pods []*datastore.PodInfo, ctx *framework.Context) ([]*datastore.PodInfo, error) {

--- a/pkg/kthena-router/scheduler/scheduler_impl_test.go
+++ b/pkg/kthena-router/scheduler/scheduler_impl_test.go
@@ -247,6 +247,99 @@ func TestSchedulePDGroup(t *testing.T) {
 	}
 }
 
+func TestSchedulePDGroupHonorsFilterPlugins(t *testing.T) {
+	store := datastore.New()
+
+	modelServer := &aiv1alpha1.ModelServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-model-server",
+			Namespace: "default",
+		},
+		Spec: aiv1alpha1.ModelServerSpec{
+			WorkloadSelector: &aiv1alpha1.WorkloadSelector{
+				PDGroup: &aiv1alpha1.PDGroup{
+					GroupKey:      "pd-group",
+					DecodeLabels:  map[string]string{"role": "decode"},
+					PrefillLabels: map[string]string{"role": "prefill"},
+				},
+			},
+		},
+	}
+	modelServerName := types.NamespacedName{Namespace: "default", Name: "test-model-server"}
+	require.NoError(t, store.AddOrUpdateModelServer(modelServer, nil))
+
+	pods := []*corev1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "decode-overloaded",
+				Namespace: "default",
+				Labels: map[string]string{
+					"pd-group": "group-1",
+					"role":     "decode",
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "prefill-overloaded-group",
+				Namespace: "default",
+				Labels: map[string]string{
+					"pd-group": "group-1",
+					"role":     "prefill",
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "decode-ready",
+				Namespace: "default",
+				Labels: map[string]string{
+					"pd-group": "group-2",
+					"role":     "decode",
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "prefill-ready",
+				Namespace: "default",
+				Labels: map[string]string{
+					"pd-group": "group-2",
+					"role":     "prefill",
+				},
+			},
+		},
+	}
+
+	for _, pod := range pods {
+		require.NoError(t, store.AddOrUpdatePod(pod, []*aiv1alpha1.ModelServer{modelServer}))
+	}
+
+	overloadedPod := store.GetPodInfo(types.NamespacedName{Namespace: "default", Name: "decode-overloaded"})
+	require.NotNil(t, overloadedPod)
+	overloadedPod.RequestWaitingNum = 20
+
+	scheduler := NewScheduler(store, nil).(*SchedulerImpl)
+	ctx := &framework.Context{
+		ModelServerName: modelServerName,
+		PDGroup: &aiv1alpha1.PDGroup{
+			GroupKey:      "pd-group",
+			DecodeLabels:  map[string]string{"role": "decode"},
+			PrefillLabels: map[string]string{"role": "prefill"},
+		},
+	}
+
+	schedulingPods, err := store.GetPodsByModelServer(modelServerName)
+	require.NoError(t, err)
+
+	require.NoError(t, scheduler.Schedule(ctx, schedulingPods))
+	require.Len(t, ctx.DecodePods, 1)
+	require.Len(t, ctx.PrefillPods, 1)
+	require.NotNil(t, ctx.PrefillPods[0])
+	assert.Equal(t, "decode-ready", ctx.DecodePods[0].Pod.Name)
+	assert.Equal(t, "prefill-ready", ctx.PrefillPods[0].Pod.Name)
+}
+
 // TestScheduleNonPDGroupWithEmptyScores tests non-PD scheduling with empty scores
 func TestScheduleNonPDGroupWithEmptyScores(t *testing.T) {
 	store := datastore.New()


### PR DESCRIPTION
/kind bug

What this PR does / why we need it:

PD disaggregated scheduling runs filter plugins before selecting pods, but the PD path later reloads decode and prefill pods from the store. That means pods filtered out by plugins such as `least-request` can still be considered for scheduling.

This PR keeps the filtered pod set and applies it again when selecting decode and prefill pods for PD-group routing.

This prevents overloaded or otherwise filtered pods from being routed to in PD disaggregated mode.

Verification:

```bash
go test ./pkg/kthena-router/scheduler
```
<img width="995" height="49" alt="image" src="https://github.com/user-attachments/assets/af758970-a6b1-4c3c-963c-3eb17fa7c50a" />

