### PR TITLE
fix: handle AddEventHandler errors in all router controllers

### DIFF
--- a/cmd/kthena-router/app/controller.go
+++ b/cmd/kthena-router/app/controller.go
@@ -112,7 +112,7 @@ func startControllers(store datastore.Store, stop <-chan struct{}, enableGateway
 		if err := ensureDefaultGateway(gatewayClient, defaultPort); err != nil {
 			klog.Fatalf("Failed to ensure default Gateway: %s", err.Error())
 		}
-
+		gatewayInformerFactory = gatewayinformers.NewSharedInformerFactory(gatewayClient, 0)
 		gatewayController, err = controller.NewGatewayController(gatewayInformerFactory, store)
 		if err != nil {
 			klog.Fatalf("Error creating gateway controller: %s", err.Error())
@@ -121,7 +121,6 @@ func startControllers(store datastore.Store, stop <-chan struct{}, enableGateway
 			gatewayInformerFactory.Gateway().V1().Gateways().Informer().HasSynced,
 			gatewayInformerFactory.Gateway().V1().HTTPRoutes().Informer().HasSynced,
 		)
-
 		if enableGatewayAPIInferenceExtension {
 			httpRouteController, err = controller.NewHTTPRouteController(gatewayInformerFactory, kubeInformerFactory, store)
 			if err != nil {
@@ -140,11 +139,6 @@ func startControllers(store datastore.Store, stop <-chan struct{}, enableGateway
 				kubeInformerFactory.Core().V1().Namespaces().Informer().HasSynced,
 				dynamicInformerFactory.ForResource(inferencev1.SchemeGroupVersion.WithResource("inferencepools")).Informer().HasSynced,
 			)
-			if err != nil {
-				klog.Fatalf("Error creating inferencepool controller: %s", err.Error())
-			}
-			cacheSyncs = append(cacheSyncs, dynamicInformerFactory.ForResource(inferencev1.SchemeGroupVersion.WithResource("inferencepools")).Informer().HasSynced)
-
 			dynamicInformerFactory.Start(stop)
 		}
 		gatewayInformerFactory.Start(stop)

--- a/cmd/kthena-router/app/controller.go
+++ b/cmd/kthena-router/app/controller.go
@@ -77,9 +77,14 @@ func startControllers(store datastore.Store, stop <-chan struct{}, enableGateway
 
 	kubeInformerFactory := informers.NewSharedInformerFactory(kubeClient, 0)
 	kthenaInformerFactory := kthenaInformers.NewSharedInformerFactory(kthenaClient, 0)
-
-	modelRouteController := controller.NewModelRouteController(kthenaInformerFactory, store)
-	modelServerController := controller.NewModelServerController(kthenaInformerFactory, kubeInformerFactory, store)
+	modelRouteController, err := controller.NewModelRouteController(kthenaInformerFactory, store)
+	if err != nil {
+		klog.Fatalf("Error creating model route controller: %s", err.Error())
+	}
+	modelServerController, err := controller.NewModelServerController(kthenaInformerFactory, kubeInformerFactory, store)
+	if err != nil {
+		klog.Fatalf("Error creating model server controller: %s", err.Error())
+	}
 
 	cacheSyncs := []cache.InformerSynced{
 		kthenaInformerFactory.Networking().V1alpha1().ModelRoutes().Informer().HasSynced,
@@ -108,25 +113,38 @@ func startControllers(store datastore.Store, stop <-chan struct{}, enableGateway
 			klog.Fatalf("Failed to ensure default Gateway: %s", err.Error())
 		}
 
-		gatewayInformerFactory = gatewayinformers.NewSharedInformerFactory(gatewayClient, 0)
-		gatewayController = controller.NewGatewayController(gatewayInformerFactory, store)
+		gatewayController, err = controller.NewGatewayController(gatewayInformerFactory, store)
+		if err != nil {
+			klog.Fatalf("Error creating gateway controller: %s", err.Error())
+		}
 		cacheSyncs = append(cacheSyncs,
 			gatewayInformerFactory.Gateway().V1().Gateways().Informer().HasSynced,
 			gatewayInformerFactory.Gateway().V1().HTTPRoutes().Informer().HasSynced,
 		)
 
 		if enableGatewayAPIInferenceExtension {
-			httpRouteController = controller.NewHTTPRouteController(gatewayInformerFactory, kubeInformerFactory, store)
+			httpRouteController, err = controller.NewHTTPRouteController(gatewayInformerFactory, kubeInformerFactory, store)
+			if err != nil {
+				klog.Fatalf("Error creating httproute controller: %s", err.Error())
+			}
 			dynamicClient, err := dynamic.NewForConfig(cfg)
 			if err != nil {
 				klog.Fatalf("Error building dynamic client: %s", err.Error())
 			}
 			dynamicInformerFactory := dynamicinformer.NewDynamicSharedInformerFactory(dynamicClient, 0)
-			inferencePoolController = controller.NewInferencePoolController(dynamicInformerFactory, store)
+			inferencePoolController, err = controller.NewInferencePoolController(dynamicInformerFactory, store)
+			if err != nil {
+				klog.Fatalf("Error creating inferencepool controller: %s", err.Error())
+			}
 			cacheSyncs = append(cacheSyncs,
 				kubeInformerFactory.Core().V1().Namespaces().Informer().HasSynced,
 				dynamicInformerFactory.ForResource(inferencev1.SchemeGroupVersion.WithResource("inferencepools")).Informer().HasSynced,
 			)
+			if err != nil {
+				klog.Fatalf("Error creating inferencepool controller: %s", err.Error())
+			}
+			cacheSyncs = append(cacheSyncs, dynamicInformerFactory.ForResource(inferencev1.SchemeGroupVersion.WithResource("inferencepools")).Informer().HasSynced)
+
 			dynamicInformerFactory.Start(stop)
 		}
 		gatewayInformerFactory.Start(stop)

--- a/pkg/kthena-router/controller/gateway_controller.go
+++ b/pkg/kthena-router/controller/gateway_controller.go
@@ -47,7 +47,7 @@ type GatewayController struct {
 func NewGatewayController(
 	gatewayInformerFactory gatewayinformers.SharedInformerFactory,
 	store datastore.Store,
-) *GatewayController {
+) (*GatewayController, error) {
 	gatewayInformer := gatewayInformerFactory.Gateway().V1().Gateways()
 
 	controller := &GatewayController{
@@ -75,10 +75,14 @@ func NewGatewayController(
 			DeleteFunc: controller.enqueueGateway,
 		},
 	}
+	var err error
+	controller.registration, err = gatewayInformer.Informer().AddEventHandler(filterHandler)
+	if err != nil {
+		return nil, fmt.Errorf("failed to add event handler for gateway controller: %w", err)
 
-	controller.registration, _ = gatewayInformer.Informer().AddEventHandler(filterHandler)
+	}
+	return controller, nil
 
-	return controller
 }
 
 func (c *GatewayController) Run(stopCh <-chan struct{}) error {

--- a/pkg/kthena-router/controller/gateway_controller.go
+++ b/pkg/kthena-router/controller/gateway_controller.go
@@ -79,10 +79,8 @@ func NewGatewayController(
 	controller.registration, err = gatewayInformer.Informer().AddEventHandler(filterHandler)
 	if err != nil {
 		return nil, fmt.Errorf("failed to add event handler for gateway controller: %w", err)
-
 	}
 	return controller, nil
-
 }
 
 func (c *GatewayController) Run(stopCh <-chan struct{}) error {

--- a/pkg/kthena-router/controller/gateway_controller_test.go
+++ b/pkg/kthena-router/controller/gateway_controller_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayfake "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/fake"
@@ -54,7 +55,8 @@ func TestGatewayController_Lifecycle(t *testing.T) {
 	gatewayInformerFactory := gatewayinformers.NewSharedInformerFactory(gatewayClient, 0)
 	store := datastore.New()
 
-	controller := NewGatewayController(gatewayInformerFactory, store)
+	controller, err := NewGatewayController(gatewayInformerFactory, store)
+	require.NoError(t, err)
 
 	stop := make(chan struct{})
 	defer close(stop)
@@ -141,7 +143,8 @@ func TestGatewayController_GatewayClassFilter(t *testing.T) {
 	gatewayInformerFactory := gatewayinformers.NewSharedInformerFactory(gatewayClient, 0)
 	store := datastore.New()
 
-	controller := NewGatewayController(gatewayInformerFactory, store)
+	controller, err := NewGatewayController(gatewayInformerFactory, store)
+	require.NoError(t, err)
 
 	stop := make(chan struct{})
 	defer close(stop)
@@ -185,7 +188,8 @@ func TestGatewayController_ErrorHandling(t *testing.T) {
 	gatewayInformerFactory := gatewayinformers.NewSharedInformerFactory(gatewayClient, 0)
 	store := datastore.New()
 
-	controller := NewGatewayController(gatewayInformerFactory, store)
+	controller, err := NewGatewayController(gatewayInformerFactory, store)
+	require.NoError(t, err)
 
 	stop := make(chan struct{})
 	defer close(stop)
@@ -209,7 +213,8 @@ func TestGatewayController_WorkQueueProcessing(t *testing.T) {
 	gatewayInformerFactory := gatewayinformers.NewSharedInformerFactory(gatewayClient, 0)
 	store := datastore.New()
 
-	controller := NewGatewayController(gatewayInformerFactory, store)
+	controller, err := NewGatewayController(gatewayInformerFactory, store)
+	require.NoError(t, err)
 
 	stop := make(chan struct{})
 	defer close(stop)

--- a/pkg/kthena-router/controller/httproute_controller.go
+++ b/pkg/kthena-router/controller/httproute_controller.go
@@ -98,6 +98,7 @@ func NewHTTPRouteController(
 		},
 	}
 	if _, err = gatewayInformer.Informer().AddEventHandler(gatewayFilter); err != nil {
+		controller.registration.Remove()
 		return nil, fmt.Errorf("failed to add gateway event handler for httproute controller: %w", err)
 	}
 

--- a/pkg/kthena-router/controller/httproute_controller.go
+++ b/pkg/kthena-router/controller/httproute_controller.go
@@ -55,7 +55,7 @@ func NewHTTPRouteController(
 	gatewayInformerFactory gatewayinformers.SharedInformerFactory,
 	kubeInformerFactory informers.SharedInformerFactory,
 	store datastore.Store,
-) *HTTPRouteController {
+) (*HTTPRouteController, error) {
 	httpRouteInformer := gatewayInformerFactory.Gateway().V1().HTTPRoutes()
 	gatewayInformer := gatewayInformerFactory.Gateway().V1().Gateways()
 	namespaceInformer := kubeInformerFactory.Core().V1().Namespaces()
@@ -71,11 +71,15 @@ func NewHTTPRouteController(
 		store:           store,
 	}
 
-	controller.registration, _ = httpRouteInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	var err error
+	controller.registration, err = httpRouteInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    controller.enqueueHTTPRoute,
 		UpdateFunc: func(old, new interface{}) { controller.enqueueHTTPRoute(new) },
 		DeleteFunc: controller.enqueueHTTPRoute,
 	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to add event handler for httproute controller: %w", err)
+	}
 
 	gatewayFilter := &cache.FilteringResourceEventHandler{
 		FilterFunc: func(obj interface{}) bool {
@@ -93,15 +97,19 @@ func NewHTTPRouteController(
 			},
 		},
 	}
-	_, _ = gatewayInformer.Informer().AddEventHandler(gatewayFilter)
+	if _, err = gatewayInformer.Informer().AddEventHandler(gatewayFilter); err != nil {
+		return nil, fmt.Errorf("failed to add gateway event handler for httproute controller: %w", err)
+	}
 
-	_, _ = namespaceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	if _, err = namespaceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    controller.enqueueHTTPRoutesForNamespace,
 		UpdateFunc: func(_, new interface{}) { controller.enqueueHTTPRoutesForNamespace(new) },
 		DeleteFunc: controller.enqueueHTTPRoutesForNamespace,
-	})
+	}); err != nil {
+		return nil, fmt.Errorf("failed to add namespace event handler for httproute controller: %w", err)
+	}
 
-	return controller
+	return controller, nil
 }
 
 func (c *HTTPRouteController) Run(stopCh <-chan struct{}) error {

--- a/pkg/kthena-router/controller/httproute_controller.go
+++ b/pkg/kthena-router/controller/httproute_controller.go
@@ -98,7 +98,6 @@ func NewHTTPRouteController(
 		},
 	}
 	if _, err = gatewayInformer.Informer().AddEventHandler(gatewayFilter); err != nil {
-		controller.registration.Remove()
 		return nil, fmt.Errorf("failed to add gateway event handler for httproute controller: %w", err)
 	}
 

--- a/pkg/kthena-router/controller/httproute_controller_test.go
+++ b/pkg/kthena-router/controller/httproute_controller_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -44,7 +45,8 @@ func TestHTTPRouteController_EnqueueHTTPRoutesForGateway(t *testing.T) {
 	gatewayInformerFactory := gatewayinformers.NewSharedInformerFactory(gatewayClient, 0)
 	store := datastore.New()
 
-	ctrl := NewHTTPRouteController(gatewayInformerFactory, kubeInformerFactory, store)
+	ctrl, err := NewHTTPRouteController(gatewayInformerFactory, kubeInformerFactory, store)
+	require.NoError(t, err)
 	stop := make(chan struct{})
 	defer close(stop)
 	gatewayInformerFactory.Start(stop)
@@ -57,7 +59,7 @@ func TestHTTPRouteController_EnqueueHTTPRoutesForGateway(t *testing.T) {
 			GatewayClassName: gatewayv1.ObjectName(DefaultGatewayClassName),
 		},
 	}
-	_, err := gatewayClient.GatewayV1().Gateways(ns).Create(ctx, gw, metav1.CreateOptions{})
+	_, err = gatewayClient.GatewayV1().Gateways(ns).Create(ctx, gw, metav1.CreateOptions{})
 	assert.NoError(t, err)
 
 	httpRoute := &gatewayv1.HTTPRoute{
@@ -126,7 +128,8 @@ func TestHTTPRouteController_EnqueueHTTPRoutesForGateway_NoMatchingRoutes(t *tes
 	gatewayInformerFactory := gatewayinformers.NewSharedInformerFactory(gatewayClient, 0)
 	store := datastore.New()
 
-	ctrl := NewHTTPRouteController(gatewayInformerFactory, kubeInformerFactory, store)
+	ctrl, err := NewHTTPRouteController(gatewayInformerFactory, kubeInformerFactory, store)
+	require.NoError(t, err)
 	stop := make(chan struct{})
 	defer close(stop)
 	gatewayInformerFactory.Start(stop)
@@ -139,7 +142,7 @@ func TestHTTPRouteController_EnqueueHTTPRoutesForGateway_NoMatchingRoutes(t *tes
 			GatewayClassName: gatewayv1.ObjectName(DefaultGatewayClassName),
 		},
 	}
-	_, err := gatewayClient.GatewayV1().Gateways(ns).Create(ctx, gw, metav1.CreateOptions{})
+	_, err = gatewayClient.GatewayV1().Gateways(ns).Create(ctx, gw, metav1.CreateOptions{})
 	assert.NoError(t, err)
 
 	httpRoute := &gatewayv1.HTTPRoute{
@@ -284,7 +287,8 @@ func TestHTTPRouteController_AllowedRoutesNamespaces(t *testing.T) {
 			_, err := gatewayClient.GatewayV1().HTTPRoutes(tt.routeNS).Create(context.Background(), httpRoute, metav1.CreateOptions{})
 			assert.NoError(t, err)
 
-			ctrl := NewHTTPRouteController(gatewayInformerFactory, kubeInformerFactory, store)
+			ctrl, err := NewHTTPRouteController(gatewayInformerFactory, kubeInformerFactory, store)
+			require.NoError(t, err)
 			stop := make(chan struct{})
 			defer close(stop)
 			kubeInformerFactory.Start(stop)
@@ -347,7 +351,8 @@ func TestHTTPRouteController_MultipleParentRefs_FirstPending(t *testing.T) {
 	_, err = gatewayClient.GatewayV1().HTTPRoutes(ns).Create(ctx, httpRoute, metav1.CreateOptions{})
 	assert.NoError(t, err)
 
-	ctrl := NewHTTPRouteController(gatewayInformerFactory, kubeInformerFactory, store)
+	ctrl, err := NewHTTPRouteController(gatewayInformerFactory, kubeInformerFactory, store)
+	require.NoError(t, err)
 	stop := make(chan struct{})
 	defer close(stop)
 	gatewayInformerFactory.Start(stop)

--- a/pkg/kthena-router/controller/inferencepool_controller.go
+++ b/pkg/kthena-router/controller/inferencepool_controller.go
@@ -46,7 +46,7 @@ type InferencePoolController struct {
 func NewInferencePoolController(
 	dynamicInformerFactory dynamicinformer.DynamicSharedInformerFactory,
 	store datastore.Store,
-) *InferencePoolController {
+) (*InferencePoolController, error) {
 	gvr := inferencev1.SchemeGroupVersion.WithResource("inferencepools")
 	inferencePoolInformer := dynamicInformerFactory.ForResource(gvr).Informer()
 
@@ -58,13 +58,17 @@ func NewInferencePoolController(
 		store:                 store,
 	}
 
-	controller.registration, _ = inferencePoolInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	var err error
+	controller.registration, err = inferencePoolInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    controller.enqueueInferencePool,
 		UpdateFunc: func(old, new interface{}) { controller.enqueueInferencePool(new) },
 		DeleteFunc: controller.enqueueInferencePool,
 	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to add event handler for inferencepool controller: %w", err)
+	}
 
-	return controller
+	return controller, nil
 }
 
 func (c *InferencePoolController) Run(stopCh <-chan struct{}) error {

--- a/pkg/kthena-router/controller/modelroute_controller.go
+++ b/pkg/kthena-router/controller/modelroute_controller.go
@@ -46,7 +46,7 @@ type ModelRouteController struct {
 func NewModelRouteController(
 	kthenaInformerFactory informersv1alpha1.SharedInformerFactory,
 	store datastore.Store,
-) *ModelRouteController {
+) (*ModelRouteController, error) {
 	modelRouteInformer := kthenaInformerFactory.Networking().V1alpha1().ModelRoutes()
 
 	controller := &ModelRouteController{
@@ -57,15 +57,19 @@ func NewModelRouteController(
 		store:            store,
 	}
 
-	controller.registration, _ = modelRouteInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	var err error
+	controller.registration, err = modelRouteInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: controller.enqueueModelRoute,
 		UpdateFunc: func(old, new interface{}) {
 			controller.enqueueModelRoute(new)
 		},
 		DeleteFunc: controller.enqueueModelRoute,
 	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to add event handler for modelroute controller: %w", err)
+	}
 
-	return controller
+	return controller, nil
 }
 
 func (c *ModelRouteController) Run(stopCh <-chan struct{}) error {

--- a/pkg/kthena-router/controller/modelroute_controller_test.go
+++ b/pkg/kthena-router/controller/modelroute_controller_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	kthenafake "github.com/volcano-sh/kthena/client-go/clientset/versioned/fake"
@@ -35,7 +36,8 @@ func TestModelRouteController_Lifecycle(t *testing.T) {
 	kthenaInformerFactory := informersv1alpha1.NewSharedInformerFactory(kthenaClient, 0)
 	store := datastore.New()
 
-	controller := NewModelRouteController(kthenaInformerFactory, store)
+	controller, err := NewModelRouteController(kthenaInformerFactory, store)
+	require.NoError(t, err)
 
 	stop := make(chan struct{})
 	defer close(stop)
@@ -146,7 +148,8 @@ func TestModelRouteController_ErrorHandling(t *testing.T) {
 	kthenaInformerFactory := informersv1alpha1.NewSharedInformerFactory(kthenaClient, 0)
 	store := datastore.New()
 
-	controller := NewModelRouteController(kthenaInformerFactory, store)
+	controller, err := NewModelRouteController(kthenaInformerFactory, store)
+	require.NoError(t, err)
 
 	stop := make(chan struct{})
 	defer close(stop)
@@ -171,7 +174,8 @@ func TestModelRouteController_WorkQueueProcessing(t *testing.T) {
 	kthenaInformerFactory := informersv1alpha1.NewSharedInformerFactory(kthenaClient, 0)
 	store := datastore.New()
 
-	controller := NewModelRouteController(kthenaInformerFactory, store)
+	controller, err := NewModelRouteController(kthenaInformerFactory, store)
+	require.NoError(t, err)
 
 	stop := make(chan struct{})
 	defer close(stop)

--- a/pkg/kthena-router/controller/modelserver_controller.go
+++ b/pkg/kthena-router/controller/modelserver_controller.go
@@ -112,9 +112,9 @@ func NewModelServerController(
 		DeleteFunc: controller.enqueuePod,
 	})
 	if err != nil {
+		controller.modelServerRegistration.Remove()
 		return nil, fmt.Errorf("failed to add pod event handler for modelserver controller: %w", err)
 	}
-
 	return controller, nil
 }
 

--- a/pkg/kthena-router/controller/modelserver_controller.go
+++ b/pkg/kthena-router/controller/modelserver_controller.go
@@ -112,7 +112,6 @@ func NewModelServerController(
 		DeleteFunc: controller.enqueuePod,
 	})
 	if err != nil {
-		controller.modelServerRegistration.Remove()
 		return nil, fmt.Errorf("failed to add pod event handler for modelserver controller: %w", err)
 	}
 	return controller, nil

--- a/pkg/kthena-router/controller/modelserver_controller.go
+++ b/pkg/kthena-router/controller/modelserver_controller.go
@@ -76,7 +76,7 @@ func NewModelServerController(
 	kthenaInformerFactory informersv1alpha1.SharedInformerFactory,
 	kubeInformerFactory informers.SharedInformerFactory,
 	store datastore.Store,
-) *ModelServerController {
+) (*ModelServerController, error) {
 	modelServerInformer := kthenaInformerFactory.Networking().V1alpha1().ModelServers()
 	podInformer := kubeInformerFactory.Core().V1().Pods()
 
@@ -90,25 +90,32 @@ func NewModelServerController(
 		store:             store,
 	}
 
+	var err error
 	// Register ModelServer event handlers
-	controller.modelServerRegistration, _ = modelServerInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	controller.modelServerRegistration, err = modelServerInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: controller.enqueueModelServer,
 		UpdateFunc: func(old, new interface{}) {
 			controller.enqueueModelServer(new)
 		},
 		DeleteFunc: controller.enqueueModelServer,
 	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to add event handler for modelserver controller: %w", err)
+	}
 
 	// Register Pod event handlers
-	controller.podRegistration, _ = podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	controller.podRegistration, err = podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: controller.enqueuePod,
 		UpdateFunc: func(old, new interface{}) {
 			controller.enqueuePod(new)
 		},
 		DeleteFunc: controller.enqueuePod,
 	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to add pod event handler for modelserver controller: %w", err)
+	}
 
-	return controller
+	return controller, nil
 }
 
 func (c *ModelServerController) Run(stopCh <-chan struct{}) error {

--- a/pkg/kthena-router/controller/modelserver_controller_test.go
+++ b/pkg/kthena-router/controller/modelserver_controller_test.go
@@ -70,11 +70,12 @@ func TestModelServerController_ModelServerLifecycle(t *testing.T) {
 	store := newStoreWithMockBackend()
 
 	// Create controller
-	controller := NewModelServerController(
+	controller, err := NewModelServerController(
 		kthenaInformerFactory,
 		kubeInformerFactory,
 		store,
 	)
+	require.NoError(t, err)
 	modelServerIndexer := kthenaInformerFactory.Networking().V1alpha1().ModelServers().Informer().GetIndexer()
 
 	stop := make(chan struct{})
@@ -271,11 +272,12 @@ func TestModelServerController_PodLifecycle(t *testing.T) {
 	store := newStoreWithMockBackend()
 
 	// Create controller
-	controller := NewModelServerController(
+	controller, err := NewModelServerController(
 		kthenaInformerFactory,
 		kubeInformerFactory,
 		store,
 	)
+	require.NoError(t, err)
 
 	stop := make(chan struct{})
 	defer close(stop)
@@ -487,11 +489,12 @@ func TestModelServerController_ErrorHandling(t *testing.T) {
 	store := newStoreWithMockBackend()
 
 	// Create controller
-	controller := NewModelServerController(
+	controller, err := NewModelServerController(
 		kthenaInformerFactory,
 		kubeInformerFactory,
 		store,
 	)
+	require.NoError(t, err)
 
 	// Test Case 1: Invalid ModelServer Key
 	t.Run("InvalidModelServerKey", func(t *testing.T) {
@@ -531,11 +534,12 @@ func TestModelServerController_WorkQueueProcessing(t *testing.T) {
 	store := newStoreWithMockBackend()
 
 	// Create controller
-	controller := NewModelServerController(
+	controller, err := NewModelServerController(
 		kthenaInformerFactory,
 		kubeInformerFactory,
 		store,
 	)
+	require.NoError(t, err)
 
 	// Test Case 1: Initial Sync Signal
 	t.Run("InitialSyncSignal", func(t *testing.T) {
@@ -606,11 +610,12 @@ func TestModelServerController_PodSelectionLogic(t *testing.T) {
 	store := newStoreWithMockBackend()
 
 	// Create controller
-	controller := NewModelServerController(
+	controller, err := NewModelServerController(
 		kthenaInformerFactory,
 		kubeInformerFactory,
 		store,
 	)
+	require.NoError(t, err)
 
 	stop := make(chan struct{})
 	defer close(stop)
@@ -794,11 +799,12 @@ func TestModelServerController_ComprehensiveLifecycleTest(t *testing.T) {
 
 	// Create controller and store
 	store := newStoreWithMockBackend()
-	controller := NewModelServerController(
+	controller, err := NewModelServerController(
 		kthenaInformerFactory,
 		kubeInformerFactory,
 		store,
 	)
+	require.NoError(t, err)
 
 	kthenaInformerFactory.Start(stopCh)
 	kubeInformerFactory.Start(stopCh)
@@ -970,11 +976,12 @@ func TestModelServerController_SharedPods(t *testing.T) {
 	store := newStoreWithMockBackend()
 
 	// Create controller
-	controller := NewModelServerController(
+	controller, err := NewModelServerController(
 		kthenaInformerFactory,
 		kubeInformerFactory,
 		store,
 	)
+	require.NoError(t, err)
 
 	stop := make(chan struct{})
 	defer close(stop)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
so all the five router controllers were  discarding the error from `AddEventHandler` with `_`, leaving `registration` as nil if the call fails and 
this causes a nil pointer panic when `Run()` tries to call `c.registration.HasSynced`.

**Which issue(s) this PR fixes**:
Fixes #1133

**Special notes for your reviewer**:


**Does this PR introduce a user-facing change?**:
```release-note

```
