### PR TITLE
fix(router): validate nil plugin args in NewLeastLatency

### DIFF
--- a/pkg/kthena-router/scheduler/plugins/least_latency.go
+++ b/pkg/kthena-router/scheduler/plugins/least_latency.go
@@ -45,7 +45,7 @@ type LeastLatencyArgs struct {
 
 func NewLeastLatency(pluginArg runtime.RawExtension) *LeastLatency {
 	var leastLatencyArgs LeastLatencyArgs
-	if yaml.Unmarshal(pluginArg.Raw, &leastLatencyArgs) != nil {
+	if pluginArg.Raw == nil || yaml.Unmarshal(pluginArg.Raw, &leastLatencyArgs) != nil {
 		klog.Errorf("Unmarshal LeastLatencyArgs error, setting default value")
 		leastLatencyArgs = LeastLatencyArgs{
 			0.5,

--- a/pkg/kthena-router/scheduler/plugins/least_latency_test.go
+++ b/pkg/kthena-router/scheduler/plugins/least_latency_test.go
@@ -110,6 +110,13 @@ func TestLeastLatencyScore(t *testing.T) {
 	}
 }
 
+func TestNewLeastLatencyNilRawUsesDefaultWeight(t *testing.T) {
+	plugin := NewLeastLatency(runtime.RawExtension{})
+	if plugin.TTFTTPOTWeightFactor != 0.5 {
+		t.Fatalf("expected default weight factor 0.5, got %v", plugin.TTFTTPOTWeightFactor)
+	}
+}
+
 func TestNewLeastLatencyInvalidArgsUsesDefaultWeight(t *testing.T) {
 	plugin := NewLeastLatency(runtime.RawExtension{Raw: []byte(`TTFTTPOTWeightFactor: [`)})
 	if plugin.TTFTTPOTWeightFactor != 0.5 {


### PR DESCRIPTION
## Summary

Validates `pluginArg.Raw == nil` in `NewLeastLatency`, matching the guard added for `NewLeastRequest` in #1003.

When plugin args are omitted, the constructor now applies the default `TTFTTPOTWeightFactor` (0.5) instead of depending on `yaml.Unmarshal` with a nil slice.

Fixes #1089

## Changes

- `pkg/kthena-router/scheduler/plugins/least_latency.go`: add nil `Raw` check before unmarshal
- `pkg/kthena-router/scheduler/plugins/least_latency_test.go`: add `TestNewLeastLatencyNilRawUsesDefaultWeight`

## Test plan

- [x] `go test ./pkg/kthena-router/scheduler/plugins/... -run LeastLatency -count=1`