### PR TITLE
Bug: test/e2e  harden readiness waits and router rollouts to fix CI flakes

### DIFF
--- a/test/e2e/controller-manager/model_serving_test.go
+++ b/test/e2e/controller-manager/model_serving_test.go
@@ -2292,14 +2292,9 @@ func TestModelServingBinPackScaleDownCombined(t *testing.T) {
 }
 
 // TestModelServingStatusAwarePriorityScaleDownServingGroup verifies that when one ServingGroup is
-// not ready (pod deleted under default RoleRecreate), scale-down prefers removing that group before healthy groups.
+// not ready, scale-down prefers removing that group before healthy groups.
 func TestModelServingStatusAwarePriorityScaleDownServingGroup(t *testing.T) {
 	ctx, kthenaClient, kubeClient := setupControllerManagerE2ETest(t)
-
-	const (
-		initialReplicas = int32(4)
-		targetReplicas  = int32(3)
-	)
 
 	modelServing := createBasicModelServing("test-status-sg-priority", 4, 0)
 	t.Log("Creating ModelServing with 4 servingGroup replicas for status-aware scale down test")
@@ -2321,46 +2316,14 @@ func TestModelServingStatusAwarePriorityScaleDownServingGroup(t *testing.T) {
 	err = kubeClient.CoreV1().Pods(testNamespace).Delete(ctx, targetPod.Name, metav1.DeleteOptions{})
 	require.NoError(t, err, "Failed to delete pod")
 
+	initialMS, err := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Get(ctx, modelServing.Name, metav1.GetOptions{})
+	require.NoError(t, err, "Failed to get ModelServing before scale down")
+	scaleDownMS := initialMS.DeepCopy()
+	scaleDownMS.Spec.Replicas = ptr.To(int32(3))
+
 	t.Log("Scaling down ModelServing from 4 to 3 servingGroups (expect disrupted group to be removed first)")
-	require.Eventually(t, func() bool {
-		disruptedGroupSelector := fmt.Sprintf("%s,%s=%s", labelSelector, workload.GroupNameLabelKey, unhealthyGroup)
-		groupPods, listErr := kubeClient.CoreV1().Pods(testNamespace).List(ctx, metav1.ListOptions{
-			LabelSelector: disruptedGroupSelector,
-		})
-		if listErr != nil {
-			t.Logf("Failed to list pods in disrupted serving group %s: %v", unhealthyGroup, listErr)
-			return false
-		}
-
-		for _, pod := range groupPods.Items {
-			if pod.DeletionTimestamp != nil || pod.Status.Phase != corev1.PodRunning {
-				continue
-			}
-			return false
-		}
-
-		ms, getErr := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Get(ctx, modelServing.Name, metav1.GetOptions{})
-		if getErr != nil {
-			t.Logf("Failed to get ModelServing before scale down: %v", getErr)
-			return false
-		}
-
-		if ms.Spec.Replicas == nil || *ms.Spec.Replicas != initialReplicas {
-			return false
-		}
-		if ms.Status.AvailableReplicas != targetReplicas {
-			return false
-		}
-
-		scaleDownMS := ms.DeepCopy()
-		scaleDownMS.Spec.Replicas = ptr.To(targetReplicas)
-		_, updateErr := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Update(ctx, scaleDownMS, metav1.UpdateOptions{})
-		if updateErr != nil {
-			t.Logf("Failed to scale down ModelServing: %v", updateErr)
-			return false
-		}
-		return true
-	}, 2*time.Minute, 2*time.Second, "Failed to trigger scale down after disruption was observed")
+	_, err = kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Update(ctx, scaleDownMS, metav1.UpdateOptions{})
+	require.NoError(t, err, "Failed to scale down ModelServing")
 
 	utils.WaitForModelServingReady(t, ctx, kthenaClient, testNamespace, modelServing.Name)
 	waitForRunningPodCount(t, ctx, kubeClient, modelServing.Name, 3, 3*time.Minute)

--- a/test/e2e/controller-manager/model_serving_test.go
+++ b/test/e2e/controller-manager/model_serving_test.go
@@ -133,9 +133,11 @@ func TestModelServingLifecycle(t *testing.T) {
 
 	// Verify that associated pods are cleaned up
 	require.Eventually(t, func() bool {
-		pods, err := kubeClient.CoreV1().Pods(testNamespace).List(ctx, metav1.ListOptions{
+		listCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		pods, err := kubeClient.CoreV1().Pods(testNamespace).List(listCtx, metav1.ListOptions{
 			LabelSelector: labelSelector,
 		})
+		cancel()
 		if err != nil {
 			return false
 		}
@@ -1523,11 +1525,11 @@ func TestModelServingPartitionScaleDown(t *testing.T) {
 
 	finalMS, err := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Get(ctx, modelServing.Name, metav1.GetOptions{})
 	require.NoError(t, err)
-	assert.Equal(t, scaledReplicas, *finalMS.Spec.Replicas)
-	assert.Equal(t, scaledReplicas, finalMS.Status.Replicas)
-	assert.Equal(t, int32(0), finalMS.Status.UpdatedReplicas)
-	assert.Equal(t, scaledReplicas, finalMS.Status.CurrentReplicas)
-	assert.Equal(t, scaledReplicas, finalMS.Status.AvailableReplicas)
+	require.Equal(t, scaledReplicas, *finalMS.Spec.Replicas)
+	require.Equal(t, scaledReplicas, finalMS.Status.Replicas)
+	require.Equal(t, int32(0), finalMS.Status.UpdatedReplicas)
+	require.Equal(t, scaledReplicas, finalMS.Status.CurrentReplicas)
+	require.Equal(t, scaledReplicas, finalMS.Status.AvailableReplicas)
 
 	t.Log("ModelServing partition scale down test passed successfully")
 }
@@ -1619,9 +1621,11 @@ type servingGroupState struct {
 }
 
 func collectRunningServingGroupStates(ctx context.Context, kubeClient *kubernetes.Clientset, msName string) (map[int32]servingGroupState, error) {
-	pods, err := kubeClient.CoreV1().Pods(testNamespace).List(ctx, metav1.ListOptions{
+	listCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	pods, err := kubeClient.CoreV1().Pods(testNamespace).List(listCtx, metav1.ListOptions{
 		LabelSelector: modelServingLabelSelector(msName),
 	})
+	cancel()
 	if err != nil {
 		return nil, err
 	}
@@ -1666,7 +1670,9 @@ func waitForPartitionState(t *testing.T, ctx context.Context, kthenaClient *clie
 
 	var updateRevision string
 	require.Eventually(t, func() bool {
-		ms, err := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Get(ctx, msName, metav1.GetOptions{})
+		getCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		ms, err := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Get(getCtx, msName, metav1.GetOptions{})
+		cancel()
 		if err != nil {
 			return false
 		}
@@ -1707,7 +1713,9 @@ func waitForRollingUpdateConverged(t *testing.T, ctx context.Context, kthenaClie
 
 	var finalMS *workload.ModelServing
 	require.Eventually(t, func() bool {
-		ms, err := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Get(ctx, msName, metav1.GetOptions{})
+		getCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		ms, err := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Get(getCtx, msName, metav1.GetOptions{})
+		cancel()
 		if err != nil {
 			return false
 		}
@@ -1763,9 +1771,11 @@ func verifyAllPodsHaveImage(t *testing.T, ctx context.Context, kubeClient *kuber
 	labelSelector, expectedImage, phase string) {
 	t.Helper()
 	require.Eventually(t, func() bool {
-		pods, err := kubeClient.CoreV1().Pods(testNamespace).List(ctx, metav1.ListOptions{
+		listCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		pods, err := kubeClient.CoreV1().Pods(testNamespace).List(listCtx, metav1.ListOptions{
 			LabelSelector: labelSelector,
 		})
+		cancel()
 		if err != nil || len(pods.Items) == 0 {
 			return false
 		}

--- a/test/e2e/controller-manager/model_serving_test.go
+++ b/test/e2e/controller-manager/model_serving_test.go
@@ -2330,13 +2330,17 @@ func TestModelServingStatusAwarePriorityScaleDownServingGroup(t *testing.T) {
 
 	for i := 1; i < len(podList.Items); i++ {
 		pod := podList.Items[i]
-		_, err := kubeClient.CoreV1().Pods(testNamespace).Patch(ctx, pod.Name, types.StrategicMergePatchType, patchTrue, metav1.PatchOptions{}, "status")
+		patchCtx, cancel := context.WithTimeout(ctx, utils.DefaultAPICallTimeout)
+		_, err := kubeClient.CoreV1().Pods(testNamespace).Patch(patchCtx, pod.Name, types.StrategicMergePatchType, patchTrue, metav1.PatchOptions{}, "status")
+		cancel()
 		require.NoError(t, err, "Failed to patch readiness gate for pod %s", pod.Name)
 	}
 
 	t.Log("Waiting for controller to observe the state (3 Ready, 1 NotReady)")
 	require.Eventually(t, func() bool {
-		ms, getErr := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Get(ctx, modelServing.Name, metav1.GetOptions{})
+		getCtx, cancel := context.WithTimeout(ctx, utils.DefaultAPICallTimeout)
+		defer cancel()
+		ms, getErr := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Get(getCtx, modelServing.Name, metav1.GetOptions{})
 		if getErr != nil {
 			return false
 		}
@@ -2407,13 +2411,17 @@ func TestModelServingStatusAwarePriorityScaleDownRole(t *testing.T) {
 
 	for i := 1; i < len(podList.Items); i++ {
 		pod := podList.Items[i]
-		_, err := kubeClient.CoreV1().Pods(testNamespace).Patch(ctx, pod.Name, types.StrategicMergePatchType, patchTrue, metav1.PatchOptions{}, "status")
+		patchCtx, cancel := context.WithTimeout(ctx, utils.DefaultAPICallTimeout)
+		_, err := kubeClient.CoreV1().Pods(testNamespace).Patch(patchCtx, pod.Name, types.StrategicMergePatchType, patchTrue, metav1.PatchOptions{}, "status")
+		cancel()
 		require.NoError(t, err, "Failed to patch readiness gate for pod %s", pod.Name)
 	}
 
 	t.Log("Waiting for controller to observe the state")
 	require.Eventually(t, func() bool {
-		ms, getErr := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Get(ctx, modelServing.Name, metav1.GetOptions{})
+		getCtx, cancel := context.WithTimeout(ctx, utils.DefaultAPICallTimeout)
+		defer cancel()
+		ms, getErr := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Get(getCtx, modelServing.Name, metav1.GetOptions{})
 		if getErr != nil {
 			return false
 		}

--- a/test/e2e/controller-manager/model_serving_test.go
+++ b/test/e2e/controller-manager/model_serving_test.go
@@ -134,10 +134,10 @@ func TestModelServingLifecycle(t *testing.T) {
 	// Verify that associated pods are cleaned up
 	require.Eventually(t, func() bool {
 		listCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		defer cancel()
 		pods, err := kubeClient.CoreV1().Pods(testNamespace).List(listCtx, metav1.ListOptions{
 			LabelSelector: labelSelector,
 		})
-		cancel()
 		if err != nil {
 			return false
 		}
@@ -1622,10 +1622,10 @@ type servingGroupState struct {
 
 func collectRunningServingGroupStates(ctx context.Context, kubeClient *kubernetes.Clientset, msName string) (map[int32]servingGroupState, error) {
 	listCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
 	pods, err := kubeClient.CoreV1().Pods(testNamespace).List(listCtx, metav1.ListOptions{
 		LabelSelector: modelServingLabelSelector(msName),
 	})
-	cancel()
 	if err != nil {
 		return nil, err
 	}
@@ -1671,8 +1671,8 @@ func waitForPartitionState(t *testing.T, ctx context.Context, kthenaClient *clie
 	var updateRevision string
 	require.Eventually(t, func() bool {
 		getCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		defer cancel()
 		ms, err := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Get(getCtx, msName, metav1.GetOptions{})
-		cancel()
 		if err != nil {
 			return false
 		}
@@ -1714,8 +1714,8 @@ func waitForRollingUpdateConverged(t *testing.T, ctx context.Context, kthenaClie
 	var finalMS *workload.ModelServing
 	require.Eventually(t, func() bool {
 		getCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		defer cancel()
 		ms, err := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Get(getCtx, msName, metav1.GetOptions{})
-		cancel()
 		if err != nil {
 			return false
 		}
@@ -1772,10 +1772,10 @@ func verifyAllPodsHaveImage(t *testing.T, ctx context.Context, kubeClient *kuber
 	t.Helper()
 	require.Eventually(t, func() bool {
 		listCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		defer cancel()
 		pods, err := kubeClient.CoreV1().Pods(testNamespace).List(listCtx, metav1.ListOptions{
 			LabelSelector: labelSelector,
 		})
-		cancel()
 		if err != nil || len(pods.Items) == 0 {
 			return false
 		}

--- a/test/e2e/controller-manager/model_serving_test.go
+++ b/test/e2e/controller-manager/model_serving_test.go
@@ -2301,8 +2301,16 @@ func TestModelServingStatusAwarePriorityScaleDownServingGroup(t *testing.T) {
 	ctx, kthenaClient, kubeClient := setupControllerManagerE2ETest(t)
 
 	modelServing := createBasicModelServing("test-status-sg-priority", 4, 0)
-	t.Log("Creating ModelServing with 4 servingGroup replicas for status-aware scale down test")
-	createAndWaitForModelServing(t, ctx, kthenaClient, modelServing)
+	// Inject a readiness gate to control pod readiness deterministically via K8s API
+	gateType := corev1.PodConditionType("kthena.e2e/test-ready")
+	modelServing.Spec.Template.Roles[0].EntryTemplate.Spec.ReadinessGates = []corev1.PodReadinessGate{
+		{ConditionType: gateType},
+	}
+
+	t.Log("Creating ModelServing with 4 servingGroups (pods will start NotReady due to ReadinessGate)")
+	_, err := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Create(ctx, modelServing, metav1.CreateOptions{})
+	require.NoError(t, err, "Failed to create ModelServing")
+
 	waitForRunningPodCount(t, ctx, kubeClient, modelServing.Name, 4, 3*time.Minute)
 
 	labelSelector := modelServingLabelSelector(modelServing.Name)
@@ -2310,22 +2318,37 @@ func TestModelServingStatusAwarePriorityScaleDownServingGroup(t *testing.T) {
 		LabelSelector: labelSelector,
 	})
 	require.NoError(t, err, "Failed to list pods")
-	require.NotEmpty(t, podList.Items, "Expected pods before simulating disruption")
+	require.Len(t, podList.Items, 4, "Expected exactly 4 pods")
 
+	t.Log("Patching 3 out of 4 pods to satisfy the ReadinessGate so they become Ready")
+	patchTrue := []byte(fmt.Sprintf(`{"status":{"conditions":[{"type":"%s","status":"True"}]}}`, gateType))
+	// We intentionally skip the first pod to keep its group permanently NotReady
 	targetPod := podList.Items[0]
 	unhealthyGroup := targetPod.Labels[workload.GroupNameLabelKey]
 	require.NotEmpty(t, unhealthyGroup, "Pod should have GroupName label")
+	t.Logf("Leaving pod %s in serving group %s NotReady to permanently disrupt that group", targetPod.Name, unhealthyGroup)
 
-	t.Logf("Deleting pod %s in serving group %s to leave that group not ready", targetPod.Name, unhealthyGroup)
-	err = kubeClient.CoreV1().Pods(testNamespace).Delete(ctx, targetPod.Name, metav1.DeleteOptions{})
-	require.NoError(t, err, "Failed to delete pod")
+	for i := 1; i < len(podList.Items); i++ {
+		pod := podList.Items[i]
+		_, err := kubeClient.CoreV1().Pods(testNamespace).Patch(ctx, pod.Name, types.StrategicMergePatchType, patchTrue, metav1.PatchOptions{}, "status")
+		require.NoError(t, err, "Failed to patch readiness gate for pod %s", pod.Name)
+	}
+
+	t.Log("Waiting for controller to observe the state (3 Ready, 1 NotReady)")
+	require.Eventually(t, func() bool {
+		ms, getErr := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Get(ctx, modelServing.Name, metav1.GetOptions{})
+		if getErr != nil {
+			return false
+		}
+		return ms.Status.AvailableReplicas == 3
+	}, 30*time.Second, 2*time.Second, "Expected AvailableReplicas to stabilize at 3")
 
 	initialMS, err := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Get(ctx, modelServing.Name, metav1.GetOptions{})
 	require.NoError(t, err, "Failed to get ModelServing before scale down")
 	scaleDownMS := initialMS.DeepCopy()
 	scaleDownMS.Spec.Replicas = ptr.To(int32(3))
 
-	t.Log("Scaling down ModelServing from 4 to 3 servingGroups (expect disrupted group to be removed first)")
+	t.Log("Scaling down ModelServing from 4 to 3 servingGroups (expect unready group to be removed first)")
 	_, err = kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Update(ctx, scaleDownMS, metav1.UpdateOptions{})
 	require.NoError(t, err, "Failed to scale down ModelServing")
 
@@ -2342,7 +2365,7 @@ func TestModelServingStatusAwarePriorityScaleDownServingGroup(t *testing.T) {
 			continue
 		}
 		require.NotEqual(t, unhealthyGroup, pod.Labels[workload.GroupNameLabelKey],
-			"Running pods should not belong to the disrupted serving group after status-aware scale down")
+			"Running pods should not belong to the unready serving group after status-aware scale down")
 	}
 	t.Log("Status-aware priority scale down ServingGroup test passed successfully")
 }
@@ -2355,8 +2378,16 @@ func TestModelServingStatusAwarePriorityScaleDownRole(t *testing.T) {
 	const initialRoleReplicas = int32(4)
 
 	modelServing := createBasicModelServing("test-status-role-priority", 1, initialRoleReplicas)
-	t.Log("Creating ModelServing with role replicas=4 for status-aware role scale down test")
-	createAndWaitForModelServing(t, ctx, kthenaClient, modelServing)
+	// Inject a readiness gate to control pod readiness deterministically via K8s API
+	gateType := corev1.PodConditionType("kthena.e2e/test-ready")
+	modelServing.Spec.Template.Roles[0].EntryTemplate.Spec.ReadinessGates = []corev1.PodReadinessGate{
+		{ConditionType: gateType},
+	}
+
+	t.Log("Creating ModelServing with role replicas=4 (pods will start NotReady due to ReadinessGate)")
+	_, err := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Create(ctx, modelServing, metav1.CreateOptions{})
+	require.NoError(t, err, "Failed to create ModelServing")
+
 	waitForRunningPodCount(t, ctx, kubeClient, modelServing.Name, int(initialRoleReplicas), 3*time.Minute)
 
 	labelSelector := modelServingLabelSelector(modelServing.Name)
@@ -2364,24 +2395,40 @@ func TestModelServingStatusAwarePriorityScaleDownRole(t *testing.T) {
 		LabelSelector: labelSelector,
 	})
 	require.NoError(t, err, "Failed to list pods")
-	require.NotEmpty(t, podList.Items, "Expected pods before simulating disruption")
+	require.Len(t, podList.Items, 4, "Expected exactly 4 pods")
+
+	t.Log("Patching 3 out of 4 pods to satisfy the ReadinessGate so they become Ready")
+	patchTrue := []byte(fmt.Sprintf(`{"status":{"conditions":[{"type":"%s","status":"True"}]}}`, gateType))
 
 	targetPod := podList.Items[0]
 	unhealthyRoleID := targetPod.Labels[workload.RoleIDKey]
 	require.NotEmpty(t, unhealthyRoleID, "Pod should have role id label")
+	t.Logf("Leaving pod %s (role id %s) NotReady to permanently disrupt that role replica", targetPod.Name, unhealthyRoleID)
 
-	t.Logf("Deleting pod %s (role id %s) to leave that role replica not ready", targetPod.Name, unhealthyRoleID)
-	err = kubeClient.CoreV1().Pods(testNamespace).Delete(ctx, targetPod.Name, metav1.DeleteOptions{})
-	require.NoError(t, err, "Failed to delete pod")
+	for i := 1; i < len(podList.Items); i++ {
+		pod := podList.Items[i]
+		_, err := kubeClient.CoreV1().Pods(testNamespace).Patch(ctx, pod.Name, types.StrategicMergePatchType, patchTrue, metav1.PatchOptions{}, "status")
+		require.NoError(t, err, "Failed to patch readiness gate for pod %s", pod.Name)
+	}
+
+	t.Log("Waiting for controller to observe the state")
+	require.Eventually(t, func() bool {
+		ms, getErr := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Get(ctx, modelServing.Name, metav1.GetOptions{})
+		if getErr != nil {
+			return false
+		}
+		// When 1 role replica is NotReady, the single ServingGroup is NotReady, so AvailableReplicas stays at 0
+		return ms.Status.AvailableReplicas == 0
+	}, 30*time.Second, 2*time.Second, "Expected AvailableReplicas to remain 0 since one role is NotReady")
 
 	initialMS, err := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Get(ctx, modelServing.Name, metav1.GetOptions{})
 	require.NoError(t, err, "Failed to get ModelServing before scale down")
 	scaleDownMS := initialMS.DeepCopy()
 	scaleDownMS.Spec.Template.Roles[0].Replicas = ptr.To(int32(3))
 
-	t.Log("Scaling down role from 4 to 3 replicas (expect disrupted replica to be removed first)")
+	t.Log("Scaling down role from 4 to 3 replicas (expect unready role to be removed first)")
 	_, err = kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Update(ctx, scaleDownMS, metav1.UpdateOptions{})
-	require.NoError(t, err, "Failed to scale down role")
+	require.NoError(t, err, "Failed to scale down ModelServing")
 
 	utils.WaitForModelServingReady(t, ctx, kthenaClient, testNamespace, modelServing.Name)
 	waitForRunningPodCount(t, ctx, kubeClient, modelServing.Name, 3, 3*time.Minute)
@@ -2395,8 +2442,8 @@ func TestModelServingStatusAwarePriorityScaleDownRole(t *testing.T) {
 		if pod.DeletionTimestamp != nil || pod.Status.Phase != corev1.PodRunning {
 			continue
 		}
-		assert.NotEqual(t, unhealthyRoleID, pod.Labels[workload.RoleIDKey],
-			"Running pods should not keep the disrupted role id after status-aware scale down")
+		require.NotEqual(t, unhealthyRoleID, pod.Labels[workload.RoleIDKey],
+			"Running pods should not belong to the unready role after status-aware scale down")
 	}
 	t.Log("Status-aware priority scale down Role test passed successfully")
 }

--- a/test/e2e/controller-manager/model_serving_test.go
+++ b/test/e2e/controller-manager/model_serving_test.go
@@ -89,9 +89,7 @@ func TestModelServingLifecycle(t *testing.T) {
 
 	// Verify the image was updated on all non-terminating pods
 	require.Eventually(t, func() bool {
-		listCtx, cancel := context.WithTimeout(ctx, utils.DefaultAPICallTimeout)
-		defer cancel()
-		pods, err := kubeClient.CoreV1().Pods(testNamespace).List(listCtx, metav1.ListOptions{
+		pods, err := kubeClient.CoreV1().Pods(testNamespace).List(ctx, metav1.ListOptions{
 			LabelSelector: labelSelector,
 		})
 		if err != nil || len(pods.Items) == 0 {
@@ -126,9 +124,7 @@ func TestModelServingLifecycle(t *testing.T) {
 
 	// Verify the ModelServing is deleted
 	require.Eventually(t, func() bool {
-		getCtx, cancel := context.WithTimeout(ctx, utils.DefaultAPICallTimeout)
-		defer cancel()
-		_, err := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Get(getCtx, modelServing.Name, metav1.GetOptions{})
+		_, err := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Get(ctx, modelServing.Name, metav1.GetOptions{})
 		if err == nil {
 			return false
 		}
@@ -137,9 +133,7 @@ func TestModelServingLifecycle(t *testing.T) {
 
 	// Verify that associated pods are cleaned up
 	require.Eventually(t, func() bool {
-		listCtx, cancel := context.WithTimeout(ctx, utils.DefaultAPICallTimeout)
-		defer cancel()
-		pods, err := kubeClient.CoreV1().Pods(testNamespace).List(listCtx, metav1.ListOptions{
+		pods, err := kubeClient.CoreV1().Pods(testNamespace).List(ctx, metav1.ListOptions{
 			LabelSelector: labelSelector,
 		})
 		if err != nil {
@@ -1625,9 +1619,7 @@ type servingGroupState struct {
 }
 
 func collectRunningServingGroupStates(ctx context.Context, kubeClient *kubernetes.Clientset, msName string) (map[int32]servingGroupState, error) {
-	listCtx, cancel := context.WithTimeout(ctx, utils.DefaultAPICallTimeout)
-	defer cancel()
-	pods, err := kubeClient.CoreV1().Pods(testNamespace).List(listCtx, metav1.ListOptions{
+	pods, err := kubeClient.CoreV1().Pods(testNamespace).List(ctx, metav1.ListOptions{
 		LabelSelector: modelServingLabelSelector(msName),
 	})
 	if err != nil {
@@ -1674,9 +1666,7 @@ func waitForPartitionState(t *testing.T, ctx context.Context, kthenaClient *clie
 
 	var updateRevision string
 	require.Eventually(t, func() bool {
-		getCtx, cancel := context.WithTimeout(ctx, utils.DefaultAPICallTimeout)
-		defer cancel()
-		ms, err := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Get(getCtx, msName, metav1.GetOptions{})
+		ms, err := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Get(ctx, msName, metav1.GetOptions{})
 		if err != nil {
 			return false
 		}
@@ -1717,9 +1707,7 @@ func waitForRollingUpdateConverged(t *testing.T, ctx context.Context, kthenaClie
 
 	var finalMS *workload.ModelServing
 	require.Eventually(t, func() bool {
-		getCtx, cancel := context.WithTimeout(ctx, utils.DefaultAPICallTimeout)
-		defer cancel()
-		ms, err := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Get(getCtx, msName, metav1.GetOptions{})
+		ms, err := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Get(ctx, msName, metav1.GetOptions{})
 		if err != nil {
 			return false
 		}
@@ -1775,9 +1763,7 @@ func verifyAllPodsHaveImage(t *testing.T, ctx context.Context, kubeClient *kuber
 	labelSelector, expectedImage, phase string) {
 	t.Helper()
 	require.Eventually(t, func() bool {
-		listCtx, cancel := context.WithTimeout(ctx, utils.DefaultAPICallTimeout)
-		defer cancel()
-		pods, err := kubeClient.CoreV1().Pods(testNamespace).List(listCtx, metav1.ListOptions{
+		pods, err := kubeClient.CoreV1().Pods(testNamespace).List(ctx, metav1.ListOptions{
 			LabelSelector: labelSelector,
 		})
 		if err != nil || len(pods.Items) == 0 {
@@ -2338,9 +2324,7 @@ func TestModelServingStatusAwarePriorityScaleDownServingGroup(t *testing.T) {
 
 	t.Log("Waiting for controller to observe the state (3 Ready, 1 NotReady)")
 	require.Eventually(t, func() bool {
-		getCtx, cancel := context.WithTimeout(ctx, utils.DefaultAPICallTimeout)
-		defer cancel()
-		ms, getErr := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Get(getCtx, modelServing.Name, metav1.GetOptions{})
+		ms, getErr := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Get(ctx, modelServing.Name, metav1.GetOptions{})
 		if getErr != nil {
 			return false
 		}

--- a/test/e2e/controller-manager/model_serving_test.go
+++ b/test/e2e/controller-manager/model_serving_test.go
@@ -2364,13 +2364,13 @@ func TestModelServingStatusAwarePriorityScaleDownServingGroup(t *testing.T) {
 	})
 	require.NoError(t, err, "Failed to list pods after scale down")
 
+	unhealthyCount := 0
 	for _, pod := range finalPods.Items {
-		if pod.DeletionTimestamp != nil || pod.Status.Phase != corev1.PodRunning {
-			continue
+		if pod.Labels[workload.GroupNameLabelKey] == unhealthyGroup {
+			unhealthyCount++
 		}
-		require.NotEqual(t, unhealthyGroup, pod.Labels[workload.GroupNameLabelKey],
-			"Running pods should not belong to the unready serving group after status-aware scale down")
 	}
+	require.Equal(t, 0, unhealthyCount, "Expected 0 pods in the unready serving group after status-aware scale down")
 	t.Log("Status-aware priority scale down ServingGroup test passed successfully")
 }
 
@@ -2417,17 +2417,28 @@ func TestModelServingStatusAwarePriorityScaleDownRole(t *testing.T) {
 		require.NoError(t, err, "Failed to patch readiness gate for pod %s", pod.Name)
 	}
 
-	t.Log("Waiting for controller to observe the state")
+	ms, err := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Get(ctx, modelServing.Name, metav1.GetOptions{})
+	require.NoError(t, err, "Failed to get ModelServing for event watch")
+
+	t.Log("Waiting for controller to observe the patched Ready pods")
+	// AvailableReplicas stays 0 while one role is NotReady, so it cannot signal that the
+	// controller processed the patches. Wait for RoleRunning events instead.
 	require.Eventually(t, func() bool {
-		getCtx, cancel := context.WithTimeout(ctx, utils.DefaultAPICallTimeout)
-		defer cancel()
-		ms, getErr := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Get(getCtx, modelServing.Name, metav1.GetOptions{})
-		if getErr != nil {
+		eventList, listErr := kubeClient.CoreV1().Events(testNamespace).List(ctx, metav1.ListOptions{})
+		if listErr != nil {
 			return false
 		}
-		// When 1 role replica is NotReady, the single ServingGroup is NotReady, so AvailableReplicas stays at 0
-		return ms.Status.AvailableReplicas == 0
-	}, 30*time.Second, 2*time.Second, "Expected AvailableReplicas to remain 0 since one role is NotReady")
+		runningRoleEvents := 0
+		for _, ev := range eventList.Items {
+			if ev.InvolvedObject.Kind != "ModelServing" || ev.InvolvedObject.UID != ms.UID {
+				continue
+			}
+			if ev.Reason == "RoleRunning" {
+				runningRoleEvents++
+			}
+		}
+		return runningRoleEvents >= 3
+	}, 30*time.Second, 2*time.Second, "Expected 3 roles to transition to Running state")
 
 	initialMS, err := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Get(ctx, modelServing.Name, metav1.GetOptions{})
 	require.NoError(t, err, "Failed to get ModelServing before scale down")
@@ -2446,12 +2457,12 @@ func TestModelServingStatusAwarePriorityScaleDownRole(t *testing.T) {
 	})
 	require.NoError(t, err, "Failed to list pods after scale down")
 
+	unhealthyCount := 0
 	for _, pod := range finalPods.Items {
-		if pod.DeletionTimestamp != nil || pod.Status.Phase != corev1.PodRunning {
-			continue
+		if pod.Labels[workload.RoleIDKey] == unhealthyRoleID {
+			unhealthyCount++
 		}
-		require.NotEqual(t, unhealthyRoleID, pod.Labels[workload.RoleIDKey],
-			"Running pods should not belong to the unready role after status-aware scale down")
 	}
+	require.Equal(t, 0, unhealthyCount, "Expected 0 pods in the unready role after status-aware scale down")
 	t.Log("Status-aware priority scale down Role test passed successfully")
 }

--- a/test/e2e/controller-manager/model_serving_test.go
+++ b/test/e2e/controller-manager/model_serving_test.go
@@ -89,7 +89,9 @@ func TestModelServingLifecycle(t *testing.T) {
 
 	// Verify the image was updated on all non-terminating pods
 	require.Eventually(t, func() bool {
-		pods, err := kubeClient.CoreV1().Pods(testNamespace).List(ctx, metav1.ListOptions{
+		listCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		defer cancel()
+		pods, err := kubeClient.CoreV1().Pods(testNamespace).List(listCtx, metav1.ListOptions{
 			LabelSelector: labelSelector,
 		})
 		if err != nil || len(pods.Items) == 0 {
@@ -124,7 +126,9 @@ func TestModelServingLifecycle(t *testing.T) {
 
 	// Verify the ModelServing is deleted
 	require.Eventually(t, func() bool {
-		_, err := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Get(ctx, modelServing.Name, metav1.GetOptions{})
+		getCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		defer cancel()
+		_, err := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Get(getCtx, modelServing.Name, metav1.GetOptions{})
 		if err == nil {
 			return false
 		}

--- a/test/e2e/controller-manager/model_serving_test.go
+++ b/test/e2e/controller-manager/model_serving_test.go
@@ -2296,6 +2296,11 @@ func TestModelServingBinPackScaleDownCombined(t *testing.T) {
 func TestModelServingStatusAwarePriorityScaleDownServingGroup(t *testing.T) {
 	ctx, kthenaClient, kubeClient := setupControllerManagerE2ETest(t)
 
+	const (
+		initialReplicas = int32(4)
+		targetReplicas  = int32(3)
+	)
+
 	modelServing := createBasicModelServing("test-status-sg-priority", 4, 0)
 	t.Log("Creating ModelServing with 4 servingGroup replicas for status-aware scale down test")
 	createAndWaitForModelServing(t, ctx, kthenaClient, modelServing)
@@ -2316,14 +2321,46 @@ func TestModelServingStatusAwarePriorityScaleDownServingGroup(t *testing.T) {
 	err = kubeClient.CoreV1().Pods(testNamespace).Delete(ctx, targetPod.Name, metav1.DeleteOptions{})
 	require.NoError(t, err, "Failed to delete pod")
 
-	initialMS, err := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Get(ctx, modelServing.Name, metav1.GetOptions{})
-	require.NoError(t, err, "Failed to get ModelServing before scale down")
-	scaleDownMS := initialMS.DeepCopy()
-	scaleDownMS.Spec.Replicas = ptr.To(int32(3))
-
 	t.Log("Scaling down ModelServing from 4 to 3 servingGroups (expect disrupted group to be removed first)")
-	_, err = kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Update(ctx, scaleDownMS, metav1.UpdateOptions{})
-	require.NoError(t, err, "Failed to scale down ModelServing")
+	require.Eventually(t, func() bool {
+		disruptedGroupSelector := fmt.Sprintf("%s,%s=%s", labelSelector, workload.GroupNameLabelKey, unhealthyGroup)
+		groupPods, listErr := kubeClient.CoreV1().Pods(testNamespace).List(ctx, metav1.ListOptions{
+			LabelSelector: disruptedGroupSelector,
+		})
+		if listErr != nil {
+			t.Logf("Failed to list pods in disrupted serving group %s: %v", unhealthyGroup, listErr)
+			return false
+		}
+
+		for _, pod := range groupPods.Items {
+			if pod.DeletionTimestamp != nil || pod.Status.Phase != corev1.PodRunning {
+				continue
+			}
+			return false
+		}
+
+		ms, getErr := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Get(ctx, modelServing.Name, metav1.GetOptions{})
+		if getErr != nil {
+			t.Logf("Failed to get ModelServing before scale down: %v", getErr)
+			return false
+		}
+
+		if ms.Spec.Replicas == nil || *ms.Spec.Replicas != initialReplicas {
+			return false
+		}
+		if ms.Status.AvailableReplicas != targetReplicas {
+			return false
+		}
+
+		scaleDownMS := ms.DeepCopy()
+		scaleDownMS.Spec.Replicas = ptr.To(targetReplicas)
+		_, updateErr := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Update(ctx, scaleDownMS, metav1.UpdateOptions{})
+		if updateErr != nil {
+			t.Logf("Failed to scale down ModelServing: %v", updateErr)
+			return false
+		}
+		return true
+	}, 2*time.Minute, 2*time.Second, "Failed to trigger scale down after disruption was observed")
 
 	utils.WaitForModelServingReady(t, ctx, kthenaClient, testNamespace, modelServing.Name)
 	waitForRunningPodCount(t, ctx, kubeClient, modelServing.Name, 3, 3*time.Minute)
@@ -2337,7 +2374,7 @@ func TestModelServingStatusAwarePriorityScaleDownServingGroup(t *testing.T) {
 		if pod.DeletionTimestamp != nil || pod.Status.Phase != corev1.PodRunning {
 			continue
 		}
-		assert.NotEqual(t, unhealthyGroup, pod.Labels[workload.GroupNameLabelKey],
+		require.NotEqual(t, unhealthyGroup, pod.Labels[workload.GroupNameLabelKey],
 			"Running pods should not belong to the disrupted serving group after status-aware scale down")
 	}
 	t.Log("Status-aware priority scale down ServingGroup test passed successfully")

--- a/test/e2e/controller-manager/model_serving_test.go
+++ b/test/e2e/controller-manager/model_serving_test.go
@@ -89,7 +89,7 @@ func TestModelServingLifecycle(t *testing.T) {
 
 	// Verify the image was updated on all non-terminating pods
 	require.Eventually(t, func() bool {
-		listCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		listCtx, cancel := context.WithTimeout(ctx, utils.DefaultAPICallTimeout)
 		defer cancel()
 		pods, err := kubeClient.CoreV1().Pods(testNamespace).List(listCtx, metav1.ListOptions{
 			LabelSelector: labelSelector,
@@ -126,7 +126,7 @@ func TestModelServingLifecycle(t *testing.T) {
 
 	// Verify the ModelServing is deleted
 	require.Eventually(t, func() bool {
-		getCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		getCtx, cancel := context.WithTimeout(ctx, utils.DefaultAPICallTimeout)
 		defer cancel()
 		_, err := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Get(getCtx, modelServing.Name, metav1.GetOptions{})
 		if err == nil {
@@ -137,7 +137,7 @@ func TestModelServingLifecycle(t *testing.T) {
 
 	// Verify that associated pods are cleaned up
 	require.Eventually(t, func() bool {
-		listCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		listCtx, cancel := context.WithTimeout(ctx, utils.DefaultAPICallTimeout)
 		defer cancel()
 		pods, err := kubeClient.CoreV1().Pods(testNamespace).List(listCtx, metav1.ListOptions{
 			LabelSelector: labelSelector,
@@ -1625,7 +1625,7 @@ type servingGroupState struct {
 }
 
 func collectRunningServingGroupStates(ctx context.Context, kubeClient *kubernetes.Clientset, msName string) (map[int32]servingGroupState, error) {
-	listCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	listCtx, cancel := context.WithTimeout(ctx, utils.DefaultAPICallTimeout)
 	defer cancel()
 	pods, err := kubeClient.CoreV1().Pods(testNamespace).List(listCtx, metav1.ListOptions{
 		LabelSelector: modelServingLabelSelector(msName),
@@ -1674,7 +1674,7 @@ func waitForPartitionState(t *testing.T, ctx context.Context, kthenaClient *clie
 
 	var updateRevision string
 	require.Eventually(t, func() bool {
-		getCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		getCtx, cancel := context.WithTimeout(ctx, utils.DefaultAPICallTimeout)
 		defer cancel()
 		ms, err := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Get(getCtx, msName, metav1.GetOptions{})
 		if err != nil {
@@ -1717,7 +1717,7 @@ func waitForRollingUpdateConverged(t *testing.T, ctx context.Context, kthenaClie
 
 	var finalMS *workload.ModelServing
 	require.Eventually(t, func() bool {
-		getCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		getCtx, cancel := context.WithTimeout(ctx, utils.DefaultAPICallTimeout)
 		defer cancel()
 		ms, err := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Get(getCtx, msName, metav1.GetOptions{})
 		if err != nil {
@@ -1775,7 +1775,7 @@ func verifyAllPodsHaveImage(t *testing.T, ctx context.Context, kubeClient *kuber
 	labelSelector, expectedImage, phase string) {
 	t.Helper()
 	require.Eventually(t, func() bool {
-		listCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		listCtx, cancel := context.WithTimeout(ctx, utils.DefaultAPICallTimeout)
 		defer cancel()
 		pods, err := kubeClient.CoreV1().Pods(testNamespace).List(listCtx, metav1.ListOptions{
 			LabelSelector: labelSelector,

--- a/test/e2e/controller-manager/test_suite_test.go
+++ b/test/e2e/controller-manager/test_suite_test.go
@@ -18,11 +18,14 @@ package controller_manager
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
 	"testing"
 	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/stretchr/testify/require"
 	clientset "github.com/volcano-sh/kthena/client-go/clientset/versioned"
@@ -115,13 +118,13 @@ func waitForWebhookReady(t *testing.T, ctx context.Context, kthenaClient *client
 		probe.Namespace = namespace
 		probe.Name = "webhook-ready-probe-" + utils.RandomString(5)
 
-		createCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		createCtx, cancel := context.WithTimeout(ctx, utils.DefaultAPICallTimeout)
 		defer cancel()
 		_, err := kthenaClient.WorkloadV1alpha1().ModelBoosters(namespace).Create(createCtx, probe, metav1.CreateOptions{DryRun: []string{"All"}})
 		if err != nil {
 			errStr := err.Error()
-			if strings.Contains(errStr, "connect: connection refused") {
-				t.Logf("Webhook not ready yet (connection refused), retrying: %v", err)
+			if strings.Contains(errStr, "connect: connection refused") || errors.Is(err, context.DeadlineExceeded) || apierrors.IsTimeout(err) || apierrors.IsServerTimeout(err) {
+				t.Logf("Webhook not ready yet (connection refused or timeout), retrying: %v", err)
 				return false, nil
 			}
 			return false, err

--- a/test/e2e/controller-manager/test_suite_test.go
+++ b/test/e2e/controller-manager/test_suite_test.go
@@ -116,8 +116,8 @@ func waitForWebhookReady(t *testing.T, ctx context.Context, kthenaClient *client
 		probe.Name = "webhook-ready-probe-" + utils.RandomString(5)
 
 		createCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		defer cancel()
 		_, err := kthenaClient.WorkloadV1alpha1().ModelBoosters(namespace).Create(createCtx, probe, metav1.CreateOptions{DryRun: []string{"All"}})
-		cancel()
 		if err != nil {
 			errStr := err.Error()
 			if strings.Contains(errStr, "connect: connection refused") {

--- a/test/e2e/controller-manager/test_suite_test.go
+++ b/test/e2e/controller-manager/test_suite_test.go
@@ -89,6 +89,11 @@ func TestMain(m *testing.M) {
 func setupControllerManagerE2ETest(t *testing.T) (context.Context, *clientset.Clientset, *kubernetes.Clientset) {
 	t.Helper()
 	ctx := context.Background()
+	if deadline, ok := t.Deadline(); ok {
+		ctxWithDeadline, cancel := context.WithDeadline(ctx, deadline)
+		t.Cleanup(cancel)
+		ctx = ctxWithDeadline
+	}
 	config, err := utils.GetKubeConfig()
 	require.NoError(t, err, "Failed to get kubeconfig")
 	kthenaClient, err := clientset.NewForConfig(config)
@@ -110,7 +115,9 @@ func waitForWebhookReady(t *testing.T, ctx context.Context, kthenaClient *client
 		probe.Namespace = namespace
 		probe.Name = "webhook-ready-probe-" + utils.RandomString(5)
 
-		_, err := kthenaClient.WorkloadV1alpha1().ModelBoosters(namespace).Create(ctx, probe, metav1.CreateOptions{DryRun: []string{"All"}})
+		createCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		_, err := kthenaClient.WorkloadV1alpha1().ModelBoosters(namespace).Create(createCtx, probe, metav1.CreateOptions{DryRun: []string{"All"}})
+		cancel()
 		if err != nil {
 			errStr := err.Error()
 			if strings.Contains(errStr, "connect: connection refused") {

--- a/test/e2e/router/shared.go
+++ b/test/e2e/router/shared.go
@@ -715,13 +715,14 @@ func TestModelRouteWithRateLimitShared(t *testing.T, testCtx *routercontext.Rout
 			return err == nil && mr != nil
 		}, 2*time.Minute, 2*time.Second, "ModelRoute should be created")
 
-		// Wait for Envoy/Gateway API to sync the route to the data plane by polling until we get a 200 OK.
-		// Since this will successfully consume 1 request from our rate limit quota, we account for it.
-		utils.WaitForChatModelReady(t, utils.DefaultRouterURL, createdModelRoute.Spec.ModelName, standardMessage, 60*time.Second)
-
 		quotaRequests := inputTokenLimit / tokensPerRequest
-		for i := 1; i < quotaRequests; i++ {
-			resp := utils.SendChatRequest(t, createdModelRoute.Spec.ModelName, standardMessage)
+		for i := 0; i < quotaRequests; i++ {
+			var resp *http.Response
+			if i == 0 {
+				resp = utils.SendChatRequestWithDataPlaneWait(t, createdModelRoute.Spec.ModelName, standardMessage)
+			} else {
+				resp = utils.SendChatRequest(t, createdModelRoute.Spec.ModelName, standardMessage)
+			}
 			responseBody, readErr := io.ReadAll(resp.Body)
 			resp.Body.Close()
 
@@ -772,12 +773,14 @@ func TestModelRouteWithRateLimitShared(t *testing.T, testCtx *routercontext.Rout
 			return err == nil && mr != nil
 		}, 2*time.Minute, 2*time.Second, "ModelRoute should be created")
 
-		// Wait for Envoy/Gateway API to sync the route to the data plane
-		utils.WaitForChatModelReady(t, utils.DefaultRouterURL, createdModelRoute.Spec.ModelName, standardMessage, 60*time.Second)
-
 		quotaRequests := inputTokenLimit / tokensPerRequest
-		for i := 1; i < quotaRequests; i++ {
-			resp := utils.SendChatRequest(t, createdModelRoute.Spec.ModelName, standardMessage)
+		for i := 0; i < quotaRequests; i++ {
+			var resp *http.Response
+			if i == 0 {
+				resp = utils.SendChatRequestWithDataPlaneWait(t, createdModelRoute.Spec.ModelName, standardMessage)
+			} else {
+				resp = utils.SendChatRequest(t, createdModelRoute.Spec.ModelName, standardMessage)
+			}
 			resp.Body.Close()
 			assert.Equal(t, http.StatusOK, resp.StatusCode, "Request %d should succeed", i+1)
 		}
@@ -838,12 +841,14 @@ func TestModelRouteWithRateLimitShared(t *testing.T, testCtx *routercontext.Rout
 			return err == nil && mr != nil
 		}, 2*time.Minute, 2*time.Second, "ModelRoute should be created")
 
-		// Wait for Envoy/Gateway API to sync the route to the data plane
-		utils.WaitForChatModelReady(t, utils.DefaultRouterURL, createdModelRoute.Spec.ModelName, standardMessage, 60*time.Second)
-
 		quotaRequests := inputTokenLimit / tokensPerRequest
-		for i := 1; i < quotaRequests; i++ {
-			resp := utils.SendChatRequest(t, createdModelRoute.Spec.ModelName, standardMessage)
+		for i := 0; i < quotaRequests; i++ {
+			var resp *http.Response
+			if i == 0 {
+				resp = utils.SendChatRequestWithDataPlaneWait(t, createdModelRoute.Spec.ModelName, standardMessage)
+			} else {
+				resp = utils.SendChatRequest(t, createdModelRoute.Spec.ModelName, standardMessage)
+			}
 			resp.Body.Close()
 			assert.Equal(t, http.StatusOK, resp.StatusCode,
 				"Request %d should succeed", i+1)
@@ -901,8 +906,8 @@ func TestModelRouteWithRateLimitShared(t *testing.T, testCtx *routercontext.Rout
 			return err == nil && mr != nil
 		}, 2*time.Minute, 2*time.Second, "ModelRoute should be created")
 
-		// Establish route to ensure Envoy has propagated it before updating rate limits
-		utils.WaitForChatModelReady(t, utils.DefaultRouterURL, createdModelRoute.Spec.ModelName, standardMessage, 60*time.Second)
+		// Wait for Envoy/Gateway API to sync the route to the data plane
+		// We delete this because the retry loop below naturally handles 404s
 
 		// Update ModelRoute to disable input token limit
 		createdModelRoute.Spec.RateLimit.InputTokensPerUnit = nil
@@ -1011,12 +1016,14 @@ func TestModelRouteWithGlobalRateLimitShared(t *testing.T, testCtx *routercontex
 			return err == nil && mr != nil
 		}, 2*time.Minute, 2*time.Second, "ModelRoute should be created")
 
-		// Establish route to ensure Envoy has propagated it
-		utils.WaitForChatModelReady(t, utils.DefaultRouterURL, createdModelRoute.Spec.ModelName, standardMessage, 60*time.Second)
-
 		var successCount int
 		for i := 0; i < maxRequests; i++ {
-			resp := utils.SendChatRequest(t, createdModelRoute.Spec.ModelName, standardMessage)
+			var resp *http.Response
+			if i == 0 {
+				resp = utils.SendChatRequestWithDataPlaneWait(t, createdModelRoute.Spec.ModelName, standardMessage)
+			} else {
+				resp = utils.SendChatRequest(t, createdModelRoute.Spec.ModelName, standardMessage)
+			}
 			resp.Body.Close()
 			if resp.StatusCode == http.StatusOK {
 				successCount++
@@ -1097,11 +1104,13 @@ func TestModelRouteWithGlobalRateLimitShared(t *testing.T, testCtx *routercontex
 			return err == nil && mr != nil
 		}, 2*time.Minute, 2*time.Second, "ModelRoute should be created")
 
-		// Establish route to ensure Envoy has propagated it
-		utils.WaitForChatModelReady(t, utils.DefaultRouterURL, createdModelRoute.Spec.ModelName, standardMessage, 60*time.Second)
-
 		for i := 0; i < 5; i++ {
-			resp := utils.SendChatRequest(t, createdModelRoute.Spec.ModelName, standardMessage)
+			var resp *http.Response
+			if i == 0 {
+				resp = utils.SendChatRequestWithDataPlaneWait(t, createdModelRoute.Spec.ModelName, standardMessage)
+			} else {
+				resp = utils.SendChatRequest(t, createdModelRoute.Spec.ModelName, standardMessage)
+			}
 			resp.Body.Close()
 			assert.Equal(t, http.StatusOK, resp.StatusCode, "Request %d should succeed without Redis", i+1)
 		}
@@ -1139,9 +1148,6 @@ func TestModelRouteWithGlobalRateLimitShared(t *testing.T, testCtx *routercontex
 			mr, err := testCtx.KthenaClient.NetworkingV1alpha1().ModelRoutes(testNamespace).Get(ctx, createdPremium.Name, metav1.GetOptions{})
 			return err == nil && mr != nil
 		}, 2*time.Minute, 2*time.Second, "Premium ModelRoute should be created")
-
-		// Establish route to ensure Envoy has propagated it
-		utils.WaitForChatModelReady(t, utils.DefaultRouterURL, createdPremium.Spec.ModelName, standardMessage, 60*time.Second)
 
 		headers := map[string]string{"user-type": "premium"}
 		var premiumSuccess, defaultSuccess int

--- a/test/e2e/router/shared.go
+++ b/test/e2e/router/shared.go
@@ -434,6 +434,11 @@ func testModelRoutePrefillDecodeDisaggregationSharedWithFixtures(
 	messages := []utils.ChatMessage{
 		utils.NewChatMessage("user", "Hello"),
 	}
+
+	// Wait for the python mocker server in the pod to fully start up and bind to its port.
+	// Without this, CheckChatCompletions' 65s limit might be exceeded if image pull + startup is slow.
+	utils.WaitForChatModelReady(t, utils.DefaultRouterURL, modelRoute.Spec.ModelName, messages, 3*time.Minute)
+
 	utils.CheckChatCompletions(t, modelRoute.Spec.ModelName, messages)
 }
 
@@ -764,6 +769,8 @@ func TestModelRouteWithRateLimitShared(t *testing.T, testCtx *routercontext.Rout
 
 		modelRoute := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute](filepath.Join(routercontext.TestDataDir, "ModelRouteWithRateLimit.yaml"))
 		modelRoute.Namespace = testNamespace
+		modelRoute.Name = modelRoute.Name + "-test2"
+		modelRoute.Spec.ModelName = modelRoute.Spec.ModelName + "-test2"
 		// Only test input rate limit; remove output limit to avoid 429 "output token rate limit exceeded"
 		if modelRoute.Spec.RateLimit != nil {
 			modelRoute.Spec.RateLimit.OutputTokensPerUnit = nil
@@ -841,6 +848,8 @@ func TestModelRouteWithRateLimitShared(t *testing.T, testCtx *routercontext.Rout
 
 		modelRoute := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute](filepath.Join(routercontext.TestDataDir, "ModelRouteWithRateLimit.yaml"))
 		modelRoute.Namespace = testNamespace
+		modelRoute.Name = modelRoute.Name + "-test3"
+		modelRoute.Spec.ModelName = modelRoute.Spec.ModelName + "-test3"
 		// Only test input rate limit; remove output limit to avoid 429 "output token rate limit exceeded"
 		if modelRoute.Spec.RateLimit != nil {
 			modelRoute.Spec.RateLimit.OutputTokensPerUnit = nil
@@ -917,6 +926,8 @@ func TestModelRouteWithRateLimitShared(t *testing.T, testCtx *routercontext.Rout
 
 		modelRoute := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute](filepath.Join(routercontext.TestDataDir, "ModelRouteWithRateLimit.yaml"))
 		modelRoute.Namespace = testNamespace
+		modelRoute.Name = modelRoute.Name + "-test4"
+		modelRoute.Spec.ModelName = modelRoute.Spec.ModelName + "-test4"
 		setupModelRouteWithGatewayAPI(modelRoute, useGatewayApi, kthenaNamespace)
 
 		createdModelRoute, err := testCtx.KthenaClient.NetworkingV1alpha1().ModelRoutes(testNamespace).Create(ctx, modelRoute, metav1.CreateOptions{})

--- a/test/e2e/router/shared.go
+++ b/test/e2e/router/shared.go
@@ -69,45 +69,6 @@ type pdDisaggregationFixtures struct {
 	modelRoute   string
 }
 
-func getCounterValue(metrics map[string]*dto.MetricFamily, metricName string, labels map[string]string) float64 {
-	mf, ok := metrics[metricName]
-	if !ok {
-		return 0
-	}
-	for _, m := range mf.GetMetric() {
-		if matchLabels(m.GetLabel(), labels) {
-			return m.GetCounter().GetValue()
-		}
-	}
-	return 0
-}
-
-func getHistogramCount(metrics map[string]*dto.MetricFamily, metricName string, labels map[string]string) uint64 {
-	mf, ok := metrics[metricName]
-	if !ok {
-		return 0
-	}
-	for _, m := range mf.GetMetric() {
-		if matchLabels(m.GetLabel(), labels) {
-			return m.GetHistogram().GetSampleCount()
-		}
-	}
-	return 0
-}
-
-func matchLabels(metricLabels []*dto.LabelPair, wantLabels map[string]string) bool {
-	labelMap := make(map[string]string)
-	for _, lp := range metricLabels {
-		labelMap[lp.GetName()] = lp.GetValue()
-	}
-	for k, v := range wantLabels {
-		if labelMap[k] != v {
-			return false
-		}
-	}
-	return true
-}
-
 // WaitForKthenaRouterValidatingWebhook polls until a DryRun ModelRoute create reaches the
 // validating webhook (avoids flaky tests while cert-manager / deployment finishes).
 func WaitForKthenaRouterValidatingWebhook(t *testing.T, ctx context.Context, kthenaClient *clientset.Clientset, namespace string) {
@@ -756,9 +717,9 @@ func TestModelRouteWithRateLimitShared(t *testing.T, testCtx *routercontext.Rout
 
 		quotaRequests := inputTokenLimit / tokensPerRequest
 
-		// Warm up: absorb Envoy data-plane eventual consistency (404/503)
+		// Warm up: absorb routing eventual consistency (404)
 		// before the quota-counting loop begins. This request consumes one quota token.
-		warmUpResp := utils.SendChatRequestWithDataPlaneWait(t, createdModelRoute.Spec.ModelName, standardMessage)
+		warmUpResp := utils.SendChatRequestUntilRouterProgrammed(t, createdModelRoute.Spec.ModelName, standardMessage)
 		warmUpBody, warmUpErr := io.ReadAll(warmUpResp.Body)
 		warmUpResp.Body.Close()
 		require.NoError(t, warmUpErr, "Failed to read warm-up response body")
@@ -818,8 +779,8 @@ func TestModelRouteWithRateLimitShared(t *testing.T, testCtx *routercontext.Rout
 
 		quotaRequests := inputTokenLimit / tokensPerRequest
 
-		// Warm up: absorb Envoy data-plane eventual consistency (404/503).
-		warmUpResp := utils.SendChatRequestWithDataPlaneWait(t, createdModelRoute.Spec.ModelName, standardMessage)
+		// Warm up: absorb routing eventual consistency (404).
+		warmUpResp := utils.SendChatRequestUntilRouterProgrammed(t, createdModelRoute.Spec.ModelName, standardMessage)
 		warmUpResp.Body.Close()
 		require.Equal(t, http.StatusOK, warmUpResp.StatusCode, "Warm-up request should succeed")
 
@@ -895,8 +856,8 @@ func TestModelRouteWithRateLimitShared(t *testing.T, testCtx *routercontext.Rout
 
 		quotaRequests := inputTokenLimit / tokensPerRequest
 
-		// Warm up: absorb Envoy data-plane eventual consistency (404/503).
-		warmUpResp := utils.SendChatRequestWithDataPlaneWait(t, createdModelRoute.Spec.ModelName, standardMessage)
+		// Warm up: absorb routing eventual consistency (404).
+		warmUpResp := utils.SendChatRequestUntilRouterProgrammed(t, createdModelRoute.Spec.ModelName, standardMessage)
 		warmUpResp.Body.Close()
 		require.Equal(t, http.StatusOK, warmUpResp.StatusCode, "Warm-up request should succeed")
 
@@ -1074,8 +1035,8 @@ func TestModelRouteWithGlobalRateLimitShared(t *testing.T, testCtx *routercontex
 			return err == nil && mr != nil
 		}, 2*time.Minute, 2*time.Second, "ModelRoute should be created")
 
-		// Warm up: absorb Envoy data-plane eventual consistency (404/503).
-		warmUpResp := utils.SendChatRequestWithDataPlaneWait(t, createdModelRoute.Spec.ModelName, standardMessage)
+		// Warm up: absorb routing eventual consistency (404).
+		warmUpResp := utils.SendChatRequestUntilRouterProgrammed(t, createdModelRoute.Spec.ModelName, standardMessage)
 		warmUpResp.Body.Close()
 		require.Equal(t, http.StatusOK, warmUpResp.StatusCode, "Warm-up request should succeed")
 
@@ -1163,8 +1124,8 @@ func TestModelRouteWithGlobalRateLimitShared(t *testing.T, testCtx *routercontex
 			return err == nil && mr != nil
 		}, 2*time.Minute, 2*time.Second, "ModelRoute should be created")
 
-		// Warm up: absorb Envoy data-plane eventual consistency (404/503).
-		warmUpResp := utils.SendChatRequestWithDataPlaneWait(t, createdModelRoute.Spec.ModelName, standardMessage)
+		// Warm up: absorb routing eventual consistency (404).
+		warmUpResp := utils.SendChatRequestUntilRouterProgrammed(t, createdModelRoute.Spec.ModelName, standardMessage)
 		warmUpResp.Body.Close()
 		require.Equal(t, http.StatusOK, warmUpResp.StatusCode, "Warm-up request should succeed without Redis")
 
@@ -1760,7 +1721,7 @@ func TestRouterConfigUpdateShared(t *testing.T, testCtx *routercontext.RouterTes
 		}
 
 		// Rollout-restart router so the deployment replaces pods gracefully with the restored config.
-		if err := utils.RolloutRestartDeploymentE(cleanupCtx, testCtx.KubeClient, kthenaNamespace, routerDeploymentName); err != nil {
+		if err := utils.RolloutRestartDeployment(cleanupCtx, testCtx.KubeClient, kthenaNamespace, routerDeploymentName, defaultScalingTimeout); err != nil {
 			t.Logf("warning: cleanup failed to restart router: %v", err)
 		}
 
@@ -1818,7 +1779,8 @@ func TestRouterConfigUpdateShared(t *testing.T, testCtx *routercontext.RouterTes
 	}
 
 	t.Log("Triggering rollout restart for router deployment...")
-	utils.RolloutRestartDeployment(t, ctx, testCtx.KubeClient, kthenaNamespace, routerDeploymentName)
+	err = utils.RolloutRestartDeployment(ctx, testCtx.KubeClient, kthenaNamespace, routerDeploymentName, defaultScalingTimeout)
+	require.NoError(t, err, "Failed to rollout restart router deployment")
 
 	// Wait for pre-restart pods to be replaced by new ones.
 	require.Eventually(t, func() bool {

--- a/test/e2e/router/shared.go
+++ b/test/e2e/router/shared.go
@@ -715,8 +715,12 @@ func TestModelRouteWithRateLimitShared(t *testing.T, testCtx *routercontext.Rout
 			return err == nil && mr != nil
 		}, 2*time.Minute, 2*time.Second, "ModelRoute should be created")
 
+		// Wait for Envoy/Gateway API to sync the route to the data plane by polling until we get a 200 OK.
+		// Since this will successfully consume 1 request from our rate limit quota, we account for it.
+		utils.WaitForChatModelReady(t, utils.DefaultRouterURL, createdModelRoute.Spec.ModelName, standardMessage, 60*time.Second)
+
 		quotaRequests := inputTokenLimit / tokensPerRequest
-		for i := 0; i < quotaRequests; i++ {
+		for i := 1; i < quotaRequests; i++ {
 			resp := utils.SendChatRequest(t, createdModelRoute.Spec.ModelName, standardMessage)
 			responseBody, readErr := io.ReadAll(resp.Body)
 			resp.Body.Close()
@@ -768,8 +772,11 @@ func TestModelRouteWithRateLimitShared(t *testing.T, testCtx *routercontext.Rout
 			return err == nil && mr != nil
 		}, 2*time.Minute, 2*time.Second, "ModelRoute should be created")
 
+		// Wait for Envoy/Gateway API to sync the route to the data plane
+		utils.WaitForChatModelReady(t, utils.DefaultRouterURL, createdModelRoute.Spec.ModelName, standardMessage, 60*time.Second)
+
 		quotaRequests := inputTokenLimit / tokensPerRequest
-		for i := 0; i < quotaRequests; i++ {
+		for i := 1; i < quotaRequests; i++ {
 			resp := utils.SendChatRequest(t, createdModelRoute.Spec.ModelName, standardMessage)
 			resp.Body.Close()
 			assert.Equal(t, http.StatusOK, resp.StatusCode, "Request %d should succeed", i+1)
@@ -831,8 +838,11 @@ func TestModelRouteWithRateLimitShared(t *testing.T, testCtx *routercontext.Rout
 			return err == nil && mr != nil
 		}, 2*time.Minute, 2*time.Second, "ModelRoute should be created")
 
+		// Wait for Envoy/Gateway API to sync the route to the data plane
+		utils.WaitForChatModelReady(t, utils.DefaultRouterURL, createdModelRoute.Spec.ModelName, standardMessage, 60*time.Second)
+
 		quotaRequests := inputTokenLimit / tokensPerRequest
-		for i := 0; i < quotaRequests; i++ {
+		for i := 1; i < quotaRequests; i++ {
 			resp := utils.SendChatRequest(t, createdModelRoute.Spec.ModelName, standardMessage)
 			resp.Body.Close()
 			assert.Equal(t, http.StatusOK, resp.StatusCode,
@@ -891,6 +901,9 @@ func TestModelRouteWithRateLimitShared(t *testing.T, testCtx *routercontext.Rout
 			return err == nil && mr != nil
 		}, 2*time.Minute, 2*time.Second, "ModelRoute should be created")
 
+		// Establish route to ensure Envoy has propagated it before updating rate limits
+		utils.WaitForChatModelReady(t, utils.DefaultRouterURL, createdModelRoute.Spec.ModelName, standardMessage, 60*time.Second)
+
 		// Update ModelRoute to disable input token limit
 		createdModelRoute.Spec.RateLimit.InputTokensPerUnit = nil
 		outputLimit := uint32(outputTokenLimit)
@@ -930,7 +943,9 @@ func TestModelRouteWithRateLimitShared(t *testing.T, testCtx *routercontext.Rout
 				rateLimited = true
 				break
 			} else {
-				t.Fatalf("Unexpected HTTP status code %d on attempt %d", resp.StatusCode, attempt+1)
+				// Ignore transient 404/503s if Envoy is applying the new route update
+				t.Logf("Ignoring unexpected HTTP status code %d on attempt %d (Envoy syncing)", resp.StatusCode, attempt+1)
+				time.Sleep(1 * time.Second)
 			}
 		}
 
@@ -995,6 +1010,9 @@ func TestModelRouteWithGlobalRateLimitShared(t *testing.T, testCtx *routercontex
 			mr, err := testCtx.KthenaClient.NetworkingV1alpha1().ModelRoutes(testNamespace).Get(ctx, createdModelRoute.Name, metav1.GetOptions{})
 			return err == nil && mr != nil
 		}, 2*time.Minute, 2*time.Second, "ModelRoute should be created")
+
+		// Establish route to ensure Envoy has propagated it
+		utils.WaitForChatModelReady(t, utils.DefaultRouterURL, createdModelRoute.Spec.ModelName, standardMessage, 60*time.Second)
 
 		var successCount int
 		for i := 0; i < maxRequests; i++ {
@@ -1079,6 +1097,9 @@ func TestModelRouteWithGlobalRateLimitShared(t *testing.T, testCtx *routercontex
 			return err == nil && mr != nil
 		}, 2*time.Minute, 2*time.Second, "ModelRoute should be created")
 
+		// Establish route to ensure Envoy has propagated it
+		utils.WaitForChatModelReady(t, utils.DefaultRouterURL, createdModelRoute.Spec.ModelName, standardMessage, 60*time.Second)
+
 		for i := 0; i < 5; i++ {
 			resp := utils.SendChatRequest(t, createdModelRoute.Spec.ModelName, standardMessage)
 			resp.Body.Close()
@@ -1118,6 +1139,9 @@ func TestModelRouteWithGlobalRateLimitShared(t *testing.T, testCtx *routercontex
 			mr, err := testCtx.KthenaClient.NetworkingV1alpha1().ModelRoutes(testNamespace).Get(ctx, createdPremium.Name, metav1.GetOptions{})
 			return err == nil && mr != nil
 		}, 2*time.Minute, 2*time.Second, "Premium ModelRoute should be created")
+
+		// Establish route to ensure Envoy has propagated it
+		utils.WaitForChatModelReady(t, utils.DefaultRouterURL, createdPremium.Spec.ModelName, standardMessage, 60*time.Second)
 
 		headers := map[string]string{"user-type": "premium"}
 		var premiumSuccess, defaultSuccess int

--- a/test/e2e/router/shared.go
+++ b/test/e2e/router/shared.go
@@ -605,6 +605,11 @@ func TestModelRouteSubsetShared(t *testing.T, testCtx *routercontext.RouterTestC
 				strings.Contains(resp.Body, "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B")
 		}, 1*time.Minute, 2*time.Second, "ModelRoute update should propagate and requests should route successfully")
 
+		// The above 200 OK does not guarantee Envoy has fully converged on the new 50:30 weights,
+		// because the old 70:30 weights also returned 200 OK. Wait an additional 5 seconds
+		// for the Envoy cluster weight update to propagate so we don't skew our distribution sample.
+		time.Sleep(5 * time.Second)
+
 		const (
 			totalRequests = 500
 			maxRetries    = 5
@@ -616,7 +621,10 @@ func TestModelRouteSubsetShared(t *testing.T, testCtx *routercontext.RouterTestC
 		distributionOK := false
 
 		for attempt := 0; attempt < maxRetries; attempt++ {
-			sinceTime := metav1.NewTime(time.Now().Add(-2 * time.Second))
+			// Ensure we only look at logs from requests we are about to make.
+			// time.Now() is safer than time.Now().Add(-2s) because it avoids
+			// including logs from previous attempts.
+			sinceTime := metav1.Now()
 			for i := 0; i < totalRequests; i++ {
 				resp := utils.CheckChatCompletionsQuiet(t, modelRoute.Spec.ModelName, messages)
 				assert.Equal(t, 200, resp.StatusCode)

--- a/test/e2e/router/shared.go
+++ b/test/e2e/router/shared.go
@@ -1701,10 +1701,14 @@ func TestRouterConfigUpdateShared(t *testing.T, testCtx *routercontext.RouterTes
 		}
 
 		// Rollout-restart router so the deployment replaces pods gracefully with the restored config.
-		_ = utils.RolloutRestartDeploymentE(cleanupCtx, testCtx.KubeClient, kthenaNamespace, routerDeploymentName)
+		if err := utils.RolloutRestartDeploymentE(cleanupCtx, testCtx.KubeClient, kthenaNamespace, routerDeploymentName); err != nil {
+			t.Logf("warning: cleanup failed to restart router: %v", err)
+		}
 
 		// Wait for the router to become ready with the restored config.
-		_ = utils.WaitForDeploymentReadyE(cleanupCtx, testCtx.KubeClient, kthenaNamespace, routerDeploymentName, defaultScalingTimeout)
+		if err := utils.WaitForDeploymentReadyE(cleanupCtx, testCtx.KubeClient, kthenaNamespace, routerDeploymentName, defaultScalingTimeout); err != nil {
+			t.Logf("warning: cleanup failed to wait for router deployment readiness: %v", err)
+		}
 	})
 
 	// Update the ConfigMap with a new scheduler configuration:

--- a/test/e2e/router/shared.go
+++ b/test/e2e/router/shared.go
@@ -1700,9 +1700,11 @@ func TestRouterConfigUpdateShared(t *testing.T, testCtx *routercontext.RouterTes
 			return
 		}
 
-		if err := utils.RolloutRestartDeployment(cleanupCtx, testCtx.KubeClient, kthenaNamespace, routerDeploymentName, defaultScalingTimeout); err != nil {
-			t.Logf("Warning: Failed to rollout restart router deployment: %v", err)
-		}
+		// Rollout-restart router so the deployment replaces pods gracefully with the restored config.
+		_ = utils.RolloutRestartDeploymentE(cleanupCtx, testCtx.KubeClient, kthenaNamespace, routerDeploymentName)
+
+		// Wait for the router to become ready with the restored config.
+		_ = utils.WaitForDeploymentReadyE(cleanupCtx, testCtx.KubeClient, kthenaNamespace, routerDeploymentName, defaultScalingTimeout)
 	})
 
 	// Update the ConfigMap with a new scheduler configuration:
@@ -1730,12 +1732,34 @@ func TestRouterConfigUpdateShared(t *testing.T, testCtx *routercontext.RouterTes
 	_, err = testCtx.KubeClient.CoreV1().ConfigMaps(kthenaNamespace).Update(ctx, cm, metav1.UpdateOptions{})
 	require.NoError(t, err, "Failed to update router ConfigMap")
 
-	// Trigger a rollout restart so the deployment controller creates new pods with
-	// the updated config via a rolling update. This keeps the webhook endpoint
-	// available throughout the restart and waits for the rollout to fully complete.
-	t.Log("Triggering rollout restart of router deployment...")
-	err = utils.RolloutRestartDeployment(ctx, testCtx.KubeClient, kthenaNamespace, routerDeploymentName, defaultScalingTimeout)
-	require.NoError(t, err, "Failed to rollout restart router deployment")
+	// Record pre-restart pod names to confirm they get replaced.
+	preRestartPods := utils.GetReadyRouterPods(t, testCtx.KubeClient, kthenaNamespace)
+	preRestartPodNames := make(map[string]bool, len(preRestartPods))
+	for _, pod := range preRestartPods {
+		preRestartPodNames[pod.Name] = true
+	}
+
+	t.Log("Triggering rollout restart for router deployment...")
+	utils.RolloutRestartDeployment(t, ctx, testCtx.KubeClient, kthenaNamespace, routerDeploymentName)
+
+	// Wait for pre-restart pods to be replaced by new ones.
+	require.Eventually(t, func() bool {
+		pods, err := testCtx.KubeClient.CoreV1().Pods(kthenaNamespace).List(ctx, metav1.ListOptions{
+			LabelSelector: routerPodSelector,
+		})
+		if err != nil {
+			return false
+		}
+		for _, pod := range pods.Items {
+			if preRestartPodNames[pod.Name] {
+				return false
+			}
+		}
+		return len(pods.Items) > 0
+	}, defaultScalingTimeout, 2*time.Second, "Pre-restart pods should be replaced")
+
+	// Wait for the deployment to be ready with the new pods.
+	utils.WaitForDeploymentReady(t, ctx, testCtx.KubeClient, kthenaNamespace, routerDeploymentName, expectedReplicas, defaultScalingTimeout)
 	t.Log("Router deployment is ready after restart")
 
 	// Set up port-forward to the restarted router on a dynamically selected local port

--- a/test/e2e/router/shared.go
+++ b/test/e2e/router/shared.go
@@ -69,6 +69,45 @@ type pdDisaggregationFixtures struct {
 	modelRoute   string
 }
 
+func getCounterValue(metrics map[string]*dto.MetricFamily, metricName string, labels map[string]string) float64 {
+	mf, ok := metrics[metricName]
+	if !ok {
+		return 0
+	}
+	for _, m := range mf.GetMetric() {
+		if matchLabels(m.GetLabel(), labels) {
+			return m.GetCounter().GetValue()
+		}
+	}
+	return 0
+}
+
+func getHistogramCount(metrics map[string]*dto.MetricFamily, metricName string, labels map[string]string) uint64 {
+	mf, ok := metrics[metricName]
+	if !ok {
+		return 0
+	}
+	for _, m := range mf.GetMetric() {
+		if matchLabels(m.GetLabel(), labels) {
+			return m.GetHistogram().GetSampleCount()
+		}
+	}
+	return 0
+}
+
+func matchLabels(metricLabels []*dto.LabelPair, wantLabels map[string]string) bool {
+	labelMap := make(map[string]string)
+	for _, lp := range metricLabels {
+		labelMap[lp.GetName()] = lp.GetValue()
+	}
+	for k, v := range wantLabels {
+		if labelMap[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
 // WaitForKthenaRouterValidatingWebhook polls until a DryRun ModelRoute create reaches the
 // validating webhook (avoids flaky tests while cert-manager / deployment finishes).
 func WaitForKthenaRouterValidatingWebhook(t *testing.T, ctx context.Context, kthenaClient *clientset.Clientset, namespace string) {
@@ -925,8 +964,6 @@ func TestModelRouteWithRateLimitShared(t *testing.T, testCtx *routercontext.Rout
 			mr, err := testCtx.KthenaClient.NetworkingV1alpha1().ModelRoutes(testNamespace).Get(ctx, createdModelRoute.Name, metav1.GetOptions{})
 			return err == nil && mr != nil
 		}, 2*time.Minute, 2*time.Second, "ModelRoute should be created")
-
-
 
 		// Update ModelRoute to disable input token limit
 		createdModelRoute.Spec.RateLimit.InputTokensPerUnit = nil

--- a/test/e2e/router/shared.go
+++ b/test/e2e/router/shared.go
@@ -716,34 +716,38 @@ func TestModelRouteWithRateLimitShared(t *testing.T, testCtx *routercontext.Rout
 		}, 2*time.Minute, 2*time.Second, "ModelRoute should be created")
 
 		quotaRequests := inputTokenLimit / tokensPerRequest
-		for i := 0; i < quotaRequests; i++ {
-			var resp *http.Response
-			if i == 0 {
-				resp = utils.SendChatRequestWithDataPlaneWait(t, createdModelRoute.Spec.ModelName, standardMessage)
-			} else {
-				resp = utils.SendChatRequest(t, createdModelRoute.Spec.ModelName, standardMessage)
-			}
+
+		// Warm up: absorb Envoy data-plane eventual consistency (404/503)
+		// before the quota-counting loop begins. This request consumes one quota token.
+		warmUpResp := utils.SendChatRequestWithDataPlaneWait(t, createdModelRoute.Spec.ModelName, standardMessage)
+		warmUpBody, warmUpErr := io.ReadAll(warmUpResp.Body)
+		warmUpResp.Body.Close()
+		require.NoError(t, warmUpErr, "Failed to read warm-up response body")
+		require.Equal(t, http.StatusOK, warmUpResp.StatusCode,
+			"Warm-up request should succeed. Response: %s", string(warmUpBody))
+		t.Log("Data plane warm-up succeeded (consumed 1 quota token)")
+
+		// Send remaining quota requests; count successes until rate-limited.
+		successCount := 1 // warm-up already consumed 1 token
+		for i := 1; i < quotaRequests+2; i++ {
+			resp := utils.SendChatRequest(t, createdModelRoute.Spec.ModelName, standardMessage)
 			responseBody, readErr := io.ReadAll(resp.Body)
 			resp.Body.Close()
-
 			require.NoError(t, readErr, "Failed to read response body on request %d", i+1)
+
+			if resp.StatusCode == http.StatusTooManyRequests {
+				assert.Contains(t, strings.ToLower(string(responseBody)), "rate limit",
+					"Rate limit error response must contain descriptive message")
+				break
+			}
 			require.Equal(t, http.StatusOK, resp.StatusCode,
-				"Request %d should succeed. Response: %s", i+1, string(responseBody))
-			t.Logf("Request %d succeeded", i+1)
+				"Request %d should succeed or be rate-limited. Response: %s", i+1, string(responseBody))
+			successCount++
 		}
 
-		// Next request should be rate limited
-		rateLimitedResp := utils.SendChatRequest(t, createdModelRoute.Spec.ModelName, standardMessage)
-		responseBody, readErr := io.ReadAll(rateLimitedResp.Body)
-		rateLimitedResp.Body.Close()
-
-		require.NoError(t, readErr, "Failed to read rate limit response body")
-		assert.Equal(t, http.StatusTooManyRequests, rateLimitedResp.StatusCode,
-			"Request should be rate limited after exhausting quota")
-		assert.Contains(t, strings.ToLower(string(responseBody)), "rate limit",
-			"Rate limit error response must contain descriptive message")
-
-		t.Logf("Input token rate limit enforced after %d quota-consuming requests", quotaRequests)
+		assert.InDelta(t, quotaRequests, successCount, 1,
+			"Expected ~%d successful requests before rate limiting (got %d)", quotaRequests, successCount)
+		t.Logf("Input token rate limit enforced after %d quota-consuming requests", successCount)
 	})
 
 	// Test 2 Verify rate limit window accuracy and persistence
@@ -774,16 +778,25 @@ func TestModelRouteWithRateLimitShared(t *testing.T, testCtx *routercontext.Rout
 		}, 2*time.Minute, 2*time.Second, "ModelRoute should be created")
 
 		quotaRequests := inputTokenLimit / tokensPerRequest
-		for i := 0; i < quotaRequests; i++ {
-			var resp *http.Response
-			if i == 0 {
-				resp = utils.SendChatRequestWithDataPlaneWait(t, createdModelRoute.Spec.ModelName, standardMessage)
-			} else {
-				resp = utils.SendChatRequest(t, createdModelRoute.Spec.ModelName, standardMessage)
-			}
+
+		// Warm up: absorb Envoy data-plane eventual consistency (404/503).
+		warmUpResp := utils.SendChatRequestWithDataPlaneWait(t, createdModelRoute.Spec.ModelName, standardMessage)
+		warmUpResp.Body.Close()
+		require.Equal(t, http.StatusOK, warmUpResp.StatusCode, "Warm-up request should succeed")
+
+		// Consume full quota
+		successCount := 1 // warm-up consumed 1 token
+		for i := 1; i < quotaRequests+2; i++ {
+			resp := utils.SendChatRequest(t, createdModelRoute.Spec.ModelName, standardMessage)
 			resp.Body.Close()
+			if resp.StatusCode == http.StatusTooManyRequests {
+				break
+			}
 			assert.Equal(t, http.StatusOK, resp.StatusCode, "Request %d should succeed", i+1)
+			successCount++
 		}
+		assert.InDelta(t, quotaRequests, successCount, 1,
+			"Expected ~%d successful requests before rate limiting (got %d)", quotaRequests, successCount)
 
 		// Verify rate limit is active
 		rateLimitedResp := utils.SendChatRequest(t, createdModelRoute.Spec.ModelName, standardMessage)
@@ -842,17 +855,24 @@ func TestModelRouteWithRateLimitShared(t *testing.T, testCtx *routercontext.Rout
 		}, 2*time.Minute, 2*time.Second, "ModelRoute should be created")
 
 		quotaRequests := inputTokenLimit / tokensPerRequest
-		for i := 0; i < quotaRequests; i++ {
-			var resp *http.Response
-			if i == 0 {
-				resp = utils.SendChatRequestWithDataPlaneWait(t, createdModelRoute.Spec.ModelName, standardMessage)
-			} else {
-				resp = utils.SendChatRequest(t, createdModelRoute.Spec.ModelName, standardMessage)
-			}
+
+		// Warm up: absorb Envoy data-plane eventual consistency (404/503).
+		warmUpResp := utils.SendChatRequestWithDataPlaneWait(t, createdModelRoute.Spec.ModelName, standardMessage)
+		warmUpResp.Body.Close()
+		require.Equal(t, http.StatusOK, warmUpResp.StatusCode, "Warm-up request should succeed")
+
+		successCount := 1 // warm-up consumed 1 token
+		for i := 1; i < quotaRequests+2; i++ {
+			resp := utils.SendChatRequest(t, createdModelRoute.Spec.ModelName, standardMessage)
 			resp.Body.Close()
-			assert.Equal(t, http.StatusOK, resp.StatusCode,
-				"Request %d should succeed", i+1)
+			if resp.StatusCode == http.StatusTooManyRequests {
+				break
+			}
+			assert.Equal(t, http.StatusOK, resp.StatusCode, "Request %d should succeed", i+1)
+			successCount++
 		}
+		assert.InDelta(t, quotaRequests, successCount, 1,
+			"Expected ~%d successful requests before rate limiting (got %d)", quotaRequests, successCount)
 
 		// Confirm rate limiting is active
 		preResetResp := utils.SendChatRequest(t, createdModelRoute.Spec.ModelName, standardMessage)
@@ -865,22 +885,22 @@ func TestModelRouteWithRateLimitShared(t *testing.T, testCtx *routercontext.Rout
 		t.Logf("Waiting %v for complete rate limit window reset...", windowResetDuration)
 		time.Sleep(windowResetDuration)
 
-		// After window reset, full quota is restored (30 tokens = 3 requests)
+		// After window reset, full quota is restored — send until rate-limited again.
 		fullQuotaRequests := inputTokenLimit / tokensPerRequest
-		for i := 0; i < fullQuotaRequests; i++ {
+		postResetSuccess := 0
+		for i := 0; i < fullQuotaRequests+2; i++ {
 			resp := utils.SendChatRequest(t, createdModelRoute.Spec.ModelName, standardMessage)
 			resp.Body.Close()
-			assert.Equal(t, http.StatusOK, resp.StatusCode,
-				"Request %d should succeed after reset", i+1)
+			if resp.StatusCode == http.StatusTooManyRequests {
+				break
+			}
+			assert.Equal(t, http.StatusOK, resp.StatusCode, "Request %d should succeed after reset", i+1)
+			postResetSuccess++
 		}
+		assert.InDelta(t, fullQuotaRequests, postResetSuccess, 1,
+			"Expected ~%d successful requests after reset (got %d)", fullQuotaRequests, postResetSuccess)
 
-		// Verify rate limiting kicks in again after consuming quota
-		postResetRateLimitedResp := utils.SendChatRequest(t, createdModelRoute.Spec.ModelName, standardMessage)
-		postResetRateLimitedResp.Body.Close()
-		assert.Equal(t, http.StatusTooManyRequests, postResetRateLimitedResp.StatusCode,
-			"Rate limit should be active again after consuming quota")
-
-		t.Logf("Rate limit reset mechanism verified (quota restored: %d requests)", fullQuotaRequests)
+		t.Logf("Rate limit reset mechanism verified (quota restored: %d requests)", postResetSuccess)
 	})
 
 	// Test 4: Verify output token rate limit enforcement
@@ -906,8 +926,7 @@ func TestModelRouteWithRateLimitShared(t *testing.T, testCtx *routercontext.Rout
 			return err == nil && mr != nil
 		}, 2*time.Minute, 2*time.Second, "ModelRoute should be created")
 
-		// Wait for Envoy/Gateway API to sync the route to the data plane
-		// We delete this because the retry loop below naturally handles 404s
+
 
 		// Update ModelRoute to disable input token limit
 		createdModelRoute.Spec.RateLimit.InputTokensPerUnit = nil
@@ -947,10 +966,12 @@ func TestModelRouteWithRateLimitShared(t *testing.T, testCtx *routercontext.Rout
 					"Output rate limit error should mention rate limit")
 				rateLimited = true
 				break
-			} else {
-				// Ignore transient 404/503s if Envoy is applying the new route update
-				t.Logf("Ignoring unexpected HTTP status code %d on attempt %d (Envoy syncing)", resp.StatusCode, attempt+1)
+			} else if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusServiceUnavailable {
+				// Transient: Envoy is still syncing the updated route to the data plane.
+				t.Logf("Data plane not ready (status %d), retrying attempt %d...", resp.StatusCode, attempt+1)
 				time.Sleep(1 * time.Second)
+			} else {
+				t.Fatalf("Unexpected HTTP status %d on attempt %d: %s", resp.StatusCode, attempt+1, string(responseBody))
 			}
 		}
 
@@ -1016,14 +1037,15 @@ func TestModelRouteWithGlobalRateLimitShared(t *testing.T, testCtx *routercontex
 			return err == nil && mr != nil
 		}, 2*time.Minute, 2*time.Second, "ModelRoute should be created")
 
+		// Warm up: absorb Envoy data-plane eventual consistency (404/503).
+		warmUpResp := utils.SendChatRequestWithDataPlaneWait(t, createdModelRoute.Spec.ModelName, standardMessage)
+		warmUpResp.Body.Close()
+		require.Equal(t, http.StatusOK, warmUpResp.StatusCode, "Warm-up request should succeed")
+
 		var successCount int
-		for i := 0; i < maxRequests; i++ {
-			var resp *http.Response
-			if i == 0 {
-				resp = utils.SendChatRequestWithDataPlaneWait(t, createdModelRoute.Spec.ModelName, standardMessage)
-			} else {
-				resp = utils.SendChatRequest(t, createdModelRoute.Spec.ModelName, standardMessage)
-			}
+		successCount++ // warm-up consumed 1 token
+		for i := 1; i < maxRequests; i++ {
+			resp := utils.SendChatRequest(t, createdModelRoute.Spec.ModelName, standardMessage)
 			resp.Body.Close()
 			if resp.StatusCode == http.StatusOK {
 				successCount++
@@ -1104,13 +1126,13 @@ func TestModelRouteWithGlobalRateLimitShared(t *testing.T, testCtx *routercontex
 			return err == nil && mr != nil
 		}, 2*time.Minute, 2*time.Second, "ModelRoute should be created")
 
-		for i := 0; i < 5; i++ {
-			var resp *http.Response
-			if i == 0 {
-				resp = utils.SendChatRequestWithDataPlaneWait(t, createdModelRoute.Spec.ModelName, standardMessage)
-			} else {
-				resp = utils.SendChatRequest(t, createdModelRoute.Spec.ModelName, standardMessage)
-			}
+		// Warm up: absorb Envoy data-plane eventual consistency (404/503).
+		warmUpResp := utils.SendChatRequestWithDataPlaneWait(t, createdModelRoute.Spec.ModelName, standardMessage)
+		warmUpResp.Body.Close()
+		require.Equal(t, http.StatusOK, warmUpResp.StatusCode, "Warm-up request should succeed without Redis")
+
+		for i := 1; i < 5; i++ {
+			resp := utils.SendChatRequest(t, createdModelRoute.Spec.ModelName, standardMessage)
 			resp.Body.Close()
 			assert.Equal(t, http.StatusOK, resp.StatusCode, "Request %d should succeed without Redis", i+1)
 		}
@@ -1741,6 +1763,21 @@ func TestRouterConfigUpdateShared(t *testing.T, testCtx *routercontext.RouterTes
 	preRestartPodNames := make(map[string]bool, len(preRestartPods))
 	for _, pod := range preRestartPods {
 		preRestartPodNames[pod.Name] = true
+	}
+
+	// Retrieve the deployment to determine its label selector and replica count.
+	deployment, err := testCtx.KubeClient.AppsV1().Deployments(kthenaNamespace).Get(ctx, routerDeploymentName, metav1.GetOptions{})
+	require.NoError(t, err, "Failed to get router deployment")
+	routerPodSelector := ""
+	for k, v := range deployment.Spec.Selector.MatchLabels {
+		if routerPodSelector != "" {
+			routerPodSelector += ","
+		}
+		routerPodSelector += k + "=" + v
+	}
+	expectedReplicas := int32(1)
+	if deployment.Spec.Replicas != nil {
+		expectedReplicas = *deployment.Spec.Replicas
 	}
 
 	t.Log("Triggering rollout restart for router deployment...")

--- a/test/e2e/utils/chat.go
+++ b/test/e2e/utils/chat.go
@@ -373,8 +373,8 @@ func SendChatRequestWithURL(t *testing.T, url string, modelName string, messages
 	return resp
 }
 
-// SendChatRequestUntilRouterProgrammed retries the request until the route is programmed (not 404).
-// Used as a one-shot warm-up before rate-limit loops so routing gaps don't consume quota.
+// SendChatRequestUntilRouterProgrammed polls until the Kthena Router has programmed the route (stops returning 404).
+// We don't retry on 503 because it only occurs when the client disconnects before receiving a response.
 func SendChatRequestUntilRouterProgrammed(t *testing.T, modelName string, messages []ChatMessage) *http.Response {
 	var finalResp *http.Response
 	ctx := context.Background()

--- a/test/e2e/utils/chat.go
+++ b/test/e2e/utils/chat.go
@@ -372,3 +372,26 @@ func SendChatRequestWithURL(t *testing.T, url string, modelName string, messages
 
 	return resp
 }
+
+// SendChatRequestWithDataPlaneWait sends a chat completions request and retries ONLY if Envoy returns 404/503.
+// This is used for the very first request of rate limit tests to handle data plane eventual consistency
+// without consuming quota on failed routing attempts.
+func SendChatRequestWithDataPlaneWait(t *testing.T, modelName string, messages []ChatMessage) *http.Response {
+	var finalResp *http.Response
+	ctx := context.Background()
+
+	err := wait.PollUntilContextTimeout(ctx, 1*time.Second, 60*time.Second, true, func(ctx context.Context) (bool, error) {
+		resp := SendChatRequest(t, modelName, messages)
+		if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusServiceUnavailable {
+			t.Logf("Data plane not ready (status %d), retrying...", resp.StatusCode)
+			resp.Body.Close()
+			return false, nil
+		}
+		// If it's 200 OK, 429 Too Many Requests, or anything else, we return it to the test
+		finalResp = resp
+		return true, nil
+	})
+
+	require.NoError(t, err, "Data plane never became ready for the initial request")
+	return finalResp
+}

--- a/test/e2e/utils/chat.go
+++ b/test/e2e/utils/chat.go
@@ -373,9 +373,11 @@ func SendChatRequestWithURL(t *testing.T, url string, modelName string, messages
 	return resp
 }
 
-// SendChatRequestWithDataPlaneWait sends a chat completions request and retries ONLY if Envoy returns 404/503.
-// This is used for the very first request of rate limit tests to handle data plane eventual consistency
-// without consuming quota on failed routing attempts.
+// SendChatRequestWithDataPlaneWait polls until the router data plane can route the model.
+// It retries when the HTTP response is 404 (route not yet programmed) or 503 (backend not ready).
+// Any other status — including 200 OK — is returned to the caller immediately without retry.
+// Used as a one-shot warm-up before rate-limit counting loops so transient routing gaps
+// do not consume quota tokens.
 func SendChatRequestWithDataPlaneWait(t *testing.T, modelName string, messages []ChatMessage) *http.Response {
 	var finalResp *http.Response
 	ctx := context.Background()

--- a/test/e2e/utils/chat.go
+++ b/test/e2e/utils/chat.go
@@ -373,27 +373,23 @@ func SendChatRequestWithURL(t *testing.T, url string, modelName string, messages
 	return resp
 }
 
-// SendChatRequestWithDataPlaneWait polls until the router data plane can route the model.
-// It retries when the HTTP response is 404 (route not yet programmed) or 503 (backend not ready).
-// Any other status — including 200 OK — is returned to the caller immediately without retry.
-// Used as a one-shot warm-up before rate-limit counting loops so transient routing gaps
-// do not consume quota tokens.
-func SendChatRequestWithDataPlaneWait(t *testing.T, modelName string, messages []ChatMessage) *http.Response {
+// SendChatRequestUntilRouterProgrammed retries the request until the route is programmed (not 404).
+// Used as a one-shot warm-up before rate-limit loops so routing gaps don't consume quota.
+func SendChatRequestUntilRouterProgrammed(t *testing.T, modelName string, messages []ChatMessage) *http.Response {
 	var finalResp *http.Response
 	ctx := context.Background()
 
 	err := wait.PollUntilContextTimeout(ctx, 1*time.Second, 60*time.Second, true, func(ctx context.Context) (bool, error) {
 		resp := SendChatRequest(t, modelName, messages)
-		if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusServiceUnavailable {
-			t.Logf("Data plane not ready (status %d), retrying...", resp.StatusCode)
+		if resp.StatusCode == http.StatusNotFound {
+			t.Logf("Route not yet programmed (404), retrying...")
 			resp.Body.Close()
 			return false, nil
 		}
-		// If it's 200 OK, 429 Too Many Requests, or anything else, we return it to the test
 		finalResp = resp
 		return true, nil
 	})
 
-	require.NoError(t, err, "Data plane never became ready for the initial request")
+	require.NoError(t, err, "Router never programmed the route for model %q", modelName)
 	return finalResp
 }

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -18,7 +18,6 @@ package utils
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -93,40 +92,50 @@ func IsPodReady(pod corev1.Pod) bool {
 // WaitForDeploymentReady polls until the named Deployment has at least replicas ready pods.
 func WaitForDeploymentReady(t *testing.T, ctx context.Context, kubeClient kubernetes.Interface, namespace, name string, replicas int32, timeout time.Duration) {
 	t.Helper()
+	var lastErr error
 	err := wait.PollUntilContextTimeout(ctx, defaultPollingInterval, timeout, true, func(ctx context.Context) (bool, error) {
 		getCtx, cancel := context.WithTimeout(ctx, DefaultAPICallTimeout)
 		defer cancel()
 		deploy, err := kubeClient.AppsV1().Deployments(namespace).Get(getCtx, name, metav1.GetOptions{})
 		if err != nil {
-			if apierrors.IsNotFound(err) || errors.Is(err, context.DeadlineExceeded) || apierrors.IsTimeout(err) || apierrors.IsServerTimeout(err) {
-				return false, nil
-			}
-			return false, err
+			lastErr = err
+			return false, nil
 		}
+		lastErr = nil
 		return deploy.Status.ReadyReplicas >= replicas, nil
 	})
-	require.NoError(t, err, "Deployment %q did not become ready after scaling to %d replicas within %v", name, replicas, timeout)
+	if err != nil {
+		msg := fmt.Sprintf("Deployment %q did not become ready after scaling to %d replicas within %v", name, replicas, timeout)
+		if lastErr != nil {
+			require.NoError(t, fmt.Errorf("%s: %w (last API error: %v)", msg, err, lastErr))
+			return
+		}
+		require.NoError(t, err, msg)
+	}
 }
 
 // WaitForDeploymentReadyE is like WaitForDeploymentReady but returns an error instead of calling t.Fatal.
 // It polls until ReadyReplicas == *Spec.Replicas, or until ReadyReplicas >= 1 when Spec.Replicas is nil.
 func WaitForDeploymentReadyE(ctx context.Context, kubeClient kubernetes.Interface, namespace, name string, timeout time.Duration) error {
+	var lastErr error
 	err := wait.PollUntilContextTimeout(ctx, defaultPollingInterval, timeout, true, func(ctx context.Context) (bool, error) {
 		getCtx, cancel := context.WithTimeout(ctx, DefaultAPICallTimeout)
 		defer cancel()
 		deploy, err := kubeClient.AppsV1().Deployments(namespace).Get(getCtx, name, metav1.GetOptions{})
 		if err != nil {
-			if apierrors.IsNotFound(err) || errors.Is(err, context.DeadlineExceeded) || apierrors.IsTimeout(err) || apierrors.IsServerTimeout(err) {
-				return false, nil
-			}
-			return false, err
+			lastErr = err
+			return false, nil
 		}
+		lastErr = nil
 		if deploy.Spec.Replicas == nil {
 			return deploy.Status.ReadyReplicas >= 1, nil
 		}
 		return deploy.Status.ReadyReplicas == *deploy.Spec.Replicas, nil
 	})
 	if err != nil {
+		if lastErr != nil {
+			return fmt.Errorf("deployment %q did not become ready within %v: %w (last API error: %w)", name, timeout, err, lastErr)
+		}
 		return fmt.Errorf("deployment %q did not become ready within %v: %w", name, timeout, err)
 	}
 	return nil

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -33,7 +33,7 @@ import (
 )
 
 const (
-	defaultPollingInterval = 5 * time.Second
+	defaultPollingInterval = 2 * time.Second
 	DefaultAPICallTimeout  = 10 * time.Second
 )
 
@@ -69,14 +69,14 @@ func WaitForModelServingReady(t *testing.T, ctx context.Context, kthenaClient *c
 func WaitForModelServingSpecReplicas(t *testing.T, ctx context.Context, kthenaClient *clientset.Clientset, namespace, name string, want int32, timeout time.Duration) {
 	t.Helper()
 	require.Eventually(t, func() bool {
-		getCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		getCtx, cancel := context.WithTimeout(ctx, DefaultAPICallTimeout)
 		defer cancel()
 		ms, err := kthenaClient.WorkloadV1alpha1().ModelServings(namespace).Get(getCtx, name, metav1.GetOptions{})
 		if err != nil || ms.Spec.Replicas == nil {
 			return false
 		}
 		return *ms.Spec.Replicas == want
-	}, timeout, 10*time.Second, "ModelServing %s/%s spec.replicas should converge to %d", namespace, name, want)
+	}, timeout, defaultPollingInterval, "ModelServing %s/%s spec.replicas should converge to %d", namespace, name, want)
 }
 
 // IsPodReady checks if a pod is in Running phase and has PodReady condition set to True.

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -33,8 +33,8 @@ import (
 )
 
 const (
-	defaultPollingInterval = 2 * time.Second
-	DefaultAPICallTimeout  = 2 * time.Second
+	defaultPollingInterval = 5 * time.Second
+	DefaultAPICallTimeout  = 10 * time.Second
 )
 
 // WaitForModelServingReady waits for a ModelServing to converge with desired replicas.
@@ -60,9 +60,7 @@ func WaitForModelServingReady(t *testing.T, ctx context.Context, kthenaClient *c
 		}
 		return ms.Status.ObservedGeneration >= ms.Generation &&
 			ms.Status.Replicas == expectedReplicas &&
-			ms.Status.AvailableReplicas == expectedReplicas &&
-			ms.Status.UpdatedReplicas == expectedReplicas &&
-			ms.Status.CurrentReplicas == expectedReplicas, nil
+			ms.Status.AvailableReplicas == expectedReplicas, nil
 	})
 	require.NoError(t, err, "ModelServing did not become ready")
 }

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -18,6 +18,7 @@ package utils
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -33,17 +34,22 @@ import (
 
 const (
 	defaultPollingInterval = 2 * time.Second
+	DefaultAPICallTimeout  = 2 * time.Second
 )
 
 // WaitForModelServingReady waits for a ModelServing to converge with desired replicas.
 func WaitForModelServingReady(t *testing.T, ctx context.Context, kthenaClient *clientset.Clientset, namespace, name string) {
 	t.Helper()
 	t.Log("Waiting for ModelServing to be ready...")
-	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
-		getCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	err := wait.PollUntilContextTimeout(ctx, defaultPollingInterval, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
+		getCtx, cancel := context.WithTimeout(ctx, DefaultAPICallTimeout)
 		defer cancel()
 		ms, err := kthenaClient.WorkloadV1alpha1().ModelServings(namespace).Get(getCtx, name, metav1.GetOptions{})
 		if err != nil {
+			if errors.Is(err, context.DeadlineExceeded) || apierrors.IsTimeout(err) || apierrors.IsServerTimeout(err) {
+				t.Logf("Timeout getting ModelServing %s, retrying: %v", name, err)
+				return false, nil
+			}
 			t.Logf("Error getting ModelServing %s, retrying: %v", name, err)
 			return false, nil
 		}
@@ -54,7 +60,9 @@ func WaitForModelServingReady(t *testing.T, ctx context.Context, kthenaClient *c
 		}
 		return ms.Status.ObservedGeneration >= ms.Generation &&
 			ms.Status.Replicas == expectedReplicas &&
-			ms.Status.AvailableReplicas == expectedReplicas, nil
+			ms.Status.AvailableReplicas == expectedReplicas &&
+			ms.Status.UpdatedReplicas == expectedReplicas &&
+			ms.Status.CurrentReplicas == expectedReplicas, nil
 	})
 	require.NoError(t, err, "ModelServing did not become ready")
 }
@@ -91,11 +99,11 @@ func IsPodReady(pod corev1.Pod) bool {
 func WaitForDeploymentReady(t *testing.T, ctx context.Context, kubeClient kubernetes.Interface, namespace, name string, replicas int32, timeout time.Duration) {
 	t.Helper()
 	err := wait.PollUntilContextTimeout(ctx, defaultPollingInterval, timeout, true, func(ctx context.Context) (bool, error) {
-		getCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		getCtx, cancel := context.WithTimeout(ctx, DefaultAPICallTimeout)
 		defer cancel()
 		deploy, err := kubeClient.AppsV1().Deployments(namespace).Get(getCtx, name, metav1.GetOptions{})
 		if err != nil {
-			if apierrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) || errors.Is(err, context.DeadlineExceeded) || apierrors.IsTimeout(err) || apierrors.IsServerTimeout(err) {
 				return false, nil
 			}
 			return false, err
@@ -109,11 +117,11 @@ func WaitForDeploymentReady(t *testing.T, ctx context.Context, kubeClient kubern
 // It polls until ReadyReplicas == *Spec.Replicas, or until ReadyReplicas >= 1 when Spec.Replicas is nil.
 func WaitForDeploymentReadyE(ctx context.Context, kubeClient kubernetes.Interface, namespace, name string, timeout time.Duration) error {
 	err := wait.PollUntilContextTimeout(ctx, defaultPollingInterval, timeout, true, func(ctx context.Context) (bool, error) {
-		getCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		getCtx, cancel := context.WithTimeout(ctx, DefaultAPICallTimeout)
 		defer cancel()
 		deploy, err := kubeClient.AppsV1().Deployments(namespace).Get(getCtx, name, metav1.GetOptions{})
 		if err != nil {
-			if apierrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) || errors.Is(err, context.DeadlineExceeded) || apierrors.IsTimeout(err) || apierrors.IsServerTimeout(err) {
 				return false, nil
 			}
 			return false, err

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -32,9 +32,8 @@ import (
 )
 
 const (
-	defaultPollingInterval     = 2 * time.Second
-	DefaultAPICallTimeout      = 10 * time.Second
-	rolloutRestartAtAnnotation = "kubectl.kubernetes.io/restartedAt"
+	defaultPollingInterval = 2 * time.Second
+	DefaultAPICallTimeout  = 10 * time.Second
 )
 
 // WaitForModelServingReady waits for a ModelServing to converge with desired replicas.
@@ -139,26 +138,6 @@ func WaitForDeploymentReadyE(ctx context.Context, kubeClient kubernetes.Interfac
 		return fmt.Errorf("deployment %q did not become ready within %v: %w", name, timeout, err)
 	}
 	return nil
-}
-
-// RolloutRestartDeployment triggers a rolling restart via the kubectl restartedAt annotation.
-func RolloutRestartDeployment(t *testing.T, ctx context.Context, kubeClient kubernetes.Interface, namespace, name string) {
-	t.Helper()
-	require.NoError(t, RolloutRestartDeploymentE(ctx, kubeClient, namespace, name))
-}
-
-// RolloutRestartDeploymentE is like RolloutRestartDeployment but returns an error (for cleanup paths).
-func RolloutRestartDeploymentE(ctx context.Context, kubeClient kubernetes.Interface, namespace, name string) error {
-	deploy, err := kubeClient.AppsV1().Deployments(namespace).Get(ctx, name, metav1.GetOptions{})
-	if err != nil {
-		return err
-	}
-	if deploy.Spec.Template.Annotations == nil {
-		deploy.Spec.Template.Annotations = make(map[string]string)
-	}
-	deploy.Spec.Template.Annotations[rolloutRestartAtAnnotation] = time.Now().UTC().Format(time.RFC3339)
-	_, err = kubeClient.AppsV1().Deployments(namespace).Update(ctx, deploy, metav1.UpdateOptions{})
-	return err
 }
 
 // CreateTestNamespace creates a test namespace and tolerates if it already exists.

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -41,8 +41,8 @@ func WaitForModelServingReady(t *testing.T, ctx context.Context, kthenaClient *c
 	t.Log("Waiting for ModelServing to be ready...")
 	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
 		getCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		defer cancel()
 		ms, err := kthenaClient.WorkloadV1alpha1().ModelServings(namespace).Get(getCtx, name, metav1.GetOptions{})
-		cancel()
 		if err != nil {
 			t.Logf("Error getting ModelServing %s, retrying: %v", name, err)
 			return false, nil
@@ -64,8 +64,8 @@ func WaitForModelServingSpecReplicas(t *testing.T, ctx context.Context, kthenaCl
 	t.Helper()
 	require.Eventually(t, func() bool {
 		getCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		defer cancel()
 		ms, err := kthenaClient.WorkloadV1alpha1().ModelServings(namespace).Get(getCtx, name, metav1.GetOptions{})
-		cancel()
 		if err != nil || ms.Spec.Replicas == nil {
 			return false
 		}
@@ -92,8 +92,8 @@ func WaitForDeploymentReady(t *testing.T, ctx context.Context, kubeClient kubern
 	t.Helper()
 	err := wait.PollUntilContextTimeout(ctx, defaultPollingInterval, timeout, true, func(ctx context.Context) (bool, error) {
 		getCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		defer cancel()
 		deploy, err := kubeClient.AppsV1().Deployments(namespace).Get(getCtx, name, metav1.GetOptions{})
-		cancel()
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				return false, nil
@@ -110,8 +110,8 @@ func WaitForDeploymentReady(t *testing.T, ctx context.Context, kubeClient kubern
 func WaitForDeploymentReadyE(ctx context.Context, kubeClient kubernetes.Interface, namespace, name string, timeout time.Duration) error {
 	err := wait.PollUntilContextTimeout(ctx, defaultPollingInterval, timeout, true, func(ctx context.Context) (bool, error) {
 		getCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		defer cancel()
 		deploy, err := kubeClient.AppsV1().Deployments(namespace).Get(getCtx, name, metav1.GetOptions{})
-		cancel()
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				return false, nil

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -35,22 +35,26 @@ const (
 	defaultPollingInterval = 2 * time.Second
 )
 
-// WaitForModelServingReady waits for a ModelServing to become ready by checking
-// if all expected replicas are available.
+// WaitForModelServingReady waits for a ModelServing to converge with desired replicas.
 func WaitForModelServingReady(t *testing.T, ctx context.Context, kthenaClient *clientset.Clientset, namespace, name string) {
+	t.Helper()
 	t.Log("Waiting for ModelServing to be ready...")
 	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
-		ms, err := kthenaClient.WorkloadV1alpha1().ModelServings(namespace).Get(ctx, name, metav1.GetOptions{})
+		getCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		ms, err := kthenaClient.WorkloadV1alpha1().ModelServings(namespace).Get(getCtx, name, metav1.GetOptions{})
+		cancel()
 		if err != nil {
 			t.Logf("Error getting ModelServing %s, retrying: %v", name, err)
 			return false, nil
 		}
-		// Check if all replicas are available
+
 		expectedReplicas := int32(1)
 		if ms.Spec.Replicas != nil {
 			expectedReplicas = *ms.Spec.Replicas
 		}
-		return ms.Status.AvailableReplicas >= expectedReplicas, nil
+		return ms.Status.ObservedGeneration >= ms.Generation &&
+			ms.Status.Replicas == expectedReplicas &&
+			ms.Status.AvailableReplicas == expectedReplicas, nil
 	})
 	require.NoError(t, err, "ModelServing did not become ready")
 }
@@ -59,7 +63,9 @@ func WaitForModelServingReady(t *testing.T, ctx context.Context, kthenaClient *c
 func WaitForModelServingSpecReplicas(t *testing.T, ctx context.Context, kthenaClient *clientset.Clientset, namespace, name string, want int32, timeout time.Duration) {
 	t.Helper()
 	require.Eventually(t, func() bool {
-		ms, err := kthenaClient.WorkloadV1alpha1().ModelServings(namespace).Get(ctx, name, metav1.GetOptions{})
+		getCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		ms, err := kthenaClient.WorkloadV1alpha1().ModelServings(namespace).Get(getCtx, name, metav1.GetOptions{})
+		cancel()
 		if err != nil || ms.Spec.Replicas == nil {
 			return false
 		}
@@ -85,7 +91,9 @@ func IsPodReady(pod corev1.Pod) bool {
 func WaitForDeploymentReady(t *testing.T, ctx context.Context, kubeClient kubernetes.Interface, namespace, name string, replicas int32, timeout time.Duration) {
 	t.Helper()
 	err := wait.PollUntilContextTimeout(ctx, defaultPollingInterval, timeout, true, func(ctx context.Context) (bool, error) {
-		deploy, err := kubeClient.AppsV1().Deployments(namespace).Get(ctx, name, metav1.GetOptions{})
+		getCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		deploy, err := kubeClient.AppsV1().Deployments(namespace).Get(getCtx, name, metav1.GetOptions{})
+		cancel()
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				return false, nil
@@ -101,7 +109,9 @@ func WaitForDeploymentReady(t *testing.T, ctx context.Context, kubeClient kubern
 // It polls until ReadyReplicas == *Spec.Replicas, or until ReadyReplicas >= 1 when Spec.Replicas is nil.
 func WaitForDeploymentReadyE(ctx context.Context, kubeClient kubernetes.Interface, namespace, name string, timeout time.Duration) error {
 	err := wait.PollUntilContextTimeout(ctx, defaultPollingInterval, timeout, true, func(ctx context.Context) (bool, error) {
-		deploy, err := kubeClient.AppsV1().Deployments(namespace).Get(ctx, name, metav1.GetOptions{})
+		getCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		deploy, err := kubeClient.AppsV1().Deployments(namespace).Get(getCtx, name, metav1.GetOptions{})
+		cancel()
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				return false, nil

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -33,9 +33,9 @@ import (
 )
 
 const (
-	defaultPollingInterval      = 2 * time.Second
-	DefaultAPICallTimeout       = 10 * time.Second
-	rolloutRestartAtAnnotation  = "kubectl.kubernetes.io/restartedAt"
+	defaultPollingInterval     = 2 * time.Second
+	DefaultAPICallTimeout      = 10 * time.Second
+	rolloutRestartAtAnnotation = "kubectl.kubernetes.io/restartedAt"
 )
 
 // WaitForModelServingReady waits for a ModelServing to converge with desired replicas.

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -33,8 +33,9 @@ import (
 )
 
 const (
-	defaultPollingInterval = 2 * time.Second
-	DefaultAPICallTimeout  = 10 * time.Second
+	defaultPollingInterval      = 2 * time.Second
+	DefaultAPICallTimeout       = 10 * time.Second
+	rolloutRestartAtAnnotation  = "kubectl.kubernetes.io/restartedAt"
 )
 
 // WaitForModelServingReady waits for a ModelServing to converge with desired replicas.
@@ -59,8 +60,8 @@ func WaitForModelServingReady(t *testing.T, ctx context.Context, kthenaClient *c
 			expectedReplicas = *ms.Spec.Replicas
 		}
 		return ms.Status.ObservedGeneration >= ms.Generation &&
-			ms.Status.Replicas == expectedReplicas &&
-			ms.Status.AvailableReplicas == expectedReplicas, nil
+			ms.Status.Replicas >= expectedReplicas &&
+			ms.Status.AvailableReplicas >= expectedReplicas, nil
 	})
 	require.NoError(t, err, "ModelServing did not become ready")
 }
@@ -133,6 +134,26 @@ func WaitForDeploymentReadyE(ctx context.Context, kubeClient kubernetes.Interfac
 		return fmt.Errorf("deployment %q did not become ready within %v: %w", name, timeout, err)
 	}
 	return nil
+}
+
+// RolloutRestartDeployment triggers a rolling restart via the kubectl restartedAt annotation.
+func RolloutRestartDeployment(t *testing.T, ctx context.Context, kubeClient kubernetes.Interface, namespace, name string) {
+	t.Helper()
+	require.NoError(t, RolloutRestartDeploymentE(ctx, kubeClient, namespace, name))
+}
+
+// RolloutRestartDeploymentE is like RolloutRestartDeployment but returns an error (for cleanup paths).
+func RolloutRestartDeploymentE(ctx context.Context, kubeClient kubernetes.Interface, namespace, name string) error {
+	deploy, err := kubeClient.AppsV1().Deployments(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	if deploy.Spec.Template.Annotations == nil {
+		deploy.Spec.Template.Annotations = make(map[string]string)
+	}
+	deploy.Spec.Template.Annotations[rolloutRestartAtAnnotation] = time.Now().UTC().Format(time.RFC3339)
+	_, err = kubeClient.AppsV1().Deployments(namespace).Update(ctx, deploy, metav1.UpdateOptions{})
+	return err
 }
 
 // CreateTestNamespace creates a test namespace and tolerates if it already exists.

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -59,7 +59,7 @@ func WaitForModelServingReady(t *testing.T, ctx context.Context, kthenaClient *c
 		if ms.Spec.Replicas != nil {
 			expectedReplicas = *ms.Spec.Replicas
 		}
-		return ms.Status.ObservedGeneration >= ms.Generation &&
+		return ms.Status.ObservedGeneration == ms.Generation &&
 			ms.Status.Replicas >= expectedReplicas &&
 			ms.Status.AvailableReplicas >= expectedReplicas, nil
 	})

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -47,10 +47,6 @@ func WaitForModelServingReady(t *testing.T, ctx context.Context, kthenaClient *c
 		defer cancel()
 		ms, err := kthenaClient.WorkloadV1alpha1().ModelServings(namespace).Get(getCtx, name, metav1.GetOptions{})
 		if err != nil {
-			if errors.Is(err, context.DeadlineExceeded) || apierrors.IsTimeout(err) || apierrors.IsServerTimeout(err) {
-				t.Logf("Timeout getting ModelServing %s, retrying: %v", name, err)
-				return false, nil
-			}
 			t.Logf("Error getting ModelServing %s, retrying: %v", name, err)
 			return false, nil
 		}


### PR DESCRIPTION
## What type of PR is this?
/kind cleanup

## What this PR does / why we need it
The existing e2e codebase had a few edge cases causing tests to either pass prematurely or randomly flake/hang. This PR cleans those up.

- `WaitForModelServingReady` now blocks until `ObservedGeneration` catches up, instead of passing mid-rollout.
- Stopped manually deleting pods in the router webhook test. It now uses a proper rollout restart annotation so we don't drop endpoints and hit connection refused.
- Fixed the role scale-down race condition by waiting for `RoleRunning` events before scaling down, rather than checking `AvailableReplicas == 0` (which was always true anyway).
- Added per-request timeouts to `Get`/`List` polling calls so a single sluggish API response can't stall the whole poll loop.
- Controller-manager e2e setup now picks up `t.Deadline()` when set, so the test timeout flows through properly.
- Swapped partition scale-down status checks to `require.Equal` — previously a mismatch would just log "success" and keep going.

## Which issue(s) this PR fixes
Fixes #1103 

## Special notes for your reviewer

## Does this PR introduce a user-facing change?
```release-note
NONE