### PR TITLE
Fix HTTPRoute PathPrefix matching

### DIFF
--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -531,28 +531,26 @@ func (r *Router) handleHTTPRoute(c *gin.Context, gatewayKey string) (bool, types
 			}
 			for _, match := range rule.Matches {
 				if match.Path != nil {
-					pathType := match.Path.Type
-					pathValue := match.Path.Value
-					if pathType != nil {
-						switch *pathType {
-						case gatewayv1.PathMatchExact:
-							if c.Request.URL.Path == *pathValue {
-								matched = true
-								break
-							}
-						case gatewayv1.PathMatchPathPrefix:
-							if strings.HasPrefix(c.Request.URL.Path, *pathValue) {
-								matched = true
-								matchedPrefix = *pathValue // Store matched prefix
-								break
-							}
-						case gatewayv1.PathMatchRegularExpression:
-							if regexMatched, err := regexp.MatchString(*pathValue, c.Request.URL.Path); err == nil && regexMatched {
-								matched = true
-								break
-							} else if err != nil {
-								klog.Warningf("Invalid regex pattern '%s' in HTTPRoute %s/%s: %v", *pathValue, route.Namespace, route.Name, err)
-							}
+					pathType := httpPathMatchType(match.Path)
+					pathValue := httpPathMatchValue(match.Path)
+					switch pathType {
+					case gatewayv1.PathMatchExact:
+						if c.Request.URL.Path == pathValue {
+							matched = true
+							break
+						}
+					case gatewayv1.PathMatchPathPrefix:
+						if ok, prefix := matchHTTPPathPrefix(c.Request.URL.Path, pathValue); ok {
+							matched = true
+							matchedPrefix = prefix
+							break
+						}
+					case gatewayv1.PathMatchRegularExpression:
+						if regexMatched, err := regexp.MatchString(pathValue, c.Request.URL.Path); err == nil && regexMatched {
+							matched = true
+							break
+						} else if err != nil {
+							klog.Warningf("Invalid regex pattern '%s' in HTTPRoute %s/%s: %v", pathValue, route.Namespace, route.Name, err)
 						}
 					}
 				} else {
@@ -627,6 +625,28 @@ func (r *Router) handleHTTPRoute(c *gin.Context, gatewayKey string) (bool, types
 	}
 
 	return true, inferencePoolName
+}
+
+func httpPathMatchType(path *gatewayv1.HTTPPathMatch) gatewayv1.PathMatchType {
+	if path.Type == nil {
+		return gatewayv1.PathMatchPathPrefix
+	}
+	return *path.Type
+}
+
+func httpPathMatchValue(path *gatewayv1.HTTPPathMatch) string {
+	if path.Value == nil {
+		return "/"
+	}
+	return *path.Value
+}
+
+func matchHTTPPathPrefix(path, prefix string) (bool, string) {
+	normalizedPrefix := strings.TrimRight(prefix, "/")
+	if normalizedPrefix == "" {
+		return strings.HasPrefix(path, "/"), "/"
+	}
+	return path == normalizedPrefix || strings.HasPrefix(path, normalizedPrefix+"/"), normalizedPrefix
 }
 
 // applyURLRewrite applies HTTPURLRewriteFilter to the request

--- a/pkg/kthena-router/router/router_test.go
+++ b/pkg/kthena-router/router/router_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/volcano-sh/kthena/pkg/kthena-router/accesslog"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/connectors"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/datastore"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 func TestMain(m *testing.M) {
@@ -63,6 +64,168 @@ func setupTestRouter(t *testing.T, backendHandler http.Handler) (*Router, datast
 	router := NewRouter(store, "../scheduler/testdata/configmap.yaml")
 
 	return router, store, backend
+}
+
+func TestRouter_HandleHTTPRoute_PathPrefix(t *testing.T) {
+	pathType := gatewayv1.PathMatchPathPrefix
+	kind := gatewayv1.Kind("Gateway")
+	group := gatewayv1.Group("inference.networking.k8s.io")
+	backendKind := gatewayv1.Kind("InferencePool")
+
+	tests := []struct {
+		name           string
+		prefix         string
+		path           string
+		defaultType    bool
+		defaultValue   bool
+		expectedMatch  bool
+		expectedPrefix string
+	}{
+		{
+			name:           "root matches root",
+			prefix:         "/",
+			path:           "/",
+			expectedMatch:  true,
+			expectedPrefix: "/",
+		},
+		{
+			name:           "root matches nested path",
+			prefix:         "/",
+			path:           "/foo/bar",
+			expectedMatch:  true,
+			expectedPrefix: "/",
+		},
+		{
+			name:           "prefix matches exact path",
+			prefix:         "/foo",
+			path:           "/foo",
+			expectedMatch:  true,
+			expectedPrefix: "/foo",
+		},
+		{
+			name:           "prefix matches path with trailing slash",
+			prefix:         "/foo",
+			path:           "/foo/",
+			expectedMatch:  true,
+			expectedPrefix: "/foo",
+		},
+		{
+			name:           "prefix matches nested path element",
+			prefix:         "/foo",
+			path:           "/foo/bar",
+			expectedMatch:  true,
+			expectedPrefix: "/foo",
+		},
+		{
+			name:           "trailing slash prefix matches exact path",
+			prefix:         "/foo/",
+			path:           "/foo",
+			expectedMatch:  true,
+			expectedPrefix: "/foo",
+		},
+		{
+			name:           "trailing slash prefix matches nested path",
+			prefix:         "/foo/",
+			path:           "/foo/bar",
+			expectedMatch:  true,
+			expectedPrefix: "/foo",
+		},
+		{
+			name:          "prefix does not match partial segment",
+			prefix:        "/foo",
+			path:          "/foobar",
+			expectedMatch: false,
+		},
+		{
+			name:          "prefix does not match partial nested segment",
+			prefix:        "/foo",
+			path:          "/foo-bar/baz",
+			expectedMatch: false,
+		},
+		{
+			name:          "prefix matching is case sensitive",
+			prefix:        "/foo",
+			path:          "/Foo",
+			expectedMatch: false,
+		},
+		{
+			name:           "missing type defaults to path prefix",
+			prefix:         "/foo",
+			path:           "/foo/bar",
+			defaultType:    true,
+			expectedMatch:  true,
+			expectedPrefix: "/foo",
+		},
+		{
+			name:           "missing value defaults to root",
+			path:           "/foo/bar",
+			defaultValue:   true,
+			expectedMatch:  true,
+			expectedPrefix: "/",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := datastore.New()
+			router := &Router{store: store}
+			pathMatch := &gatewayv1.HTTPPathMatch{}
+			if !tt.defaultType {
+				pathMatch.Type = &pathType
+			}
+			if !tt.defaultValue {
+				pathMatch.Value = &tt.prefix
+			}
+			route := &gatewayv1.HTTPRoute{
+				ObjectMeta: v1.ObjectMeta{Name: "route", Namespace: "default"},
+				Spec: gatewayv1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{
+						ParentRefs: []gatewayv1.ParentReference{
+							{
+								Name: "gw",
+								Kind: &kind,
+							},
+						},
+					},
+					Rules: []gatewayv1.HTTPRouteRule{
+						{
+							Matches: []gatewayv1.HTTPRouteMatch{
+								{
+									Path: pathMatch,
+								},
+							},
+							BackendRefs: []gatewayv1.HTTPBackendRef{
+								{
+									BackendRef: gatewayv1.BackendRef{
+										BackendObjectReference: gatewayv1.BackendObjectReference{
+											Group: &group,
+											Kind:  &backendKind,
+											Name:  "pool",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			assert.NoError(t, store.AddOrUpdateHTTPRoute(route))
+
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request, _ = http.NewRequest(http.MethodPost, tt.path, nil)
+
+			matched, pool := router.handleHTTPRoute(c, "default/gw")
+			assert.Equal(t, tt.expectedMatch, matched)
+			if !tt.expectedMatch {
+				return
+			}
+			assert.Equal(t, types.NamespacedName{Namespace: "default", Name: "pool"}, pool)
+			prefix, exists := c.Get("matchedPrefix")
+			assert.True(t, exists)
+			assert.Equal(t, tt.expectedPrefix, prefix)
+		})
+	}
 }
 
 func TestRouter_HandlerFunc_AggregatedMode(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

HTTPRoute PathPrefix matching now follows Gateway API path element matching. A prefix like `/foo` no longer matches `/foobar`.

**Which issue(s) this PR fixes**:

Fixes #1117

**Special notes for your reviewer**:

NONE

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```