### PR TITLE
fix(model-serving): fail CreatePodsByRole when workerTemplate is missing

### DIFF
--- a/pkg/model-serving-controller/controller/model_serving_controller.go
+++ b/pkg/model-serving-controller/controller/model_serving_controller.go
@@ -2103,6 +2103,10 @@ func (c *ModelServingController) CreatePodsForServingGroup(ctx context.Context, 
 }
 
 func (c *ModelServingController) CreatePodsByRole(ctx context.Context, role workloadv1alpha1.Role, ms *workloadv1alpha1.ModelServing, roleIndex int, servingGroupOrdinal int, revision string, roleTemplateHashOptional ...string) error {
+	if role.WorkerReplicas > 0 && role.WorkerTemplate == nil {
+		return fmt.Errorf("workerTemplate is required when workerReplicas is greater than 0 for role %s", role.Name)
+	}
+
 	servingGroupName := utils.GenerateServingGroupName(ms.Name, servingGroupOrdinal)
 	// TODO(hzxuzhonghu): build the plugin chain only once per ModelServing
 	// This is not critical now, so we leave it for future optimization.
@@ -2125,10 +2129,6 @@ func (c *ModelServingController) CreatePodsByRole(ctx context.Context, role work
 	c.podGroupManager.AnnotatePodWithPodGroup(entryPod, ms, servingGroupName, taskName)
 	if err := c.createPod(ctx, ms, servingGroupName, role.Name, roleID, entryPod, true, chain, "entry"); err != nil {
 		return err
-	}
-	if role.WorkerReplicas > 0 && role.WorkerTemplate == nil {
-		klog.Errorf("WorkerTemplate is required when workerReplicas > 0 for role %s. This should have been caught by webhook validation.", role.Name)
-		return nil
 	}
 
 	for i := 1; i <= int(role.WorkerReplicas); i++ {

--- a/pkg/model-serving-controller/controller/model_serving_controller_test.go
+++ b/pkg/model-serving-controller/controller/model_serving_controller_test.go
@@ -7287,3 +7287,30 @@ func TestResolveRoleTemplateHash_ReturnsEmptyWhenControllerRevisionNotFound(t *t
 	hash := controller.resolveRoleTemplateHash(ms, roleName, pod)
 	assert.Equal(t, "", hash)
 }
+
+func TestCreatePodsByRole_RejectsMissingWorkerTemplateBeforeCreatingPods(t *testing.T) {
+	kubeClient := kubefake.NewSimpleClientset()
+	controller := &ModelServingController{kubeClientSet: kubeClient}
+
+	ms := &workloadv1alpha1.ModelServing{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "test-ms"},
+	}
+	role := workloadv1alpha1.Role{
+		Name:           "role1",
+		Replicas:       ptr.To(int32(1)),
+		WorkerReplicas: 1,
+		EntryTemplate: workloadv1alpha1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "c", Image: "test:latest"}},
+			},
+		},
+	}
+
+	err := controller.CreatePodsByRole(context.Background(), role, ms, 0, 0, "rev1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "workerTemplate is required when workerReplicas is greater than 0")
+
+	pods, listErr := kubeClient.CoreV1().Pods("default").List(context.Background(), metav1.ListOptions{})
+	require.NoError(t, listErr)
+	assert.Empty(t, pods.Items)
+}


### PR DESCRIPTION
## Summary

`CreatePodsByRole` could create an entry pod and then return success (`nil`) when `workerReplicas > 0` but `workerTemplate` was unset. Reconciliation treated that as success, leaving a role with an entry pod and no workers.

This change validates the role spec at the start of `CreatePodsByRole` and returns an error before any pods are created.

## Motivation

Admission webhook (`validateWorkerReplicas`) already rejects this spec on create/update, but the controller should fail closed when the invariant is violated (webhook disabled, fail-open, direct API writes, tests calling `CreatePodsByRole` directly).

## Changes

- Move `workerReplicas` / `workerTemplate` validation to the top of `CreatePodsByRole`.
- Return `fmt.Errorf(...)` instead of logging and returning `nil` after entry pod creation.
- Add unit test ensuring no pods are created when the spec is invalid.

## Test plan

- [x] `go test ./pkg/model-serving-controller/controller/ -run TestCreatePodsByRole_RejectsMissingWorkerTemplateBeforeCreatingPods -count=1`
- [ ] `go test ./pkg/model-serving-controller/controller/ -count=1` (optional broader package run)

fixes #1105 