### PR TITLE
Respect Gateway allowedRoutes

### DIFF
--- a/cmd/kthena-router/app/controller.go
+++ b/cmd/kthena-router/app/controller.go
@@ -116,14 +116,17 @@ func startControllers(store datastore.Store, stop <-chan struct{}, enableGateway
 		)
 
 		if enableGatewayAPIInferenceExtension {
-			httpRouteController = controller.NewHTTPRouteController(gatewayInformerFactory, store)
+			httpRouteController = controller.NewHTTPRouteController(gatewayInformerFactory, kubeInformerFactory, store)
 			dynamicClient, err := dynamic.NewForConfig(cfg)
 			if err != nil {
 				klog.Fatalf("Error building dynamic client: %s", err.Error())
 			}
 			dynamicInformerFactory := dynamicinformer.NewDynamicSharedInformerFactory(dynamicClient, 0)
 			inferencePoolController = controller.NewInferencePoolController(dynamicInformerFactory, store)
-			cacheSyncs = append(cacheSyncs, dynamicInformerFactory.ForResource(inferencev1.SchemeGroupVersion.WithResource("inferencepools")).Informer().HasSynced)
+			cacheSyncs = append(cacheSyncs,
+				kubeInformerFactory.Core().V1().Namespaces().Informer().HasSynced,
+				dynamicInformerFactory.ForResource(inferencev1.SchemeGroupVersion.WithResource("inferencepools")).Informer().HasSynced,
+			)
 			dynamicInformerFactory.Start(stop)
 		}
 		gatewayInformerFactory.Start(stop)

--- a/pkg/kthena-router/controller/httproute_controller.go
+++ b/pkg/kthena-router/controller/httproute_controller.go
@@ -22,9 +22,12 @@ import (
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
+	informers "k8s.io/client-go/informers"
+	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
@@ -38,7 +41,9 @@ import (
 type HTTPRouteController struct {
 	httpRouteLister gatewaylisters.HTTPRouteLister
 	gatewayLister   gatewaylisters.GatewayLister
+	namespaceLister corelisters.NamespaceLister
 	httpRouteSynced cache.InformerSynced
+	namespaceSynced cache.InformerSynced
 	registration    cache.ResourceEventHandlerRegistration
 
 	workqueue   workqueue.TypedRateLimitingInterface[any]
@@ -48,15 +53,19 @@ type HTTPRouteController struct {
 
 func NewHTTPRouteController(
 	gatewayInformerFactory gatewayinformers.SharedInformerFactory,
+	kubeInformerFactory informers.SharedInformerFactory,
 	store datastore.Store,
 ) *HTTPRouteController {
 	httpRouteInformer := gatewayInformerFactory.Gateway().V1().HTTPRoutes()
 	gatewayInformer := gatewayInformerFactory.Gateway().V1().Gateways()
+	namespaceInformer := kubeInformerFactory.Core().V1().Namespaces()
 
 	controller := &HTTPRouteController{
 		httpRouteLister: httpRouteInformer.Lister(),
 		gatewayLister:   gatewayInformer.Lister(),
+		namespaceLister: namespaceInformer.Lister(),
 		httpRouteSynced: httpRouteInformer.Informer().HasSynced,
+		namespaceSynced: namespaceInformer.Informer().HasSynced,
 		workqueue:       workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[any]()),
 		initialSync:     &atomic.Bool{},
 		store:           store,
@@ -86,6 +95,14 @@ func NewHTTPRouteController(
 	}
 	_, _ = gatewayInformer.Informer().AddEventHandler(gatewayFilter)
 
+	_, _ = namespaceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: controller.enqueueHTTPRoutesForNamespace,
+		UpdateFunc: func(_, new interface{}) {
+			controller.enqueueHTTPRoutesForNamespace(new)
+		},
+		DeleteFunc: controller.enqueueHTTPRoutesForNamespace,
+	})
+
 	return controller
 }
 
@@ -93,7 +110,7 @@ func (c *HTTPRouteController) Run(stopCh <-chan struct{}) error {
 	defer utilruntime.HandleCrash()
 	defer c.workqueue.ShutDown()
 
-	if ok := cache.WaitForCacheSync(stopCh, c.httpRouteSynced); !ok {
+	if ok := cache.WaitForCacheSync(stopCh, c.httpRouteSynced, c.namespaceSynced); !ok {
 		return fmt.Errorf("failed to wait for caches to sync")
 	}
 	c.workqueue.Add(initialSyncSignal)
@@ -163,11 +180,9 @@ func (c *HTTPRouteController) syncHandler(key string) error {
 		return err
 	}
 
-	// Only process HTTPRoutes that reference kthena-router GatewayClass
-	// Check all parentRefs - process immediately if any matches, retry only if no match and a Gateway is pending
 	var gatewayPending bool
 	for _, parentRef := range httpRoute.Spec.ParentRefs {
-		if parentRef.Kind == nil || *parentRef.Kind != "Gateway" {
+		if !isGatewayParentRef(parentRef) {
 			continue
 		}
 		gatewayNamespace := httpRoute.Namespace
@@ -183,13 +198,19 @@ func (c *HTTPRouteController) syncHandler(key string) error {
 			continue
 		}
 		if string(gw.Spec.GatewayClassName) == DefaultGatewayClassName {
-			return c.store.AddOrUpdateHTTPRoute(httpRoute)
+			allowed, err := c.gatewayAllowsHTTPRoute(gw, httpRoute, parentRef)
+			if err != nil {
+				return err
+			}
+			if allowed {
+				return c.store.AddOrUpdateHTTPRoute(httpRoute)
+			}
 		}
 	}
 	if gatewayPending {
 		return fmt.Errorf("gateway not synced yet")
 	}
-	klog.V(4).Infof("Skipping HTTPRoute %s/%s: does not reference kthena-router Gateway", namespace, name)
+	klog.V(4).Infof("Skipping HTTPRoute %s/%s: does not reference an allowed kthena-router Gateway", namespace, name)
 	_ = c.store.DeleteHTTPRoute(key)
 	return nil
 }
@@ -216,7 +237,7 @@ func (c *HTTPRouteController) enqueueHTTPRoutesForGateway(obj interface{}) {
 	}
 	for _, route := range routes {
 		for _, parentRef := range route.Spec.ParentRefs {
-			if parentRef.Kind != nil && *parentRef.Kind == "Gateway" {
+			if isGatewayParentRef(parentRef) {
 				ns := route.Namespace
 				if parentRef.Namespace != nil {
 					ns = string(*parentRef.Namespace)
@@ -228,4 +249,95 @@ func (c *HTTPRouteController) enqueueHTTPRoutesForGateway(obj interface{}) {
 			}
 		}
 	}
+}
+
+func (c *HTTPRouteController) enqueueHTTPRoutesForNamespace(obj interface{}) {
+	if deleted, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+		obj = deleted.Obj
+	}
+	namespace, ok := obj.(metav1.Object)
+	if !ok {
+		return
+	}
+	routes, err := c.httpRouteLister.HTTPRoutes(namespace.GetName()).List(labels.Everything())
+	if err != nil {
+		klog.Errorf("failed to list HTTPRoutes for namespace %s: %v", namespace.GetName(), err)
+		return
+	}
+	for _, route := range routes {
+		c.workqueue.Add(fmt.Sprintf("%s/%s", route.Namespace, route.Name))
+	}
+}
+
+func (c *HTTPRouteController) gatewayAllowsHTTPRoute(gateway *gatewayv1.Gateway, route *gatewayv1.HTTPRoute, parentRef gatewayv1.ParentReference) (bool, error) {
+	for _, listener := range gateway.Spec.Listeners {
+		if !parentRefSelectsListener(parentRef, listener) || !listenerAllowsHTTPRouteKind(listener) {
+			continue
+		}
+		allowed, err := c.listenerAllowsRouteNamespace(listener, gateway.Namespace, route.Namespace)
+		if err != nil || allowed {
+			return allowed, err
+		}
+	}
+	return false, nil
+}
+
+func (c *HTTPRouteController) listenerAllowsRouteNamespace(listener gatewayv1.Listener, gatewayNamespace, routeNamespace string) (bool, error) {
+	if listener.AllowedRoutes == nil || listener.AllowedRoutes.Namespaces == nil || listener.AllowedRoutes.Namespaces.From == nil {
+		return routeNamespace == gatewayNamespace, nil
+	}
+	switch *listener.AllowedRoutes.Namespaces.From {
+	case gatewayv1.NamespacesFromAll:
+		return true, nil
+	case gatewayv1.NamespacesFromSame:
+		return routeNamespace == gatewayNamespace, nil
+	case gatewayv1.NamespacesFromSelector:
+		if listener.AllowedRoutes.Namespaces.Selector == nil {
+			return false, nil
+		}
+		selector, err := metav1.LabelSelectorAsSelector(listener.AllowedRoutes.Namespaces.Selector)
+		if err != nil {
+			return false, err
+		}
+		namespace, err := c.namespaceLister.Get(routeNamespace)
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		if err != nil {
+			return false, err
+		}
+		return selector.Matches(labels.Set(namespace.Labels)), nil
+	default:
+		return false, nil
+	}
+}
+
+func isGatewayParentRef(parentRef gatewayv1.ParentReference) bool {
+	if parentRef.Group != nil && string(*parentRef.Group) != gatewayv1.GroupName {
+		return false
+	}
+	return parentRef.Kind == nil || *parentRef.Kind == "Gateway"
+}
+
+func parentRefSelectsListener(parentRef gatewayv1.ParentReference, listener gatewayv1.Listener) bool {
+	if parentRef.SectionName != nil && *parentRef.SectionName != listener.Name {
+		return false
+	}
+	if parentRef.Port != nil && *parentRef.Port != listener.Port {
+		return false
+	}
+	return true
+}
+
+func listenerAllowsHTTPRouteKind(listener gatewayv1.Listener) bool {
+	if listener.AllowedRoutes == nil || len(listener.AllowedRoutes.Kinds) == 0 {
+		return listener.Protocol == gatewayv1.HTTPProtocolType || listener.Protocol == gatewayv1.HTTPSProtocolType
+	}
+	for _, kind := range listener.AllowedRoutes.Kinds {
+		groupAllowed := kind.Group == nil || string(*kind.Group) == gatewayv1.GroupName
+		if groupAllowed && kind.Kind == "HTTPRoute" {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/kthena-router/controller/httproute_controller_test.go
+++ b/pkg/kthena-router/controller/httproute_controller_test.go
@@ -22,7 +22,10 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubeinformers "k8s.io/client-go/informers"
+	kubefake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayfake "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/fake"
@@ -36,9 +39,10 @@ func ptr[T any](v T) *T { return &v }
 func TestHTTPRouteController_EnqueueHTTPRoutesForGateway(t *testing.T) {
 	gatewayClient := gatewayfake.NewSimpleClientset()
 	gatewayInformerFactory := gatewayinformers.NewSharedInformerFactory(gatewayClient, 0)
+	kubeInformerFactory := kubeinformers.NewSharedInformerFactory(kubefake.NewSimpleClientset(), 0)
 	store := datastore.New()
 
-	ctrl := NewHTTPRouteController(gatewayInformerFactory, store)
+	ctrl := NewHTTPRouteController(gatewayInformerFactory, kubeInformerFactory, store)
 	stop := make(chan struct{})
 	defer close(stop)
 	gatewayInformerFactory.Start(stop)
@@ -116,9 +120,10 @@ func TestHTTPRouteController_EnqueueHTTPRoutesForGateway(t *testing.T) {
 func TestHTTPRouteController_EnqueueHTTPRoutesForGateway_NoMatchingRoutes(t *testing.T) {
 	gatewayClient := gatewayfake.NewSimpleClientset()
 	gatewayInformerFactory := gatewayinformers.NewSharedInformerFactory(gatewayClient, 0)
+	kubeInformerFactory := kubeinformers.NewSharedInformerFactory(kubefake.NewSimpleClientset(), 0)
 	store := datastore.New()
 
-	ctrl := NewHTTPRouteController(gatewayInformerFactory, store)
+	ctrl := NewHTTPRouteController(gatewayInformerFactory, kubeInformerFactory, store)
 	stop := make(chan struct{})
 	defer close(stop)
 	gatewayInformerFactory.Start(stop)
@@ -167,6 +172,7 @@ func TestHTTPRouteController_EnqueueHTTPRoutesForGateway_NoMatchingRoutes(t *tes
 func TestHTTPRouteController_MultipleParentRefs_FirstPending(t *testing.T) {
 	gatewayClient := gatewayfake.NewSimpleClientset()
 	gatewayInformerFactory := gatewayinformers.NewSharedInformerFactory(gatewayClient, 0)
+	kubeInformerFactory := kubeinformers.NewSharedInformerFactory(kubefake.NewSimpleClientset(), 0)
 	store := datastore.New()
 
 	ctx := context.Background()
@@ -175,6 +181,9 @@ func TestHTTPRouteController_MultipleParentRefs_FirstPending(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "gateway-2"},
 		Spec: gatewayv1.GatewaySpec{
 			GatewayClassName: gatewayv1.ObjectName(DefaultGatewayClassName),
+			Listeners: []gatewayv1.Listener{
+				{Name: "http", Protocol: gatewayv1.HTTPProtocolType, Port: 80},
+			},
 		},
 	}
 	_, err := gatewayClient.GatewayV1().Gateways(ns).Create(ctx, gw2, metav1.CreateOptions{})
@@ -195,7 +204,7 @@ func TestHTTPRouteController_MultipleParentRefs_FirstPending(t *testing.T) {
 	_, err = gatewayClient.GatewayV1().HTTPRoutes(ns).Create(ctx, httpRoute, metav1.CreateOptions{})
 	assert.NoError(t, err)
 
-	ctrl := NewHTTPRouteController(gatewayInformerFactory, store)
+	ctrl := NewHTTPRouteController(gatewayInformerFactory, kubeInformerFactory, store)
 	stop := make(chan struct{})
 	defer close(stop)
 	gatewayInformerFactory.Start(stop)
@@ -207,4 +216,192 @@ func TestHTTPRouteController_MultipleParentRefs_FirstPending(t *testing.T) {
 	err = ctrl.syncHandler(ns + "/route-multi")
 	assert.NoError(t, err)
 	assert.NotNil(t, store.GetHTTPRoute(ns+"/route-multi"))
+}
+
+func TestHTTPRouteController_AllowedRoutesDefaultSameNamespace(t *testing.T) {
+	gatewayClient := gatewayfake.NewSimpleClientset()
+	kubeClient := kubefake.NewSimpleClientset()
+	gatewayInformerFactory := gatewayinformers.NewSharedInformerFactory(gatewayClient, 0)
+	kubeInformerFactory := kubeinformers.NewSharedInformerFactory(kubeClient, 0)
+	store := datastore.New()
+
+	ctx := context.Background()
+	gatewayNamespace := "default"
+	gateway := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Namespace: gatewayNamespace, Name: "gateway-1"},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: gatewayv1.ObjectName(DefaultGatewayClassName),
+			Listeners: []gatewayv1.Listener{
+				{Name: "http", Protocol: gatewayv1.HTTPProtocolType, Port: 80},
+			},
+		},
+	}
+	_, err := gatewayClient.GatewayV1().Gateways(gatewayNamespace).Create(ctx, gateway, metav1.CreateOptions{})
+	assert.NoError(t, err)
+	assert.NoError(t, store.AddOrUpdateGateway(gateway))
+
+	sameNamespaceRoute := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Namespace: gatewayNamespace, Name: "same-route"},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{{Name: gatewayv1.ObjectName("gateway-1")}},
+			},
+		},
+	}
+	_, err = gatewayClient.GatewayV1().HTTPRoutes(gatewayNamespace).Create(ctx, sameNamespaceRoute, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	otherNamespaceRoute := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "other-ns", Name: "other-route"},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{{Name: gatewayv1.ObjectName("gateway-1"), Namespace: ptr(gatewayv1.Namespace(gatewayNamespace))}},
+			},
+		},
+	}
+	_, err = gatewayClient.GatewayV1().HTTPRoutes("other-ns").Create(ctx, otherNamespaceRoute, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	ctrl := NewHTTPRouteController(gatewayInformerFactory, kubeInformerFactory, store)
+	stop := make(chan struct{})
+	defer close(stop)
+	gatewayInformerFactory.Start(stop)
+	kubeInformerFactory.Start(stop)
+
+	if !cache.WaitForCacheSync(stop,
+		gatewayInformerFactory.Gateway().V1().HTTPRoutes().Informer().HasSynced,
+		kubeInformerFactory.Core().V1().Namespaces().Informer().HasSynced,
+	) {
+		t.Fatal("cache sync timeout")
+	}
+
+	assert.NoError(t, ctrl.syncHandler(gatewayNamespace+"/same-route"))
+	assert.NotNil(t, store.GetHTTPRoute(gatewayNamespace+"/same-route"))
+
+	assert.NoError(t, ctrl.syncHandler("other-ns/other-route"))
+	assert.Nil(t, store.GetHTTPRoute("other-ns/other-route"))
+}
+
+func TestHTTPRouteController_AllowedRoutesAllNamespaces(t *testing.T) {
+	gatewayClient := gatewayfake.NewSimpleClientset()
+	kubeClient := kubefake.NewSimpleClientset()
+	gatewayInformerFactory := gatewayinformers.NewSharedInformerFactory(gatewayClient, 0)
+	kubeInformerFactory := kubeinformers.NewSharedInformerFactory(kubeClient, 0)
+	store := datastore.New()
+
+	ctx := context.Background()
+	fromAll := gatewayv1.NamespacesFromAll
+	gatewayNamespace := "default"
+	gateway := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Namespace: gatewayNamespace, Name: "gateway-1"},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: gatewayv1.ObjectName(DefaultGatewayClassName),
+			Listeners: []gatewayv1.Listener{
+				{
+					Name:     "http",
+					Protocol: gatewayv1.HTTPProtocolType,
+					Port:     80,
+					AllowedRoutes: &gatewayv1.AllowedRoutes{
+						Namespaces: &gatewayv1.RouteNamespaces{From: &fromAll},
+					},
+				},
+			},
+		},
+	}
+	_, err := gatewayClient.GatewayV1().Gateways(gatewayNamespace).Create(ctx, gateway, metav1.CreateOptions{})
+	assert.NoError(t, err)
+	assert.NoError(t, store.AddOrUpdateGateway(gateway))
+
+	route := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "other-ns", Name: "route"},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{{Name: gatewayv1.ObjectName("gateway-1"), Namespace: ptr(gatewayv1.Namespace(gatewayNamespace))}},
+			},
+		},
+	}
+	_, err = gatewayClient.GatewayV1().HTTPRoutes("other-ns").Create(ctx, route, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	ctrl := NewHTTPRouteController(gatewayInformerFactory, kubeInformerFactory, store)
+	stop := make(chan struct{})
+	defer close(stop)
+	gatewayInformerFactory.Start(stop)
+	kubeInformerFactory.Start(stop)
+
+	if !cache.WaitForCacheSync(stop, gatewayInformerFactory.Gateway().V1().HTTPRoutes().Informer().HasSynced) {
+		t.Fatal("cache sync timeout")
+	}
+
+	assert.NoError(t, ctrl.syncHandler("other-ns/route"))
+	assert.NotNil(t, store.GetHTTPRoute("other-ns/route"))
+}
+
+func TestHTTPRouteController_AllowedRoutesNamespaceSelector(t *testing.T) {
+	gatewayClient := gatewayfake.NewSimpleClientset()
+	kubeClient := kubefake.NewSimpleClientset(
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "selected-ns", Labels: map[string]string{"team": "ai"}}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "blocked-ns", Labels: map[string]string{"team": "ops"}}},
+	)
+	gatewayInformerFactory := gatewayinformers.NewSharedInformerFactory(gatewayClient, 0)
+	kubeInformerFactory := kubeinformers.NewSharedInformerFactory(kubeClient, 0)
+	store := datastore.New()
+
+	ctx := context.Background()
+	fromSelector := gatewayv1.NamespacesFromSelector
+	gatewayNamespace := "default"
+	gateway := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Namespace: gatewayNamespace, Name: "gateway-1"},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: gatewayv1.ObjectName(DefaultGatewayClassName),
+			Listeners: []gatewayv1.Listener{
+				{
+					Name:     "http",
+					Protocol: gatewayv1.HTTPProtocolType,
+					Port:     80,
+					AllowedRoutes: &gatewayv1.AllowedRoutes{
+						Namespaces: &gatewayv1.RouteNamespaces{
+							From:     &fromSelector,
+							Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"team": "ai"}},
+						},
+					},
+				},
+			},
+		},
+	}
+	_, err := gatewayClient.GatewayV1().Gateways(gatewayNamespace).Create(ctx, gateway, metav1.CreateOptions{})
+	assert.NoError(t, err)
+	assert.NoError(t, store.AddOrUpdateGateway(gateway))
+
+	for _, namespace := range []string{"selected-ns", "blocked-ns"} {
+		route := &gatewayv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "route"},
+			Spec: gatewayv1.HTTPRouteSpec{
+				CommonRouteSpec: gatewayv1.CommonRouteSpec{
+					ParentRefs: []gatewayv1.ParentReference{{Name: gatewayv1.ObjectName("gateway-1"), Namespace: ptr(gatewayv1.Namespace(gatewayNamespace))}},
+				},
+			},
+		}
+		_, err = gatewayClient.GatewayV1().HTTPRoutes(namespace).Create(ctx, route, metav1.CreateOptions{})
+		assert.NoError(t, err)
+	}
+
+	ctrl := NewHTTPRouteController(gatewayInformerFactory, kubeInformerFactory, store)
+	stop := make(chan struct{})
+	defer close(stop)
+	gatewayInformerFactory.Start(stop)
+	kubeInformerFactory.Start(stop)
+
+	if !cache.WaitForCacheSync(stop,
+		gatewayInformerFactory.Gateway().V1().HTTPRoutes().Informer().HasSynced,
+		kubeInformerFactory.Core().V1().Namespaces().Informer().HasSynced,
+	) {
+		t.Fatal("cache sync timeout")
+	}
+
+	assert.NoError(t, ctrl.syncHandler("selected-ns/route"))
+	assert.NotNil(t, store.GetHTTPRoute("selected-ns/route"))
+
+	assert.NoError(t, ctrl.syncHandler("blocked-ns/route"))
+	assert.Nil(t, store.GetHTTPRoute("blocked-ns/route"))
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Enforces Gateway listener `allowedRoutes` before storing HTTPRoutes for the router.

**Which issue(s) this PR fixes**:

Fixes #1132

**Special notes for your reviewer**:

NONE

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
