### PR TITLE
Fix stale ModelServer pod bindings

### DIFF
--- a/pkg/kthena-router/controller/modelserver_controller.go
+++ b/pkg/kthena-router/controller/modelserver_controller.go
@@ -290,10 +290,11 @@ func (c *ModelServerController) addOrUpdatePod(pod *corev1.Pod) error {
 		servers = append(servers, item)
 	}
 
-	if len(servers) > 0 {
-		if err := c.store.AddOrUpdatePod(pod, servers); err != nil {
-			return fmt.Errorf("failed to add or update pod %s/%s in data store: %v", pod.Namespace, pod.Name, err)
-		}
+	if len(servers) == 0 && c.store.GetPodInfo(utils.GetNamespaceName(pod)) == nil {
+		return nil
+	}
+	if err := c.store.AddOrUpdatePod(pod, servers); err != nil {
+		return fmt.Errorf("failed to add or update pod %s/%s in data store: %v", pod.Namespace, pod.Name, err)
 	}
 
 	return nil

--- a/pkg/kthena-router/controller/modelserver_controller_test.go
+++ b/pkg/kthena-router/controller/modelserver_controller_test.go
@@ -1062,6 +1062,141 @@ func TestModelServerController_SharedPods(t *testing.T) {
 	assert.True(t, pod2Info.HasModelServer(ms2Name), "pod2 should reference ms2")
 }
 
+func TestModelServerController_ModelServerSelectorUpdateClearsOldPods(t *testing.T) {
+	kubeClient := kubefake.NewSimpleClientset()
+	kthenaClient := kthenafake.NewSimpleClientset()
+
+	ms := &aiv1alpha1.ModelServer{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "model"},
+		Spec: aiv1alpha1.ModelServerSpec{
+			InferenceEngine: aiv1alpha1.VLLM,
+			WorkloadSelector: &aiv1alpha1.WorkloadSelector{
+				MatchLabels: map[string]string{"app": "old"},
+			},
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "pod",
+			Labels:    map[string]string{"app": "old"},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+
+	_, err := kthenaClient.NetworkingV1alpha1().ModelServers("default").Create(context.Background(), ms, metav1.CreateOptions{})
+	require.NoError(t, err)
+	_, err = kubeClient.CoreV1().Pods("default").Create(context.Background(), pod, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	kubeInformerFactory := informers.NewSharedInformerFactory(kubeClient, 0)
+	kthenaInformerFactory := informersv1alpha1.NewSharedInformerFactory(kthenaClient, 0)
+	store := newStoreWithMockBackend()
+	controller := NewModelServerController(kthenaInformerFactory, kubeInformerFactory, store)
+
+	stop := make(chan struct{})
+	defer close(stop)
+	kthenaInformerFactory.Start(stop)
+	kubeInformerFactory.Start(stop)
+
+	require.True(t, waitForCacheSync(t, 5*time.Second, controller.modelServerSynced, controller.podSynced))
+	require.NoError(t, controller.syncModelServerHandler("default/model"))
+	pods, err := store.GetPodsByModelServer(utils.GetNamespaceName(ms))
+	require.NoError(t, err)
+	require.Len(t, pods, 1)
+
+	updated := ms.DeepCopy()
+	updated.Spec.WorkloadSelector.MatchLabels = map[string]string{"app": "new"}
+	_, err = kthenaClient.NetworkingV1alpha1().ModelServers("default").Update(context.Background(), updated, metav1.UpdateOptions{})
+	require.NoError(t, err)
+	require.True(t, waitForObjectInCache(t, 2*time.Second, func() bool {
+		got, err := controller.modelServerLister.ModelServers("default").Get("model")
+		return err == nil && got.Spec.WorkloadSelector.MatchLabels["app"] == "new"
+	}))
+
+	require.NoError(t, controller.syncModelServerHandler("default/model"))
+	pods, err = store.GetPodsByModelServer(utils.GetNamespaceName(ms))
+	require.NoError(t, err)
+	assert.Empty(t, pods)
+
+	podInfo := store.GetPodInfo(utils.GetNamespaceName(pod))
+	require.NotNil(t, podInfo)
+	assert.False(t, podInfo.HasModelServer(utils.GetNamespaceName(ms)))
+}
+
+func TestModelServerController_PodLabelUpdateClearsOldModelServer(t *testing.T) {
+	kubeClient := kubefake.NewSimpleClientset()
+	kthenaClient := kthenafake.NewSimpleClientset()
+
+	ms := &aiv1alpha1.ModelServer{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "model"},
+		Spec: aiv1alpha1.ModelServerSpec{
+			InferenceEngine: aiv1alpha1.VLLM,
+			WorkloadSelector: &aiv1alpha1.WorkloadSelector{
+				MatchLabels: map[string]string{"app": "model"},
+			},
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "pod",
+			Labels:    map[string]string{"app": "model"},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+
+	_, err := kthenaClient.NetworkingV1alpha1().ModelServers("default").Create(context.Background(), ms, metav1.CreateOptions{})
+	require.NoError(t, err)
+	_, err = kubeClient.CoreV1().Pods("default").Create(context.Background(), pod, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	kubeInformerFactory := informers.NewSharedInformerFactory(kubeClient, 0)
+	kthenaInformerFactory := informersv1alpha1.NewSharedInformerFactory(kthenaClient, 0)
+	store := newStoreWithMockBackend()
+	controller := NewModelServerController(kthenaInformerFactory, kubeInformerFactory, store)
+
+	stop := make(chan struct{})
+	defer close(stop)
+	kthenaInformerFactory.Start(stop)
+	kubeInformerFactory.Start(stop)
+
+	require.True(t, waitForCacheSync(t, 5*time.Second, controller.modelServerSynced, controller.podSynced))
+	require.NoError(t, controller.syncModelServerHandler("default/model"))
+	require.NoError(t, controller.syncPodHandler("default/pod"))
+	pods, err := store.GetPodsByModelServer(utils.GetNamespaceName(ms))
+	require.NoError(t, err)
+	require.Len(t, pods, 1)
+
+	updatedPod := pod.DeepCopy()
+	updatedPod.Labels = map[string]string{"app": "other"}
+	_, err = kubeClient.CoreV1().Pods("default").Update(context.Background(), updatedPod, metav1.UpdateOptions{})
+	require.NoError(t, err)
+	require.True(t, waitForObjectInCache(t, 2*time.Second, func() bool {
+		got, err := controller.podLister.Pods("default").Get("pod")
+		return err == nil && got.Labels["app"] == "other"
+	}))
+
+	require.NoError(t, controller.syncPodHandler("default/pod"))
+	pods, err = store.GetPodsByModelServer(utils.GetNamespaceName(ms))
+	require.NoError(t, err)
+	assert.Empty(t, pods)
+
+	podInfo := store.GetPodInfo(utils.GetNamespaceName(pod))
+	require.NotNil(t, podInfo)
+	assert.False(t, podInfo.HasModelServer(utils.GetNamespaceName(ms)))
+}
+
 // Helper functions for testing
 
 // waitForCacheSync waits for the informer caches to sync with a timeout

--- a/pkg/kthena-router/datastore/store.go
+++ b/pkg/kthena-router/datastore/store.go
@@ -640,26 +640,47 @@ func (s *store) DecrPodOnFlightRequests(podName types.NamespacedName) {
 func (s *store) AddOrUpdateModelServer(ms *aiv1alpha1.ModelServer, pods sets.Set[types.NamespacedName]) error {
 	name := utils.GetNamespaceName(ms)
 	var modelServerObj *modelServer
+	var oldPods sets.Set[types.NamespacedName]
+	var newPods sets.Set[types.NamespacedName]
 	if value, ok := s.modelServer.Load(name); !ok {
 		modelServerObj = newModelServer(ms)
-		// New object — no concurrent access yet, safe to write without lock
-		if len(pods) != 0 {
-			modelServerObj.pods = pods
+		if pods != nil {
+			newPods = pods.Copy()
+			modelServerObj.pods = newPods
 		}
 	} else {
 		modelServerObj = value.(*modelServer)
-		// Existing object — concurrent readers may access modelServer and pods,
-		// so we must hold the lock to prevent data races.
 		modelServerObj.mutex.Lock()
+		oldPods = modelServerObj.pods.Copy()
 		modelServerObj.modelServer = ms
-		if len(pods) != 0 {
-			// do not operate s.pods here, which are done within pod handler
-			modelServerObj.pods = pods
+		if pods != nil {
+			newPods = pods.Copy()
+			modelServerObj.pods = newPods
+			modelServerObj.pdGroups = make(map[string]*PDGroupPods)
 		}
 		modelServerObj.mutex.Unlock()
 	}
 	s.modelServer.Store(name, modelServerObj)
+	if pods != nil {
+		s.updateModelServerPodBindings(name, modelServerObj, oldPods, newPods)
+	}
 	return nil
+}
+
+func (s *store) updateModelServerPodBindings(modelServerName types.NamespacedName, modelServerObj *modelServer, oldPods, newPods sets.Set[types.NamespacedName]) {
+	for podName := range oldPods.Difference(newPods) {
+		if value, ok := s.pods.Load(podName); ok {
+			podInfo := value.(*PodInfo)
+			podInfo.RemoveModelServer(modelServerName)
+		}
+	}
+	for podName := range newPods {
+		if value, ok := s.pods.Load(podName); ok {
+			podInfo := value.(*PodInfo)
+			podInfo.AddModelServer(modelServerName)
+			modelServerObj.categorizePodForPDGroup(podName, podInfo.Pod.Labels)
+		}
+	}
 }
 
 func (s *store) DeleteModelServer(ms types.NamespacedName) error {

--- a/pkg/kthena-router/datastore/store_test.go
+++ b/pkg/kthena-router/datastore/store_test.go
@@ -317,6 +317,17 @@ func TestStoreAddOrUpdatePod(t *testing.T) {
 		ms2Info := value.(*modelServer)
 		assert.Equal(t, ms2Info.pods.Len(), 0, "model server 2 should not reference the pod")
 	}
+
+	err = s.AddOrUpdatePod(pod, []*aiv1alpha1.ModelServer{})
+	assert.NoError(t, err)
+	if value, ok := s.pods.Load(podName); ok {
+		podInfo := value.(*PodInfo)
+		assert.Equal(t, 0, podInfo.modelServer.Len(), "pod should not reference any model servers")
+	}
+	if value, ok := s.modelServer.Load(utils.GetNamespaceName(ms1)); ok {
+		ms1Info := value.(*modelServer)
+		assert.Equal(t, 0, ms1Info.pods.Len(), "model server 1 should not reference the pod")
+	}
 }
 
 func TestStoreDeletePod(t *testing.T) {
@@ -390,6 +401,7 @@ func TestStoreDeletePod_MultiModelServers(t *testing.T) {
 func TestStoreAddOrUpdateModelServer(t *testing.T) {
 	s := &store{
 		modelServer: sync.Map{},
+		pods:        sync.Map{},
 	}
 	ms := &aiv1alpha1.ModelServer{
 		ObjectMeta: metav1.ObjectMeta{
@@ -419,6 +431,22 @@ func TestStoreAddOrUpdateModelServer(t *testing.T) {
 		msInfo := value.(*modelServer)
 		assert.True(t, msInfo.pods.Contains(types.NamespacedName{Namespace: "default", Name: "pod2"}))
 		assert.False(t, msInfo.pods.Contains(types.NamespacedName{Namespace: "default", Name: "pod1"}))
+	}
+
+	pod2Name := types.NamespacedName{Namespace: "default", Name: "pod2"}
+	podInfo := &PodInfo{
+		Pod:         &corev1.Pod{},
+		modelServer: sets.New[types.NamespacedName](msName),
+		models:      sets.New[string](),
+	}
+	s.pods.Store(pod2Name, podInfo)
+
+	err = s.AddOrUpdateModelServer(ms, sets.New[types.NamespacedName]())
+	assert.NoError(t, err)
+	if value, ok := s.modelServer.Load(msName); ok {
+		msInfo := value.(*modelServer)
+		assert.True(t, msInfo.pods.IsEmpty())
+		assert.False(t, podInfo.HasModelServer(msName))
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fixes stale ModelServer pod bindings when a selector update or pod label update leaves no matching pods.

**Which issue(s) this PR fixes**:

Fixes #1122

**Special notes for your reviewer**:

NONE

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
