### PR TITLE
improve prefix store lock performance

### DIFF
--- a/pkg/kthena-router/scheduler/plugins/cache/prefix_store.go
+++ b/pkg/kthena-router/scheduler/plugins/cache/prefix_store.go
@@ -201,26 +201,36 @@ func (s *ModelPrefixStore) Add(model string, hashes []uint64, pod *datastore.Pod
 		Name:      pod.Pod.Name,
 	}
 
-	s.podHashesMu.Lock()
+	// Double-check locking: avoid exclusive lock when the entry already exists.
+	s.podHashesMu.RLock()
 	podLRU, exists := s.podHashes[nsName]
+	s.podHashesMu.RUnlock()
 	if !exists {
-		podLRU, _ = NewLRUCache(s.hashCapacity, func(key hashModelKey, value struct{}) {
-			// onEvict callback need to acquire `modelCache.mu.Lock()` as well, so start a goroutine to run it async.
-			go s.onHashEvicted(key.model, []uint64{key.hash}, nsName)
-		})
-		s.podHashes[nsName] = podLRU
+		s.podHashesMu.Lock()
+		podLRU, exists = s.podHashes[nsName]
+		if !exists {
+			podLRU, _ = NewLRUCache(s.hashCapacity, func(key hashModelKey, value struct{}) {
+				// onEvict callback need to acquire `modelCache.mu.Lock()` as well, so start a goroutine to run it async.
+				go s.onHashEvicted(key.model, []uint64{key.hash}, nsName)
+			})
+			s.podHashes[nsName] = podLRU
+		}
+		s.podHashesMu.Unlock()
 	}
-	s.podHashesMu.Unlock()
 
-	// Note there could a be case where Add and Evict happen concurrently.
-	// The modelHash could be deleted, that does not matter much, since the prefix cache is an approximate cache.
-	s.entriesMu.Lock()
+	// Double-check locking for model entries map.
+	s.entriesMu.RLock()
 	modelCache, exists := s.entries[model]
+	s.entriesMu.RUnlock()
 	if !exists {
-		modelCache = newModelHashes()
-		s.entries[model] = modelCache
+		s.entriesMu.Lock()
+		modelCache, exists = s.entries[model]
+		if !exists {
+			modelCache = newModelHashes()
+			s.entries[model] = modelCache
+		}
+		s.entriesMu.Unlock()
 	}
-	s.entriesMu.Unlock()
 
 	// Add hashes from the end to the beginning to avoid
 	// the situation where a long prefix can be matched but a shorter prefix cannot.


### PR DESCRIPTION


**What type of PR is this?**

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:

Replace exclusive Lock() in Add() with RLock-first double-check pattern for both podHashes and entries maps. Since the common case is that the model entry and pod LRU already exist, this avoids serializing all post-schedule cache updates behind an exclusive write lock under high concurrency.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
