### PR TITLE
cleanup: fix typo in updateInterval constant and remove redundant

### DIFF
--- a/pkg/kthena-router/datastore/store.go
+++ b/pkg/kthena-router/datastore/store.go
@@ -66,10 +66,8 @@ const (
 	// defaultMetricsScrapeInterval is the default polling interval for pod metrics.
 	defaultMetricsScrapeInterval = 1 * time.Second
 	metricsScrapeIntervalEnv     = "METRICS_SCRAPE_INTERVAL"
-
 	// maxConcurrentPodScrapes caps goroutines spawned per metrics scrape cycle.
 	maxConcurrentPodScrapes = 100
-
 	// onFlightSyncInterval caps Redis read traffic from SyncOnFlightCounts.
 	// At most one HMGET is issued per interval regardless of request rate;
 	// all other callers use the local atomic values maintained by Incr/Decr.
@@ -1493,8 +1491,6 @@ func selectFromWeightedSlice(weights []uint32) (int, error) {
 		return 0, fmt.Errorf("no weights provided")
 	}
 
-	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
-
 	totalWeight := 0
 	for _, weight := range weights {
 		totalWeight += int(weight)
@@ -1504,7 +1500,7 @@ func selectFromWeightedSlice(weights []uint32) (int, error) {
 		return 0, fmt.Errorf("total weight is zero")
 	}
 
-	randomNum := rng.Intn(totalWeight)
+	randomNum := rand.Intn(totalWeight)
 
 	for i, weight := range weights {
 		randomNum -= int(weight)

--- a/pkg/kthena-router/datastore/store.go
+++ b/pkg/kthena-router/datastore/store.go
@@ -64,7 +64,7 @@ var (
 const (
 	// Configuration constants for fairness scheduling
 	defaultQueueQPS = 100
-	uppdateInterval = 1 * time.Second
+	updateInterval  = 1 * time.Second
 )
 
 // createTokenTracker creates a token tracker with configuration from environment variables
@@ -423,7 +423,7 @@ func (s *store) Run(ctx context.Context) {
 					return true
 				})
 				s.initialSynced.Store(true)
-				time.Sleep(uppdateInterval)
+				time.Sleep(updateInterval)
 			}
 		}
 	}()
@@ -1142,8 +1142,6 @@ func selectFromWeightedSlice(weights []uint32) (int, error) {
 		return 0, fmt.Errorf("no weights provided")
 	}
 
-	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
-
 	totalWeight := 0
 	for _, weight := range weights {
 		totalWeight += int(weight)
@@ -1153,7 +1151,7 @@ func selectFromWeightedSlice(weights []uint32) (int, error) {
 		return 0, fmt.Errorf("total weight is zero")
 	}
 
-	randomNum := rng.Intn(totalWeight)
+	randomNum := rand.Intn(totalWeight)
 
 	for i, weight := range weights {
 		randomNum -= int(weight)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
 small cleanups in `store.go`:
1. Fix typo `uppdateInterval' => 'updateInterval`

2. Remove per-call `rand.New(rand.NewSource(time.Now().UnixNano()))` in `selectFromWeightedSlice` — replaced with `rand.Intn()` which is auto-seeded and thread safe 

**Which issue(s) this PR fixes**:
Fixes #1092
