### PR TITLE
remove unused GetModelRoutesByGateway

### DIFF
--- a/pkg/kthena-router/datastore/store.go
+++ b/pkg/kthena-router/datastore/store.go
@@ -1796,16 +1796,39 @@ func (s *store) GetModelRoutesByGateway(gatewayKey string) []*aiv1alpha1.ModelRo
 		for routeKey := range routeSet {
 			// Find the ModelRoute in routes or loraRoutes
 			if info, ok := s.routeInfo[routeKey]; ok {
+				var foundRoute *aiv1alpha1.ModelRoute
+
 				// Try to find from primary model routes
 				if info.model != "" {
 					if routes, exists := s.routes[info.model]; exists {
 						for _, route := range routes {
 							if route.Namespace+"/"+route.Name == routeKey {
-								result = append(result, route)
+								foundRoute = route
 								break
 							}
 						}
 					}
+				}
+
+				// If not found, check lora routes (handles lora-only ModelRoutes)
+				if foundRoute == nil {
+					for _, lora := range info.loras {
+						if loraRoutes, ok := s.loraRoutes[lora]; ok {
+							for _, route := range loraRoutes {
+								if route.Namespace+"/"+route.Name == routeKey {
+									foundRoute = route
+									break
+								}
+							}
+							if foundRoute != nil {
+								break
+							}
+						}
+					}
+				}
+
+				if foundRoute != nil {
+					result = append(result, foundRoute)
 				}
 			}
 		}

--- a/pkg/kthena-router/datastore/store.go
+++ b/pkg/kthena-router/datastore/store.go
@@ -231,7 +231,6 @@ type Store interface {
 	GetHTTPRoute(key string) *gatewayv1.HTTPRoute
 	GetAllHTTPRoutes() []*gatewayv1.HTTPRoute
 	GetHTTPRoutesByGateway(gatewayKey string) []*gatewayv1.HTTPRoute
-	GetModelRoutesByGateway(gatewayKey string) []*aiv1alpha1.ModelRoute
 
 	// Debug interface methods
 	GetAllModelRoutes() map[string]*aiv1alpha1.ModelRoute
@@ -1781,55 +1780,6 @@ func (s *store) GetHTTPRoutesByGateway(gatewayKey string) []*gatewayv1.HTTPRoute
 		for routeKey := range routeSet {
 			if hr, ok := s.httpRoutes[routeKey]; ok {
 				result = append(result, hr)
-			}
-		}
-	}
-	return result
-}
-
-func (s *store) GetModelRoutesByGateway(gatewayKey string) []*aiv1alpha1.ModelRoute {
-	s.routeMutex.RLock()
-	defer s.routeMutex.RUnlock()
-
-	var result []*aiv1alpha1.ModelRoute
-	if routeSet, exists := s.gatewayModelRoutes[gatewayKey]; exists {
-		for routeKey := range routeSet {
-			// Find the ModelRoute in routes or loraRoutes
-			if info, ok := s.routeInfo[routeKey]; ok {
-				var foundRoute *aiv1alpha1.ModelRoute
-
-				// Try to find from primary model routes
-				if info.model != "" {
-					if routes, exists := s.routes[info.model]; exists {
-						for _, route := range routes {
-							if route.Namespace+"/"+route.Name == routeKey {
-								foundRoute = route
-								break
-							}
-						}
-					}
-				}
-
-				// If not found, check lora routes (handles lora-only ModelRoutes)
-				if foundRoute == nil {
-					for _, lora := range info.loras {
-						if loraRoutes, ok := s.loraRoutes[lora]; ok {
-							for _, route := range loraRoutes {
-								if route.Namespace+"/"+route.Name == routeKey {
-									foundRoute = route
-									break
-								}
-							}
-							if foundRoute != nil {
-								break
-							}
-						}
-					}
-				}
-
-				if foundRoute != nil {
-					result = append(result, foundRoute)
-				}
 			}
 		}
 	}

--- a/pkg/kthena-router/debug/handlers_test.go
+++ b/pkg/kthena-router/debug/handlers_test.go
@@ -207,7 +207,13 @@ func (m *MockStore) GetAllPods() map[types.NamespacedName]*datastore.PodInfo {
 	}
 	return args.Get(0).(map[types.NamespacedName]*datastore.PodInfo)
 }
-
+func (m *MockStore) GetModelRoute(namespacedName string) *aiv1alpha1.ModelRoute {
+	args := m.Called(namespacedName)
+	if args.Get(0) == nil {
+		return nil
+	}
+	return args.Get(0).(*aiv1alpha1.ModelRoute)
+}
 func (m *MockStore) AddOrUpdateGateway(gateway *gatewayv1.Gateway) error {
 	args := m.Called(gateway)
 	return args.Error(0)

--- a/pkg/kthena-router/debug/handlers_test.go
+++ b/pkg/kthena-router/debug/handlers_test.go
@@ -208,14 +208,6 @@ func (m *MockStore) GetAllPods() map[types.NamespacedName]*datastore.PodInfo {
 	return args.Get(0).(map[types.NamespacedName]*datastore.PodInfo)
 }
 
-func (m *MockStore) GetModelRoute(namespacedName string) *aiv1alpha1.ModelRoute {
-	args := m.Called(namespacedName)
-	if args.Get(0) == nil {
-		return nil
-	}
-	return args.Get(0).(*aiv1alpha1.ModelRoute)
-}
-
 func (m *MockStore) AddOrUpdateGateway(gateway *gatewayv1.Gateway) error {
 	args := m.Called(gateway)
 	return args.Error(0)
@@ -300,14 +292,6 @@ func (m *MockStore) GetHTTPRoutesByGateway(gatewayKey string) []*gatewayv1.HTTPR
 		return nil
 	}
 	return args.Get(0).([]*gatewayv1.HTTPRoute)
-}
-
-func (m *MockStore) GetModelRoutesByGateway(gatewayKey string) []*aiv1alpha1.ModelRoute {
-	args := m.Called(gatewayKey)
-	if args.Get(0) == nil {
-		return nil
-	}
-	return args.Get(0).([]*aiv1alpha1.ModelRoute)
 }
 
 func (m *MockStore) GetAllHTTPRoutes() []*gatewayv1.HTTPRoute {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
`GetModelRoutesByGateway` onlyy looked up ModelRoutes by their base model name and dropping lora-only routes (where `Spec.ModelName` is empty but `Spec.LoraAdapters` is set), these routes are correctly registered in `gatewayModelRoutes` by `AddOrUpdateModelRoute` but were never returned. so this fix adds the lora fallback lookup while consistent with `GetAllModelRoutes` and `GetModelRoute`.

**Which issue(s) this PR fixes**:
Fixes #1077


