### PR TITLE
metrics: check HTTP status before parsing response

### DIFF
--- a/pkg/kthena-router/backend/metrics/metrics.go
+++ b/pkg/kthena-router/backend/metrics/metrics.go
@@ -53,6 +53,10 @@ func ParseMetricsURL(url string) (map[string]*dto.MetricFamily, error) {
 		}
 	}()
 
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to fetch metrics from %s: HTTP %d", url, resp.StatusCode)
+	}
+
 	parser := expfmt.NewTextParser(model.UTF8Validation)
 	allMetrics, err := parser.TextToMetricFamilies(resp.Body)
 	if err != nil {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Adds HTTP status validation before parsing metrics responses.

Previously, non-200 responses (such as 404/500) returning HTML or JSON
were parsed as Prometheus metrics text, resulting in misleading parsing errors.

This PR returns a proper error for non-200 HTTP responses before parsing.

**Which issue(s) this PR fixes**:

Fixes #1136

**Special notes for your reviewer**:

NONE

**Does this PR introduce a user-facing change?**:

```release-note
NONE