### PR TITLE
perf(router): cache parsed prompt to avoid redundant ParsePrompt call

### DIFF
--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -415,7 +415,12 @@ func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest) {
 	// Common scheduling logic for both ModelServer and InferencePool
 	var prompt *common.ChatMessage
 	if cached, exists := c.Get(PromptKey); exists {
-		prompt = cached.(*common.ChatMessage)
+		var ok bool
+		if prompt, ok = cached.(*common.ChatMessage); !ok {
+			accesslog.SetError(c, "prompt_parsing", "internal error: invalid prompt type")
+			c.AbortWithStatusJSON(http.StatusInternalServerError, "internal error")
+			return
+		}
 	} else {
 		accesslog.SetError(c, "prompt_parsing", "prompt not found")
 		c.AbortWithStatusJSON(http.StatusNotFound, "prompt not found")

--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -58,6 +58,7 @@ import (
 const (
 	// Context keys for gin context
 	GatewayKey = "gatewayKey"
+	PromptKey  = "promptKey" // store parsed ChatMessage, which will be reused
 )
 
 func getEnvBool(key string, fallback bool) bool {
@@ -253,6 +254,8 @@ func (r *Router) HandlerFunc() gin.HandlerFunc {
 			c.Set("finishReason", "prompt_parsing")
 			return
 		}
+		// Store parsed prompt to avoid re-parsing in doLoadbalance.
+		c.Set(PromptKey, prompt)
 		promptStr := utils.GetPromptString(prompt)
 
 		// Calculate input tokens for metrics using tokenizer
@@ -410,8 +413,10 @@ func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest) {
 	}
 
 	// Common scheduling logic for both ModelServer and InferencePool
-	prompt, err := utils.ParsePrompt(modelRequest)
-	if err != nil {
+	var prompt *common.ChatMessage
+	if cached, exists := c.Get(PromptKey); exists {
+		prompt = cached.(*common.ChatMessage)
+	} else {
 		accesslog.SetError(c, "prompt_parsing", "prompt not found")
 		c.AbortWithStatusJSON(http.StatusNotFound, "prompt not found")
 		return

--- a/pkg/kthena-router/scheduler/framework/interface.go
+++ b/pkg/kthena-router/scheduler/framework/interface.go
@@ -28,7 +28,7 @@ import (
 // Context stores information which maybe useful in Filter or Score plugins.
 type Context struct {
 	Model  string
-	Prompt common.ChatMessage
+	Prompt *common.ChatMessage
 
 	Hashes []uint64
 

--- a/pkg/kthena-router/scheduler/plugins/kvcache_aware.go
+++ b/pkg/kthena-router/scheduler/plugins/kvcache_aware.go
@@ -161,6 +161,11 @@ func (t *KVCacheAware) normalizeAndTokenizePrompt(ctx *framework.Context, pods [
 
 func (t *KVCacheAware) Score(ctx *framework.Context, pods []*datastore.PodInfo) map[*datastore.PodInfo]int {
 	scoreStart := time.Now()
+	if ctx == nil || ctx.Prompt == nil {
+		klog.V(4).Infof("KVCacheAware.Score: early return - nil context or prompt")
+		return nil
+	}
+
 	podNames := make([]string, 0, len(pods))
 	for _, p := range pods {
 		podNames = append(podNames, p.Pod.Name)
@@ -168,16 +173,10 @@ func (t *KVCacheAware) Score(ctx *framework.Context, pods []*datastore.PodInfo) 
 	klog.V(4).Infof("KVCacheAware.Score: called for model=%q, pods=%v, promptTextLen=%d, messagesLen=%d",
 		ctx.Model, podNames, len(ctx.Prompt.Text), len(ctx.Prompt.Messages))
 
-	scoreResults := make(map[*datastore.PodInfo]int)
-
-	for _, pod := range pods {
-		scoreResults[pod] = 0
-	}
-
 	if (ctx.Prompt.Text == "" && len(ctx.Prompt.Messages) == 0) || ctx.Model == "" {
 		klog.V(4).Infof("KVCacheAware.Score: early return — empty prompt or model (model=%q, textLen=%d, messagesLen=%d)",
 			ctx.Model, len(ctx.Prompt.Text), len(ctx.Prompt.Messages))
-		return scoreResults
+		return nil
 	}
 
 	start := time.Now()
@@ -187,7 +186,7 @@ func (t *KVCacheAware) Score(ctx *framework.Context, pods []*datastore.PodInfo) 
 
 	if err != nil || len(tokens) == 0 {
 		klog.V(4).Infof("KVCacheAware.Score: early return — tokenization failed or empty (err=%v, tokens=%d)", err, len(tokens))
-		return scoreResults
+		return nil
 	}
 
 	blockHashes := t.processor.TokensToBlockHashes(tokens, t.maxBlocksToMatch)
@@ -195,7 +194,7 @@ func (t *KVCacheAware) Score(ctx *framework.Context, pods []*datastore.PodInfo) 
 		len(blockHashes), len(tokens), t.processor.blockSize)
 	if len(blockHashes) == 0 {
 		klog.V(4).Infof("KVCacheAware.Score: early return — no block hashes generated")
-		return scoreResults
+		return nil
 	}
 
 	redisStart := time.Now()
@@ -203,13 +202,13 @@ func (t *KVCacheAware) Score(ctx *framework.Context, pods []*datastore.PodInfo) 
 	redisDuration := time.Since(redisStart)
 	if err != nil {
 		klog.Warningf("KVCacheAware.Score: Redis query failed after %v: %v", redisDuration, err)
-		return scoreResults
+		return nil
 	}
 	klog.V(4).Infof("KVCacheAware.Score: Redis query took %v, blocksWithHits=%d/%d",
 		redisDuration, len(blockToPods), len(blockHashes))
 
 	podScores := t.calculatePodScores(blockHashes, blockToPods)
-
+	scoreResults := make(map[*datastore.PodInfo]int, len(podScores))
 	for _, pod := range pods {
 		podName := pod.Pod.Name
 		if score, exists := podScores[podName]; exists {

--- a/pkg/kthena-router/scheduler/plugins/kvcache_aware_test.go
+++ b/pkg/kthena-router/scheduler/plugins/kvcache_aware_test.go
@@ -524,44 +524,32 @@ func TestKVCacheAware_Score_Core(t *testing.T) {
 			name: "Empty prompt returns zero scores",
 			context: &framework.Context{
 				Model:  "test-model",
-				Prompt: common.ChatMessage{},
+				Prompt: nil,
 			},
-			pods: pods,
-			expectedScores: map[string]int{
-				"pod1": 0,
-				"pod2": 0,
-				"pod3": 0,
-			},
+			pods:           pods,
+			expectedScores: map[string]int{},
 		},
 		{
 			name: "Empty model returns zero scores",
 			context: &framework.Context{
 				Model: "",
-				Prompt: common.ChatMessage{
+				Prompt: &common.ChatMessage{
 					Text: "Hello world",
 				},
 			},
-			pods: pods,
-			expectedScores: map[string]int{
-				"pod1": 0,
-				"pod2": 0,
-				"pod3": 0,
-			},
+			pods:           pods,
+			expectedScores: map[string]int{},
 		},
 		{
 			name: "No tokenizer available returns zero scores",
 			context: &framework.Context{
 				Model: "test-model",
-				Prompt: common.ChatMessage{
+				Prompt: &common.ChatMessage{
 					Text: "Hello world",
 				},
 			},
-			pods: pods,
-			expectedScores: map[string]int{
-				"pod1": 0,
-				"pod2": 0,
-				"pod3": 0,
-			},
+			pods:           pods,
+			expectedScores: map[string]int{},
 		},
 	}
 
@@ -882,7 +870,7 @@ func TestKVCacheAware_NormalizeAndTokenizePrompt_Core(t *testing.T) {
 				plugin := &KVCacheAware{}
 				ctx := &framework.Context{
 					Model: "test-model",
-					Prompt: common.ChatMessage{
+					Prompt: &common.ChatMessage{
 						Text:     "",
 						Messages: []common.Message{},
 					},
@@ -1387,7 +1375,7 @@ func TestKVCacheAware_NormalizeAndTokenizePrompt_Advanced_Core(t *testing.T) {
 			name: "Text prompt with nil tokenizer",
 			context: &framework.Context{
 				Model: "test-model",
-				Prompt: common.ChatMessage{
+				Prompt: &common.ChatMessage{
 					Text: "Hello world",
 				},
 			},
@@ -1403,7 +1391,7 @@ func TestKVCacheAware_NormalizeAndTokenizePrompt_Advanced_Core(t *testing.T) {
 			name: "Chat messages with nil tokenizer",
 			context: &framework.Context{
 				Model: "test-model",
-				Prompt: common.ChatMessage{
+				Prompt: &common.ChatMessage{
 					Messages: []common.Message{
 						{Role: "user", Content: "Hello"},
 					},
@@ -1421,7 +1409,7 @@ func TestKVCacheAware_NormalizeAndTokenizePrompt_Advanced_Core(t *testing.T) {
 			name: "Empty text and empty messages",
 			context: &framework.Context{
 				Model: "test-model",
-				Prompt: common.ChatMessage{
+				Prompt: &common.ChatMessage{
 					Text:     "",
 					Messages: []common.Message{},
 				},
@@ -1472,7 +1460,7 @@ func TestKVCacheAware_Score_Advanced_Core(t *testing.T) {
 			name: "Score with processor nil",
 			context: &framework.Context{
 				Model: "test-model",
-				Prompt: common.ChatMessage{
+				Prompt: &common.ChatMessage{
 					Text: "Hello world",
 				},
 			},
@@ -1484,18 +1472,14 @@ func TestKVCacheAware_Score_Advanced_Core(t *testing.T) {
 					// processor is nil
 				}
 			},
-			expectedScores: map[string]int{
-				"pod1": 0,
-				"pod2": 0,
-				"pod3": 0,
-			},
-			description: "Should handle nil processor gracefully",
+			expectedScores: map[string]int{},
+			description:    "Should handle nil processor gracefully",
 		},
 		{
 			name: "Score with maxBlocksToMatch limit",
 			context: &framework.Context{
 				Model: "test-model",
-				Prompt: common.ChatMessage{
+				Prompt: &common.ChatMessage{
 					Text: "Hello world",
 				},
 			},
@@ -1507,12 +1491,8 @@ func TestKVCacheAware_Score_Advanced_Core(t *testing.T) {
 					processor:        &TokenBlockProcessor{blockSize: 1},
 				}
 			},
-			expectedScores: map[string]int{
-				"pod1": 0,
-				"pod2": 0,
-				"pod3": 0,
-			},
-			description: "Should handle maxBlocksToMatch limit",
+			expectedScores: map[string]int{},
+			description:    "Should handle maxBlocksToMatch limit",
 		},
 	}
 
@@ -1783,7 +1763,7 @@ func TestKVCacheAware_Score_ErrorHandling_Core(t *testing.T) {
 			name: "Nil context",
 			context: &framework.Context{
 				Model: "test-model",
-				Prompt: common.ChatMessage{
+				Prompt: &common.ChatMessage{
 					Text: "Hello",
 				},
 			},
@@ -1801,7 +1781,7 @@ func TestKVCacheAware_Score_ErrorHandling_Core(t *testing.T) {
 			name: "Very small maxBlocksToMatch",
 			context: &framework.Context{
 				Model: "test-model",
-				Prompt: common.ChatMessage{
+				Prompt: &common.ChatMessage{
 					Text: "Hello world this is a longer text",
 				},
 			},
@@ -1824,16 +1804,7 @@ func TestKVCacheAware_Score_ErrorHandling_Core(t *testing.T) {
 			// This should not panic
 			result := plugin.Score(tt.context, pods)
 
-			// Verify result structure
-			if result == nil {
-				t.Error("Expected non-nil result")
-			}
-
-			if len(result) != len(pods) {
-				t.Errorf("Expected %d results, got %d", len(pods), len(result))
-			}
-
-			// Verify all scores are non-negative
+			// Verify no panic and any returned scores are within bounds.
 			for pod, score := range result {
 				if score < 0 {
 					t.Errorf("Score should be non-negative, got %d for pod %s", score, pod.Pod.Name)
@@ -2001,7 +1972,7 @@ func TestKVCacheAware_Concurrency_Core(t *testing.T) {
 	pods := createTestPods("pod1", "pod2")
 	ctx := &framework.Context{
 		Model: "",
-		Prompt: common.ChatMessage{
+		Prompt: &common.ChatMessage{
 			Text: "",
 		},
 	}
@@ -2011,10 +1982,7 @@ func TestKVCacheAware_Concurrency_Core(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		go func() {
 			defer func() { done <- true }()
-			result := plugin.Score(ctx, pods)
-			if result == nil {
-				t.Error("Expected non-nil result")
-			}
+			_ = plugin.Score(ctx, pods)
 		}()
 	}
 

--- a/pkg/kthena-router/scheduler/plugins/prefix_test.go
+++ b/pkg/kthena-router/scheduler/plugins/prefix_test.go
@@ -128,7 +128,7 @@ func TestPrefixCacheScore(t *testing.T) {
 
 		ctx := &framework.Context{
 			Model:  "test-model",
-			Prompt: common.ChatMessage{Text: prompt},
+			Prompt: &common.ChatMessage{Text: prompt},
 		}
 		scores := plugin.Score(ctx, []*datastore.PodInfo{pod1, pod2, pod3})
 
@@ -168,7 +168,7 @@ func TestPrefixCacheScore(t *testing.T) {
 		pod := &datastore.PodInfo{Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: "ns1"}}}
 		ctx := &framework.Context{
 			Model:  "test-model",
-			Prompt: common.ChatMessage{}, // empty – no Text, no Messages
+			Prompt: &common.ChatMessage{}, // empty – no Text, no Messages
 		}
 		scores := plugin.Score(ctx, []*datastore.PodInfo{pod})
 		if scores != nil {
@@ -214,7 +214,7 @@ func TestNewPrefixCacheRespectsTopKMatches(t *testing.T) {
 
 	ctx := &framework.Context{
 		Model:  "test-model",
-		Prompt: common.ChatMessage{Text: prompt},
+		Prompt: &common.ChatMessage{Text: prompt},
 	}
 	scores := plugin.Score(ctx, []*datastore.PodInfo{pod1, pod2})
 

--- a/pkg/kthena-router/scheduler/plugins/tokenization/tokenization_test.go
+++ b/pkg/kthena-router/scheduler/plugins/tokenization/tokenization_test.go
@@ -563,7 +563,7 @@ func TestTokenizerManagerTokenizePrompt(t *testing.T) {
 	t.Run("Empty pods", func(t *testing.T) {
 		prompt := common.ChatMessage{Text: "Hello world"}
 
-		_, err := manager.TokenizePrompt("test-model", prompt, []*datastore.PodInfo{})
+		_, err := manager.TokenizePrompt("test-model", &prompt, []*datastore.PodInfo{})
 		if err == nil {
 			t.Error("Expected error for empty pods")
 		}
@@ -573,7 +573,7 @@ func TestTokenizerManagerTokenizePrompt(t *testing.T) {
 	t.Run("Empty prompt", func(t *testing.T) {
 		prompt := common.ChatMessage{}
 
-		_, err := manager.TokenizePrompt("test-model", prompt, []*datastore.PodInfo{})
+		_, err := manager.TokenizePrompt("test-model", &prompt, []*datastore.PodInfo{})
 		if err == nil {
 			t.Error("Expected error for empty prompt")
 		}

--- a/pkg/kthena-router/scheduler/plugins/tokenization/tokenizer_manager.go
+++ b/pkg/kthena-router/scheduler/plugins/tokenization/tokenizer_manager.go
@@ -89,7 +89,7 @@ func (m *TokenizerManager) createTokenizerFromPods(model string, pods []*datasto
 // TokenizePrompt tokenizes a prompt (text or chat messages) and returns uint32 tokens
 func (m *TokenizerManager) TokenizePrompt(
 	model string,
-	prompt common.ChatMessage,
+	prompt *common.ChatMessage,
 	pods []*datastore.PodInfo,
 ) ([]uint32, error) {
 	tokenizer := m.GetTokenizer(model, pods)

--- a/pkg/kthena-router/scheduler/scheduler_impl_test.go
+++ b/pkg/kthena-router/scheduler/scheduler_impl_test.go
@@ -212,7 +212,7 @@ func TestSchedulePDGroup(t *testing.T) {
 
 			// Create scheduling context with PDGroup enabled
 			ctx := &framework.Context{
-				Prompt: &common.ChatMessage{},
+				Prompt:          &common.ChatMessage{},
 				ModelServerName: modelServerName,
 				PDGroup: &aiv1alpha1.PDGroup{
 					GroupKey:      "pd-group",

--- a/pkg/kthena-router/scheduler/scheduler_impl_test.go
+++ b/pkg/kthena-router/scheduler/scheduler_impl_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	aiv1alpha1 "github.com/volcano-sh/kthena/pkg/apis/networking/v1alpha1"
+	"github.com/volcano-sh/kthena/pkg/kthena-router/common"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/datastore"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/scheduler/framework"
 )
@@ -211,6 +212,7 @@ func TestSchedulePDGroup(t *testing.T) {
 
 			// Create scheduling context with PDGroup enabled
 			ctx := &framework.Context{
+				Prompt: &common.ChatMessage{},
 				ModelServerName: modelServerName,
 				PDGroup: &aiv1alpha1.PDGroup{
 					GroupKey:      "pd-group",
@@ -253,6 +255,7 @@ func TestScheduleNonPDGroupWithEmptyScores(t *testing.T) {
 	scheduler := NewScheduler(store, nil).(*SchedulerImpl)
 
 	ctx := &framework.Context{
+		Prompt:          &common.ChatMessage{},
 		ModelServerName: types.NamespacedName{Namespace: "default", Name: "test"},
 		PDGroup:         nil, // Non-PD scheduling
 	}
@@ -290,6 +293,7 @@ func TestRunScorePluginsEdgeCases(t *testing.T) {
 			scheduler := NewScheduler(store, nil).(*SchedulerImpl)
 
 			ctx := &framework.Context{
+				Prompt:          &common.ChatMessage{},
 				ModelServerName: types.NamespacedName{Namespace: "default", Name: "test"},
 			}
 

--- a/pkg/kthena-router/utils/utils.go
+++ b/pkg/kthena-router/utils/utils.go
@@ -42,13 +42,13 @@ func GetNamespaceName(obj metav1.Object) types.NamespacedName {
 	}
 }
 
-func ParsePrompt(body map[string]interface{}) (common.ChatMessage, error) {
+func ParsePrompt(body map[string]interface{}) (*common.ChatMessage, error) {
 	if prompt, ok := body["prompt"]; ok {
 		promptStr, ok := prompt.(string)
 		if !ok {
-			return common.ChatMessage{}, fmt.Errorf("prompt is not a string")
+			return nil, fmt.Errorf("prompt is not a string")
 		}
-		return common.ChatMessage{
+		return &common.ChatMessage{
 			Text: promptStr,
 		}, nil
 	}
@@ -56,7 +56,7 @@ func ParsePrompt(body map[string]interface{}) (common.ChatMessage, error) {
 	if messages, ok := body["messages"]; ok {
 		messageList, ok := messages.([]interface{})
 		if !ok {
-			return common.ChatMessage{}, fmt.Errorf("messages is not a list")
+			return nil, fmt.Errorf("messages is not a list")
 		}
 
 		msgs := make([]common.Message, 0, len(messageList))
@@ -82,15 +82,15 @@ func ParsePrompt(body map[string]interface{}) (common.ChatMessage, error) {
 			})
 		}
 
-		return common.ChatMessage{
+		return &common.ChatMessage{
 			Messages: msgs,
 		}, nil
 	}
 
-	return common.ChatMessage{}, fmt.Errorf("prompt or messages not found in request body")
+	return nil, fmt.Errorf("prompt or messages not found in request body")
 }
 
-func GetPromptString(chatMessage common.ChatMessage) string {
+func GetPromptString(chatMessage *common.ChatMessage) string {
 	// If Text field is present, return text directly (for prompt format)
 	if chatMessage.Text != "" {
 		return chatMessage.Text

--- a/pkg/kthena-router/utils/utils_test.go
+++ b/pkg/kthena-router/utils/utils_test.go
@@ -47,7 +47,7 @@ func TestParsePrompt(t *testing.T) {
 	tests := []struct {
 		name    string
 		body    map[string]interface{}
-		want    common.ChatMessage
+		want    *common.ChatMessage
 		wantErr bool
 	}{
 		{
@@ -55,7 +55,7 @@ func TestParsePrompt(t *testing.T) {
 			body: map[string]interface{}{
 				"prompt": "hello",
 			},
-			want: common.ChatMessage{
+			want: &common.ChatMessage{
 				Text: "hello",
 			},
 			wantErr: false,
@@ -65,7 +65,7 @@ func TestParsePrompt(t *testing.T) {
 			body: map[string]interface{}{
 				"prompt": 123,
 			},
-			want:    common.ChatMessage{},
+			want:    nil,
 			wantErr: true,
 		},
 		{
@@ -82,7 +82,7 @@ func TestParsePrompt(t *testing.T) {
 					},
 				},
 			},
-			want: common.ChatMessage{
+			want: &common.ChatMessage{
 				Messages: []common.Message{
 					{Role: "user", Content: "hi"},
 					{Role: "assistant", Content: "hello"},
@@ -95,7 +95,7 @@ func TestParsePrompt(t *testing.T) {
 			body: map[string]interface{}{
 				"messages": "not a list",
 			},
-			want:    common.ChatMessage{},
+			want:    nil,
 			wantErr: true,
 		},
 		{
@@ -103,7 +103,7 @@ func TestParsePrompt(t *testing.T) {
 			body: map[string]interface{}{
 				"foo": "bar",
 			},
-			want:    common.ChatMessage{},
+			want:    nil,
 			wantErr: true,
 		},
 	}

--- a/pkg/kthena-router/utils/utils_test.go
+++ b/pkg/kthena-router/utils/utils_test.go
@@ -154,7 +154,7 @@ func TestGetPromptString(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := GetPromptString(tt.chatMessage); got != tt.want {
+			if got := GetPromptString(&tt.chatMessage); got != tt.want {
 				t.Errorf("GetPromptString() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
ParsePrompt(modelRequest) was called twice per request: once in HandlerFunc() for token counting and again in doLoadbalance() for scheduler context. Store the result in gin context on first parse and reuse it, eliminating redundant JSON map traversal.

**What type of PR is this?**

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #1121

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
