### PR TITLE
Add first-class SGLang engine support to ModelBooster

### DIFF
--- a/charts/kthena/charts/workload/crds/workload.serving.volcano.sh_modelboosters.yaml
+++ b/charts/kthena/charts/workload/crds/workload.serving.volcano.sh_modelboosters.yaml
@@ -479,6 +479,8 @@ spec:
                     enum:
                     - vLLM
                     - vLLMDisaggregated
+                    - SGLang
+                    - SGLangDisaggregated
                     type: string
                   workers:
                     description: Workers is the list of workers associated with this

--- a/docs/kthena/docs/reference/crd/workload.serving.volcano.sh.md
+++ b/docs/kthena/docs/reference/crd/workload.serving.volcano.sh.md
@@ -363,7 +363,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `name` _string_ | Name is the name of the backend. Can't duplicate with other ModelBackend name in the same ModelBooster CR.<br />Note: update name will cause the old modelInfer deletion and a new modelInfer creation. |  | Pattern: `^[a-z0-9]([-a-z0-9]*[a-z0-9])?$` <br /> |
-| `type` _[ModelBackendType](#modelbackendtype)_ | Type is the type of the backend. |  | Enum: [vLLM vLLMDisaggregated] <br /> |
+| `type` _[ModelBackendType](#modelbackendtype)_ | Type is the type of the backend. |  | Enum: [vLLM vLLMDisaggregated SGLang SGLangDisaggregated] <br /> |
 | `modelURI` _string_ | ModelURI is the URI where you download the model. Support hf://, s3://, pvc://, ms://. |  | Pattern: `^(hf://\|s3://\|pvc://\|ms://).+` <br /> |
 | `cacheURI` _string_ | CacheURI is the URI where the downloaded model stored. Support hostpath://, pvc://. |  | Pattern: `^(hostpath://\|pvc://).+` <br /> |
 | `envFrom` _[EnvFromSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#envfromsource-v1-core) array_ | List of sources to populate environment variables in the container.<br />The keys defined within a source must be a C_IDENTIFIER. All invalid keys<br />will be reported as an event when the container is starting. When a key exists in multiple<br />sources, the value associated with the last source will take precedence.<br />Values defined by an Env with a duplicate key will take precedence.<br />Cannot be updated. |  |  |
@@ -382,7 +382,7 @@ _Underlying type:_ _string_
 ModelBackendType defines the type of model backend.
 
 _Validation:_
-- Enum: [vLLM vLLMDisaggregated]
+- Enum: [vLLM vLLMDisaggregated SGLang SGLangDisaggregated]
 
 _Appears in:_
 - [ModelBackend](#modelbackend)
@@ -392,6 +392,7 @@ _Appears in:_
 | `vLLM` | ModelBackendTypeVLLM represents a vLLM backend.<br /> |
 | `vLLMDisaggregated` | ModelBackendTypeVLLMDisaggregated represents a disaggregated vLLM backend.<br /> |
 | `SGLang` | ModelBackendTypeSGLang represents an SGLang backend.<br /> |
+| `SGLangDisaggregated` | ModelBackendTypeSGLangDisaggregated represents a disaggregated SGLang backend.<br /> |
 | `MindIE` | ModelBackendTypeMindIE represents a MindIE backend.<br /> |
 | `MindIEDisaggregated` | ModelBackendTypeMindIEDisaggregated represents a disaggregated MindIE backend.<br /> |
 

--- a/docs/proposal/sglang-engine-design.md
+++ b/docs/proposal/sglang-engine-design.md
@@ -21,13 +21,17 @@ the router backend adapter, KV connectors, and the tokenizer adapter. SGLang
 previously had only partial, router-side support and was rejected by the
 ModelBooster converter.
 
-This proposal lifts SGLang to a first-class backend. The user-visible outcome:
-a user declares a `ModelBooster` with `backend.type: SGLang` or
+This proposal lifts SGLang to a first-class backend in the control plane
+(API, converter, templates, webhook). The user-visible outcome: a user
+declares a `ModelBooster` with `backend.type: SGLang` or
 `SGLangDisaggregated` and gets a working aggregated or PD-disaggregated SGLang
-deployment with the same scheduler-plugin behavior, drain semantics, gang
-scheduling, and PD-disaggregation tooling that vLLM ModelBoosters get — the
-router automatically selects the SGLang KV connector and a dedicated SGLang
-tokenizer adapter.
+deployment with the same drain semantics, gang scheduling, and PD bootstrap
+hand-off that vLLM ModelBoosters get; the router auto-selects the existing
+SGLang KV connector based on `InferenceEngine`.
+
+Router-side SGLang work (tokenizer adapter, per-engine endpoint resolution,
+KVCacheAware knob rename) is intentionally out of scope here and is tracked in
+a separate PR.
 
 ### Motivation
 
@@ -49,20 +53,19 @@ not declaratively run SGLang through the platform's primary workload CRD.
 - **Disaggregated SGLang (PD)**: `ModelBooster` with
   `backend.type: SGLangDisaggregated` materializes prefill + decode roles wired
   up for SGLang's `bootstrap_room`/`bootstrap_host` KV-handoff protocol.
-- **Full router integration**: SGLang pods participate in metric-aware
-  scheduling, prefix/KV-cache-aware scoring, and OpenAI-compatible request
-  proxying — selecting the SGLang KV connector automatically.
-- **Dedicated tokenizer adapter**: SGLang's `/tokenize` endpoint is used
-  directly for prefix-cache scoring rather than reusing the vLLM adapter.
+- **Router KV-connector selection**: the existing router auto-selects
+  `ConnectorTypeSGLang` whenever `ModelServer.Spec.InferenceEngine == SGLang`
+  and `KVConnector` is nil. The converter cooperating with this contract
+  (emitting `KVConnector: nil` for SGLang) is in scope here; no new router
+  code is added.
 
 #### Non-Goals
 
 - **Multi-node SGLang (Ray/torchrun)**: out of scope for v1. Both the
   aggregated and disaggregated builders return an explicit error if
   `Pods > 1`.
-- **Native SGLang chat-tokenize**: the adapter flattens chat messages to a
-  role-prefixed text string. Adding a first-party chat-tokenize call is
-  deferred until SGLang ships such an endpoint.
+- **Router-side SGLang tokenizer adapter, per-engine endpoint resolution,
+  KVCacheAware knob rename**: tracked in a separate PR and not landed here.
 - **SGLang version-portable metric names**: the router-side metric names match
   SGLang ≥ 0.4.x. A config-driven metric-name map for older versions is out of
   scope.
@@ -102,20 +105,22 @@ automatically and runs the prefill/decode bootstrap protocol.
 - The webhook permits a prefill-only disaggregated spec while the converter
   errors on it — this split deliberately matches the existing
   `vLLMDisaggregated` precedent.
-- The preStop drain hook and the `/dev/shm` (memory-medium) volume are emitted
-  for **aggregated** SGLang only, not for the disaggregated `prefill`/`decode`
-  roles. This matches the established kthena template convention: `vllm.yaml`,
-  `vllm-pd.yaml`, and `sglang-pd.yaml` all omit both, so the asymmetry is the
-  aggregated path being *enriched*, not the PD path being deprived. PD pods
-  have a distinct termination contract (bootstrap-room teardown / KV-transfer
-  completion) that a request-count drain does not model; extending graceful
-  drain to PD is tracked as a follow-up rather than silently reusing the
-  aggregated script.
-- The aggregated preStop drain is bounded to ~300s (60 × 5s) and aligned with
-  `terminationGracePeriodSeconds`, sums all metric series (multi-model safe),
-  uses an integer comparison (immune to Prometheus `0` vs `0.0` formatting),
-  and exits immediately if the metrics endpoint is unreachable — so a
-  stuck/absent metric can never block termination past the grace period.
+- The preStop drain hook and the memory-medium `/dev/shm` volume are emitted
+  on **all** SGLang engine containers — aggregated `leader`, and both
+  disaggregated `prefill` and `decode`. The drain is bounded to ~300s
+  (60 × 5s) and aligned with `terminationGracePeriodSeconds`, sums all
+  `sglang:num_running_reqs` / `sglang:num_queue_reqs` series (multi-model
+  safe), uses an integer comparison (immune to Prometheus `0` vs `0.0`
+  formatting), and exits immediately if the metrics endpoint is unreachable —
+  so a stuck/absent metric can never block termination past the grace period.
+  The shared `dshm` volume is required by the mooncake transfer engine and
+  NCCL in the disaggregated path and is harmless in the aggregated path.
+- The kthena runtime sidecar receives `--engine sglang` for both aggregated
+  and disaggregated SGLang. The Python runtime's `_get_real_engine_type`
+  collapses `vllm`/`vllmdisaggregated` → `EngineType.VLLM` but only recognizes
+  the literal string `sglang`; emitting `sglangdisaggregated` would crash the
+  sidecar on startup with `UnsupportedEngineError`. The converter centralizes
+  this in a `runtimeEngineName(backendType)` helper.
 
 #### Risks and Mitigations
 
@@ -183,24 +188,15 @@ Two new embed.FS templates parallel the vLLM ones:
 Multi-node SGLang (Ray/torchrun) is out of scope for v1;
 `buildSGLangModelServing` errors out if `Pods > 1`.
 
-#### Router Tokenizer Adapter
+#### Router Tokenizer Adapter (out of scope here)
 
-`pkg/kthena-router/scheduler/plugins/tokenization/`:
-
-- `sglang.go` — new adapter against SGLang's `POST /tokenize` endpoint.
-  Defensive response parsing accepts `token_ids`, `tokens`, or `input_ids`
-  field names so the adapter survives SGLang's field-name drift across
-  versions. Chat inputs are flattened to a single role-prefixed text prompt
-  since SGLang has no native chat tokenize endpoint.
-- `tokenizer.go` — `NewRemoteTokenizer` is now engine-aware
-  (`vllm`/`sglang`/empty=vLLM-default).
-- `tokenizer_manager.go` — per-pod routing:
-  `engineEndpointForPod(podIP, podInfo.GetEngine())` resolves the right port
-  (8000 for vLLM, 30000 for SGLang) and adapter. Pods with unknown engines are
-  skipped, not silently routed to a default.
-- `kvcache_aware.go` — `EnableVLLMRemote` config knob renamed to
-  `EnableRemoteTokenizer`; the engine and endpoint are resolved per-pod, not
-  from a static template string.
+A dedicated SGLang tokenizer adapter (`pkg/kthena-router/scheduler/plugins/
+tokenization/sglang.go`), engine-aware `NewRemoteTokenizer`, per-engine
+endpoint resolution in `tokenizer_manager.go`, and the `EnableVLLMRemote` →
+`EnableRemoteTokenizer` rename in `kvcache_aware.go` are tracked in a separate
+PR. Until that lands, the router's KVCacheAware plugin continues using its
+existing vLLM-only tokenizer path for SGLang pods. This PR ships only the
+control-plane slice (API + converter + templates + webhook).
 
 #### Webhook
 
@@ -246,14 +242,11 @@ bootstrap protocol:
 | Suite | Coverage |
 |---|---|
 | `convert/model_serving_test.go` `TestCreateModelServingResources` | Golden-file diff: `testdata/input/sglang-{aggregated,disaggregated}-model.yaml` → `testdata/expected/sglang-{aggregated,disaggregated}-model-serving.yaml`. Any converter change not captured in a fixture update fails the suite. |
-| `convert/model_serving_test.go` `TestBuildSGLang*` | Structural assertions: command flags, `--host 0.0.0.0`, `--port 30000`, no `POD_IP`/`VLLM_USE_V1` env, disaggregation flags appear only on PD roles. |
-| `convert/model_server_test.go` `TestBuildSGLang*Routing` | `WorkloadPort.Port == 30000`, `InferenceEngine == SGLang`, `KVConnector` nil, `PDGroup` only set for disaggregated. |
+| `convert/model_serving_test.go` `TestBuildSGLangModelServing` / `TestBuildSGLangDisaggregatedModelServing` | Structural assertions: engine container named `engine`, command flags, `--host 0.0.0.0`, `--port 30000`, no `POD_IP`/`VLLM_USE_V1` env, preStop drain on `sglang:num_running_reqs`, memory-backed `/dev/shm`, `terminationGracePeriodSeconds`. Disaggregated test also asserts the runtime sidecar receives `--engine sglang` (never `sglangdisaggregated`). |
+| `convert/model_serving_test.go` `TestBuildSGLangModelServerRouting` / `TestBuildSGLangDisaggregatedModelServerRouting` | `WorkloadPort.Port == 30000`, `InferenceEngine == SGLang`, `KVConnector` nil, `PDGroup` only set for disaggregated. |
+| `convert/model_serving_test.go` `TestBuildSGLangCommandsTransferBackendDedup` | `buildSGLangCommands` does not duplicate `--disaggregation-transfer-backend` when the user supplies it in `worker.Config` (in either dash or underscore key form); default `mooncake` is still applied when unset. |
 | `webhook/model_validator_test.go` `TestValidateBackendWorkerTypes_SGLang` | Aggregated requires one server worker; Disaggregated requires prefill+decode-only. |
-| `tokenization/tokenization_test.go` `TestSGLangAdapter` | Completion + chat request shapes; response parsing for all three SGLang field-name variants. |
-| `tokenization_test.go` `TestEngineEndpointForPod` | Per-engine port and adapter resolution. |
-| `tokenization_test.go` `TestTokenizerManager_GetTokenizer_PicksSGLangPort` | End-to-end manager path picks port 30000 for an SGLang pod. |
-| `router/router_test.go` `TestRouter_HandlerFunc_SGLangAggregated` | Aggregated SGLang request proxies to the backend with no bootstrap mutation. |
-| `router/router_test.go` `TestRouter_HandlerFunc_SGLangDisaggregated` | Both requests fire concurrently, share the same `bootstrap_room`, decode carries `bootstrap_host` = prefill pod IP. |
+| `webhook/model_validator_test.go` `TestValidateSGLangReservedFlags` | Rejects worker.config keys the converter hard-codes (port/host/disaggregation-mode/...); allows non-reserved keys such as `disaggregation-transfer-backend`. |
 
 ##### Layer 3 — Controller-manager E2E (Kind, no GPU)
 
@@ -269,11 +262,11 @@ bootstrap protocol:
 
 ##### Layer 4 — Router E2E (Kind, no GPU)
 
-`test/e2e/router/` already exercises the router against fake backends per
-engine. The unit-level router tests above
-(`TestRouter_HandlerFunc_SGLang*`) cover the SGLang bootstrap protocol
-semantics; the router E2E suite can be extended with a `ModelServer-sglang.yaml`
-testdata fixture if a kind-based check is desired.
+Out of scope for this PR. The router-side SGLang tokenizer adapter and
+per-engine endpoint resolution land in a separate PR; that PR will own the
+matching router unit and E2E coverage. The pre-existing `pkg/kthena-router/
+backend/sglang/metrics.go`, `connectors/sglang.go`, and router KV-connector
+auto-selection on `InferenceEngine == SGLang` are unchanged here.
 
 ##### Layer 5 — GPU verification (requires real hardware)
 
@@ -303,11 +296,6 @@ Disaggregated SGLang on a two-GPU node:
 
 ### Alternatives
 
-- **Reuse the vLLM tokenizer adapter for SGLang.** Rejected: SGLang's
-  `/tokenize` request/response schema and field names differ from vLLM and
-  drift across SGLang versions; reusing the vLLM adapter would silently
-  produce wrong tokenizations for prefix-cache scoring. A dedicated adapter
-  with defensive response parsing is more robust.
 - **Keep rejecting SGLang in the converter; require hand-written
   `ModelServing` YAML.** Rejected: that leaves SGLang a second-class citizen,
   duplicates the rollout/gang/drain logic users would have to hand-author, and
@@ -325,3 +313,43 @@ Disaggregated SGLang on a two-GPU node:
   narrowing the `ModelBackendType` enum to only what is wired
   (`vLLM;vLLMDisaggregated;SGLang;SGLangDisaggregated`) avoids advertising
   unimplemented backends in the CRD schema.
+
+### Known Limitations / Follow-ups
+
+These are intentionally out of scope for the first PR but tracked here so they
+are not lost:
+
+- **Readiness probe uses `/health`, not `/health_generate`.** SGLang's
+  `/health` returns 200 once the HTTP process is up — *before* model weights
+  finish loading — so the router can briefly route to a pod that 503s. SGLang
+  also exposes `/health_generate`, which runs an actual generation and only
+  succeeds once the model is serving. A follow-up should switch the *readiness*
+  probe to `/health_generate` (keeping `/health` for liveness) so traffic is
+  gated on true model-readiness. Deferred because the longer warmup cost of
+  `/health_generate` needs measuring against the `initialDelaySeconds` budget.
+- **`--served-model-name` is not auto-defaulted.** If the user omits
+  `served-model-name` in `worker.config`, SGLang advertises the model under its
+  on-disk path on `/v1/models`, so the auto-created `ModelRoute` (whose
+  `modelName` is the ModelBooster name) will not match and routing fails. The
+  examples set it explicitly. A follow-up should inject
+  `--served-model-name <model.Name>` when the user did not supply one, matching
+  what the router expects.
+- **Disaggregated bootstrap wiring is minimal.** `buildSGLangCommands` emits
+  only `--disaggregation-mode` and `--disaggregation-transfer-backend`. The
+  SGLang bootstrap server port (default 8998) is not exposed as a
+  `containerPort`, and the engine binds `--host 0.0.0.0` rather than the pod
+  IP. The router's `ConnectorTypeSGLang` injects `bootstrap_host`/
+  `bootstrap_room` per request, so aggregated and router-orchestrated PD work,
+  but a fuller PD design (explicit bootstrap port exposure, host advertisement)
+  is needed before disaggregated SGLang is GPU-validated. Disaggregated is not
+  part of the tested path in the first PR.
+- **`spec.topologySpreadConstraints` in the launch templates is dead config.**
+  `ModelServing.Spec` has no `topologySpreadConstraints` field, so the block
+  present in `vllm.yaml`/`sglang.yaml` is silently dropped by
+  `loadModelServingTemplate`. It was deliberately *not* carried into
+  `sglang-pd.yaml` to avoid misleading no-op YAML. Real anti-affinity/spread
+  for engine pods should be expressed at the pod template
+  (`entryTemplate.spec.topologySpreadConstraints`, a real `PodSpec` field) for
+  both vLLM and SGLang in a separate change.
+- **Multi-node (Pods > 1).** Explicitly rejected at convert time with a clear
+  error; no Ray/torchrun bootstrap template is provided for SGLang in v1.

--- a/docs/proposal/sglang-engine-design.md
+++ b/docs/proposal/sglang-engine-design.md
@@ -1,0 +1,327 @@
+---
+title: First-Class SGLang Support in Kthena
+authors:
+- "@kube-gopher"
+reviewers:
+- TBD
+approvers:
+- TBD
+
+creation-date: 2026-05-17
+
+---
+
+## First-Class SGLang Support in Kthena
+
+### Summary
+
+Kthena supports the vLLM inference engine end-to-end across five layers: API
+types, the ModelBooster → ModelServing converter, embedded launch templates,
+the router backend adapter, KV connectors, and the tokenizer adapter. SGLang
+previously had only partial, router-side support and was rejected by the
+ModelBooster converter.
+
+This proposal lifts SGLang to a first-class backend. The user-visible outcome:
+a user declares a `ModelBooster` with `backend.type: SGLang` or
+`SGLangDisaggregated` and gets a working aggregated or PD-disaggregated SGLang
+deployment with the same scheduler-plugin behavior, drain semantics, gang
+scheduling, and PD-disaggregation tooling that vLLM ModelBoosters get — the
+router automatically selects the SGLang KV connector and a dedicated SGLang
+tokenizer adapter.
+
+### Motivation
+
+SGLang already had partial integration: the router-side metrics scraper
+(`pkg/kthena-router/backend/sglang/metrics.go`), the PD bootstrap connector
+(`pkg/kthena-router/connectors/sglang.go`), the `InferenceEngine: SGLang` enum,
+and example CRs. However, the ModelBooster converter
+(`pkg/model-booster-controller/convert/model_server.go`) returned
+"please use vLLM backend", the `ModelBackendType` kubebuilder enum did not
+permit SGLang, there was no SGLang launch template or tokenizer adapter, and
+the webhook blocked disaggregated SGLang topologies. As a result, users could
+not declaratively run SGLang through the platform's primary workload CRD.
+
+#### Goals
+
+- **Aggregated SGLang**: `ModelBooster` with `backend.type: SGLang`
+  materializes a `ModelServing` running a single-node SGLang server
+  (`sglang.launch_server`).
+- **Disaggregated SGLang (PD)**: `ModelBooster` with
+  `backend.type: SGLangDisaggregated` materializes prefill + decode roles wired
+  up for SGLang's `bootstrap_room`/`bootstrap_host` KV-handoff protocol.
+- **Full router integration**: SGLang pods participate in metric-aware
+  scheduling, prefix/KV-cache-aware scoring, and OpenAI-compatible request
+  proxying — selecting the SGLang KV connector automatically.
+- **Dedicated tokenizer adapter**: SGLang's `/tokenize` endpoint is used
+  directly for prefix-cache scoring rather than reusing the vLLM adapter.
+
+#### Non-Goals
+
+- **Multi-node SGLang (Ray/torchrun)**: out of scope for v1. Both the
+  aggregated and disaggregated builders return an explicit error if
+  `Pods > 1`.
+- **Native SGLang chat-tokenize**: the adapter flattens chat messages to a
+  role-prefixed text string. Adding a first-party chat-tokenize call is
+  deferred until SGLang ships such an endpoint.
+- **SGLang version-portable metric names**: the router-side metric names match
+  SGLang ≥ 0.4.x. A config-driven metric-name map for older versions is out of
+  scope.
+
+### Proposal
+
+A user creating a `ModelBooster` selects an SGLang backend type and receives a
+fully materialized, router-integrated deployment without authoring any
+low-level `ModelServing` YAML — exactly mirroring the existing vLLM experience.
+
+#### User Stories
+
+##### Story 1 — Aggregated SGLang
+
+A user submits a `ModelBooster` with `backend.type: SGLang` and a single
+`server` worker. The controller materializes a `ModelServing` with the kthena
+`runtime` sidecar + an `engine` container running
+`python3 -m sglang.launch_server`. The router discovers the pod, scrapes
+`sglang:*` metrics, and proxies OpenAI-compatible requests to it.
+
+##### Story 2 — Disaggregated SGLang (PD)
+
+A user submits a `ModelBooster` with `backend.type: SGLangDisaggregated` and
+`prefill` + `decode` workers. The controller materializes two roles wired for
+SGLang's bootstrap KV-handoff. The router selects `ConnectorTypeSGLang`
+automatically and runs the prefill/decode bootstrap protocol.
+
+#### Notes/Constraints/Caveats
+
+- The engine binds `--host 0.0.0.0` (not `$(POD_IP)`). This is required so the
+  runtime sidecar and the preStop drain can reach the engine on
+  `localhost:30000`.
+- `getKvConnectorSpec` returns `nil` for SGLang on purpose: SGLang's KV handoff
+  is selected by the router from `InferenceEngine`, not from a user-supplied
+  `kv-transfer-config` blob. Producing `KVConnector: nil` is the contract that
+  makes end-to-end PD work with no extra code.
+- The webhook permits a prefill-only disaggregated spec while the converter
+  errors on it — this split deliberately matches the existing
+  `vLLMDisaggregated` precedent.
+- The preStop drain hook and the `/dev/shm` (memory-medium) volume are emitted
+  for **aggregated** SGLang only, not for the disaggregated `prefill`/`decode`
+  roles. This matches the established kthena template convention: `vllm.yaml`,
+  `vllm-pd.yaml`, and `sglang-pd.yaml` all omit both, so the asymmetry is the
+  aggregated path being *enriched*, not the PD path being deprived. PD pods
+  have a distinct termination contract (bootstrap-room teardown / KV-transfer
+  completion) that a request-count drain does not model; extending graceful
+  drain to PD is tracked as a follow-up rather than silently reusing the
+  aggregated script.
+- The aggregated preStop drain is bounded to ~300s (60 × 5s) and aligned with
+  `terminationGracePeriodSeconds`, sums all metric series (multi-model safe),
+  uses an integer comparison (immune to Prometheus `0` vs `0.0` formatting),
+  and exits immediately if the metrics endpoint is unreachable — so a
+  stuck/absent metric can never block termination past the grace period.
+
+#### Risks and Mitigations
+
+- **`--host 0.0.0.0` exposure**: binding all interfaces is broader than
+  `$(POD_IP)`. Mitigation: the engine port (30000) is not exposed via a
+  Service unless the converter emits one; pod network policy governs reach
+  ability, identical to the vLLM path which also binds broadly.
+- **Metric-name version drift**: preStop drain relies on
+  `sglang:num_running_reqs` / `sglang:num_queue_reqs`. These match the shipped
+  `backend/sglang/metrics.go` (SGLang ≥ 0.4.x). Mitigation: documented as a
+  Non-Goal; a config-driven name map is the follow-up if older versions must be
+  supported.
+- **Chat-tokenize approximation**: flattening chat to a role-prefixed string
+  can diverge from a model's true chat template, slightly skewing prefix-cache
+  scoring (a scheduling hint, not correctness). Mitigation: scoped to scoring
+  only; swap for a native endpoint when available.
+- **No GPU e2e coverage**: SGLang needs a GPU, so e2e asserts CR
+  materialization only. Mitigation: Layer 5 GPU verification steps are
+  documented for manual/hardware runs; unit + golden-file tests pin the
+  generated manifest shape.
+
+### Design Details
+
+#### API Types
+
+`pkg/apis/workload/v1alpha1/model_booster_types.go` — the `ModelBackendType`
+kubebuilder enum is narrowed to exactly the supported set:
+
+```
++kubebuilder:validation:Enum=vLLM;vLLMDisaggregated;SGLang;SGLangDisaggregated
+```
+
+New const `ModelBackendTypeSGLangDisaggregated`. `make generate` regenerates
+the `modelboosters` CRD and the CRD enum docs.
+
+#### ModelBooster → ModelServing Converter
+
+`pkg/model-booster-controller/convert/`:
+
+| Helper | Role |
+|---|---|
+| `buildSGLangModelServing` | Aggregated SGLang. Emits a single `leader` role with the kthena `runtime` sidecar + `engine` container running `python3 -m sglang.launch_server --model-path ... --host 0.0.0.0 --port 30000 --enable-metrics`. Binding `0.0.0.0` lets the runtime sidecar and the preStop drain reach the engine on `localhost:30000`. PreStop hook drains via `sglang:num_running_reqs` / `sglang:num_queue_reqs`. |
+| `buildSGLangDisaggregatedModelServing` | Two roles — `prefill` and `decode` — with `--disaggregation-mode <role> --disaggregation-transfer-backend mooncake` appended. Gang policy requires both roles. Multi-node (`Pods > 1`) is rejected, matching the aggregated path. |
+| `buildSGLangCommands` | Shared command builder; user-supplied worker `Config` is flattened to POSIX flags by the renamed `utils.ConvertEngineArgsFromJson`. |
+
+Engine-aware `WorkloadPort` resolution: `getEnginePort(backend.Type)` returns
+8000 for vLLM, 30000 for SGLang. The vLLM `VLLM_USE_V1=1` env var is now only
+injected for vLLM-typed backends.
+
+`getKvConnectorSpec` short-circuits for SGLang: it returns `nil` because
+SGLang's KV handoff is selected by the router based on `InferenceEngine`, not
+by the user-supplied `kv-transfer-config` blob.
+
+#### Launch Templates
+
+Two new embed.FS templates parallel the vLLM ones:
+
+- `templates/sglang.yaml` — aggregated. Single role with runtime sidecar +
+  engine container; readiness probe `:30000/health`, preStop drain on
+  SGLang-named metrics.
+- `templates/sglang-pd.yaml` — disaggregated. Prefill + decode roles, both
+  exposing port 30000. Mirrors the vLLM disaggregated topology and gang
+  policy.
+
+Multi-node SGLang (Ray/torchrun) is out of scope for v1;
+`buildSGLangModelServing` errors out if `Pods > 1`.
+
+#### Router Tokenizer Adapter
+
+`pkg/kthena-router/scheduler/plugins/tokenization/`:
+
+- `sglang.go` — new adapter against SGLang's `POST /tokenize` endpoint.
+  Defensive response parsing accepts `token_ids`, `tokens`, or `input_ids`
+  field names so the adapter survives SGLang's field-name drift across
+  versions. Chat inputs are flattened to a single role-prefixed text prompt
+  since SGLang has no native chat tokenize endpoint.
+- `tokenizer.go` — `NewRemoteTokenizer` is now engine-aware
+  (`vllm`/`sglang`/empty=vLLM-default).
+- `tokenizer_manager.go` — per-pod routing:
+  `engineEndpointForPod(podIP, podInfo.GetEngine())` resolves the right port
+  (8000 for vLLM, 30000 for SGLang) and adapter. Pods with unknown engines are
+  skipped, not silently routed to a default.
+- `kvcache_aware.go` — `EnableVLLMRemote` config knob renamed to
+  `EnableRemoteTokenizer`; the engine and endpoint are resolved per-pod, not
+  from a static template string.
+
+#### Webhook
+
+`pkg/model-booster-controller/webhook/model_validator.go` — new rule mirroring
+`vLLMDisaggregated`: `SGLangDisaggregated` backends must have all workers typed
+`prefill` or `decode`. Aggregated SGLang reuses the existing "exactly one
+server worker" branch.
+
+#### KV Connector Selection (no change to existing code)
+
+The router at `pkg/kthena-router/router/router.go:944` already auto-selects
+`ConnectorTypeSGLang` whenever `ModelServer.Spec.InferenceEngine == SGLang` and
+no explicit `KVConnector` is set. The converter producing `KVConnector: nil`
+for SGLang is the contract that makes this work end-to-end.
+
+The SGLang connector (`pkg/kthena-router/connectors/sglang.go`) handles the
+bootstrap protocol:
+
+- Generates a unique `bootstrap_room` (random int63) shared by the prefill and
+  decode requests.
+- Sets `bootstrap_host` to the prefill pod's IP on the decode request only —
+  that is where the decode receiver opens the bootstrap HTTP connection to
+  fetch ZMQ endpoint metadata.
+- Runs prefill and decode concurrently; cancels the prefill context if decode
+  fails so the prefill bootstrap server doesn't hang.
+
+#### Test Plan
+
+##### Layer 1 — Static / Generation (no env)
+
+- `make gen-crd` regenerates the modelboosters CRD with the new enum members.
+- `./hack/update-codegen.sh` is a no-op for SGLang (no API struct shape
+  changed) but is run for CI parity.
+- `make gen-docs` refreshes
+  `docs/kthena/docs/reference/crd/workload.serving.volcano.sh.md` with the
+  widened enum.
+- `make gen-check` confirms the above produce no drift beyond the source-code
+  changes.
+- `make lint` (golangci-lint v1.64.8) — clean.
+
+##### Layer 2 — Unit tests
+
+| Suite | Coverage |
+|---|---|
+| `convert/model_serving_test.go` `TestCreateModelServingResources` | Golden-file diff: `testdata/input/sglang-{aggregated,disaggregated}-model.yaml` → `testdata/expected/sglang-{aggregated,disaggregated}-model-serving.yaml`. Any converter change not captured in a fixture update fails the suite. |
+| `convert/model_serving_test.go` `TestBuildSGLang*` | Structural assertions: command flags, `--host 0.0.0.0`, `--port 30000`, no `POD_IP`/`VLLM_USE_V1` env, disaggregation flags appear only on PD roles. |
+| `convert/model_server_test.go` `TestBuildSGLang*Routing` | `WorkloadPort.Port == 30000`, `InferenceEngine == SGLang`, `KVConnector` nil, `PDGroup` only set for disaggregated. |
+| `webhook/model_validator_test.go` `TestValidateBackendWorkerTypes_SGLang` | Aggregated requires one server worker; Disaggregated requires prefill+decode-only. |
+| `tokenization/tokenization_test.go` `TestSGLangAdapter` | Completion + chat request shapes; response parsing for all three SGLang field-name variants. |
+| `tokenization_test.go` `TestEngineEndpointForPod` | Per-engine port and adapter resolution. |
+| `tokenization_test.go` `TestTokenizerManager_GetTokenizer_PicksSGLangPort` | End-to-end manager path picks port 30000 for an SGLang pod. |
+| `router/router_test.go` `TestRouter_HandlerFunc_SGLangAggregated` | Aggregated SGLang request proxies to the backend with no bootstrap mutation. |
+| `router/router_test.go` `TestRouter_HandlerFunc_SGLangDisaggregated` | Both requests fire concurrently, share the same `bootstrap_room`, decode carries `bootstrap_host` = prefill pod IP. |
+
+##### Layer 3 — Controller-manager E2E (Kind, no GPU)
+
+`test/e2e/controller-manager/model_booster_test.go`
+`TestSGLangModelMaterialization`:
+
+- Creates an SGLang and an SGLangDisaggregated `ModelBooster` in the test
+  namespace.
+- Waits for the controller to emit the `ModelServing`.
+- Asserts on the structure of the materialized ModelServing — engine command,
+  ports, env, disaggregation flags. **Does not** wait for pods to become Ready
+  (SGLang needs a GPU).
+
+##### Layer 4 — Router E2E (Kind, no GPU)
+
+`test/e2e/router/` already exercises the router against fake backends per
+engine. The unit-level router tests above
+(`TestRouter_HandlerFunc_SGLang*`) cover the SGLang bootstrap protocol
+semantics; the router E2E suite can be extended with a `ModelServer-sglang.yaml`
+testdata fixture if a kind-based check is desired.
+
+##### Layer 5 — GPU verification (requires real hardware)
+
+Aggregated SGLang on a single-GPU node:
+
+1. `kubectl apply -f examples/model-booster/sglang-aggregated.yaml`
+2. `kubectl wait` for the `ModelBooster` `Active` condition (mirrors the vLLM
+   `TestModelCR` shape).
+3. `curl POST http://<router>/v1/chat/completions` against the served model
+   name; assert a non-empty completion and sane `usage` token counts.
+4. Scrape `/metrics` on the SGLang pod (port 30000); confirm
+   `sglang:num_running_reqs` increments under sustained load and the preStop
+   drain logic blocks termination while requests are in flight.
+
+Disaggregated SGLang on a two-GPU node:
+
+1. `kubectl apply -f examples/model-booster/sglang-disaggregated.yaml`
+2. Verify both `prefill` and `decode` pods become `Ready`.
+3. Send an inference request; confirm via `kubectl logs` that:
+   - The prefill pod logs a bootstrap-room exchange (the decode receiver
+     connecting).
+   - The decode pod logs a successful KV-transfer receive on the same
+     `bootstrap_room`.
+4. Compare the streamed output token-by-token against the aggregated mode for
+   the same prompt — catches semantic drift in the disaggregated KV-transfer
+   path.
+
+### Alternatives
+
+- **Reuse the vLLM tokenizer adapter for SGLang.** Rejected: SGLang's
+  `/tokenize` request/response schema and field names differ from vLLM and
+  drift across SGLang versions; reusing the vLLM adapter would silently
+  produce wrong tokenizations for prefix-cache scoring. A dedicated adapter
+  with defensive response parsing is more robust.
+- **Keep rejecting SGLang in the converter; require hand-written
+  `ModelServing` YAML.** Rejected: that leaves SGLang a second-class citizen,
+  duplicates the rollout/gang/drain logic users would have to hand-author, and
+  diverges from the vLLM experience. The hand-written low-level path remains
+  available but is no longer the only option.
+- **Bind the engine to `--host $(POD_IP)`.** Rejected: the runtime sidecar and
+  the preStop drain reach the engine over `localhost:30000`; binding only the
+  pod IP breaks both. `--host 0.0.0.0` is required and matches the vLLM path.
+- **Model SGLang KV handoff via the user-supplied `kv-transfer-config`
+  (vLLM-style).** Rejected: SGLang's handoff is a bootstrap protocol selected
+  by the router from `InferenceEngine`. Emitting `KVConnector: nil` and letting
+  the router pick `ConnectorTypeSGLang` keeps the contract in one place and
+  requires no new connector-config surface.
+- **Single shared "engine args" enum / MindIE-style placeholder.** Rejected:
+  narrowing the `ModelBackendType` enum to only what is wired
+  (`vLLM;vLLMDisaggregated;SGLang;SGLangDisaggregated`) avoids advertising
+  unimplemented backends in the CRD schema.

--- a/examples/model-booster/sglang-aggregated.yaml
+++ b/examples/model-booster/sglang-aggregated.yaml
@@ -1,0 +1,34 @@
+apiVersion: workload.serving.volcano.sh/v1alpha1
+kind: ModelBooster
+metadata:
+  name: sglang-qwen-06b
+spec:
+  backend:
+    name: "backend1"
+    type: "SGLang"
+    modelURI: "hf://Qwen/Qwen3-0.6B"
+    cacheURI: "hostpath://tmp/cache"
+    minReplicas: 1
+    maxReplicas: 1
+    env:
+      - name: "HF_ENDPOINT" # Optional: Use a Hugging Face mirror if you have network issues
+        value: "https://hf-mirror.com"
+    workers:
+      - type: "server"
+        image: "docker.io/lmsysorg/sglang:latest"
+        replicas: 1
+        pods: 1
+        # Flags here are appended after the kthena defaults.
+        config:
+          served-model-name: "Qwen3-0.6B"
+          mem-fraction-static: "0.85"
+          trust-remote-code: ""
+        resources:
+          limits:
+            nvidia.com/gpu: "1"
+            cpu: "4"
+            memory: "12Gi"
+          requests:
+            nvidia.com/gpu: "1"
+            cpu: "2"
+            memory: "12Gi"

--- a/examples/model-booster/sglang-disaggregated.yaml
+++ b/examples/model-booster/sglang-disaggregated.yaml
@@ -1,0 +1,47 @@
+apiVersion: workload.serving.volcano.sh/v1alpha1
+kind: ModelBooster
+metadata:
+  name: sglang-qwen-06b-pd
+spec:
+  backend:
+    name: "backend1"
+    type: "SGLangDisaggregated"
+    modelURI: "hf://Qwen/Qwen3-0.6B"
+    cacheURI: "hostpath://tmp/cache"
+    minReplicas: 1
+    maxReplicas: 1
+    workers:
+      - type: prefill
+        image: "docker.io/lmsysorg/sglang:latest"
+        replicas: 1
+        pods: 1
+        # kthena injects --disaggregation-mode=prefill and
+        # --disaggregation-transfer-backend=mooncake; override here if needed.
+        config:
+          served-model-name: "Qwen3-0.6B"
+          mem-fraction-static: "0.85"
+        resources:
+          limits:
+            nvidia.com/gpu: "1"
+            cpu: "4"
+            memory: "12Gi"
+          requests:
+            nvidia.com/gpu: "1"
+            cpu: "2"
+            memory: "12Gi"
+      - type: decode
+        image: "docker.io/lmsysorg/sglang:latest"
+        replicas: 1
+        pods: 1
+        config:
+          served-model-name: "Qwen3-0.6B"
+          mem-fraction-static: "0.85"
+        resources:
+          limits:
+            nvidia.com/gpu: "1"
+            cpu: "4"
+            memory: "12Gi"
+          requests:
+            nvidia.com/gpu: "1"
+            cpu: "2"
+            memory: "12Gi"

--- a/pkg/apis/workload/v1alpha1/model_booster_types.go
+++ b/pkg/apis/workload/v1alpha1/model_booster_types.go
@@ -108,7 +108,7 @@ type ModelBackend struct {
 }
 
 // ModelBackendType defines the type of model backend.
-// +kubebuilder:validation:Enum=vLLM;vLLMDisaggregated
+// +kubebuilder:validation:Enum=vLLM;vLLMDisaggregated;SGLang;SGLangDisaggregated
 type ModelBackendType string
 
 const (
@@ -118,6 +118,8 @@ const (
 	ModelBackendTypeVLLMDisaggregated ModelBackendType = "vLLMDisaggregated"
 	// ModelBackendTypeSGLang represents an SGLang backend.
 	ModelBackendTypeSGLang ModelBackendType = "SGLang"
+	// ModelBackendTypeSGLangDisaggregated represents a disaggregated SGLang backend.
+	ModelBackendTypeSGLangDisaggregated ModelBackendType = "SGLangDisaggregated"
 	// ModelBackendTypeMindIE represents a MindIE backend.
 	ModelBackendTypeMindIE ModelBackendType = "MindIE"
 	// ModelBackendTypeMindIEDisaggregated represents a disaggregated MindIE backend.

--- a/pkg/model-booster-controller/convert/model_server.go
+++ b/pkg/model-booster-controller/convert/model_server.go
@@ -43,8 +43,10 @@ func BuildModelServer(model *workload.ModelBooster) ([]*networking.ModelServer, 
 	switch backend.Type {
 	case workload.ModelBackendTypeVLLM, workload.ModelBackendTypeVLLMDisaggregated:
 		inferenceEngine = networking.VLLM
+	case workload.ModelBackendTypeSGLang, workload.ModelBackendTypeSGLangDisaggregated:
+		inferenceEngine = networking.SGLang
 	default:
-		return nil, fmt.Errorf("not support %s backend yet, please use vLLM backend", backend.Type)
+		return nil, fmt.Errorf("not support %s backend yet", backend.Type)
 	}
 	servedModelName := getServedModelName(model, backend)
 	pdGroup := getPdGroup(backend)
@@ -74,7 +76,7 @@ func BuildModelServer(model *workload.ModelBooster) ([]*networking.ModelServer, 
 				PDGroup: pdGroup,
 			},
 			WorkloadPort: networking.WorkloadPort{
-				Port: 8000, // todo: get port from config
+				Port: getEnginePort(backend.Type),
 			},
 			TrafficPolicy: &networking.TrafficPolicy{
 				Retry: &networking.Retry{
@@ -91,7 +93,23 @@ func BuildModelServer(model *workload.ModelBooster) ([]*networking.ModelServer, 
 	return modelServers, nil
 }
 
+// getEnginePort returns the engine's listen port (vLLM 8000, SGLang 30000).
+func getEnginePort(backendType workload.ModelBackendType) int32 {
+	switch backendType {
+	case workload.ModelBackendTypeSGLang, workload.ModelBackendTypeSGLangDisaggregated:
+		return 30000
+	default:
+		return 8000
+	}
+}
+
 func getKvConnectorSpec(backend workload.ModelBackend) (*networking.KVConnectorSpec, error) {
+	// SGLang does not use the vLLM kv-transfer-config tree; the router picks the
+	// SGLang connector via InferenceEngine.
+	if backend.Type == workload.ModelBackendTypeSGLang ||
+		backend.Type == workload.ModelBackendTypeSGLangDisaggregated {
+		return nil, nil
+	}
 	var connectorType *networking.KVConnectorType
 	foundConfig := false
 	for _, worker := range backend.Workers {
@@ -146,7 +164,9 @@ func getKvConnectorSpec(backend workload.ModelBackend) (*networking.KVConnectorS
 
 func getPdGroup(backend workload.ModelBackend) *networking.PDGroup {
 	switch backend.Type {
-	case workload.ModelBackendTypeVLLMDisaggregated, workload.ModelBackendTypeMindIEDisaggregated:
+	case workload.ModelBackendTypeVLLMDisaggregated,
+		workload.ModelBackendTypeSGLangDisaggregated,
+		workload.ModelBackendTypeMindIEDisaggregated:
 		return &networking.PDGroup{
 			GroupKey: workload.GroupNameLabelKey,
 			PrefillLabels: map[string]string{

--- a/pkg/model-booster-controller/convert/model_serving.go
+++ b/pkg/model-booster-controller/convert/model_serving.go
@@ -39,13 +39,15 @@ import (
 )
 
 const (
-	CacheURIPrefixPVC              = "pvc://"
-	CacheURIPrefixHostPath         = "hostpath://"
-	URIPrefixSeparator             = "://"
-	VllmTemplatePath               = "templates/vllm.yaml"
-	VllmDisaggregatedTemplatePath  = "templates/vllm-pd.yaml"
-	VllmMultiNodeServingScriptPath = "examples/online_serving/multi-node-serving.sh"
-	modelRouteRuleName             = "default"
+	CacheURIPrefixPVC               = "pvc://"
+	CacheURIPrefixHostPath          = "hostpath://"
+	URIPrefixSeparator              = "://"
+	VllmTemplatePath                = "templates/vllm.yaml"
+	VllmDisaggregatedTemplatePath   = "templates/vllm-pd.yaml"
+	VllmMultiNodeServingScriptPath  = "examples/online_serving/multi-node-serving.sh"
+	SGLangTemplatePath              = "templates/sglang.yaml"
+	SGLangDisaggregatedTemplatePath = "templates/sglang-pd.yaml"
+	modelRouteRuleName              = "default"
 	// /dev/shm is too small to support NCCL, we need a larger memory volume
 	dshm = "dshm"
 )
@@ -63,6 +65,10 @@ func BuildModelServing(model *workload.ModelBooster) (*workload.ModelServing, er
 		serving, err = buildVllmModelServing(model)
 	case workload.ModelBackendTypeVLLMDisaggregated:
 		serving, err = buildVllmDisaggregatedModelServing(model)
+	case workload.ModelBackendTypeSGLang:
+		serving, err = buildSGLangModelServing(model)
+	case workload.ModelBackendTypeSGLangDisaggregated:
+		serving, err = buildSGLangDisaggregatedModelServing(model)
 	default:
 		return nil, fmt.Errorf("not support model backend type: %s", backend.Type)
 	}
@@ -326,6 +332,245 @@ func buildVllmModelServing(model *workload.ModelBooster) (*workload.ModelServing
 	return loadModelServingTemplate(VllmTemplatePath, &data)
 }
 
+// buildSGLangModelServing handles aggregated SGLang backend creation.
+func buildSGLangModelServing(model *workload.ModelBooster) (*workload.ModelServing, error) {
+	backend := &model.Spec.Backend
+	workersMap := mapWorkers(backend.Workers)
+	if workersMap[workload.ModelWorkerTypeServer] == nil {
+		return nil, fmt.Errorf("server worker not found in backend: %s", backend.Name)
+	}
+	if workersMap[workload.ModelWorkerTypeServer].Pods > 1 {
+		return nil, fmt.Errorf("multi-node SGLang (Pods > 1) is not yet supported")
+	}
+	cacheVolume, err := buildCacheVolume(backend)
+	if err != nil {
+		return nil, err
+	}
+	modelDownloadPath := GetCachePath(backend.CacheURI) + GetMountPath(backend.ModelURI)
+	commands, err := buildSGLangCommands(&workersMap[workload.ModelWorkerTypeServer].Config, modelDownloadPath, "")
+	if err != nil {
+		return nil, err
+	}
+
+	initContainers := buildModelDownloaderInitContainers(model, backend, cacheVolume, modelDownloadPath)
+
+	engineEnv := buildEngineEnvVars(backend)
+	data := map[string]interface{}{
+		"MODEL_SERVING_TEMPLATE_METADATA": &metav1.ObjectMeta{
+			Name:      utils.GetBackendResourceName(model.Name, backend.Name),
+			Namespace: model.Namespace,
+			Labels:    utils.GetModelControllerLabels(model, backend.Name, icUtils.Revision(backend)),
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: workload.GroupVersion.String(),
+					Kind:       workload.ModelKind.Kind,
+					Name:       model.Name,
+					UID:        model.UID,
+				},
+			},
+		},
+		"MODEL_NAME":       model.Name,
+		"BACKEND_REPLICAS": backend.MinReplicas,
+		"ENGINE_ENV":       engineEnv,
+		"SERVER_REPLICAS":  workersMap[workload.ModelWorkerTypeServer].Replicas,
+		"SERVER_ENTRY_TEMPLATE_METADATA": &metav1.ObjectMeta{
+			Labels: utils.GetModelControllerLabels(model, backend.Name, icUtils.Revision(backend)),
+		},
+		"VOLUMES": []*corev1.Volume{
+			cacheVolume,
+			{
+				Name: dshm,
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{
+						Medium: corev1.StorageMediumMemory,
+					},
+				},
+			},
+		},
+		"VOLUME_MOUNTS": []corev1.VolumeMount{{
+			Name:      cacheVolume.Name,
+			MountPath: GetCachePath(backend.CacheURI),
+		}, {
+			Name:      dshm,
+			MountPath: "/dev/shm",
+		}},
+		"INIT_CONTAINERS":                    initContainers,
+		"MODEL_DOWNLOAD_ENVFROM":             backend.EnvFrom,
+		"MODEL_SERVING_RUNTIME_IMAGE":        config.Config.RuntimeImage(),
+		"MODEL_SERVING_RUNTIME_PORT":         env.GetEnvValueOrDefault[int32](backend, env.RuntimePort, 8100),
+		"MODEL_SERVING_RUNTIME_URL":          env.GetEnvValueOrDefault[string](backend, env.RuntimeUrl, "http://localhost:30000"),
+		"MODEL_SERVING_RUNTIME_METRICS_PATH": env.GetEnvValueOrDefault[string](backend, env.RuntimeMetricsPath, "/metrics"),
+		"MODEL_SERVING_RUNTIME_ENGINE":       strings.ToLower(string(backend.Type)),
+		"MODEL_SERVING_RUNTIME_POD":          "$(POD_NAME).$(NAMESPACE)",
+		"ENGINE_SERVER_RESOURCES":            workersMap[workload.ModelWorkerTypeServer].Resources,
+		"ENGINE_SERVER_IMAGE":                workersMap[workload.ModelWorkerTypeServer].Image,
+		"ENGINE_SERVER_COMMAND":              commands,
+		"SCHEDULER_NAME":                     backend.SchedulerName,
+		"RUNTIME_CLASS_NAME":                 backend.RuntimeClassName,
+	}
+	return loadModelServingTemplate(SGLangTemplatePath, &data)
+}
+
+// buildSGLangDisaggregatedModelServing handles disaggregated SGLang backend creation.
+func buildSGLangDisaggregatedModelServing(model *workload.ModelBooster) (*workload.ModelServing, error) {
+	backend := &model.Spec.Backend
+	workersMap := mapWorkers(backend.Workers)
+	if workersMap[workload.ModelWorkerTypePrefill] == nil {
+		return nil, fmt.Errorf("prefill worker not found in backend")
+	}
+	if workersMap[workload.ModelWorkerTypeDecode] == nil {
+		return nil, fmt.Errorf("decode worker not found in backend")
+	}
+	if workersMap[workload.ModelWorkerTypePrefill].Pods > 1 || workersMap[workload.ModelWorkerTypeDecode].Pods > 1 {
+		return nil, fmt.Errorf("multi-node SGLang (Pods > 1) is not yet supported")
+	}
+	cacheVolume, err := buildCacheVolume(backend)
+	if err != nil {
+		return nil, err
+	}
+	modelDownloadPath := GetCachePath(backend.CacheURI) + GetMountPath(backend.ModelURI)
+
+	initContainers := buildModelDownloaderInitContainers(model, backend, cacheVolume, modelDownloadPath)
+
+	var prefillCommand []string
+	var decodeCommand []string
+	for _, worker := range backend.Workers {
+		switch worker.Type {
+		case workload.ModelWorkerTypePrefill:
+			prefillCommand, err = buildSGLangCommands(&worker.Config, modelDownloadPath, "prefill")
+			if err != nil {
+				return nil, err
+			}
+		case workload.ModelWorkerTypeDecode:
+			decodeCommand, err = buildSGLangCommands(&worker.Config, modelDownloadPath, "decode")
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	prefillEngineEnv := buildEngineEnvVars(backend)
+	decodeEngineEnv := buildEngineEnvVars(backend)
+
+	data := map[string]interface{}{
+		"MODEL_SERVING_TEMPLATE_METADATA": &metav1.ObjectMeta{
+			Name:      utils.GetBackendResourceName(model.Name, backend.Name),
+			Namespace: model.Namespace,
+			Labels:    utils.GetModelControllerLabels(model, backend.Name, icUtils.Revision(backend)),
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: workload.GroupVersion.String(),
+					Kind:       workload.ModelKind.Kind,
+					Name:       model.Name,
+					UID:        model.UID,
+				},
+			},
+		},
+		"VOLUME_MOUNTS": []corev1.VolumeMount{{
+			Name:      cacheVolume.Name,
+			MountPath: GetCachePath(backend.CacheURI),
+		}},
+		"VOLUMES": []*corev1.Volume{
+			cacheVolume,
+		},
+		"MODEL_NAME":             model.Name,
+		"BACKEND_REPLICAS":       backend.MinReplicas,
+		"INIT_CONTAINERS":        initContainers,
+		"MODEL_DOWNLOAD_ENVFROM": backend.EnvFrom,
+		"ENGINE_PREFILL_COMMAND": prefillCommand,
+		"ENGINE_DECODE_COMMAND":  decodeCommand,
+		"SERVER_ENTRY_TEMPLATE_METADATA": &metav1.ObjectMeta{
+			Labels: utils.GetModelControllerLabels(model, backend.Name, icUtils.Revision(backend)),
+		},
+		"MODEL_SERVING_RUNTIME_IMAGE":        config.Config.RuntimeImage(),
+		"MODEL_SERVING_RUNTIME_PORT":         env.GetEnvValueOrDefault[int32](backend, env.RuntimePort, 8100),
+		"MODEL_SERVING_RUNTIME_URL":          env.GetEnvValueOrDefault[string](backend, env.RuntimeUrl, "http://localhost:30000"),
+		"MODEL_SERVING_RUNTIME_METRICS_PATH": env.GetEnvValueOrDefault[string](backend, env.RuntimeMetricsPath, "/metrics"),
+		"ENGINE_PREFILL_ENV":                 prefillEngineEnv,
+		"ENGINE_DECODE_ENV":                  decodeEngineEnv,
+		"MODEL_SERVING_RUNTIME_ENGINE":       strings.ToLower(string(backend.Type)),
+		"MODEL_SERVING_RUNTIME_POD":          "$(POD_NAME).$(NAMESPACE)",
+		"PREFILL_REPLICAS":                   workersMap[workload.ModelWorkerTypePrefill].Replicas,
+		"DECODE_REPLICAS":                    workersMap[workload.ModelWorkerTypeDecode].Replicas,
+		"ENGINE_DECODE_RESOURCES":            workersMap[workload.ModelWorkerTypeDecode].Resources,
+		"ENGINE_DECODE_IMAGE":                workersMap[workload.ModelWorkerTypeDecode].Image,
+		"ENGINE_PREFILL_RESOURCES":           workersMap[workload.ModelWorkerTypePrefill].Resources,
+		"ENGINE_PREFILL_IMAGE":               workersMap[workload.ModelWorkerTypePrefill].Image,
+		"SCHEDULER_NAME":                     backend.SchedulerName,
+		"RUNTIME_CLASS_NAME":                 backend.RuntimeClassName,
+	}
+	return loadModelServingTemplate(SGLangDisaggregatedTemplatePath, &data)
+}
+
+// buildSGLangCommands builds the SGLang launch command. A non-empty role
+// ("prefill"/"decode") appends disaggregation flags.
+func buildSGLangCommands(workerConfig *apiextensionsv1.JSON, modelDownloadPath string, role string) ([]string, error) {
+	commands := []string{
+		"python3", "-m", "sglang.launch_server",
+		"--model-path", modelDownloadPath,
+		"--host", "0.0.0.0",
+		"--port", "30000",
+		"--enable-metrics",
+	}
+	if role == "prefill" || role == "decode" {
+		commands = append(commands,
+			"--disaggregation-mode", role,
+			"--disaggregation-transfer-backend", "mooncake",
+		)
+	}
+	args, err := utils.ConvertEngineArgsFromJson(workerConfig)
+	if err != nil {
+		return nil, err
+	}
+	commands = append(commands, args...)
+	return commands, nil
+}
+
+// buildModelDownloaderInitContainers builds the shared model-downloader init container.
+func buildModelDownloaderInitContainers(model *workload.ModelBooster, backend *workload.ModelBackend, cacheVolume *corev1.Volume, modelDownloadPath string) []corev1.Container {
+	var envVars []corev1.EnvVar
+	endpointEnvVars := env.GetEnvValueOrDefault[[]corev1.EnvVar](backend, env.Endpoint, []corev1.EnvVar{
+		{Name: env.Endpoint},
+	})
+	if len(endpointEnvVars) > 0 && endpointEnvVars[0].Value != "" {
+		envVars = append(envVars, endpointEnvVars[0])
+	}
+	hfEndpointEnvVars := env.GetEnvValueOrDefault[[]corev1.EnvVar](backend, env.HfEndpoint, []corev1.EnvVar{
+		{Name: env.HfEndpoint},
+	})
+	if len(hfEndpointEnvVars) > 0 && hfEndpointEnvVars[0].Value != "" {
+		envVars = append(envVars, hfEndpointEnvVars[0])
+	}
+	msTokenEnvVars := env.GetEnvValueOrDefault[[]corev1.EnvVar](backend, env.MsToken, []corev1.EnvVar{
+		{Name: env.MsToken},
+	})
+	if len(msTokenEnvVars) > 0 && msTokenEnvVars[0].Value != "" {
+		envVars = append(envVars, msTokenEnvVars[0])
+	}
+	msRevisionEnvVars := env.GetEnvValueOrDefault[[]corev1.EnvVar](backend, env.MsRevision, []corev1.EnvVar{
+		{Name: env.MsRevision},
+	})
+	if len(msRevisionEnvVars) > 0 && msRevisionEnvVars[0].Value != "" {
+		envVars = append(envVars, msRevisionEnvVars[0])
+	}
+	return []corev1.Container{
+		{
+			Name:  model.Name + "-model-downloader",
+			Image: config.Config.DownloaderImage(),
+			Args: []string{
+				"--source", backend.ModelURI,
+				"--output-dir", modelDownloadPath,
+			},
+			Env:     envVars,
+			EnvFrom: backend.EnvFrom,
+			VolumeMounts: []corev1.VolumeMount{{
+				Name:      cacheVolume.Name,
+				MountPath: GetCachePath(backend.CacheURI),
+			}},
+		},
+	}
+}
+
 // mapWorkers creates a map of workers by type.
 func mapWorkers(workers []workload.ModelWorker) map[workload.ModelWorkerType]*workload.ModelWorker {
 	workersMap := make(map[workload.ModelWorkerType]*workload.ModelWorker, len(workers))
@@ -339,7 +584,7 @@ func mapWorkers(workers []workload.ModelWorker) map[workload.ModelWorkerType]*wo
 func buildCommands(backend *workload.ModelBackend, workerConfig *apiextensionsv1.JSON, modelDownloadPath string,
 	workersMap map[workload.ModelWorkerType]*workload.ModelWorker) ([]string, error) {
 	commands := []string{"python3", "-m", "vllm.entrypoints.openai.api_server", "--model", modelDownloadPath}
-	args, err := utils.ConvertVLLMArgsFromJson(workerConfig)
+	args, err := utils.ConvertEngineArgsFromJson(workerConfig)
 	commands = append(commands, args...)
 	if workersMap[workload.ModelWorkerTypeServer] != nil && workersMap[workload.ModelWorkerTypeServer].Pods > 1 {
 		commands = append(commands, "--distributed_executor_backend", "ray")
@@ -514,7 +759,12 @@ func buildEngineEnvVars(backend *workload.ModelBackend, additionalEnvs ...corev1
 				FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"},
 			},
 		},
-		{Name: "VLLM_USE_V1", Value: "1"},
+	}
+	if backend.Type == workload.ModelBackendTypeVLLM ||
+		backend.Type == workload.ModelBackendTypeVLLMDisaggregated {
+		standardEnvs = append(standardEnvs, corev1.EnvVar{Name: "VLLM_USE_V1", Value: "1"})
+	}
+	standardEnvs = append(standardEnvs, []corev1.EnvVar{
 		{
 			Name: "REDIS_HOST",
 			ValueFrom: &corev1.EnvVarSource{
@@ -545,6 +795,6 @@ func buildEngineEnvVars(backend *workload.ModelBackend, additionalEnvs ...corev1
 				},
 			},
 		},
-	}
+	}...)
 	return append(append(append([]corev1.EnvVar(nil), backend.Env...), standardEnvs...), additionalEnvs...)
 }

--- a/pkg/model-booster-controller/convert/model_serving.go
+++ b/pkg/model-booster-controller/convert/model_serving.go
@@ -198,7 +198,7 @@ func buildVllmDisaggregatedModelServing(model *workload.ModelBooster) (*workload
 		"MODEL_SERVING_RUNTIME_METRICS_PATH": env.GetEnvValueOrDefault[string](backend, env.RuntimeMetricsPath, "/metrics"),
 		"ENGINE_PREFILL_ENV":                 prefillEngineEnv,
 		"ENGINE_DECODE_ENV":                  decodeEngineEnv,
-		"MODEL_SERVING_RUNTIME_ENGINE":       strings.ToLower(string(backend.Type)),
+		"MODEL_SERVING_RUNTIME_ENGINE":       runtimeEngineName(backend.Type),
 		"MODEL_SERVING_RUNTIME_POD":          "$(POD_NAME).$(NAMESPACE)",
 		"PREFILL_REPLICAS":                   workersMap[workload.ModelWorkerTypePrefill].Replicas,
 		"DECODE_REPLICAS":                    workersMap[workload.ModelWorkerTypeDecode].Replicas,
@@ -230,48 +230,7 @@ func buildVllmModelServing(model *workload.ModelBooster) (*workload.ModelServing
 		return nil, err
 	}
 
-	// Build an initial container list including model downloader container
-	var envVars []corev1.EnvVar
-	endpointEnvVars := env.GetEnvValueOrDefault[[]corev1.EnvVar](backend, env.Endpoint, []corev1.EnvVar{
-		{Name: env.Endpoint},
-	})
-	if len(endpointEnvVars) > 0 && endpointEnvVars[0].Value != "" {
-		envVars = append(envVars, endpointEnvVars[0])
-	}
-	hfEndpointEnvVars := env.GetEnvValueOrDefault[[]corev1.EnvVar](backend, env.HfEndpoint, []corev1.EnvVar{
-		{Name: env.HfEndpoint},
-	})
-	if len(hfEndpointEnvVars) > 0 && hfEndpointEnvVars[0].Value != "" {
-		envVars = append(envVars, hfEndpointEnvVars[0])
-	}
-	msTokenEnvVars := env.GetEnvValueOrDefault[[]corev1.EnvVar](backend, env.MsToken, []corev1.EnvVar{
-		{Name: env.MsToken},
-	})
-	if len(msTokenEnvVars) > 0 && msTokenEnvVars[0].Value != "" {
-		envVars = append(envVars, msTokenEnvVars[0])
-	}
-	msRevisionEnvVars := env.GetEnvValueOrDefault[[]corev1.EnvVar](backend, env.MsRevision, []corev1.EnvVar{
-		{Name: env.MsRevision},
-	})
-	if len(msRevisionEnvVars) > 0 && msRevisionEnvVars[0].Value != "" {
-		envVars = append(envVars, msRevisionEnvVars[0])
-	}
-	initContainers := []corev1.Container{
-		{
-			Name:  model.Name + "-model-downloader",
-			Image: config.Config.DownloaderImage(),
-			Args: []string{
-				"--source", backend.ModelURI,
-				"--output-dir", modelDownloadPath,
-			},
-			Env:     envVars,
-			EnvFrom: backend.EnvFrom,
-			VolumeMounts: []corev1.VolumeMount{{
-				Name:      cacheVolume.Name,
-				MountPath: GetCachePath(backend.CacheURI),
-			}},
-		},
-	}
+	initContainers := buildModelDownloaderInitContainers(model, backend, cacheVolume, modelDownloadPath)
 
 	engineEnv := buildEngineEnvVars(backend)
 	data := map[string]interface{}{
@@ -320,7 +279,7 @@ func buildVllmModelServing(model *workload.ModelBooster) (*workload.ModelServing
 		"MODEL_SERVING_RUNTIME_PORT":         env.GetEnvValueOrDefault[int32](backend, env.RuntimePort, 8100),
 		"MODEL_SERVING_RUNTIME_URL":          env.GetEnvValueOrDefault[string](backend, env.RuntimeUrl, "http://localhost:8000"),
 		"MODEL_SERVING_RUNTIME_METRICS_PATH": env.GetEnvValueOrDefault[string](backend, env.RuntimeMetricsPath, "/metrics"),
-		"MODEL_SERVING_RUNTIME_ENGINE":       strings.ToLower(string(backend.Type)),
+		"MODEL_SERVING_RUNTIME_ENGINE":       runtimeEngineName(backend.Type),
 		"MODEL_SERVING_RUNTIME_POD":          "$(POD_NAME).$(NAMESPACE)",
 		"ENGINE_SERVER_RESOURCES":            workersMap[workload.ModelWorkerTypeServer].Resources,
 		"ENGINE_SERVER_IMAGE":                workersMap[workload.ModelWorkerTypeServer].Image,
@@ -400,7 +359,7 @@ func buildSGLangModelServing(model *workload.ModelBooster) (*workload.ModelServi
 		"MODEL_SERVING_RUNTIME_PORT":         env.GetEnvValueOrDefault[int32](backend, env.RuntimePort, 8100),
 		"MODEL_SERVING_RUNTIME_URL":          env.GetEnvValueOrDefault[string](backend, env.RuntimeUrl, "http://localhost:30000"),
 		"MODEL_SERVING_RUNTIME_METRICS_PATH": env.GetEnvValueOrDefault[string](backend, env.RuntimeMetricsPath, "/metrics"),
-		"MODEL_SERVING_RUNTIME_ENGINE":       strings.ToLower(string(backend.Type)),
+		"MODEL_SERVING_RUNTIME_ENGINE":       runtimeEngineName(backend.Type),
 		"MODEL_SERVING_RUNTIME_POD":          "$(POD_NAME).$(NAMESPACE)",
 		"ENGINE_SERVER_RESOURCES":            workersMap[workload.ModelWorkerTypeServer].Resources,
 		"ENGINE_SERVER_IMAGE":                workersMap[workload.ModelWorkerTypeServer].Image,
@@ -469,9 +428,20 @@ func buildSGLangDisaggregatedModelServing(model *workload.ModelBooster) (*worklo
 		"VOLUME_MOUNTS": []corev1.VolumeMount{{
 			Name:      cacheVolume.Name,
 			MountPath: GetCachePath(backend.CacheURI),
+		}, {
+			Name:      dshm,
+			MountPath: "/dev/shm",
 		}},
 		"VOLUMES": []*corev1.Volume{
 			cacheVolume,
+			{
+				Name: dshm,
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{
+						Medium: corev1.StorageMediumMemory,
+					},
+				},
+			},
 		},
 		"MODEL_NAME":             model.Name,
 		"BACKEND_REPLICAS":       backend.MinReplicas,
@@ -488,7 +458,7 @@ func buildSGLangDisaggregatedModelServing(model *workload.ModelBooster) (*worklo
 		"MODEL_SERVING_RUNTIME_METRICS_PATH": env.GetEnvValueOrDefault[string](backend, env.RuntimeMetricsPath, "/metrics"),
 		"ENGINE_PREFILL_ENV":                 prefillEngineEnv,
 		"ENGINE_DECODE_ENV":                  decodeEngineEnv,
-		"MODEL_SERVING_RUNTIME_ENGINE":       strings.ToLower(string(backend.Type)),
+		"MODEL_SERVING_RUNTIME_ENGINE":       runtimeEngineName(backend.Type),
 		"MODEL_SERVING_RUNTIME_POD":          "$(POD_NAME).$(NAMESPACE)",
 		"PREFILL_REPLICAS":                   workersMap[workload.ModelWorkerTypePrefill].Replicas,
 		"DECODE_REPLICAS":                    workersMap[workload.ModelWorkerTypeDecode].Replicas,
@@ -503,7 +473,9 @@ func buildSGLangDisaggregatedModelServing(model *workload.ModelBooster) (*worklo
 }
 
 // buildSGLangCommands builds the SGLang launch command. A non-empty role
-// ("prefill"/"decode") appends disaggregation flags.
+// ("prefill"/"decode") appends disaggregation flags. The default transfer
+// backend is omitted when the user already supplied one in worker.Config,
+// so the rendered command never contains duplicate flags.
 func buildSGLangCommands(workerConfig *apiextensionsv1.JSON, modelDownloadPath string, role string) ([]string, error) {
 	commands := []string{
 		"python3", "-m", "sglang.launch_server",
@@ -513,10 +485,14 @@ func buildSGLangCommands(workerConfig *apiextensionsv1.JSON, modelDownloadPath s
 		"--enable-metrics",
 	}
 	if role == "prefill" || role == "decode" {
-		commands = append(commands,
-			"--disaggregation-mode", role,
-			"--disaggregation-transfer-backend", "mooncake",
-		)
+		commands = append(commands, "--disaggregation-mode", role)
+		userSetTransferBackend, err := workerConfigHasKey(workerConfig, "disaggregation-transfer-backend")
+		if err != nil {
+			return nil, err
+		}
+		if !userSetTransferBackend {
+			commands = append(commands, "--disaggregation-transfer-backend", "mooncake")
+		}
 	}
 	args, err := utils.ConvertEngineArgsFromJson(workerConfig)
 	if err != nil {
@@ -524,6 +500,34 @@ func buildSGLangCommands(workerConfig *apiextensionsv1.JSON, modelDownloadPath s
 	}
 	commands = append(commands, args...)
 	return commands, nil
+}
+
+func runtimeEngineName(backendType workload.ModelBackendType) string {
+	switch backendType {
+	case workload.ModelBackendTypeSGLang, workload.ModelBackendTypeSGLangDisaggregated:
+		return "sglang"
+	default:
+		return strings.ToLower(string(backendType))
+	}
+}
+
+// workerConfigHasKey reports whether worker.Config contains the given flag
+// after normalizing keys to dash form (the same normalization performed by
+// ConvertEngineArgsFromJson and the SGLang reserved-flag validator).
+func workerConfigHasKey(workerConfig *apiextensionsv1.JSON, normalizedKey string) (bool, error) {
+	if workerConfig == nil || workerConfig.Raw == nil {
+		return false, nil
+	}
+	var configMap map[string]interface{}
+	if err := json.Unmarshal(workerConfig.Raw, &configMap); err != nil {
+		return false, fmt.Errorf("failed to unmarshal worker config: %w", err)
+	}
+	for k := range configMap {
+		if strings.ReplaceAll(k, "_", "-") == normalizedKey {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // buildModelDownloaderInitContainers builds the shared model-downloader init container.

--- a/pkg/model-booster-controller/convert/model_serving_test.go
+++ b/pkg/model-booster-controller/convert/model_serving_test.go
@@ -170,6 +170,16 @@ func TestCreateModelServingResources(t *testing.T) {
 			expected: loadYaml[workload.ModelServing](t, "testdata/expected/disaggregated-model-serving-mooncake.yaml"),
 		},
 		{
+			name:     "SGLang aggregated",
+			input:    loadYaml[workload.ModelBooster](t, "testdata/input/sglang-aggregated-model.yaml"),
+			expected: loadYaml[workload.ModelServing](t, "testdata/expected/sglang-aggregated-model-serving.yaml"),
+		},
+		{
+			name:     "SGLang disaggregated",
+			input:    loadYaml[workload.ModelBooster](t, "testdata/input/sglang-disaggregated-model.yaml"),
+			expected: loadYaml[workload.ModelServing](t, "testdata/expected/sglang-disaggregated-model-serving.yaml"),
+		},
+		{
 			name:  "vLLM with runtimeClassName",
 			input: loadYaml[workload.ModelBooster](t, "testdata/input/model-with-runtimeclass.yaml"),
 			checkFn: func(t *testing.T, got *workload.ModelServing) {
@@ -274,6 +284,112 @@ func TestBuildModelServingSkipEngineDependencyInstall(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBuildSGLangModelServing(t *testing.T) {
+	model := loadYaml[workload.ModelBooster](t, "testdata/input/sglang-aggregated-model.yaml")
+	serving, err := BuildModelServing(model)
+	assert.NoError(t, err)
+	assert.NotNil(t, serving)
+	assert.Len(t, serving.Spec.Template.Roles, 1, "aggregated SGLang produces a single 'leader' role")
+
+	role := serving.Spec.Template.Roles[0]
+	assert.Equal(t, "leader", role.Name)
+	assert.Equal(t, int32(0), role.WorkerReplicas)
+
+	containers := role.EntryTemplate.Spec.Containers
+	assert.Len(t, containers, 2, "expected runtime sidecar + engine container")
+
+	var engine *corev1.Container
+	for i := range containers {
+		if containers[i].Name == "engine" {
+			engine = &containers[i]
+			break
+		}
+	}
+	assert.NotNil(t, engine, "engine container must be present")
+	if engine == nil {
+		return
+	}
+	command := strings.Join(engine.Command, " ")
+	assert.Contains(t, command, "sglang.launch_server")
+	// Bind 0.0.0.0 so the runtime sidecar and preStop drain can reach the
+	// engine on localhost:30000.
+	assert.Contains(t, command, "--host 0.0.0.0")
+	assert.NotContains(t, command, "$(POD_IP)")
+	assert.Contains(t, command, "--port 30000")
+	assert.Contains(t, command, "--enable-metrics")
+	assert.Contains(t, command, "--mem-fraction-static 0.85")
+	assert.NotContains(t, command, "VLLM_USE_V1")
+
+	for _, e := range engine.Env {
+		assert.NotEqual(t, "POD_IP", e.Name, "POD_IP env is unused once SGLang binds 0.0.0.0")
+		assert.NotEqual(t, "VLLM_USE_V1", e.Name)
+	}
+}
+
+func TestBuildSGLangDisaggregatedModelServing(t *testing.T) {
+	model := loadYaml[workload.ModelBooster](t, "testdata/input/sglang-disaggregated-model.yaml")
+	serving, err := BuildModelServing(model)
+	assert.NoError(t, err)
+	assert.NotNil(t, serving)
+	assert.Len(t, serving.Spec.Template.Roles, 2)
+
+	roleByName := map[string]*workload.Role{}
+	for i, r := range serving.Spec.Template.Roles {
+		roleByName[r.Name] = &serving.Spec.Template.Roles[i]
+	}
+	for _, expectedRole := range []string{"prefill", "decode"} {
+		r, ok := roleByName[expectedRole]
+		assert.True(t, ok, "role %q not found", expectedRole)
+		if !ok {
+			continue
+		}
+		var engine *corev1.Container
+		for i := range r.EntryTemplate.Spec.Containers {
+			if r.EntryTemplate.Spec.Containers[i].Name == "sglang" {
+				engine = &r.EntryTemplate.Spec.Containers[i]
+				break
+			}
+		}
+		assert.NotNil(t, engine, "role %q must have an sglang engine container", expectedRole)
+		if engine == nil {
+			continue
+		}
+		command := strings.Join(engine.Command, " ")
+		assert.Contains(t, command, "--disaggregation-mode "+expectedRole)
+		assert.Contains(t, command, "--disaggregation-transfer-backend mooncake")
+		assert.Contains(t, command, "--host 0.0.0.0")
+		assert.NotContains(t, command, "$(POD_IP)")
+
+		for _, e := range engine.Env {
+			assert.NotEqual(t, "POD_IP", e.Name, "role %q: POD_IP env is unused once SGLang binds 0.0.0.0", expectedRole)
+		}
+	}
+}
+
+func TestBuildSGLangModelServerRouting(t *testing.T) {
+	model := loadYaml[workload.ModelBooster](t, "testdata/input/sglang-aggregated-model.yaml")
+	servers, err := BuildModelServer(model)
+	assert.NoError(t, err)
+	assert.Len(t, servers, 1)
+	spec := servers[0].Spec
+	assert.Equal(t, "SGLang", string(spec.InferenceEngine))
+	assert.Equal(t, int32(30000), spec.WorkloadPort.Port)
+	assert.Nil(t, spec.KVConnector)
+	assert.Nil(t, spec.WorkloadSelector.PDGroup)
+}
+
+func TestBuildSGLangDisaggregatedModelServerRouting(t *testing.T) {
+	model := loadYaml[workload.ModelBooster](t, "testdata/input/sglang-disaggregated-model.yaml")
+	servers, err := BuildModelServer(model)
+	assert.NoError(t, err)
+	assert.Len(t, servers, 1)
+	spec := servers[0].Spec
+	assert.Equal(t, "SGLang", string(spec.InferenceEngine))
+	assert.Equal(t, int32(30000), spec.WorkloadPort.Port)
+	assert.Nil(t, spec.KVConnector)
+	assert.NotNil(t, spec.WorkloadSelector.PDGroup)
 }
 
 func TestBuildCacheVolume(t *testing.T) {

--- a/pkg/model-booster-controller/convert/model_serving_test.go
+++ b/pkg/model-booster-controller/convert/model_serving_test.go
@@ -25,6 +25,7 @@ import (
 	workload "github.com/volcano-sh/kthena/pkg/apis/workload/v1alpha1"
 	"github.com/volcano-sh/kthena/pkg/model-booster-controller/env"
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/utils/ptr"
 )
 
@@ -345,14 +346,24 @@ func TestBuildSGLangDisaggregatedModelServing(t *testing.T) {
 		if !ok {
 			continue
 		}
-		var engine *corev1.Container
+		var engine, runtime *corev1.Container
 		for i := range r.EntryTemplate.Spec.Containers {
-			if r.EntryTemplate.Spec.Containers[i].Name == "sglang" {
+			switch r.EntryTemplate.Spec.Containers[i].Name {
+			case "engine":
 				engine = &r.EntryTemplate.Spec.Containers[i]
-				break
+			case "runtime":
+				runtime = &r.EntryTemplate.Spec.Containers[i]
 			}
 		}
-		assert.NotNil(t, engine, "role %q must have an sglang engine container", expectedRole)
+		assert.NotNil(t, engine, "role %q must have an engine container", expectedRole)
+		assert.NotNil(t, runtime, "role %q must have a runtime sidecar", expectedRole)
+		if runtime != nil {
+			args := strings.Join(runtime.Args, " ")
+			assert.Contains(t, args, "--engine sglang",
+				"role %q runtime sidecar must receive --engine sglang (the runtime rejects 'sglangdisaggregated')", expectedRole)
+			assert.NotContains(t, args, "sglangdisaggregated",
+				"role %q runtime sidecar must not receive 'sglangdisaggregated'", expectedRole)
+		}
 		if engine == nil {
 			continue
 		}
@@ -365,6 +376,22 @@ func TestBuildSGLangDisaggregatedModelServing(t *testing.T) {
 		for _, e := range engine.Env {
 			assert.NotEqual(t, "POD_IP", e.Name, "role %q: POD_IP env is unused once SGLang binds 0.0.0.0", expectedRole)
 		}
+
+		assert.NotNil(t, engine.Lifecycle, "role %q engine must have a preStop drain hook", expectedRole)
+		if engine.Lifecycle != nil && engine.Lifecycle.PreStop != nil {
+			drain := strings.Join(engine.Lifecycle.PreStop.Exec.Command, " ")
+			assert.Contains(t, drain, "sglang:num_running_reqs", "role %q drain must inspect SGLang metrics", expectedRole)
+		}
+		hasDshm := false
+		for _, vm := range engine.VolumeMounts {
+			if vm.MountPath == "/dev/shm" {
+				hasDshm = true
+			}
+		}
+		assert.True(t, hasDshm, "role %q engine must mount a memory-backed /dev/shm", expectedRole)
+
+		assert.NotNil(t, r.EntryTemplate.Spec.TerminationGracePeriodSeconds,
+			"role %q must set terminationGracePeriodSeconds to bound the drain", expectedRole)
 	}
 }
 
@@ -390,6 +417,41 @@ func TestBuildSGLangDisaggregatedModelServerRouting(t *testing.T) {
 	assert.Equal(t, int32(30000), spec.WorkloadPort.Port)
 	assert.Nil(t, spec.KVConnector)
 	assert.NotNil(t, spec.WorkloadSelector.PDGroup)
+}
+
+func TestBuildSGLangCommandsTransferBackendDedup(t *testing.T) {
+	cases := []struct {
+		name   string
+		config string
+		want   string
+	}{
+		{"dash form", `{"disaggregation-transfer-backend":"nixl"}`, "nixl"},
+		{"underscore form", `{"disaggregation_transfer_backend":"nixl"}`, "nixl"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &apiextensionsv1.JSON{Raw: []byte(tc.config)}
+			cmd, err := buildSGLangCommands(cfg, "/tmp/model", "prefill")
+			assert.NoError(t, err)
+			occurrences := 0
+			for i, tok := range cmd {
+				if tok == "--disaggregation-transfer-backend" {
+					occurrences++
+					if i+1 < len(cmd) {
+						assert.Equal(t, tc.want, cmd[i+1])
+					}
+				}
+			}
+			assert.Equal(t, 1, occurrences,
+				"--disaggregation-transfer-backend must appear exactly once, got %v", cmd)
+		})
+	}
+
+	t.Run("default applied when user did not set it", func(t *testing.T) {
+		cmd, err := buildSGLangCommands(nil, "/tmp/model", "decode")
+		assert.NoError(t, err)
+		assert.Contains(t, strings.Join(cmd, " "), "--disaggregation-transfer-backend mooncake")
+	})
 }
 
 func TestBuildCacheVolume(t *testing.T) {

--- a/pkg/model-booster-controller/convert/templates/sglang-pd.yaml
+++ b/pkg/model-booster-controller/convert/templates/sglang-pd.yaml
@@ -18,12 +18,15 @@ spec:
           spec:
             runtimeClassName: ${RUNTIME_CLASS_NAME}
             initContainers: ${INIT_CONTAINERS}
+            terminationGracePeriodSeconds: 300
+            volumes: ${VOLUMES}
             containers:
               - name: runtime
                 image: ${MODEL_SERVING_RUNTIME_IMAGE}
                 ports:
                   - containerPort: ${MODEL_SERVING_RUNTIME_PORT}
                 env: ${ENGINE_PREFILL_ENV}
+                envFrom: ${MODEL_DOWNLOAD_ENVFROM}
                 args:
                   - --port
                   - ${MODEL_SERVING_RUNTIME_PORT}
@@ -37,7 +40,13 @@ spec:
                   - ${MODEL_SERVING_RUNTIME_POD}
                   - --model
                   - ${MODEL_NAME}
-              - name: sglang
+                readinessProbe:
+                  httpGet:
+                    path: /health
+                    port: ${MODEL_SERVING_RUNTIME_PORT}
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+              - name: engine
                 image: ${ENGINE_PREFILL_IMAGE}
                 ports:
                   - containerPort: 30000
@@ -45,6 +54,7 @@ spec:
                 command: ${ENGINE_PREFILL_COMMAND}
                 imagePullPolicy: IfNotPresent
                 resources: ${ENGINE_PREFILL_RESOURCES}
+                volumeMounts: ${VOLUME_MOUNTS}
                 readinessProbe:
                   initialDelaySeconds: 180
                   periodSeconds: 5
@@ -59,8 +69,30 @@ spec:
                   httpGet:
                     path: /health
                     port: 30000
-                volumeMounts: ${VOLUME_MOUNTS}
-            volumes: ${VOLUMES}
+                lifecycle:
+                  preStop:
+                    exec:
+                      command:
+                        - /bin/sh
+                        - -c
+                        - |
+                          # Drain in-flight requests, bounded so it cannot exceed terminationGracePeriodSeconds.
+                          i=0
+                          while [ $i -lt 60 ]; do
+                            METRICS=$(curl -sf http://localhost:30000/metrics 2>/dev/null) || {
+                              echo "Terminating: metrics endpoint unreachable, engine already stopping" >> /proc/1/fd/1
+                              exit 0
+                            }
+                            PENDING=$(echo "$METRICS" | awk '/^sglang:num_running_reqs/ || /^sglang:num_queue_reqs/ {s+=$2} END {printf "%d", s+0}')
+                            if [ "$PENDING" -le 0 ]; then
+                              echo "Terminating: drained, no active or waiting requests" >> /proc/1/fd/1
+                              exit 0
+                            fi
+                            echo "Terminating: $PENDING in-flight requests, waiting" >> /proc/1/fd/1
+                            i=$((i+1))
+                            sleep 5
+                          done
+                          echo "Terminating: drain deadline reached, proceeding" >> /proc/1/fd/1
         workerReplicas: 0
         workerTemplate:
           spec:
@@ -72,6 +104,8 @@ spec:
           spec:
             runtimeClassName: ${RUNTIME_CLASS_NAME}
             initContainers: ${INIT_CONTAINERS}
+            terminationGracePeriodSeconds: 300
+            volumes: ${VOLUMES}
             containers:
               - name: runtime
                 image: ${MODEL_SERVING_RUNTIME_IMAGE}
@@ -92,7 +126,13 @@ spec:
                   - ${MODEL_SERVING_RUNTIME_POD}
                   - --model
                   - ${MODEL_NAME}
-              - name: sglang
+                readinessProbe:
+                  httpGet:
+                    path: /health
+                    port: ${MODEL_SERVING_RUNTIME_PORT}
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+              - name: engine
                 image: ${ENGINE_DECODE_IMAGE}
                 ports:
                   - containerPort: 30000
@@ -100,6 +140,7 @@ spec:
                 command: ${ENGINE_DECODE_COMMAND}
                 imagePullPolicy: IfNotPresent
                 resources: ${ENGINE_DECODE_RESOURCES}
+                volumeMounts: ${VOLUME_MOUNTS}
                 readinessProbe:
                   initialDelaySeconds: 180
                   periodSeconds: 5
@@ -114,8 +155,30 @@ spec:
                   httpGet:
                     path: /health
                     port: 30000
-                volumeMounts: ${VOLUME_MOUNTS}
-            volumes: ${VOLUMES}
+                lifecycle:
+                  preStop:
+                    exec:
+                      command:
+                        - /bin/sh
+                        - -c
+                        - |
+                          # Drain in-flight requests, bounded so it cannot exceed terminationGracePeriodSeconds.
+                          i=0
+                          while [ $i -lt 60 ]; do
+                            METRICS=$(curl -sf http://localhost:30000/metrics 2>/dev/null) || {
+                              echo "Terminating: metrics endpoint unreachable, engine already stopping" >> /proc/1/fd/1
+                              exit 0
+                            }
+                            PENDING=$(echo "$METRICS" | awk '/^sglang:num_running_reqs/ || /^sglang:num_queue_reqs/ {s+=$2} END {printf "%d", s+0}')
+                            if [ "$PENDING" -le 0 ]; then
+                              echo "Terminating: drained, no active or waiting requests" >> /proc/1/fd/1
+                              exit 0
+                            fi
+                            echo "Terminating: $PENDING in-flight requests, waiting" >> /proc/1/fd/1
+                            i=$((i+1))
+                            sleep 5
+                          done
+                          echo "Terminating: drain deadline reached, proceeding" >> /proc/1/fd/1
         workerReplicas: 0
         workerTemplate:
           spec:

--- a/pkg/model-booster-controller/convert/templates/sglang-pd.yaml
+++ b/pkg/model-booster-controller/convert/templates/sglang-pd.yaml
@@ -1,0 +1,122 @@
+apiVersion: workload.serving.volcano.sh/v1alpha1
+kind: ModelServing
+metadata: ${MODEL_SERVING_TEMPLATE_METADATA}
+spec:
+  schedulerName: ${SCHEDULER_NAME}
+  replicas: ${BACKEND_REPLICAS}
+  template:
+    restartGracePeriodSeconds: 60
+    gangPolicy:
+      minRoleReplicas:
+        prefill: ${PREFILL_REPLICAS}
+        decode: ${DECODE_REPLICAS}
+    roles:
+      - name: prefill
+        replicas: ${PREFILL_REPLICAS}
+        entryTemplate:
+          metadata: ${SERVER_ENTRY_TEMPLATE_METADATA}
+          spec:
+            runtimeClassName: ${RUNTIME_CLASS_NAME}
+            initContainers: ${INIT_CONTAINERS}
+            containers:
+              - name: runtime
+                image: ${MODEL_SERVING_RUNTIME_IMAGE}
+                ports:
+                  - containerPort: ${MODEL_SERVING_RUNTIME_PORT}
+                env: ${ENGINE_PREFILL_ENV}
+                args:
+                  - --port
+                  - ${MODEL_SERVING_RUNTIME_PORT}
+                  - --engine
+                  - ${MODEL_SERVING_RUNTIME_ENGINE}
+                  - --engine-base-url
+                  - ${MODEL_SERVING_RUNTIME_URL}
+                  - --engine-metrics-path
+                  - ${MODEL_SERVING_RUNTIME_METRICS_PATH}
+                  - --pod
+                  - ${MODEL_SERVING_RUNTIME_POD}
+                  - --model
+                  - ${MODEL_NAME}
+              - name: sglang
+                image: ${ENGINE_PREFILL_IMAGE}
+                ports:
+                  - containerPort: 30000
+                env: ${ENGINE_PREFILL_ENV}
+                command: ${ENGINE_PREFILL_COMMAND}
+                imagePullPolicy: IfNotPresent
+                resources: ${ENGINE_PREFILL_RESOURCES}
+                readinessProbe:
+                  initialDelaySeconds: 180
+                  periodSeconds: 5
+                  failureThreshold: 3
+                  httpGet:
+                    path: /health
+                    port: 30000
+                livenessProbe:
+                  initialDelaySeconds: 300
+                  periodSeconds: 15
+                  failureThreshold: 3
+                  httpGet:
+                    path: /health
+                    port: 30000
+                volumeMounts: ${VOLUME_MOUNTS}
+            volumes: ${VOLUMES}
+        workerReplicas: 0
+        workerTemplate:
+          spec:
+            containers: []
+      - name: decode
+        replicas: ${DECODE_REPLICAS}
+        entryTemplate:
+          metadata: ${SERVER_ENTRY_TEMPLATE_METADATA}
+          spec:
+            runtimeClassName: ${RUNTIME_CLASS_NAME}
+            initContainers: ${INIT_CONTAINERS}
+            containers:
+              - name: runtime
+                image: ${MODEL_SERVING_RUNTIME_IMAGE}
+                ports:
+                  - containerPort: ${MODEL_SERVING_RUNTIME_PORT}
+                env: ${ENGINE_DECODE_ENV}
+                envFrom: ${MODEL_DOWNLOAD_ENVFROM}
+                args:
+                  - --port
+                  - ${MODEL_SERVING_RUNTIME_PORT}
+                  - --engine
+                  - ${MODEL_SERVING_RUNTIME_ENGINE}
+                  - --engine-base-url
+                  - ${MODEL_SERVING_RUNTIME_URL}
+                  - --engine-metrics-path
+                  - ${MODEL_SERVING_RUNTIME_METRICS_PATH}
+                  - --pod
+                  - ${MODEL_SERVING_RUNTIME_POD}
+                  - --model
+                  - ${MODEL_NAME}
+              - name: sglang
+                image: ${ENGINE_DECODE_IMAGE}
+                ports:
+                  - containerPort: 30000
+                env: ${ENGINE_DECODE_ENV}
+                command: ${ENGINE_DECODE_COMMAND}
+                imagePullPolicy: IfNotPresent
+                resources: ${ENGINE_DECODE_RESOURCES}
+                readinessProbe:
+                  initialDelaySeconds: 180
+                  periodSeconds: 5
+                  failureThreshold: 3
+                  httpGet:
+                    path: /health
+                    port: 30000
+                livenessProbe:
+                  initialDelaySeconds: 300
+                  periodSeconds: 15
+                  failureThreshold: 3
+                  httpGet:
+                    path: /health
+                    port: 30000
+                volumeMounts: ${VOLUME_MOUNTS}
+            volumes: ${VOLUMES}
+        workerReplicas: 0
+        workerTemplate:
+          spec:
+            containers: []

--- a/pkg/model-booster-controller/convert/templates/sglang.yaml
+++ b/pkg/model-booster-controller/convert/templates/sglang.yaml
@@ -1,0 +1,105 @@
+apiVersion: workload.serving.volcano.sh/v1alpha1
+kind: ModelServing
+metadata: ${MODEL_SERVING_TEMPLATE_METADATA}
+spec:
+  schedulerName: ${SCHEDULER_NAME}
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: DoNotSchedule
+      labelSelector:
+        matchLabels:
+          modelserving.volcano.sh/name: ${MODEL_NAME}
+  replicas: ${BACKEND_REPLICAS}
+  template:
+    restartGracePeriodSeconds: 60
+    gangPolicy:
+      minRoleReplicas:
+        leader: ${SERVER_REPLICAS}
+    roles:
+      - name: leader
+        replicas: ${SERVER_REPLICAS}
+        entryTemplate:
+          metadata: ${SERVER_ENTRY_TEMPLATE_METADATA}
+          spec:
+            runtimeClassName: ${RUNTIME_CLASS_NAME}
+            initContainers: ${INIT_CONTAINERS}
+            terminationGracePeriodSeconds: 300
+            volumes: ${VOLUMES}
+            containers:
+              - name: runtime
+                image: ${MODEL_SERVING_RUNTIME_IMAGE}
+                ports:
+                  - containerPort: ${MODEL_SERVING_RUNTIME_PORT}
+                env: ${ENGINE_ENV}
+                envFrom: ${MODEL_DOWNLOAD_ENVFROM}
+                args:
+                  - --port
+                  - ${MODEL_SERVING_RUNTIME_PORT}
+                  - --engine
+                  - ${MODEL_SERVING_RUNTIME_ENGINE}
+                  - --engine-base-url
+                  - ${MODEL_SERVING_RUNTIME_URL}
+                  - --engine-metrics-path
+                  - ${MODEL_SERVING_RUNTIME_METRICS_PATH}
+                  - --pod
+                  - ${MODEL_SERVING_RUNTIME_POD}
+                  - --model
+                  - ${MODEL_NAME}
+                readinessProbe:
+                  httpGet:
+                    path: /health
+                    port: ${MODEL_SERVING_RUNTIME_PORT}
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+              - name: engine
+                image: ${ENGINE_SERVER_IMAGE}
+                command: ${ENGINE_SERVER_COMMAND}
+                env: ${ENGINE_ENV}
+                resources: ${ENGINE_SERVER_RESOURCES}
+                volumeMounts: ${VOLUME_MOUNTS}
+                ports:
+                  - containerPort: 30000
+                readinessProbe:
+                  failureThreshold: 3
+                  httpGet:
+                    path: /health
+                    port: 30000
+                    scheme: HTTP
+                  initialDelaySeconds: 180
+                  periodSeconds: 5
+                  successThreshold: 1
+                  timeoutSeconds: 1
+                lifecycle:
+                  preStop:
+                    exec:
+                      command:
+                        - /bin/sh
+                        - -c
+                        - |
+                          # Drain in-flight requests before termination. Bounded
+                          # to ~300s so a stuck/absent metric cannot block past
+                          # terminationGracePeriodSeconds. Sums all series so
+                          # multi-model pods are handled, and uses an integer
+                          # comparison so Prometheus float formatting ("0" vs
+                          # "0.0") does not matter.
+                          i=0
+                          while [ $i -lt 60 ]; do
+                            METRICS=$(curl -sf http://localhost:30000/metrics 2>/dev/null) || {
+                              echo "Terminating: metrics endpoint unreachable, engine already stopping" >> /proc/1/fd/1
+                              exit 0
+                            }
+                            PENDING=$(echo "$METRICS" | awk '/^sglang:num_running_reqs/ || /^sglang:num_queue_reqs/ {s+=$2} END {printf "%d", s+0}')
+                            if [ "$PENDING" -le 0 ]; then
+                              echo "Terminating: drained, no active or waiting requests" >> /proc/1/fd/1
+                              exit 0
+                            fi
+                            echo "Terminating: $PENDING in-flight requests, waiting" >> /proc/1/fd/1
+                            i=$((i+1))
+                            sleep 5
+                          done
+                          echo "Terminating: drain deadline reached, proceeding" >> /proc/1/fd/1
+        workerReplicas: 0
+        workerTemplate:
+          spec:
+            containers: []

--- a/pkg/model-booster-controller/convert/templates/sglang.yaml
+++ b/pkg/model-booster-controller/convert/templates/sglang.yaml
@@ -61,15 +61,19 @@ spec:
                 ports:
                   - containerPort: 30000
                 readinessProbe:
+                  initialDelaySeconds: 180
+                  periodSeconds: 5
                   failureThreshold: 3
                   httpGet:
                     path: /health
                     port: 30000
-                    scheme: HTTP
-                  initialDelaySeconds: 180
-                  periodSeconds: 5
-                  successThreshold: 1
-                  timeoutSeconds: 1
+                livenessProbe:
+                  initialDelaySeconds: 300
+                  periodSeconds: 15
+                  failureThreshold: 3
+                  httpGet:
+                    path: /health
+                    port: 30000
                 lifecycle:
                   preStop:
                     exec:
@@ -77,12 +81,7 @@ spec:
                         - /bin/sh
                         - -c
                         - |
-                          # Drain in-flight requests before termination. Bounded
-                          # to ~300s so a stuck/absent metric cannot block past
-                          # terminationGracePeriodSeconds. Sums all series so
-                          # multi-model pods are handled, and uses an integer
-                          # comparison so Prometheus float formatting ("0" vs
-                          # "0.0") does not matter.
+                          # Drain in-flight requests, bounded so it cannot exceed terminationGracePeriodSeconds.
                           i=0
                           while [ $i -lt 60 ]; do
                             METRICS=$(curl -sf http://localhost:30000/metrics 2>/dev/null) || {

--- a/pkg/model-booster-controller/convert/testdata/expected/sglang-aggregated-model-serving.yaml
+++ b/pkg/model-booster-controller/convert/testdata/expected/sglang-aggregated-model-serving.yaml
@@ -134,12 +134,7 @@ spec:
                   - /bin/sh
                   - -c
                   - |
-                    # Drain in-flight requests before termination. Bounded
-                    # to ~300s so a stuck/absent metric cannot block past
-                    # terminationGracePeriodSeconds. Sums all series so
-                    # multi-model pods are handled, and uses an integer
-                    # comparison so Prometheus float formatting ("0" vs
-                    # "0.0") does not matter.
+                    # Drain in-flight requests, bounded so it cannot exceed terminationGracePeriodSeconds.
                     i=0
                     while [ $i -lt 60 ]; do
                       METRICS=$(curl -sf http://localhost:30000/metrics 2>/dev/null) || {
@@ -156,6 +151,13 @@ spec:
                       sleep 5
                     done
                     echo "Terminating: drain deadline reached, proceeding" >> /proc/1/fd/1
+            livenessProbe:
+              failureThreshold: 3
+              httpGet:
+                path: /health
+                port: 30000
+              initialDelaySeconds: 300
+              periodSeconds: 15
             name: engine
             ports:
             - containerPort: 30000
@@ -164,11 +166,8 @@ spec:
               httpGet:
                 path: /health
                 port: 30000
-                scheme: HTTP
               initialDelaySeconds: 180
               periodSeconds: 5
-              successThreshold: 1
-              timeoutSeconds: 1
             resources:
               limits:
                 cpu: "4"

--- a/pkg/model-booster-controller/convert/testdata/expected/sglang-aggregated-model-serving.yaml
+++ b/pkg/model-booster-controller/convert/testdata/expected/sglang-aggregated-model-serving.yaml
@@ -1,0 +1,209 @@
+apiVersion: workload.serving.volcano.sh/v1alpha1
+kind: ModelServing
+metadata:
+  labels:
+    workload.serving.volcano.sh/backend-name: backend1
+    workload.serving.volcano.sh/managed-by: workload.serving.volcano.sh
+    workload.serving.volcano.sh/model-name: sglang-test
+    workload.serving.volcano.sh/model-uid: sglang-uid
+    workload.serving.volcano.sh/revision: 7546df7bc8
+  name: sglang-test-backend1
+  namespace: default
+  ownerReferences:
+  - apiVersion: workload.serving.volcano.sh/v1alpha1
+    kind: ModelBooster
+    name: sglang-test
+    uid: sglang-uid
+spec:
+  replicas: 1
+  schedulerName: ""
+  template:
+    gangPolicy:
+      minRoleReplicas:
+        leader: 1
+    restartGracePeriodSeconds: 60
+    roles:
+    - entryTemplate:
+        metadata:
+          labels:
+            workload.serving.volcano.sh/backend-name: backend1
+            workload.serving.volcano.sh/managed-by: workload.serving.volcano.sh
+            workload.serving.volcano.sh/model-name: sglang-test
+            workload.serving.volcano.sh/model-uid: sglang-uid
+            workload.serving.volcano.sh/revision: 7546df7bc8
+        spec:
+          containers:
+          - args:
+            - --port
+            - "8100"
+            - --engine
+            - sglang
+            - --engine-base-url
+            - http://localhost:30000
+            - --engine-metrics-path
+            - /metrics
+            - --pod
+            - $(POD_NAME).$(NAMESPACE)
+            - --model
+            - sglang-test
+            env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: REDIS_HOST
+              valueFrom:
+                configMapKeyRef:
+                  key: REDIS_HOST
+                  name: redis-config
+                  optional: true
+            - name: REDIS_PORT
+              valueFrom:
+                configMapKeyRef:
+                  key: REDIS_PORT
+                  name: redis-config
+                  optional: true
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: REDIS_PASSWORD
+                  name: redis-secret
+                  optional: true
+            image: kthena/runtime:latest
+            name: runtime
+            ports:
+            - containerPort: 8100
+            readinessProbe:
+              httpGet:
+                path: /health
+                port: 8100
+              initialDelaySeconds: 5
+              periodSeconds: 10
+            resources: {}
+          - command:
+            - python3
+            - -m
+            - sglang.launch_server
+            - --model-path
+            - /tmp/test/4005c13ab5d91cb094e41048356abe39
+            - --host
+            - 0.0.0.0
+            - --port
+            - "30000"
+            - --enable-metrics
+            - --mem-fraction-static
+            - "0.85"
+            - --served-model-name
+            - Qwen3-0.6B
+            env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: REDIS_HOST
+              valueFrom:
+                configMapKeyRef:
+                  key: REDIS_HOST
+                  name: redis-config
+                  optional: true
+            - name: REDIS_PORT
+              valueFrom:
+                configMapKeyRef:
+                  key: REDIS_PORT
+                  name: redis-config
+                  optional: true
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: REDIS_PASSWORD
+                  name: redis-secret
+                  optional: true
+            image: docker.io/lmsysorg/sglang:latest
+            lifecycle:
+              preStop:
+                exec:
+                  command:
+                  - /bin/sh
+                  - -c
+                  - |
+                    # Drain in-flight requests before termination. Bounded
+                    # to ~300s so a stuck/absent metric cannot block past
+                    # terminationGracePeriodSeconds. Sums all series so
+                    # multi-model pods are handled, and uses an integer
+                    # comparison so Prometheus float formatting ("0" vs
+                    # "0.0") does not matter.
+                    i=0
+                    while [ $i -lt 60 ]; do
+                      METRICS=$(curl -sf http://localhost:30000/metrics 2>/dev/null) || {
+                        echo "Terminating: metrics endpoint unreachable, engine already stopping" >> /proc/1/fd/1
+                        exit 0
+                      }
+                      PENDING=$(echo "$METRICS" | awk '/^sglang:num_running_reqs/ || /^sglang:num_queue_reqs/ {s+=$2} END {printf "%d", s+0}')
+                      if [ "$PENDING" -le 0 ]; then
+                        echo "Terminating: drained, no active or waiting requests" >> /proc/1/fd/1
+                        exit 0
+                      fi
+                      echo "Terminating: $PENDING in-flight requests, waiting" >> /proc/1/fd/1
+                      i=$((i+1))
+                      sleep 5
+                    done
+                    echo "Terminating: drain deadline reached, proceeding" >> /proc/1/fd/1
+            name: engine
+            ports:
+            - containerPort: 30000
+            readinessProbe:
+              failureThreshold: 3
+              httpGet:
+                path: /health
+                port: 30000
+                scheme: HTTP
+              initialDelaySeconds: 180
+              periodSeconds: 5
+              successThreshold: 1
+              timeoutSeconds: 1
+            resources:
+              limits:
+                cpu: "4"
+                memory: 12Gi
+                nvidia.com/gpu: "1"
+            volumeMounts:
+            - mountPath: /tmp/test
+              name: backend1-weights
+            - mountPath: /dev/shm
+              name: dshm
+          initContainers:
+          - args:
+            - --source
+            - hf://Qwen/Qwen3-0.6B
+            - --output-dir
+            - /tmp/test/4005c13ab5d91cb094e41048356abe39
+            image: kthena/downloader:latest
+            name: sglang-test-model-downloader
+            resources: {}
+            volumeMounts:
+            - mountPath: /tmp/test
+              name: backend1-weights
+          terminationGracePeriodSeconds: 300
+          volumes:
+          - hostPath:
+              path: /tmp/test
+              type: DirectoryOrCreate
+            name: backend1-weights
+          - emptyDir:
+              medium: Memory
+            name: dshm
+      name: leader
+      replicas: 1
+      workerReplicas: 0
+      workerTemplate:
+        spec:
+          containers: []
+status: {}

--- a/pkg/model-booster-controller/convert/testdata/expected/sglang-disaggregated-model-serving.yaml
+++ b/pkg/model-booster-controller/convert/testdata/expected/sglang-disaggregated-model-serving.yaml
@@ -1,0 +1,329 @@
+apiVersion: workload.serving.volcano.sh/v1alpha1
+kind: ModelServing
+metadata:
+  labels:
+    workload.serving.volcano.sh/backend-name: backend1
+    workload.serving.volcano.sh/managed-by: workload.serving.volcano.sh
+    workload.serving.volcano.sh/model-name: sglang-pd-test
+    workload.serving.volcano.sh/model-uid: sglang-pd-uid
+    workload.serving.volcano.sh/revision: c7b4948f5
+  name: sglang-pd-test-backend1
+  namespace: default
+  ownerReferences:
+  - apiVersion: workload.serving.volcano.sh/v1alpha1
+    kind: ModelBooster
+    name: sglang-pd-test
+    uid: sglang-pd-uid
+spec:
+  replicas: 1
+  schedulerName: ""
+  template:
+    gangPolicy:
+      minRoleReplicas:
+        decode: 1
+        prefill: 1
+    restartGracePeriodSeconds: 60
+    roles:
+    - entryTemplate:
+        metadata:
+          labels:
+            workload.serving.volcano.sh/backend-name: backend1
+            workload.serving.volcano.sh/managed-by: workload.serving.volcano.sh
+            workload.serving.volcano.sh/model-name: sglang-pd-test
+            workload.serving.volcano.sh/model-uid: sglang-pd-uid
+            workload.serving.volcano.sh/revision: c7b4948f5
+        spec:
+          containers:
+          - args:
+            - --port
+            - "8100"
+            - --engine
+            - sglangdisaggregated
+            - --engine-base-url
+            - http://localhost:30000
+            - --engine-metrics-path
+            - /metrics
+            - --pod
+            - $(POD_NAME).$(NAMESPACE)
+            - --model
+            - sglang-pd-test
+            env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: REDIS_HOST
+              valueFrom:
+                configMapKeyRef:
+                  key: REDIS_HOST
+                  name: redis-config
+                  optional: true
+            - name: REDIS_PORT
+              valueFrom:
+                configMapKeyRef:
+                  key: REDIS_PORT
+                  name: redis-config
+                  optional: true
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: REDIS_PASSWORD
+                  name: redis-secret
+                  optional: true
+            image: kthena/runtime:latest
+            name: runtime
+            ports:
+            - containerPort: 8100
+            resources: {}
+          - command:
+            - python3
+            - -m
+            - sglang.launch_server
+            - --model-path
+            - /tmp/test/4005c13ab5d91cb094e41048356abe39
+            - --host
+            - 0.0.0.0
+            - --port
+            - "30000"
+            - --enable-metrics
+            - --disaggregation-mode
+            - prefill
+            - --disaggregation-transfer-backend
+            - mooncake
+            - --mem-fraction-static
+            - "0.85"
+            - --served-model-name
+            - Qwen3-0.6B
+            env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: REDIS_HOST
+              valueFrom:
+                configMapKeyRef:
+                  key: REDIS_HOST
+                  name: redis-config
+                  optional: true
+            - name: REDIS_PORT
+              valueFrom:
+                configMapKeyRef:
+                  key: REDIS_PORT
+                  name: redis-config
+                  optional: true
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: REDIS_PASSWORD
+                  name: redis-secret
+                  optional: true
+            image: docker.io/lmsysorg/sglang:latest
+            imagePullPolicy: IfNotPresent
+            livenessProbe:
+              failureThreshold: 3
+              httpGet:
+                path: /health
+                port: 30000
+              initialDelaySeconds: 300
+              periodSeconds: 15
+            name: sglang
+            ports:
+            - containerPort: 30000
+            readinessProbe:
+              failureThreshold: 3
+              httpGet:
+                path: /health
+                port: 30000
+              initialDelaySeconds: 180
+              periodSeconds: 5
+            resources:
+              limits:
+                cpu: "4"
+                memory: 12Gi
+                nvidia.com/gpu: "1"
+            volumeMounts:
+            - mountPath: /tmp/test
+              name: backend1-weights
+          initContainers:
+          - args:
+            - --source
+            - hf://Qwen/Qwen3-0.6B
+            - --output-dir
+            - /tmp/test/4005c13ab5d91cb094e41048356abe39
+            image: kthena/downloader:latest
+            name: sglang-pd-test-model-downloader
+            resources: {}
+            volumeMounts:
+            - mountPath: /tmp/test
+              name: backend1-weights
+          volumes:
+          - hostPath:
+              path: /tmp/test
+              type: DirectoryOrCreate
+            name: backend1-weights
+      name: prefill
+      replicas: 1
+      workerReplicas: 0
+      workerTemplate:
+        spec:
+          containers: []
+    - entryTemplate:
+        metadata:
+          labels:
+            workload.serving.volcano.sh/backend-name: backend1
+            workload.serving.volcano.sh/managed-by: workload.serving.volcano.sh
+            workload.serving.volcano.sh/model-name: sglang-pd-test
+            workload.serving.volcano.sh/model-uid: sglang-pd-uid
+            workload.serving.volcano.sh/revision: c7b4948f5
+        spec:
+          containers:
+          - args:
+            - --port
+            - "8100"
+            - --engine
+            - sglangdisaggregated
+            - --engine-base-url
+            - http://localhost:30000
+            - --engine-metrics-path
+            - /metrics
+            - --pod
+            - $(POD_NAME).$(NAMESPACE)
+            - --model
+            - sglang-pd-test
+            env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: REDIS_HOST
+              valueFrom:
+                configMapKeyRef:
+                  key: REDIS_HOST
+                  name: redis-config
+                  optional: true
+            - name: REDIS_PORT
+              valueFrom:
+                configMapKeyRef:
+                  key: REDIS_PORT
+                  name: redis-config
+                  optional: true
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: REDIS_PASSWORD
+                  name: redis-secret
+                  optional: true
+            image: kthena/runtime:latest
+            name: runtime
+            ports:
+            - containerPort: 8100
+            resources: {}
+          - command:
+            - python3
+            - -m
+            - sglang.launch_server
+            - --model-path
+            - /tmp/test/4005c13ab5d91cb094e41048356abe39
+            - --host
+            - 0.0.0.0
+            - --port
+            - "30000"
+            - --enable-metrics
+            - --disaggregation-mode
+            - decode
+            - --disaggregation-transfer-backend
+            - mooncake
+            - --mem-fraction-static
+            - "0.85"
+            - --served-model-name
+            - Qwen3-0.6B
+            env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: REDIS_HOST
+              valueFrom:
+                configMapKeyRef:
+                  key: REDIS_HOST
+                  name: redis-config
+                  optional: true
+            - name: REDIS_PORT
+              valueFrom:
+                configMapKeyRef:
+                  key: REDIS_PORT
+                  name: redis-config
+                  optional: true
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: REDIS_PASSWORD
+                  name: redis-secret
+                  optional: true
+            image: docker.io/lmsysorg/sglang:latest
+            imagePullPolicy: IfNotPresent
+            livenessProbe:
+              failureThreshold: 3
+              httpGet:
+                path: /health
+                port: 30000
+              initialDelaySeconds: 300
+              periodSeconds: 15
+            name: sglang
+            ports:
+            - containerPort: 30000
+            readinessProbe:
+              failureThreshold: 3
+              httpGet:
+                path: /health
+                port: 30000
+              initialDelaySeconds: 180
+              periodSeconds: 5
+            resources:
+              limits:
+                cpu: "4"
+                memory: 12Gi
+                nvidia.com/gpu: "1"
+            volumeMounts:
+            - mountPath: /tmp/test
+              name: backend1-weights
+          initContainers:
+          - args:
+            - --source
+            - hf://Qwen/Qwen3-0.6B
+            - --output-dir
+            - /tmp/test/4005c13ab5d91cb094e41048356abe39
+            image: kthena/downloader:latest
+            name: sglang-pd-test-model-downloader
+            resources: {}
+            volumeMounts:
+            - mountPath: /tmp/test
+              name: backend1-weights
+          volumes:
+          - hostPath:
+              path: /tmp/test
+              type: DirectoryOrCreate
+            name: backend1-weights
+      name: decode
+      replicas: 1
+      workerReplicas: 0
+      workerTemplate:
+        spec:
+          containers: []
+status: {}

--- a/pkg/model-booster-controller/convert/testdata/expected/sglang-disaggregated-model-serving.yaml
+++ b/pkg/model-booster-controller/convert/testdata/expected/sglang-disaggregated-model-serving.yaml
@@ -38,7 +38,7 @@ spec:
             - --port
             - "8100"
             - --engine
-            - sglangdisaggregated
+            - sglang
             - --engine-base-url
             - http://localhost:30000
             - --engine-metrics-path
@@ -78,6 +78,12 @@ spec:
             name: runtime
             ports:
             - containerPort: 8100
+            readinessProbe:
+              httpGet:
+                path: /health
+                port: 8100
+              initialDelaySeconds: 5
+              periodSeconds: 10
             resources: {}
           - command:
             - python3
@@ -127,6 +133,30 @@ spec:
                   optional: true
             image: docker.io/lmsysorg/sglang:latest
             imagePullPolicy: IfNotPresent
+            lifecycle:
+              preStop:
+                exec:
+                  command:
+                  - /bin/sh
+                  - -c
+                  - |
+                    # Drain in-flight requests, bounded so it cannot exceed terminationGracePeriodSeconds.
+                    i=0
+                    while [ $i -lt 60 ]; do
+                      METRICS=$(curl -sf http://localhost:30000/metrics 2>/dev/null) || {
+                        echo "Terminating: metrics endpoint unreachable, engine already stopping" >> /proc/1/fd/1
+                        exit 0
+                      }
+                      PENDING=$(echo "$METRICS" | awk '/^sglang:num_running_reqs/ || /^sglang:num_queue_reqs/ {s+=$2} END {printf "%d", s+0}')
+                      if [ "$PENDING" -le 0 ]; then
+                        echo "Terminating: drained, no active or waiting requests" >> /proc/1/fd/1
+                        exit 0
+                      fi
+                      echo "Terminating: $PENDING in-flight requests, waiting" >> /proc/1/fd/1
+                      i=$((i+1))
+                      sleep 5
+                    done
+                    echo "Terminating: drain deadline reached, proceeding" >> /proc/1/fd/1
             livenessProbe:
               failureThreshold: 3
               httpGet:
@@ -134,7 +164,7 @@ spec:
                 port: 30000
               initialDelaySeconds: 300
               periodSeconds: 15
-            name: sglang
+            name: engine
             ports:
             - containerPort: 30000
             readinessProbe:
@@ -152,6 +182,8 @@ spec:
             volumeMounts:
             - mountPath: /tmp/test
               name: backend1-weights
+            - mountPath: /dev/shm
+              name: dshm
           initContainers:
           - args:
             - --source
@@ -164,11 +196,15 @@ spec:
             volumeMounts:
             - mountPath: /tmp/test
               name: backend1-weights
+          terminationGracePeriodSeconds: 300
           volumes:
           - hostPath:
               path: /tmp/test
               type: DirectoryOrCreate
             name: backend1-weights
+          - emptyDir:
+              medium: Memory
+            name: dshm
       name: prefill
       replicas: 1
       workerReplicas: 0
@@ -189,7 +225,7 @@ spec:
             - --port
             - "8100"
             - --engine
-            - sglangdisaggregated
+            - sglang
             - --engine-base-url
             - http://localhost:30000
             - --engine-metrics-path
@@ -229,6 +265,12 @@ spec:
             name: runtime
             ports:
             - containerPort: 8100
+            readinessProbe:
+              httpGet:
+                path: /health
+                port: 8100
+              initialDelaySeconds: 5
+              periodSeconds: 10
             resources: {}
           - command:
             - python3
@@ -278,6 +320,30 @@ spec:
                   optional: true
             image: docker.io/lmsysorg/sglang:latest
             imagePullPolicy: IfNotPresent
+            lifecycle:
+              preStop:
+                exec:
+                  command:
+                  - /bin/sh
+                  - -c
+                  - |
+                    # Drain in-flight requests, bounded so it cannot exceed terminationGracePeriodSeconds.
+                    i=0
+                    while [ $i -lt 60 ]; do
+                      METRICS=$(curl -sf http://localhost:30000/metrics 2>/dev/null) || {
+                        echo "Terminating: metrics endpoint unreachable, engine already stopping" >> /proc/1/fd/1
+                        exit 0
+                      }
+                      PENDING=$(echo "$METRICS" | awk '/^sglang:num_running_reqs/ || /^sglang:num_queue_reqs/ {s+=$2} END {printf "%d", s+0}')
+                      if [ "$PENDING" -le 0 ]; then
+                        echo "Terminating: drained, no active or waiting requests" >> /proc/1/fd/1
+                        exit 0
+                      fi
+                      echo "Terminating: $PENDING in-flight requests, waiting" >> /proc/1/fd/1
+                      i=$((i+1))
+                      sleep 5
+                    done
+                    echo "Terminating: drain deadline reached, proceeding" >> /proc/1/fd/1
             livenessProbe:
               failureThreshold: 3
               httpGet:
@@ -285,7 +351,7 @@ spec:
                 port: 30000
               initialDelaySeconds: 300
               periodSeconds: 15
-            name: sglang
+            name: engine
             ports:
             - containerPort: 30000
             readinessProbe:
@@ -303,6 +369,8 @@ spec:
             volumeMounts:
             - mountPath: /tmp/test
               name: backend1-weights
+            - mountPath: /dev/shm
+              name: dshm
           initContainers:
           - args:
             - --source
@@ -315,11 +383,15 @@ spec:
             volumeMounts:
             - mountPath: /tmp/test
               name: backend1-weights
+          terminationGracePeriodSeconds: 300
           volumes:
           - hostPath:
               path: /tmp/test
               type: DirectoryOrCreate
             name: backend1-weights
+          - emptyDir:
+              medium: Memory
+            name: dshm
       name: decode
       replicas: 1
       workerReplicas: 0

--- a/pkg/model-booster-controller/convert/testdata/input/sglang-aggregated-model.yaml
+++ b/pkg/model-booster-controller/convert/testdata/input/sglang-aggregated-model.yaml
@@ -1,0 +1,27 @@
+apiVersion: workload.serving.volcano.sh/v1alpha1
+kind: ModelBooster
+metadata:
+  name: sglang-test
+  namespace: default
+  uid: sglang-uid
+spec:
+  backend:
+    name: backend1
+    type: SGLang
+    modelURI: hf://Qwen/Qwen3-0.6B
+    cacheURI: hostpath:///tmp/test
+    minReplicas: 1
+    maxReplicas: 1
+    workers:
+      - type: server
+        image: docker.io/lmsysorg/sglang:latest
+        replicas: 1
+        pods: 1
+        config:
+          served-model-name: "Qwen3-0.6B"
+          mem-fraction-static: "0.85"
+        resources:
+          limits:
+            nvidia.com/gpu: "1"
+            cpu: "4"
+            memory: 12Gi

--- a/pkg/model-booster-controller/convert/testdata/input/sglang-disaggregated-model.yaml
+++ b/pkg/model-booster-controller/convert/testdata/input/sglang-disaggregated-model.yaml
@@ -1,0 +1,39 @@
+apiVersion: workload.serving.volcano.sh/v1alpha1
+kind: ModelBooster
+metadata:
+  name: sglang-pd-test
+  namespace: default
+  uid: sglang-pd-uid
+spec:
+  backend:
+    name: backend1
+    type: SGLangDisaggregated
+    modelURI: hf://Qwen/Qwen3-0.6B
+    cacheURI: hostpath:///tmp/test
+    minReplicas: 1
+    maxReplicas: 1
+    workers:
+      - type: prefill
+        image: docker.io/lmsysorg/sglang:latest
+        replicas: 1
+        pods: 1
+        config:
+          served-model-name: "Qwen3-0.6B"
+          mem-fraction-static: "0.85"
+        resources:
+          limits:
+            nvidia.com/gpu: "1"
+            cpu: "4"
+            memory: 12Gi
+      - type: decode
+        image: docker.io/lmsysorg/sglang:latest
+        replicas: 1
+        pods: 1
+        config:
+          served-model-name: "Qwen3-0.6B"
+          mem-fraction-static: "0.85"
+        resources:
+          limits:
+            nvidia.com/gpu: "1"
+            cpu: "4"
+            memory: 12Gi

--- a/pkg/model-booster-controller/utils/template.go
+++ b/pkg/model-booster-controller/utils/template.go
@@ -82,7 +82,9 @@ func ReplaceEmbeddedPlaceholders(s string, values *map[string]interface{}) (stri
 	return result.String(), nil
 }
 
-func ConvertVLLMArgsFromJson(config *apiextensionsv1.JSON) ([]string, error) {
+// ConvertEngineArgsFromJson flattens a JSON object into `--foo-bar VALUE` flags,
+// sorted by key. Shared by vLLM and SGLang.
+func ConvertEngineArgsFromJson(config *apiextensionsv1.JSON) ([]string, error) {
 	if config == nil || config.Raw == nil {
 		return []string{}, nil
 	}

--- a/pkg/model-booster-controller/utils/template_test.go
+++ b/pkg/model-booster-controller/utils/template_test.go
@@ -131,7 +131,7 @@ func TestReplaceEmbeddedPlaceholders(t *testing.T) {
 	}
 }
 
-func TestConvertVLLMArgsFromJson(t *testing.T) {
+func TestConvertEngineArgsFromJson(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    *apiextensionsv1.JSON
@@ -200,7 +200,7 @@ func TestConvertVLLMArgsFromJson(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := ConvertVLLMArgsFromJson(tt.input)
+			result, err := ConvertEngineArgsFromJson(tt.input)
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {

--- a/pkg/model-booster-controller/webhook/model_validator.go
+++ b/pkg/model-booster-controller/webhook/model_validator.go
@@ -129,6 +129,18 @@ func validateBackendWorkerTypes(model *registryv1alpha1.ModelBooster) field.Erro
 		}
 	}
 
+	if backend.Type == registryv1alpha1.ModelBackendTypeSGLangDisaggregated {
+		for j, w := range workers {
+			if w.Type != registryv1alpha1.ModelWorkerTypePrefill && w.Type != registryv1alpha1.ModelWorkerTypeDecode {
+				allErrs = append(allErrs, field.Invalid(
+					backendPath.Child("workers").Index(j).Child("type"),
+					w.Type,
+					"If backend type is 'SGLangDisaggregated', all workers must be type 'prefill' or 'decode'",
+				))
+			}
+		}
+	}
+
 	// Rule 3: MindIEDisaggregated -> all workers must be 'prefill', 'decode', 'controller', or 'coordinator'
 	if backend.Type == registryv1alpha1.ModelBackendTypeMindIEDisaggregated {
 		validTypes := map[registryv1alpha1.ModelWorkerType]struct{}{

--- a/pkg/model-booster-controller/webhook/model_validator.go
+++ b/pkg/model-booster-controller/webhook/model_validator.go
@@ -17,6 +17,7 @@ limitations under the License.
 package webhook
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
@@ -81,6 +82,7 @@ func (v *ModelValidator) validateModel(model *registryv1alpha1.ModelBooster) (bo
 	allErrs = append(allErrs, validateWorkerImages(model)...)
 	allErrs = append(allErrs, validateAutoScalingPolicyScope(model)...)
 	allErrs = append(allErrs, validateBackendWorkerTypes(model)...)
+	allErrs = append(allErrs, validateSGLangReservedFlags(model)...)
 
 	if len(allErrs) > 0 {
 		// Convert field errors to a formatted multi-line error message
@@ -155,6 +157,51 @@ func validateBackendWorkerTypes(model *registryv1alpha1.ModelBooster) field.Erro
 					backendPath.Child("workers").Index(j).Child("type"),
 					w.Type,
 					"If backend type is 'MindIEDisaggregated', all workers must be type 'prefill', 'decode', 'controller', or 'coordinator' (not 'server')",
+				))
+			}
+		}
+	}
+	return allErrs
+}
+
+// validateSGLangReservedFlags rejects worker.config keys the converter
+// hard-codes for SGLang: overriding e.g. port leaves the pod silently
+// never-ready since the containerPort/probe/WorkloadPort stay 30000.
+func validateSGLangReservedFlags(model *registryv1alpha1.ModelBooster) field.ErrorList {
+	var allErrs field.ErrorList
+	backend := model.Spec.Backend
+	if backend.Type != registryv1alpha1.ModelBackendTypeSGLang &&
+		backend.Type != registryv1alpha1.ModelBackendTypeSGLangDisaggregated {
+		return allErrs
+	}
+	reserved := map[string]struct{}{
+		"model-path":          {},
+		"host":                {},
+		"port":                {},
+		"enable-metrics":      {},
+		"disaggregation-mode": {},
+	}
+	backendPath := field.NewPath("spec").Child("backend")
+	for j, w := range backend.Workers {
+		if w.Config.Raw == nil {
+			continue
+		}
+		var configMap map[string]interface{}
+		if err := json.Unmarshal(w.Config.Raw, &configMap); err != nil {
+			allErrs = append(allErrs, field.Invalid(
+				backendPath.Child("workers").Index(j).Child("config"),
+				string(w.Config.Raw),
+				fmt.Sprintf("config is not a valid JSON object: %v", err),
+			))
+			continue
+		}
+		for key := range configMap {
+			normalized := strings.ReplaceAll(key, "_", "-")
+			if _, ok := reserved[normalized]; ok {
+				allErrs = append(allErrs, field.Invalid(
+					backendPath.Child("workers").Index(j).Child("config").Key(key),
+					key,
+					fmt.Sprintf("'%s' is managed by kthena for SGLang backends and must not be set in worker.config", key),
 				))
 			}
 		}

--- a/pkg/model-booster-controller/webhook/model_validator_test.go
+++ b/pkg/model-booster-controller/webhook/model_validator_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	registryv1alpha1 "github.com/volcano-sh/kthena/pkg/apis/workload/v1alpha1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -171,6 +172,81 @@ func TestValidateBackendWorkerTypes_SGLang(t *testing.T) {
 			),
 			wantValid: false,
 			errSubstr: "SGLangDisaggregated",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			valid, errorMsg := validator.validateModel(tt.model)
+			assert.Equal(t, tt.wantValid, valid, "errorMsg=%s", errorMsg)
+			if tt.errSubstr != "" {
+				assert.Contains(t, errorMsg, tt.errSubstr)
+			}
+		})
+	}
+}
+
+func TestValidateSGLangReservedFlags(t *testing.T) {
+	validator := &ModelValidator{}
+	mkModel := func(backendType registryv1alpha1.ModelBackendType, raw string) *registryv1alpha1.ModelBooster {
+		w := registryv1alpha1.ModelWorker{
+			Type: registryv1alpha1.ModelWorkerTypeServer, Pods: 1, Image: "sglang:latest",
+		}
+		if backendType == registryv1alpha1.ModelBackendTypeSGLangDisaggregated {
+			w.Type = registryv1alpha1.ModelWorkerTypePrefill
+		}
+		if raw != "" {
+			w.Config = apiextensionsv1.JSON{Raw: []byte(raw)}
+		}
+		workers := []registryv1alpha1.ModelWorker{w}
+		if backendType == registryv1alpha1.ModelBackendTypeSGLangDisaggregated {
+			workers = append(workers, registryv1alpha1.ModelWorker{
+				Type: registryv1alpha1.ModelWorkerTypeDecode, Pods: 1, Image: "sglang:latest",
+			})
+		}
+		return &registryv1alpha1.ModelBooster{
+			ObjectMeta: metav1.ObjectMeta{Name: "m", Namespace: "default"},
+			Spec: registryv1alpha1.ModelBoosterSpec{
+				Backend: registryv1alpha1.ModelBackend{
+					Name: "b1", Type: backendType, MinReplicas: 1, MaxReplicas: 1, Workers: workers,
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name      string
+		model     *registryv1alpha1.ModelBooster
+		wantValid bool
+		errSubstr string
+	}{
+		{
+			name:      "non-reserved flags are allowed",
+			model:     mkModel(registryv1alpha1.ModelBackendTypeSGLang, `{"mem-fraction-static":"0.85","trust-remote-code":""}`),
+			wantValid: true,
+		},
+		{
+			name:      "port override is rejected",
+			model:     mkModel(registryv1alpha1.ModelBackendTypeSGLang, `{"port":"8080"}`),
+			wantValid: false,
+			errSubstr: "managed by kthena",
+		},
+		{
+			name:      "host override (underscore form) is rejected",
+			model:     mkModel(registryv1alpha1.ModelBackendTypeSGLang, `{"host":"127.0.0.1"}`),
+			wantValid: false,
+			errSubstr: "managed by kthena",
+		},
+		{
+			name:      "disaggregation-mode override is rejected for disaggregated",
+			model:     mkModel(registryv1alpha1.ModelBackendTypeSGLangDisaggregated, `{"disaggregation_mode":"prefill"}`),
+			wantValid: false,
+			errSubstr: "managed by kthena",
+		},
+		{
+			name:      "disaggregation-transfer-backend stays user-overridable",
+			model:     mkModel(registryv1alpha1.ModelBackendTypeSGLangDisaggregated, `{"disaggregation-transfer-backend":"nixl"}`),
+			wantValid: true,
 		},
 	}
 

--- a/pkg/model-booster-controller/webhook/model_validator_test.go
+++ b/pkg/model-booster-controller/webhook/model_validator_test.go
@@ -114,3 +114,73 @@ func TestValidateModel_NoErrors(t *testing.T) {
 	assert.True(t, valid)
 	assert.Empty(t, errorMsg)
 }
+
+// TestValidateBackendWorkerTypes_SGLang covers SGLang and SGLangDisaggregated
+// worker-type rules.
+func TestValidateBackendWorkerTypes_SGLang(t *testing.T) {
+	validator := &ModelValidator{}
+	mkModel := func(backendType registryv1alpha1.ModelBackendType, workers ...registryv1alpha1.ModelWorker) *registryv1alpha1.ModelBooster {
+		return &registryv1alpha1.ModelBooster{
+			ObjectMeta: metav1.ObjectMeta{Name: "m", Namespace: "default"},
+			Spec: registryv1alpha1.ModelBoosterSpec{
+				Backend: registryv1alpha1.ModelBackend{
+					Name:        "b1",
+					Type:        backendType,
+					MinReplicas: 1,
+					MaxReplicas: 1,
+					Workers:     workers,
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name      string
+		model     *registryv1alpha1.ModelBooster
+		wantValid bool
+		errSubstr string
+	}{
+		{
+			name: "SGLang with exactly one server worker is valid",
+			model: mkModel(registryv1alpha1.ModelBackendTypeSGLang,
+				registryv1alpha1.ModelWorker{Type: registryv1alpha1.ModelWorkerTypeServer, Pods: 1, Image: "sglang:latest"},
+			),
+			wantValid: true,
+		},
+		{
+			name: "SGLang with a non-server worker is rejected",
+			model: mkModel(registryv1alpha1.ModelBackendTypeSGLang,
+				registryv1alpha1.ModelWorker{Type: registryv1alpha1.ModelWorkerTypePrefill, Pods: 1, Image: "sglang:latest"},
+			),
+			wantValid: false,
+			errSubstr: "worker type must be 'server'",
+		},
+		{
+			name: "SGLangDisaggregated with prefill+decode is valid",
+			model: mkModel(registryv1alpha1.ModelBackendTypeSGLangDisaggregated,
+				registryv1alpha1.ModelWorker{Type: registryv1alpha1.ModelWorkerTypePrefill, Pods: 1, Image: "sglang:latest"},
+				registryv1alpha1.ModelWorker{Type: registryv1alpha1.ModelWorkerTypeDecode, Pods: 1, Image: "sglang:latest"},
+			),
+			wantValid: true,
+		},
+		{
+			name: "SGLangDisaggregated containing a server worker is rejected",
+			model: mkModel(registryv1alpha1.ModelBackendTypeSGLangDisaggregated,
+				registryv1alpha1.ModelWorker{Type: registryv1alpha1.ModelWorkerTypePrefill, Pods: 1, Image: "sglang:latest"},
+				registryv1alpha1.ModelWorker{Type: registryv1alpha1.ModelWorkerTypeServer, Pods: 1, Image: "sglang:latest"},
+			),
+			wantValid: false,
+			errSubstr: "SGLangDisaggregated",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			valid, errorMsg := validator.validateModel(tt.model)
+			assert.Equal(t, tt.wantValid, valid, "errorMsg=%s", errorMsg)
+			if tt.errSubstr != "" {
+				assert.Contains(t, errorMsg, tt.errSubstr)
+			}
+		})
+	}
+}

--- a/test/e2e/controller-manager/model_booster_test.go
+++ b/test/e2e/controller-manager/model_booster_test.go
@@ -138,12 +138,12 @@ func TestSGLangModelMaterialization(t *testing.T) {
 
 			var engine *corev1.Container
 			for i := range r.EntryTemplate.Spec.Containers {
-				if r.EntryTemplate.Spec.Containers[i].Name == "sglang" {
+				if r.EntryTemplate.Spec.Containers[i].Name == "engine" {
 					engine = &r.EntryTemplate.Spec.Containers[i]
 					break
 				}
 			}
-			require.NotNil(t, engine, "role %q must have an sglang engine container", expectedRole)
+			require.NotNil(t, engine, "role %q must have an engine container", expectedRole)
 			command := strings.Join(engine.Command, " ")
 			assert.Contains(t, command, "--disaggregation-mode "+expectedRole)
 			assert.Contains(t, command, "--disaggregation-transfer-backend mooncake")

--- a/test/e2e/controller-manager/model_booster_test.go
+++ b/test/e2e/controller-manager/model_booster_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controller_manager
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -57,6 +58,169 @@ func TestModelCR(t *testing.T) {
 	}
 	utils.CheckChatCompletions(t, "test-model", messages)
 	// TODO(user): Add tests for updating and deleting ModelBooster
+}
+
+// TestSGLangModelMaterialization checks that aggregated and disaggregated
+// SGLang ModelBoosters materialize into ModelServings with the correct command,
+// port, env, and disaggregation flags. Pods are not awaited (SGLang needs a GPU).
+func TestSGLangModelMaterialization(t *testing.T) {
+	ctx, kthenaClient, _ := setupControllerManagerE2ETest(t)
+	waitForWebhookReady(t, ctx, kthenaClient, testNamespace)
+
+	t.Run("Aggregated", func(t *testing.T) {
+		model := createSGLangAggregatedTestModel()
+		_, err := kthenaClient.WorkloadV1alpha1().ModelBoosters(testNamespace).Create(ctx, model, metav1.CreateOptions{})
+		require.NoError(t, err, "Failed to create SGLang ModelBooster")
+		defer func() {
+			_ = kthenaClient.WorkloadV1alpha1().ModelBoosters(testNamespace).Delete(ctx, model.Name, metav1.DeleteOptions{})
+		}()
+
+		var serving *workload.ModelServing
+		require.Eventually(t, func() bool {
+			ms, err := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Get(ctx, "sglang-agg-backend1", metav1.GetOptions{})
+			if err != nil {
+				t.Logf("get serving: %v", err)
+				return false
+			}
+			serving = ms
+			return true
+		}, 1*time.Minute, 2*time.Second, "ModelServing for SGLang ModelBooster not created in time")
+
+		require.Len(t, serving.Spec.Template.Roles, 1, "aggregated SGLang must have a single role")
+		role := serving.Spec.Template.Roles[0]
+		assert.Equal(t, "leader", role.Name)
+
+		var engine *corev1.Container
+		for i := range role.EntryTemplate.Spec.Containers {
+			if role.EntryTemplate.Spec.Containers[i].Name == "engine" {
+				engine = &role.EntryTemplate.Spec.Containers[i]
+				break
+			}
+		}
+		require.NotNil(t, engine, "engine container must be present")
+		command := strings.Join(engine.Command, " ")
+		assert.Contains(t, command, "sglang.launch_server")
+		assert.Contains(t, command, "--port 30000")
+		assert.Contains(t, command, "--host 0.0.0.0")
+		assert.NotContains(t, command, "$(POD_IP)")
+		assert.NotContains(t, command, "--disaggregation-mode")
+		assert.False(t, hasEnv(engine.Env, "POD_IP"), "POD_IP env is unused once SGLang binds 0.0.0.0")
+	})
+
+	t.Run("Disaggregated", func(t *testing.T) {
+		model := createSGLangDisaggregatedTestModel()
+		_, err := kthenaClient.WorkloadV1alpha1().ModelBoosters(testNamespace).Create(ctx, model, metav1.CreateOptions{})
+		require.NoError(t, err, "Failed to create SGLangDisaggregated ModelBooster")
+		defer func() {
+			_ = kthenaClient.WorkloadV1alpha1().ModelBoosters(testNamespace).Delete(ctx, model.Name, metav1.DeleteOptions{})
+		}()
+
+		var serving *workload.ModelServing
+		require.Eventually(t, func() bool {
+			ms, err := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Get(ctx, "sglang-pd-backend1", metav1.GetOptions{})
+			if err != nil {
+				t.Logf("get serving: %v", err)
+				return false
+			}
+			serving = ms
+			return true
+		}, 1*time.Minute, 2*time.Second, "ModelServing for SGLangDisaggregated not created in time")
+
+		require.Len(t, serving.Spec.Template.Roles, 2)
+		roleByName := map[string]*workload.Role{}
+		for i := range serving.Spec.Template.Roles {
+			r := &serving.Spec.Template.Roles[i]
+			roleByName[r.Name] = r
+		}
+		for _, expectedRole := range []string{"prefill", "decode"} {
+			r, ok := roleByName[expectedRole]
+			require.True(t, ok, "role %q must exist", expectedRole)
+
+			var engine *corev1.Container
+			for i := range r.EntryTemplate.Spec.Containers {
+				if r.EntryTemplate.Spec.Containers[i].Name == "sglang" {
+					engine = &r.EntryTemplate.Spec.Containers[i]
+					break
+				}
+			}
+			require.NotNil(t, engine, "role %q must have an sglang engine container", expectedRole)
+			command := strings.Join(engine.Command, " ")
+			assert.Contains(t, command, "--disaggregation-mode "+expectedRole)
+			assert.Contains(t, command, "--disaggregation-transfer-backend mooncake")
+			assert.Contains(t, command, "--host 0.0.0.0")
+			assert.NotContains(t, command, "$(POD_IP)")
+			assert.False(t, hasEnv(engine.Env, "POD_IP"), "role %q: POD_IP env is unused once SGLang binds 0.0.0.0", expectedRole)
+		}
+	})
+}
+
+func hasEnv(envs []corev1.EnvVar, name string) bool {
+	for _, e := range envs {
+		if e.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func createSGLangAggregatedTestModel() *workload.ModelBooster {
+	config := &apiextensionsv1.JSON{Raw: []byte(`{"served-model-name":"sglang-test"}`)}
+	return &workload.ModelBooster{
+		ObjectMeta: metav1.ObjectMeta{Name: "sglang-agg", Namespace: testNamespace},
+		Spec: workload.ModelBoosterSpec{
+			Name: "sglang-agg",
+			Backend: workload.ModelBackend{
+				Name:        "backend1",
+				Type:        workload.ModelBackendTypeSGLang,
+				ModelURI:    "hf://Qwen/Qwen3-0.6B",
+				CacheURI:    "hostpath:///tmp/cache",
+				MinReplicas: 1,
+				MaxReplicas: 1,
+				Workers: []workload.ModelWorker{
+					{
+						Type:      workload.ModelWorkerTypeServer,
+						Image:     "docker.io/lmsysorg/sglang:latest",
+						Replicas:  1,
+						Pods:      1,
+						Config:    *config,
+						Resources: corev1ResourceRequirements(),
+					},
+				},
+			},
+		},
+	}
+}
+
+func createSGLangDisaggregatedTestModel() *workload.ModelBooster {
+	config := &apiextensionsv1.JSON{Raw: []byte(`{"served-model-name":"sglang-test"}`)}
+	worker := func(t workload.ModelWorkerType) workload.ModelWorker {
+		return workload.ModelWorker{
+			Type:      t,
+			Image:     "docker.io/lmsysorg/sglang:latest",
+			Replicas:  1,
+			Pods:      1,
+			Config:    *config,
+			Resources: corev1ResourceRequirements(),
+		}
+	}
+	return &workload.ModelBooster{
+		ObjectMeta: metav1.ObjectMeta{Name: "sglang-pd", Namespace: testNamespace},
+		Spec: workload.ModelBoosterSpec{
+			Name: "sglang-pd",
+			Backend: workload.ModelBackend{
+				Name:        "backend1",
+				Type:        workload.ModelBackendTypeSGLangDisaggregated,
+				ModelURI:    "hf://Qwen/Qwen3-0.6B",
+				CacheURI:    "hostpath:///tmp/cache",
+				MinReplicas: 1,
+				MaxReplicas: 1,
+				Workers: []workload.ModelWorker{
+					worker(workload.ModelWorkerTypePrefill),
+					worker(workload.ModelWorkerTypeDecode),
+				},
+			},
+		},
+	}
 }
 
 func createValidModelBoosterForWebhookTest() *workload.ModelBooster {


### PR DESCRIPTION
### What

Makes SGLang a peer engine to vLLM in the ModelBooster → ModelServing path (aggregated + PD-disaggregated). Widens the ModelBackendType enum, adds the SGLang converter + two embedded templates (port 30000, --host 0.0.0.0, SGLang-aware preStop drain, /dev/shm), gates VLLM_USE_V1 to vLLM, leaves KVConnector nil (router auto-selects via InferenceEngine), and adds webhook rules (worker-type + reserved-flag rejection). Examples, design doc, golden tests, and a kind e2e materialization test included.

### Why

vLLM was fully wired while SGLang's converter path rejected it, forcing hand-written ModelServing YAML and losing lifecycle/autoscaling/KV-aware routing

### Scope note: 
Router tokenizer/KV-cache and runtime SGLANG_DISAGGREGATED work are intentionally excluded (overlap with #997).

### Testing
build/vet/lint/gen clean; -race green for converter + webhook; Layer-5 GPU inference deferred (no compatible GPU — environment, not code).

Fixes #1058

