### PR TITLE
fix(model-serving): sync PodGroup NetworkTopology on ModelServing topology updates

### DIFF
--- a/pkg/model-serving-controller/podgroupmanager/manager.go
+++ b/pkg/model-serving-controller/podgroupmanager/manager.go
@@ -302,7 +302,7 @@ func (m *Manager) createPodGroup(ctx context.Context, ms *workloadv1alpha1.Model
 		podGroup.Spec.Queue = queue
 	}
 
-	syncPodGroupGroupNetworkTopology(ms, &podGroup.Spec)
+	syncPodGroupNetworkTopology(ms, &podGroup.Spec)
 
 	if m.hasSubGroupPolicy.Load() {
 		podGroup = appendSubGroupPolicy(ms, podGroup, minRoleMember)
@@ -437,7 +437,7 @@ func (m *Manager) updatePodGroupIfNeeded(ctx context.Context, existing *scheduli
 		// When the queue annotation is removed (or set to empty) queue field is set to empty string.
 		updated.Spec.Queue = extractQueueName(ms)
 
-		syncPodGroupGroupNetworkTopology(ms, &updated.Spec)
+		syncPodGroupNetworkTopology(ms, &updated.Spec)
 
 		// Apply network topology policy
 		if m.hasSubGroupPolicy.Load() {
@@ -583,7 +583,7 @@ func podGroupCRDHasSubGroup(crd *apiextv1.CustomResourceDefinition) bool {
 	return false
 }
 
-// syncPodGroupGroupNetworkTopology sets or clears PodGroup group-level NetworkTopology
+// syncPodGroupNetworkTopology sets or clears PodGroup group-level NetworkTopology
 // from ModelServing spec.template.networkTopology.groupPolicy.
 func syncPodGroupNetworkTopology(ms *workloadv1alpha1.ModelServing, spec *schedulingv1beta1.PodGroupSpec) {
 	if ms.Spec.Template.NetworkTopology != nil && ms.Spec.Template.NetworkTopology.GroupPolicy != nil {

--- a/pkg/model-serving-controller/podgroupmanager/manager.go
+++ b/pkg/model-serving-controller/podgroupmanager/manager.go
@@ -302,12 +302,7 @@ func (m *Manager) createPodGroup(ctx context.Context, ms *workloadv1alpha1.Model
 		podGroup.Spec.Queue = queue
 	}
 
-	if ms.Spec.Template.NetworkTopology != nil {
-		// set NetworkTopology if configured in ModelServing
-		if ms.Spec.Template.NetworkTopology.GroupPolicy != nil {
-			podGroup.Spec.NetworkTopology = ms.Spec.Template.NetworkTopology.GroupPolicy
-		}
-	}
+	syncPodGroupGroupNetworkTopology(ms, &podGroup.Spec)
 
 	if m.hasSubGroupPolicy.Load() {
 		podGroup = appendSubGroupPolicy(ms, podGroup, minRoleMember)
@@ -441,6 +436,8 @@ func (m *Manager) updatePodGroupIfNeeded(ctx context.Context, existing *scheduli
 		// Sync queue name from ModelServing annotations if configured.
 		// When the queue annotation is removed (or set to empty) queue field is set to empty string.
 		updated.Spec.Queue = extractQueueName(ms)
+
+		syncPodGroupGroupNetworkTopology(ms, &updated.Spec)
 
 		// Apply network topology policy
 		if m.hasSubGroupPolicy.Load() {
@@ -584,6 +581,16 @@ func podGroupCRDHasSubGroup(crd *apiextv1.CustomResourceDefinition) bool {
 		}
 	}
 	return false
+}
+
+// syncPodGroupGroupNetworkTopology sets or clears PodGroup group-level NetworkTopology
+// from ModelServing spec.template.networkTopology.groupPolicy.
+func syncPodGroupGroupNetworkTopology(ms *workloadv1alpha1.ModelServing, spec *schedulingv1beta1.PodGroupSpec) {
+	if ms.Spec.Template.NetworkTopology != nil && ms.Spec.Template.NetworkTopology.GroupPolicy != nil {
+		spec.NetworkTopology = ms.Spec.Template.NetworkTopology.GroupPolicy
+		return
+	}
+	spec.NetworkTopology = nil
 }
 
 func hasPodGroupChanged(current, updated *schedulingv1beta1.PodGroup) bool {

--- a/pkg/model-serving-controller/podgroupmanager/manager.go
+++ b/pkg/model-serving-controller/podgroupmanager/manager.go
@@ -585,7 +585,7 @@ func podGroupCRDHasSubGroup(crd *apiextv1.CustomResourceDefinition) bool {
 
 // syncPodGroupGroupNetworkTopology sets or clears PodGroup group-level NetworkTopology
 // from ModelServing spec.template.networkTopology.groupPolicy.
-func syncPodGroupGroupNetworkTopology(ms *workloadv1alpha1.ModelServing, spec *schedulingv1beta1.PodGroupSpec) {
+func syncPodGroupNetworkTopology(ms *workloadv1alpha1.ModelServing, spec *schedulingv1beta1.PodGroupSpec) {
 	if ms.Spec.Template.NetworkTopology != nil && ms.Spec.Template.NetworkTopology.GroupPolicy != nil {
 		spec.NetworkTopology = ms.Spec.Template.NetworkTopology.GroupPolicy
 		return

--- a/pkg/model-serving-controller/podgroupmanager/manager_test.go
+++ b/pkg/model-serving-controller/podgroupmanager/manager_test.go
@@ -1377,3 +1377,102 @@ func TestUpdatePodGroupQueueBehavior(t *testing.T) {
 		assert.Equal(t, "", updated.Spec.Queue)
 	})
 }
+
+func newMinimalMSWithGroupTopology(mode string) *workloadv1alpha1.ModelServing {
+	ms := newMinimalMS("")
+	if mode == "" {
+		return ms
+	}
+	tier := 3
+	ms.Spec.Template.NetworkTopology = &workloadv1alpha1.NetworkTopology{
+		GroupPolicy: &schedulingv1beta1.NetworkTopologySpec{
+			Mode:               schedulingv1beta1.NetworkTopologyMode(mode),
+			HighestTierAllowed: &tier,
+		},
+	}
+	return ms
+}
+
+// TestUpdatePodGroupNetworkTopologyBehavior verifies that updatePodGroupIfNeeded syncs
+// Spec.NetworkTopology from ModelServing spec.template.networkTopology.groupPolicy.
+func TestUpdatePodGroupNetworkTopologyBehavior(t *testing.T) {
+	oldTopology := &schedulingv1beta1.NetworkTopologySpec{
+		Mode: schedulingv1beta1.NetworkTopologyMode("old-mode"),
+	}
+	newTopology := &schedulingv1beta1.NetworkTopologySpec{
+		Mode: schedulingv1beta1.NetworkTopologyMode("new-mode"),
+	}
+
+	buildExistingPG := func(topology *schedulingv1beta1.NetworkTopologySpec) *schedulingv1beta1.PodGroup {
+		return &schedulingv1beta1.PodGroup{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-pg",
+				Namespace: "default",
+			},
+			Spec: schedulingv1beta1.PodGroupSpec{
+				MinMember:       1,
+				NetworkTopology: topology,
+			},
+		}
+	}
+
+	setupManager := func(existingPG *schedulingv1beta1.PodGroup) (*Manager, *volcanofake.Clientset) {
+		fakeVolcano := volcanofake.NewSimpleClientset(existingPG)
+		fakeApiext := apiextfake.NewSimpleClientset(testhelper.CreatePodGroupCRD())
+		mgr := NewManager(nil, fakeVolcano, fakeApiext, nil)
+		mgr.hasPodGroupCRD.Store(true)
+		mgr.hasSubGroupPolicy.Store(false)
+
+		indexer := cache.NewIndexer(
+			cache.MetaNamespaceKeyFunc,
+			cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		)
+		err := indexer.Add(existingPG)
+		assert.NoError(t, err)
+		mgr.PodGroupLister = volcanoschedulerlister.NewPodGroupLister(indexer)
+		return mgr, fakeVolcano
+	}
+
+	t.Run("groupPolicy change updates Spec.NetworkTopology", func(t *testing.T) {
+		pg := buildExistingPG(oldTopology.DeepCopy())
+		mgr, fakeVolcano := setupManager(pg)
+		ms := newMinimalMSWithGroupTopology("new-mode")
+
+		err := mgr.updatePodGroupIfNeeded(context.Background(), pg, ms)
+		assert.NoError(t, err)
+
+		updated, err := fakeVolcano.SchedulingV1beta1().PodGroups("default").Get(
+			context.Background(), "test-pg", metav1.GetOptions{})
+		assert.NoError(t, err)
+		assert.Equal(t, newTopology.Mode, updated.Spec.NetworkTopology.Mode)
+	})
+
+	t.Run("topology removed clears Spec.NetworkTopology", func(t *testing.T) {
+		pg := buildExistingPG(oldTopology.DeepCopy())
+		mgr, fakeVolcano := setupManager(pg)
+		ms := newMinimalMS("")
+
+		err := mgr.updatePodGroupIfNeeded(context.Background(), pg, ms)
+		assert.NoError(t, err)
+
+		updated, err := fakeVolcano.SchedulingV1beta1().PodGroups("default").Get(
+			context.Background(), "test-pg", metav1.GetOptions{})
+		assert.NoError(t, err)
+		assert.Nil(t, updated.Spec.NetworkTopology)
+	})
+
+	t.Run("topology added when absent sets Spec.NetworkTopology", func(t *testing.T) {
+		pg := buildExistingPG(nil)
+		mgr, fakeVolcano := setupManager(pg)
+		ms := newMinimalMSWithGroupTopology("new-mode")
+
+		err := mgr.updatePodGroupIfNeeded(context.Background(), pg, ms)
+		assert.NoError(t, err)
+
+		updated, err := fakeVolcano.SchedulingV1beta1().PodGroups("default").Get(
+			context.Background(), "test-pg", metav1.GetOptions{})
+		assert.NoError(t, err)
+		assert.NotNil(t, updated.Spec.NetworkTopology)
+		assert.Equal(t, schedulingv1beta1.NetworkTopologyMode("new-mode"), updated.Spec.NetworkTopology.Mode)
+	})
+}

--- a/pkg/model-serving-controller/podgroupmanager/manager_test.go
+++ b/pkg/model-serving-controller/podgroupmanager/manager_test.go
@@ -1396,12 +1396,10 @@ func newMinimalMSWithGroupTopology(mode string) *workloadv1alpha1.ModelServing {
 // TestUpdatePodGroupNetworkTopologyBehavior verifies that updatePodGroupIfNeeded syncs
 // Spec.NetworkTopology from ModelServing spec.template.networkTopology.groupPolicy.
 func TestUpdatePodGroupNetworkTopologyBehavior(t *testing.T) {
-	oldTopology := &schedulingv1beta1.NetworkTopologySpec{
-		Mode: schedulingv1beta1.NetworkTopologyMode("old-mode"),
-	}
-	newTopology := &schedulingv1beta1.NetworkTopologySpec{
-		Mode: schedulingv1beta1.NetworkTopologyMode("new-mode"),
-	}
+	const (
+		oldMode = schedulingv1beta1.NetworkTopologyMode("old-mode")
+		newMode = schedulingv1beta1.NetworkTopologyMode("new-mode")
+	)
 
 	buildExistingPG := func(topology *schedulingv1beta1.NetworkTopologySpec) *schedulingv1beta1.PodGroup {
 		return &schedulingv1beta1.PodGroup{
@@ -1433,46 +1431,67 @@ func TestUpdatePodGroupNetworkTopologyBehavior(t *testing.T) {
 		return mgr, fakeVolcano
 	}
 
-	t.Run("groupPolicy change updates Spec.NetworkTopology", func(t *testing.T) {
-		pg := buildExistingPG(oldTopology.DeepCopy())
-		mgr, fakeVolcano := setupManager(pg)
-		ms := newMinimalMSWithGroupTopology("new-mode")
+	tests := []struct {
+		name              string
+		existingTopology  *schedulingv1beta1.NetworkTopologySpec
+		groupTopologyMode string
+		wantTopologyNil   bool
+		wantTopologyMode  schedulingv1beta1.NetworkTopologyMode
+	}{
+		{
+			name: "groupPolicy change updates Spec.NetworkTopology",
+			existingTopology: &schedulingv1beta1.NetworkTopologySpec{
+				Mode: oldMode,
+			},
+			groupTopologyMode: "new-mode",
+			wantTopologyMode:  newMode,
+		},
+		{
+			name: "topology removed clears Spec.NetworkTopology",
+			existingTopology: &schedulingv1beta1.NetworkTopologySpec{
+				Mode: oldMode,
+			},
+			groupTopologyMode: "",
+			wantTopologyNil:   true,
+		},
+		{
+			name:              "topology added when absent sets Spec.NetworkTopology",
+			existingTopology:  nil,
+			groupTopologyMode: "new-mode",
+			wantTopologyMode:  newMode,
+		},
+	}
 
-		err := mgr.updatePodGroupIfNeeded(context.Background(), pg, ms)
-		assert.NoError(t, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var existingTopology *schedulingv1beta1.NetworkTopologySpec
+			if tt.existingTopology != nil {
+				existingTopology = tt.existingTopology.DeepCopy()
+			}
+			pg := buildExistingPG(existingTopology)
+			mgr, fakeVolcano := setupManager(pg)
 
-		updated, err := fakeVolcano.SchedulingV1beta1().PodGroups("default").Get(
-			context.Background(), "test-pg", metav1.GetOptions{})
-		assert.NoError(t, err)
-		assert.Equal(t, newTopology.Mode, updated.Spec.NetworkTopology.Mode)
-	})
+			var ms *workloadv1alpha1.ModelServing
+			if tt.groupTopologyMode == "" {
+				ms = newMinimalMS("")
+			} else {
+				ms = newMinimalMSWithGroupTopology(tt.groupTopologyMode)
+			}
 
-	t.Run("topology removed clears Spec.NetworkTopology", func(t *testing.T) {
-		pg := buildExistingPG(oldTopology.DeepCopy())
-		mgr, fakeVolcano := setupManager(pg)
-		ms := newMinimalMS("")
+			err := mgr.updatePodGroupIfNeeded(context.Background(), pg, ms)
+			assert.NoError(t, err)
 
-		err := mgr.updatePodGroupIfNeeded(context.Background(), pg, ms)
-		assert.NoError(t, err)
+			updated, err := fakeVolcano.SchedulingV1beta1().PodGroups("default").Get(
+				context.Background(), "test-pg", metav1.GetOptions{})
+			assert.NoError(t, err)
 
-		updated, err := fakeVolcano.SchedulingV1beta1().PodGroups("default").Get(
-			context.Background(), "test-pg", metav1.GetOptions{})
-		assert.NoError(t, err)
-		assert.Nil(t, updated.Spec.NetworkTopology)
-	})
-
-	t.Run("topology added when absent sets Spec.NetworkTopology", func(t *testing.T) {
-		pg := buildExistingPG(nil)
-		mgr, fakeVolcano := setupManager(pg)
-		ms := newMinimalMSWithGroupTopology("new-mode")
-
-		err := mgr.updatePodGroupIfNeeded(context.Background(), pg, ms)
-		assert.NoError(t, err)
-
-		updated, err := fakeVolcano.SchedulingV1beta1().PodGroups("default").Get(
-			context.Background(), "test-pg", metav1.GetOptions{})
-		assert.NoError(t, err)
-		assert.NotNil(t, updated.Spec.NetworkTopology)
-		assert.Equal(t, schedulingv1beta1.NetworkTopologyMode("new-mode"), updated.Spec.NetworkTopology.Mode)
-	})
+			if tt.wantTopologyNil {
+				assert.Nil(t, updated.Spec.NetworkTopology)
+				return
+			}
+			if assert.NotNil(t, updated.Spec.NetworkTopology) {
+				assert.Equal(t, tt.wantTopologyMode, updated.Spec.NetworkTopology.Mode)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary

`updatePodGroupIfNeeded` updated `MinMember`, `MinResources`, `Queue`, and `SubGroupPolicy`, but never re-derived `Spec.NetworkTopology` from the current `ModelServing`. After a topology change or removal, Volcano PodGroups could keep stale group-level constraints until manually deleted.

This PR introduces `syncPodGroupGroupNetworkTopology` and uses it in both `createPodGroup` and `updatePodGroupIfNeeded` so group-level topology stays aligned with `spec.template.networkTopology.groupPolicy`, including clearing the field when topology is removed.

## Changes

- Add `syncPodGroupGroupNetworkTopology` in `pkg/model-serving-controller/podgroupmanager/manager.go`
- Call it from `createPodGroup` (replacing inline logic) and `updatePodGroupIfNeeded`
- Add `TestUpdatePodGroupNetworkTopologyBehavior` covering policy change, removal, and addition

## Test plan

- [x] `go test ./pkg/model-serving-controller/podgroupmanager/...`
- [ ] Manual: create a `ModelServing` with `spec.template.networkTopology.groupPolicy`, confirm PodGroup topology; patch topology or remove it; verify PodGroup `spec.networkTopology` updates without deleting the PodGroup

fixes #1087