### PR TITLE
Prevent scheduling field standalone update

### DIFF
--- a/pkg/model-serving-controller/webhook/validator.go
+++ b/pkg/model-serving-controller/webhook/validator.go
@@ -17,8 +17,10 @@ limitations under the License.
 package webhook
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
+	"reflect"
 	"strconv"
 	"strings"
 
@@ -53,7 +55,7 @@ func (v *ModelServingValidator) Handle(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Validate the ModelServing
-	allowed, reason := v.validateModelServing(modelServing)
+	allowed, reason := v.validateModelServing(admissionReview, modelServing)
 
 	// Create the admission response
 	admissionResponse := admissionv1.AdmissionResponse{
@@ -79,7 +81,7 @@ func (v *ModelServingValidator) Handle(w http.ResponseWriter, r *http.Request) {
 }
 
 // validateModelServing validates the ModelServing resource
-func (v *ModelServingValidator) validateModelServing(modelServing *workloadv1alpha1.ModelServing) (bool, string) {
+func (v *ModelServingValidator) validateModelServing(review *admissionv1.AdmissionReview, modelServing *workloadv1alpha1.ModelServing) (bool, string) {
 	var allErrs field.ErrorList
 
 	allErrs = append(allErrs, validGeneratedNameLength(modelServing)...)
@@ -90,6 +92,7 @@ func (v *ModelServingValidator) validateModelServing(modelServing *workloadv1alp
 	allErrs = append(allErrs, validateGangPolicy(modelServing)...)
 	allErrs = append(allErrs, validateWorkerReplicas(modelServing)...)
 	allErrs = append(allErrs, validateRecoveryPolicyAndRolloutStrategy(modelServing)...)
+	allErrs = append(allErrs, validateSchedulingFieldUpdate(review, modelServing)...)
 
 	if len(allErrs) > 0 {
 		var messages []string
@@ -421,6 +424,58 @@ func validateRecoveryPolicyAndRolloutStrategy(ms *workloadv1alpha1.ModelServing)
 				workloadv1alpha1.RoleRecreate,
 				workloadv1alpha1.RoleRollingUpdate,
 			),
+		))
+	}
+
+	return allErrs
+}
+
+// validateSchedulingFieldUpdate rejects UPDATE requests that modify
+// spec.template.gangPolicy or spec.template.networkTopology without also
+// changing spec.template.roles. These scheduling fields only take effect
+// during pod creation; changing them alone on a running ServingGroup is
+// a no-op and confusing to users.
+func validateSchedulingFieldUpdate(review *admissionv1.AdmissionReview, newMS *workloadv1alpha1.ModelServing) field.ErrorList {
+	var allErrs field.ErrorList
+
+	if review == nil || review.Request == nil || review.Request.Operation != admissionv1.Update {
+		return allErrs
+	}
+
+	if review.Request.OldObject.Raw == nil {
+		return allErrs
+	}
+
+	var oldMS workloadv1alpha1.ModelServing
+	if err := json.Unmarshal(review.Request.OldObject.Raw, &oldMS); err != nil {
+		klog.Errorf("failed to unmarshal old ModelServing for scheduling-field validation: %v", err)
+		return allErrs
+	}
+
+	gangPolicyChanged := !reflect.DeepEqual(oldMS.Spec.Template.GangPolicy, newMS.Spec.Template.GangPolicy)
+	networkTopologyChanged := !reflect.DeepEqual(oldMS.Spec.Template.NetworkTopology, newMS.Spec.Template.NetworkTopology)
+
+	if !gangPolicyChanged && !networkTopologyChanged {
+		return allErrs
+	}
+
+	rolesChanged := !reflect.DeepEqual(oldMS.Spec.Template.Roles, newMS.Spec.Template.Roles)
+	if rolesChanged {
+		return allErrs
+	}
+
+	// At this point, scheduling fields changed but roles did not.
+	tplPath := field.NewPath("spec").Child("template")
+	if gangPolicyChanged {
+		allErrs = append(allErrs, field.Forbidden(
+			tplPath.Child("gangPolicy"),
+			"gangPolicy cannot be updated without also changing roles; scheduling policy only takes effect when pods are recreated",
+		))
+	}
+	if networkTopologyChanged {
+		allErrs = append(allErrs, field.Forbidden(
+			tplPath.Child("networkTopology"),
+			"networkTopology cannot be updated without also changing roles; scheduling policy only takes effect when pods are recreated",
 		))
 	}
 

--- a/pkg/model-serving-controller/webhook/validator_test.go
+++ b/pkg/model-serving-controller/webhook/validator_test.go
@@ -17,12 +17,15 @@ limitations under the License.
 package webhook
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	workloadv1alpha1 "github.com/volcano-sh/kthena/pkg/apis/workload/v1alpha1"
 
+	admissionv1 "k8s.io/api/admission/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/ptr"
@@ -1347,6 +1350,157 @@ func TestValidateRecoveryPolicyAndRolloutStrategy(t *testing.T) {
 
 			for i := range got {
 				assert.Equalf(t, tt.want[i].Error(), got[i].Error(), "Error mismatch at index %d", i)
+			}
+		})
+	}
+}
+
+// buildUpdateReview is a helper that creates an AdmissionReview for an UPDATE
+// operation, embedding the given old ModelServing in OldObject.
+func buildUpdateReview(oldMS *workloadv1alpha1.ModelServing) *admissionv1.AdmissionReview {
+	raw, _ := json.Marshal(oldMS)
+	return &admissionv1.AdmissionReview{
+		Request: &admissionv1.AdmissionRequest{
+			Operation: admissionv1.Update,
+			OldObject: runtime.RawExtension{Raw: raw},
+		},
+	}
+}
+
+func TestValidateSchedulingFieldUpdate(t *testing.T) {
+	replicas := int32(3)
+	roleReplicas := int32(2)
+
+	baseMS := func() *workloadv1alpha1.ModelServing {
+		return &workloadv1alpha1.ModelServing{
+			ObjectMeta: v1.ObjectMeta{Name: "test-ms"},
+			Spec: workloadv1alpha1.ModelServingSpec{
+				Replicas: &replicas,
+				Template: workloadv1alpha1.ServingGroup{
+					GangPolicy: &workloadv1alpha1.GangPolicy{
+						MinRoleReplicas: map[string]int32{"prefill": 1},
+					},
+					NetworkTopology: &workloadv1alpha1.NetworkTopology{},
+					Roles: []workloadv1alpha1.Role{
+						{
+							Name:           "prefill",
+							Replicas:       &roleReplicas,
+							WorkerReplicas: 0,
+						},
+						{
+							Name:           "decode",
+							Replicas:       &roleReplicas,
+							WorkerReplicas: 0,
+						},
+					},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name    string
+		review  *admissionv1.AdmissionReview
+		newMS   *workloadv1alpha1.ModelServing
+		wantLen int
+		wantErr string // substring to check in the first error, empty = no check
+	}{
+		{
+			name: "reject: only gangPolicy changed",
+			review: func() *admissionv1.AdmissionReview {
+				return buildUpdateReview(baseMS())
+			}(),
+			newMS: func() *workloadv1alpha1.ModelServing {
+				ms := baseMS()
+				ms.Spec.Template.GangPolicy.MinRoleReplicas["prefill"] = 2
+				return ms
+			}(),
+			wantLen: 1,
+			wantErr: "gangPolicy cannot be updated without also changing roles",
+		},
+		{
+			name: "reject: only networkTopology changed",
+			review: func() *admissionv1.AdmissionReview {
+				return buildUpdateReview(baseMS())
+			}(),
+			newMS: func() *workloadv1alpha1.ModelServing {
+				ms := baseMS()
+				ms.Spec.Template.NetworkTopology = nil // changed from non-nil to nil
+				return ms
+			}(),
+			wantLen: 1,
+			wantErr: "networkTopology cannot be updated without also changing roles",
+		},
+		{
+			name: "reject: both gangPolicy and networkTopology changed without roles",
+			review: func() *admissionv1.AdmissionReview {
+				return buildUpdateReview(baseMS())
+			}(),
+			newMS: func() *workloadv1alpha1.ModelServing {
+				ms := baseMS()
+				ms.Spec.Template.GangPolicy.MinRoleReplicas["decode"] = 1
+				ms.Spec.Template.NetworkTopology = nil
+				return ms
+			}(),
+			wantLen: 2,
+		},
+		{
+			name: "allow: gangPolicy changed together with roles",
+			review: func() *admissionv1.AdmissionReview {
+				return buildUpdateReview(baseMS())
+			}(),
+			newMS: func() *workloadv1alpha1.ModelServing {
+				ms := baseMS()
+				ms.Spec.Template.GangPolicy.MinRoleReplicas["prefill"] = 2
+				// Also change roles
+				newReplicas := int32(3)
+				ms.Spec.Template.Roles[0].Replicas = &newReplicas
+				return ms
+			}(),
+			wantLen: 0,
+		},
+		{
+			name: "allow: networkTopology changed together with roles",
+			review: func() *admissionv1.AdmissionReview {
+				return buildUpdateReview(baseMS())
+			}(),
+			newMS: func() *workloadv1alpha1.ModelServing {
+				ms := baseMS()
+				ms.Spec.Template.NetworkTopology = nil
+				// Also change roles
+				ms.Spec.Template.Roles = ms.Spec.Template.Roles[:1]
+				return ms
+			}(),
+			wantLen: 0,
+		},
+		{
+			name: "allow: neither scheduling field changed",
+			review: func() *admissionv1.AdmissionReview {
+				return buildUpdateReview(baseMS())
+			}(),
+			newMS: func() *workloadv1alpha1.ModelServing {
+				ms := baseMS()
+				// Change only replicas (not a scheduling field)
+				newReplicas := int32(5)
+				ms.Spec.Replicas = &newReplicas
+				return ms
+			}(),
+			wantLen: 0,
+		},
+		{
+			name: "allow: CREATE operation (nil review)",
+			review: nil,
+			newMS:  baseMS(),
+			wantLen: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := validateSchedulingFieldUpdate(tt.review, tt.newMS)
+			assert.Equal(t, tt.wantLen, len(got), "unexpected error count: %v", got)
+			if tt.wantErr != "" && len(got) > 0 {
+				assert.Contains(t, got[0].Detail, tt.wantErr)
 			}
 		})
 	}

--- a/pkg/model-serving-controller/webhook/validator_test.go
+++ b/pkg/model-serving-controller/webhook/validator_test.go
@@ -1488,9 +1488,47 @@ func TestValidateSchedulingFieldUpdate(t *testing.T) {
 			wantLen: 0,
 		},
 		{
-			name: "allow: CREATE operation (nil review)",
-			review: nil,
-			newMS:  baseMS(),
+			name: "allow: invalid json in old object",
+			review: func() *admissionv1.AdmissionReview {
+				review := buildUpdateReview(baseMS())
+				review.Request.OldObject.Raw = []byte("invalid-json")
+				return review
+			}(),
+			newMS:   baseMS(),
+			wantLen: 0,
+		},
+		{
+			name: "allow: old object raw is nil",
+			review: func() *admissionv1.AdmissionReview {
+				review := buildUpdateReview(baseMS())
+				review.Request.OldObject.Raw = nil
+				return review
+			}(),
+			newMS:   baseMS(),
+			wantLen: 0,
+		},
+		{
+			name: "allow: request is nil",
+			review: &admissionv1.AdmissionReview{
+				Request: nil,
+			},
+			newMS:   baseMS(),
+			wantLen: 0,
+		},
+		{
+			name: "allow: CREATE operation (not UPDATE)",
+			review: func() *admissionv1.AdmissionReview {
+				review := buildUpdateReview(baseMS())
+				review.Request.Operation = admissionv1.Create
+				return review
+			}(),
+			newMS:   baseMS(),
+			wantLen: 0,
+		},
+		{
+			name:    "allow: review is nil",
+			review:  nil,
+			newMS:   baseMS(),
 			wantLen: 0,
 		},
 	}

--- a/pkg/model-serving-controller/webhook/validator_test.go
+++ b/pkg/model-serving-controller/webhook/validator_test.go
@@ -127,7 +127,7 @@ func TestValidateModelServingMissingReplicasDoesNotPanic(t *testing.T) {
 	var allowed bool
 	var reason string
 	assert.NotPanics(t, func() {
-		allowed, reason = validator.validateModelServing(ms)
+		allowed, reason = validator.validateModelServing(nil, ms)
 	})
 	assert.False(t, allowed)
 	assert.Contains(t, reason, "spec.replicas")


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement

What this PR does / why we need it: This PR improves the validation in the model-serving-controller admission webhook by strictly rejecting standalone updates to `gangPolicy` or `networkTopology` on an active `ModelServing` resource.

Currently, because these two fields only take effect during pod creation (scheduling-time), a user can update them on a running ServingGroup without any actual pods being rescheduled. This results in the API silently accepting the update while the running cluster state remains unchanged which is highly confusing and causes configuration drift.

**To fix this, this PR:**

Detects if `gangPolicy` or `networkTopology` is being updated on an existing resource.
Enforces that these scheduling fields can only be modified if the roles field is also being modified (since role changes trigger pod recreation, naturally applying the new scheduling configurations).
Explicitly ignores CREATE operations, keeping standard resource initialization unaffected.
**Which issue(s) this PR fixes:** 

Fixes #575 

**Special notes for your reviewer:** The validation uses AdmissionReview.Request.OldObject.Raw to fetch the previous state of the ModelServing resource to perform strict deep-equality checks against the incoming update. The unit test suite (validator_test.go) has been thoroughly updated to cover 7 distinct cases, including rejection logic and standard allows.

**Does this PR introduce a user-facing change?:**

>release-note
Added strict admission webhook validation for `ModelServing` resources to prevent standalone updates to `gangPolicy` and `networkTopology`. Updates to these scheduling-time fields are now rejected unless accompanied by a `roles` update, eliminating silent configuration drift on running resources.