### PR TITLE
Test/get model routes by gateway

### DIFF
--- a/pkg/kthena-router/datastore/store.go
+++ b/pkg/kthena-router/datastore/store.go
@@ -1796,16 +1796,39 @@ func (s *store) GetModelRoutesByGateway(gatewayKey string) []*aiv1alpha1.ModelRo
 		for routeKey := range routeSet {
 			// Find the ModelRoute in routes or loraRoutes
 			if info, ok := s.routeInfo[routeKey]; ok {
+				var foundRoute *aiv1alpha1.ModelRoute
+
 				// Try to find from primary model routes
 				if info.model != "" {
 					if routes, exists := s.routes[info.model]; exists {
 						for _, route := range routes {
 							if route.Namespace+"/"+route.Name == routeKey {
-								result = append(result, route)
+								foundRoute = route
 								break
 							}
 						}
 					}
+				}
+
+				// If not found, check lora routes (handles lora-only ModelRoutes)
+				if foundRoute == nil {
+					for _, lora := range info.loras {
+						if loraRoutes, ok := s.loraRoutes[lora]; ok {
+							for _, route := range loraRoutes {
+								if route.Namespace+"/"+route.Name == routeKey {
+									foundRoute = route
+									break
+								}
+							}
+							if foundRoute != nil {
+								break
+							}
+						}
+					}
+				}
+
+				if foundRoute != nil {
+					result = append(result, foundRoute)
 				}
 			}
 		}

--- a/pkg/kthena-router/datastore/store_test.go
+++ b/pkg/kthena-router/datastore/store_test.go
@@ -35,6 +35,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 // ptr is a helper function to get pointer to a value
@@ -1899,4 +1900,127 @@ func TestMatchModelServer_EmptyTargetModels_FallsThrough(t *testing.T) {
 	server, _, _, err := s.MatchModelServer("my-model", req, "")
 	assert.NoError(t, err)
 	assert.Equal(t, types.NamespacedName{Namespace: "default", Name: "good-server"}, server)
+}
+
+func TestGetModelRoutesByGateway_BaseModelRoute(t *testing.T) {
+	s := &store{
+		routeInfo:          make(map[string]*modelRouteInfo),
+		routes:             make(map[string][]*aiv1alpha1.ModelRoute),
+		loraRoutes:         make(map[string][]*aiv1alpha1.ModelRoute),
+		gatewayModelRoutes: make(map[string]sets.Set[string]),
+		callbacks:          make(map[string][]CallbackFunc),
+	}
+
+	kind := gatewayv1.Kind("Gateway")
+	mr := &aiv1alpha1.ModelRoute{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "base-route"},
+		Spec: aiv1alpha1.ModelRouteSpec{
+			ModelName: "llama3",
+			ParentRefs: []gatewayv1.ParentReference{
+				{Name: "my-gateway", Kind: &kind},
+			},
+		},
+	}
+	assert.NoError(t, s.AddOrUpdateModelRoute(mr))
+
+	result := s.GetModelRoutesByGateway("default/my-gateway")
+	assert.Len(t, result, 1)
+	assert.Equal(t, "base-route", result[0].Name)
+}
+
+func TestGetModelRoutesByGateway_LoraOnlyRoute(t *testing.T) {
+	s := &store{
+		routeInfo:          make(map[string]*modelRouteInfo),
+		routes:             make(map[string][]*aiv1alpha1.ModelRoute),
+		loraRoutes:         make(map[string][]*aiv1alpha1.ModelRoute),
+		gatewayModelRoutes: make(map[string]sets.Set[string]),
+		callbacks:          make(map[string][]CallbackFunc),
+	}
+
+	kind := gatewayv1.Kind("Gateway")
+	mr := &aiv1alpha1.ModelRoute{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "lora-only-route"},
+		Spec: aiv1alpha1.ModelRouteSpec{
+			ModelName:    "",
+			LoraAdapters: []string{"lora-adapter-1"},
+			ParentRefs: []gatewayv1.ParentReference{
+				{Name: "my-gateway", Kind: &kind},
+			},
+		},
+	}
+	assert.NoError(t, s.AddOrUpdateModelRoute(mr))
+
+	result := s.GetModelRoutesByGateway("default/my-gateway")
+	assert.Len(t, result, 1, "lora-only ModelRoute must not be silently dropped")
+	assert.Equal(t, "lora-only-route", result[0].Name)
+}
+
+func TestGetModelRoutesByGateway_WrongGateway(t *testing.T) {
+	s := &store{
+		routeInfo:          make(map[string]*modelRouteInfo),
+		routes:             make(map[string][]*aiv1alpha1.ModelRoute),
+		loraRoutes:         make(map[string][]*aiv1alpha1.ModelRoute),
+		gatewayModelRoutes: make(map[string]sets.Set[string]),
+		callbacks:          make(map[string][]CallbackFunc),
+	}
+
+	kind := gatewayv1.Kind("Gateway")
+	mr := &aiv1alpha1.ModelRoute{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "base-route"},
+		Spec: aiv1alpha1.ModelRouteSpec{
+			ModelName: "llama3",
+			ParentRefs: []gatewayv1.ParentReference{
+				{Name: "gateway-a", Kind: &kind},
+			},
+		},
+	}
+	assert.NoError(t, s.AddOrUpdateModelRoute(mr))
+
+	result := s.GetModelRoutesByGateway("default/gateway-b")
+	assert.Empty(t, result, "route attached to gateway-a must not appear for gateway-b")
+}
+
+func TestGetModelRoutesByGateway_UnknownGateway(t *testing.T) {
+	s := &store{
+		routeInfo:          make(map[string]*modelRouteInfo),
+		routes:             make(map[string][]*aiv1alpha1.ModelRoute),
+		loraRoutes:         make(map[string][]*aiv1alpha1.ModelRoute),
+		gatewayModelRoutes: make(map[string]sets.Set[string]),
+		callbacks:          make(map[string][]CallbackFunc),
+	}
+
+	result := s.GetModelRoutesByGateway("default/nonexistent")
+	assert.Empty(t, result)
+}
+
+func TestGetModelRoutesByGateway_MultipleRoutesMixedTypes(t *testing.T) {
+	s := &store{
+		routeInfo:          make(map[string]*modelRouteInfo),
+		routes:             make(map[string][]*aiv1alpha1.ModelRoute),
+		loraRoutes:         make(map[string][]*aiv1alpha1.ModelRoute),
+		gatewayModelRoutes: make(map[string]sets.Set[string]),
+		callbacks:          make(map[string][]CallbackFunc),
+	}
+
+	kind := gatewayv1.Kind("Gateway")
+	parentRefs := []gatewayv1.ParentReference{{Name: "my-gateway", Kind: &kind}}
+
+	baseRoute := &aiv1alpha1.ModelRoute{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "base-route"},
+		Spec:       aiv1alpha1.ModelRouteSpec{ModelName: "llama3", ParentRefs: parentRefs},
+	}
+	loraRoute := &aiv1alpha1.ModelRoute{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "lora-route"},
+		Spec:       aiv1alpha1.ModelRouteSpec{LoraAdapters: []string{"adapter-1"}, ParentRefs: parentRefs},
+	}
+
+	assert.NoError(t, s.AddOrUpdateModelRoute(baseRoute))
+	assert.NoError(t, s.AddOrUpdateModelRoute(loraRoute))
+
+	result := s.GetModelRoutesByGateway("default/my-gateway")
+	assert.Len(t, result, 2)
+
+	names := []string{result[0].Name, result[1].Name}
+	assert.Contains(t, names, "base-route")
+	assert.Contains(t, names, "lora-route")
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind enhancement

**What this PR does / why we need it**:
UT's for  `GetModelRoutesByGateway` . includes a regression test for the lora-only route bug fixed in #1077 to prevent future breakage.

**Which issue(s) this PR fixes**:
Fixes #1094

**Special notes for your reviewer**:
Cherry-picked the fix from #1077 onto this branch so the lora-only regression test passes.
<img width="737" height="269" alt="image" src="https://github.com/user-attachments/assets/0e1971a1-539f-41dd-b6d3-8602b6189263" />
