### PR TITLE
fix: correct inverted condition in shouldRebuildLocked()

### DIFF
--- a/pkg/kthena-router/datastore/fairness_queue.go
+++ b/pkg/kthena-router/datastore/fairness_queue.go
@@ -295,7 +295,7 @@ func (r *Request) isCancelled() bool {
 }
 
 func (pq *RequestPriorityQueue) shouldRebuildLocked() bool {
-	return pq.config.RebuildThreshold <= 0 || len(pq.heap) <= pq.config.RebuildThreshold
+	return pq.config.RebuildThreshold <= 0 || len(pq.heap) >= pq.config.RebuildThreshold
 }
 
 // rebuildHeap refreshes priorities for all queued items and rebuilds the heap.


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
`shouldRebuildLocked()` used `<=` instead of `>=` causing heap rebuilds to trigger on small heaps and skip on large ones under high load

**Which issue(s) this PR fixes**:
Fixes #1109

**Special notes for your reviewer**:


**Does this PR introduce a user-facing change?**:
```release-note

```
