### PR TITLE
Remove reading request.Body twice

### DIFF
--- a/pkg/kthena-router/connectors/transport.go
+++ b/pkg/kthena-router/connectors/transport.go
@@ -125,8 +125,11 @@ func BuildDecodeRequest(c *gin.Context, req *http.Request, modelRequest map[stri
 
 	reqCopy := req.Clone(req.Context())
 	reqCopy.URL.Scheme = "http"
-	reqCopy.Body = io.NopCloser(bytes.NewBuffer(body))
+	reqCopy.Body = io.NopCloser(bytes.NewReader(body))
 	reqCopy.ContentLength = int64(len(body))
+	reqCopy.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(body)), nil
+	}
 
 	return reqCopy
 }

--- a/pkg/kthena-router/connectors/transport_test.go
+++ b/pkg/kthena-router/connectors/transport_test.go
@@ -379,6 +379,21 @@ func TestBuildDecodeRequest(t *testing.T) {
 
 			// URL scheme should be http
 			assert.Equal(t, "http", result.URL.Scheme)
+
+			// Verify GetBody is set and returns the same content as Body
+			require.NotNil(t, result.GetBody)
+			getBodyReader, err := result.GetBody()
+			require.NoError(t, err)
+			getBodyBytes, err := io.ReadAll(getBodyReader)
+			require.NoError(t, err)
+			assert.Equal(t, body, getBodyBytes, "GetBody should return the same content as Body")
+
+			// Verify GetBody is reusable (can be called multiple times)
+			getBodyReader2, err := result.GetBody()
+			require.NoError(t, err)
+			getBodyBytes2, err := io.ReadAll(getBodyReader2)
+			require.NoError(t, err)
+			assert.Equal(t, body, getBodyBytes2, "GetBody should be reusable and return the same content on subsequent calls")
 		})
 	}
 }

--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -480,8 +480,7 @@ func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest) {
 		accesslog.SetRequestRouting(c, modelRouteName, modelServerFullName, "")
 	}
 
-	req := c.Request
-	if err := r.proxyModelEndpoint(c, req, ctx, modelRequest, port); err != nil {
+	if err := r.proxyModelEndpoint(c, ctx, modelRequest, port); err != nil {
 		klog.Errorf("request failed reqID: %s: %v", c.Request.Header.Get("x-request-id"), err)
 		accesslog.SetError(c, "proxy", "request processing failed")
 		c.AbortWithStatusJSON(http.StatusInternalServerError, "request processing failed")
@@ -613,7 +612,6 @@ func (r *Router) applyURLRewrite(c *gin.Context, urlRewrite *gatewayv1.HTTPURLRe
 
 func (r *Router) proxy(
 	c *gin.Context,
-	req *http.Request,
 	ctx *framework.Context,
 	stream bool,
 	port int32,
@@ -629,21 +627,16 @@ func (r *Router) proxy(
 		}
 	}
 
-	// Capture body bytes once so each retry attempt gets a fresh reader.
-	// transport.RoundTrip drains req.Body on every call, so reusing the same
-	// request across loop iterations sends an empty body to subsequent pods.
-	var bodyBytes []byte
-	if req.Body != nil {
-		b, err := io.ReadAll(req.Body)
-		req.Body.Close()
-		if err != nil {
-			return fmt.Errorf("failed to read request body: %w", err)
-		}
-		bodyBytes = b
-	}
-
+	req := c.Request
 	for i := 0; i < len(ctx.BestPods); i++ {
-		req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+		if req.GetBody != nil {
+			body, err := req.GetBody()
+			if err != nil {
+				return fmt.Errorf("failed to rebuild request body: %w", err)
+			}
+			req.Body = body
+		}
+
 		pod := ctx.BestPods[i]
 		podObj := pod.GetPod()
 		podName := types.NamespacedName{Namespace: podObj.Namespace, Name: podObj.Name}
@@ -651,7 +644,6 @@ func (r *Router) proxy(
 		// Track this request as in-flight to the chosen pod. This is instant and
 		// feeds the scheduler immediately, avoiding the ~1 s engine-metrics lag.
 		r.store.IncrPodOnFlightRequests(podName)
-
 		// Increment upstream request count with both modelServer and modelRoute
 		r.metrics.IncActiveUpstreamRequests(modelServerName, modelRouteName)
 
@@ -681,7 +673,6 @@ func (r *Router) proxy(
 
 func (r *Router) proxyModelEndpoint(
 	c *gin.Context,
-	req *http.Request,
 	ctx *framework.Context,
 	modelRequest ModelRequest,
 	port int32,
@@ -699,12 +690,11 @@ func (r *Router) proxyModelEndpoint(
 
 	// proxy to pd aggregated pod
 	if ctx.BestPods != nil {
-		// build request
-		decodeRequest := connectors.BuildDecodeRequest(c, req, modelRequest)
+		c.Request = connectors.BuildDecodeRequest(c, c.Request, modelRequest)
 		stream := isStreaming(modelRequest)
 		modelName := ctx.Model
 		userID := c.GetString(common.UserIdKey)
-		err := r.proxy(c, decodeRequest, ctx, stream, port, func(resp handlers.OpenAIResponse) {
+		err := r.proxy(c, ctx, stream, port, func(resp handlers.OpenAIResponse) {
 			if resp.Usage.TotalTokens <= 0 {
 				return
 			}
@@ -741,7 +731,7 @@ func (r *Router) proxyModelEndpoint(
 	}
 
 	// PD disaggregated mode - use KV connector
-	return r.proxyToPDDisaggregated(c, req, ctx, kvConnector, modelRequest, port)
+	return r.proxyToPDDisaggregated(c, ctx, kvConnector, modelRequest, port)
 }
 
 func (r *Router) GetModelServer(modelName string, req *http.Request) (*v1alpha1.ModelServer, error) {
@@ -942,7 +932,6 @@ func (r *Router) getKVConnector(modelServerName types.NamespacedName) (connector
 // proxyToPDDisaggregated handles PD disaggregated routing using KV connectors
 func (r *Router) proxyToPDDisaggregated(
 	c *gin.Context,
-	req *http.Request,
 	ctx *framework.Context,
 	kvConnector connectors.KVConnector,
 	modelRequest ModelRequest,


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind security
/kind documentation
/kind feature

-->

/kind enhancement


**What this PR does / why we need it**:

This is a kind of perf improvement. Before we read request body twice, now only once.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
