### PR TITLE
test(e2e): add self-healing coverage for ModelBooster

### DIFF
--- a/pkg/model-booster-controller/controller/model_booster_controller.go
+++ b/pkg/model-booster-controller/controller/model_booster_controller.go
@@ -400,6 +400,20 @@ func NewModelBoosterController(kubeClient kubernetes.Interface, client clientset
 		klog.Fatal("Unable to add model server event handler")
 		return nil
 	}
+	_, err = autoscalingPoliciesInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		DeleteFunc: mc.deleteAutoscalingPolicy,
+	})
+	if err != nil {
+		klog.Fatal("Unable to add autoscaling policy event handler")
+		return nil
+	}
+	_, err = autoscalingPolicyBindingsInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		DeleteFunc: mc.deleteAutoscalingPolicyBinding,
+	})
+	if err != nil {
+		klog.Fatal("Unable to add autoscaling policy binding event handler")
+		return nil
+	}
 	mc.syncHandler = mc.reconcile
 	mc.loadConfigFromConfigMap()
 	return mc
@@ -450,8 +464,24 @@ func (mc *ModelBoosterController) triggerModel(old any, new any) {
 	}
 }
 
+// unwrapTombstone safely extracts the underlying object from a potential cache.DeletedFinalStateUnknown tombstone.
+func unwrapTombstone(obj any) (any, bool) {
+	if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+		obj = tombstone.Obj
+		if obj == nil {
+			return nil, false
+		}
+	}
+	return obj, true
+}
+
 // deleteModelServing is called when a ModelServing is deleted. It will reconcile the ModelBooster. Recreate model serving.
 func (mc *ModelBoosterController) deleteModelServing(obj any) {
+	obj, ok := unwrapTombstone(obj)
+	if !ok {
+		klog.Error("failed to unwrap tombstone when deleteModelServing")
+		return
+	}
 	modelServing, ok := obj.(*workload.ModelServing)
 	if !ok {
 		klog.Error("failed to parse ModelServing when deleteModelServing")
@@ -467,6 +497,11 @@ func (mc *ModelBoosterController) deleteModelServing(obj any) {
 
 // deleteModelRoute is called when a ModelRoute is deleted. It will reconcile the ModelBooster. Recreate model route.
 func (mc *ModelBoosterController) deleteModelRoute(obj any) {
+	obj, ok := unwrapTombstone(obj)
+	if !ok {
+		klog.Error("failed to unwrap tombstone when deleteModelRoute")
+		return
+	}
 	modelRoute, ok := obj.(*networkingv1alpha1.ModelRoute)
 	if !ok {
 		klog.Error("failed to parse ModelRoute when deleteModelRoute")
@@ -482,6 +517,11 @@ func (mc *ModelBoosterController) deleteModelRoute(obj any) {
 
 // deleteModelServer is called when a ModelServer is deleted. It will reconcile the ModelBooster. Recreate model server.
 func (mc *ModelBoosterController) deleteModelServer(obj any) {
+	obj, ok := unwrapTombstone(obj)
+	if !ok {
+		klog.Error("failed to unwrap tombstone when deleteModelServer")
+		return
+	}
 	modelServer, ok := obj.(*networkingv1alpha1.ModelServer)
 	if !ok {
 		klog.Error("failed to parse ModelServer when deleteModelServer")
@@ -490,6 +530,46 @@ func (mc *ModelBoosterController) deleteModelServer(obj any) {
 	klog.V(4).Infof("model server: %s is deleted", klog.KObj(modelServer))
 	if len(modelServer.OwnerReferences) > 0 {
 		if model, err := mc.modelBoosterLister.ModelBoosters(modelServer.Namespace).Get(modelServer.OwnerReferences[0].Name); err == nil {
+			mc.enqueueModelBooster(model)
+		}
+	}
+}
+
+// deleteAutoscalingPolicy is called when an AutoscalingPolicy is deleted. It will reconcile the ModelBooster. Recreate AutoscalingPolicy.
+func (mc *ModelBoosterController) deleteAutoscalingPolicy(obj any) {
+	obj, ok := unwrapTombstone(obj)
+	if !ok {
+		klog.Error("failed to unwrap tombstone when deleteAutoscalingPolicy")
+		return
+	}
+	policy, ok := obj.(*workload.AutoscalingPolicy)
+	if !ok {
+		klog.Error("failed to parse AutoscalingPolicy when deleteAutoscalingPolicy")
+		return
+	}
+	klog.V(4).Infof("autoscaling policy: %s is deleted", klog.KObj(policy))
+	if len(policy.OwnerReferences) > 0 {
+		if model, err := mc.modelBoosterLister.ModelBoosters(policy.Namespace).Get(policy.OwnerReferences[0].Name); err == nil {
+			mc.enqueueModelBooster(model)
+		}
+	}
+}
+
+// deleteAutoscalingPolicyBinding is called when an AutoscalingPolicyBinding is deleted. It will reconcile the ModelBooster. Recreate AutoscalingPolicyBinding.
+func (mc *ModelBoosterController) deleteAutoscalingPolicyBinding(obj any) {
+	obj, ok := unwrapTombstone(obj)
+	if !ok {
+		klog.Error("failed to unwrap tombstone when deleteAutoscalingPolicyBinding")
+		return
+	}
+	binding, ok := obj.(*workload.AutoscalingPolicyBinding)
+	if !ok {
+		klog.Error("failed to parse AutoscalingPolicyBinding when deleteAutoscalingPolicyBinding")
+		return
+	}
+	klog.V(4).Infof("autoscaling policy binding: %s is deleted", klog.KObj(binding))
+	if len(binding.OwnerReferences) > 0 {
+		if model, err := mc.modelBoosterLister.ModelBoosters(binding.Namespace).Get(binding.OwnerReferences[0].Name); err == nil {
 			mc.enqueueModelBooster(model)
 		}
 	}

--- a/test/e2e/controller-manager/model_booster_test.go
+++ b/test/e2e/controller-manager/model_booster_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controller_manager
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -96,6 +97,97 @@ func TestModelCR(t *testing.T) {
 		}
 		return false
 	}, 2*time.Minute, 5*time.Second, "ModelBooster was not deleted")
+}
+
+// TestModelBoosterSelfHealing validates that the controller instantly self-heals deleted child resources.
+func TestModelBoosterSelfHealing(t *testing.T) {
+	ctx, kthenaClient, _ := setupControllerManagerE2ETest(t)
+
+	// Create a Model CR in the test namespace
+	model := createTestModel()
+	model.Name = "self-healing-test-model"
+	model.Spec.Name = "self-healing-test-model"
+
+	createdModel, err := kthenaClient.WorkloadV1alpha1().ModelBoosters(testNamespace).Create(ctx, model, metav1.CreateOptions{})
+	require.NoError(t, err, "Failed to create Model CR")
+	assert.NotNil(t, createdModel)
+
+	t.Cleanup(func() {
+		if err := kthenaClient.WorkloadV1alpha1().ModelBoosters(testNamespace).Delete(context.Background(), model.Name, metav1.DeleteOptions{}); err != nil {
+			t.Logf("cleanup: failed to delete ModelBooster %s: %v", model.Name, err)
+		}
+	})
+
+	t.Logf("Created Model CR: %s/%s", createdModel.Namespace, createdModel.Name)
+
+	// Wait for the Model to be Active
+	require.Eventually(t, func() bool {
+		m, err := kthenaClient.WorkloadV1alpha1().ModelBoosters(testNamespace).Get(ctx, model.Name, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		return meta.IsStatusConditionPresentAndEqual(m.Status.Conditions,
+			string(workload.ModelStatusConditionTypeActive), metav1.ConditionTrue)
+	}, 5*time.Minute, 5*time.Second, "Model did not become Active")
+
+	t.Log("Model is active. Testing self-healing of AutoscalingPolicy...")
+
+	// Find the generated AutoscalingPolicy
+	policies, err := kthenaClient.WorkloadV1alpha1().AutoscalingPolicies(testNamespace).List(ctx, metav1.ListOptions{})
+	require.NoError(t, err)
+	var policyToDelete *workload.AutoscalingPolicy
+	for i := range policies.Items {
+		for _, owner := range policies.Items[i].OwnerReferences {
+			if owner.Name == model.Name {
+				policyToDelete = &policies.Items[i]
+				break
+			}
+		}
+	}
+	require.NotNil(t, policyToDelete, "Expected at least one AutoscalingPolicy to be generated for the model")
+
+	err = kthenaClient.WorkloadV1alpha1().AutoscalingPolicies(testNamespace).Delete(ctx, policyToDelete.Name, metav1.DeleteOptions{})
+	require.NoError(t, err, "Failed to delete AutoscalingPolicy")
+
+	// Wait for the controller to self-heal and recreate it
+	require.Eventually(t, func() bool {
+		recreated, err := kthenaClient.WorkloadV1alpha1().AutoscalingPolicies(testNamespace).Get(ctx, policyToDelete.Name, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		// Make sure it's a new instance (different UID)
+		return recreated.UID != policyToDelete.UID
+	}, 1*time.Minute, 2*time.Second, "Controller failed to self-heal deleted AutoscalingPolicy")
+
+	t.Log("AutoscalingPolicy was successfully self-healed. Testing ModelServing...")
+
+	// Find the generated ModelServing
+	servings, err := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).List(ctx, metav1.ListOptions{})
+	require.NoError(t, err)
+	var servingToDelete *workload.ModelServing
+	for i := range servings.Items {
+		for _, owner := range servings.Items[i].OwnerReferences {
+			if owner.Name == model.Name {
+				servingToDelete = &servings.Items[i]
+				break
+			}
+		}
+	}
+	require.NotNil(t, servingToDelete, "Expected at least one ModelServing to be generated for the model")
+
+	err = kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Delete(ctx, servingToDelete.Name, metav1.DeleteOptions{})
+	require.NoError(t, err, "Failed to delete ModelServing")
+
+	// Wait for the controller to self-heal and recreate it
+	require.Eventually(t, func() bool {
+		recreated, err := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Get(ctx, servingToDelete.Name, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		return recreated.UID != servingToDelete.UID
+	}, 1*time.Minute, 2*time.Second, "Controller failed to self-heal deleted ModelServing")
+
+	t.Log("ModelServing was successfully self-healed. Test complete.")
 }
 
 func createValidModelBoosterForWebhookTest() *workload.ModelBooster {

--- a/test/e2e/controller-manager/model_booster_test.go
+++ b/test/e2e/controller-manager/model_booster_test.go
@@ -18,6 +18,7 @@ package controller_manager
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -107,6 +108,14 @@ func TestModelBoosterSelfHealing(t *testing.T) {
 	model := createTestModel()
 	model.Name = "self-healing-test-model"
 	model.Spec.Name = "self-healing-test-model"
+	model.Spec.AutoscalingPolicy = &workload.AutoscalingPolicySpec{
+		Metrics: []workload.AutoscalingPolicyMetric{
+			{
+				MetricName:  "concurrency",
+				TargetValue: resource.MustParse("10"),
+			},
+		},
+	}
 
 	createdModel, err := kthenaClient.WorkloadV1alpha1().ModelBoosters(testNamespace).Create(ctx, model, metav1.CreateOptions{})
 	require.NoError(t, err, "Failed to create Model CR")
@@ -132,19 +141,12 @@ func TestModelBoosterSelfHealing(t *testing.T) {
 
 	t.Log("Model is active. Testing self-healing of AutoscalingPolicy...")
 
-	// Find the generated AutoscalingPolicy
-	policies, err := kthenaClient.WorkloadV1alpha1().AutoscalingPolicies(testNamespace).List(ctx, metav1.ListOptions{})
-	require.NoError(t, err)
-	var policyToDelete *workload.AutoscalingPolicy
-	for i := range policies.Items {
-		for _, owner := range policies.Items[i].OwnerReferences {
-			if owner.Name == model.Name {
-				policyToDelete = &policies.Items[i]
-				break
-			}
-		}
-	}
-	require.NotNil(t, policyToDelete, "Expected at least one AutoscalingPolicy to be generated for the model")
+	// The controller contract guarantees the child resource is named: {modelName}-{backendName}
+	expectedChildName := fmt.Sprintf("%s-%s", model.Name, model.Spec.Backend.Name)
+
+	// Fetch the generated AutoscalingPolicy deterministically by name
+	policyToDelete, err := kthenaClient.WorkloadV1alpha1().AutoscalingPolicies(testNamespace).Get(ctx, expectedChildName, metav1.GetOptions{})
+	require.NoError(t, err, "Expected AutoscalingPolicy to be generated with deterministic name")
 
 	err = kthenaClient.WorkloadV1alpha1().AutoscalingPolicies(testNamespace).Delete(ctx, policyToDelete.Name, metav1.DeleteOptions{})
 	require.NoError(t, err, "Failed to delete AutoscalingPolicy")
@@ -161,19 +163,9 @@ func TestModelBoosterSelfHealing(t *testing.T) {
 
 	t.Log("AutoscalingPolicy was successfully self-healed. Testing ModelServing...")
 
-	// Find the generated ModelServing
-	servings, err := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).List(ctx, metav1.ListOptions{})
-	require.NoError(t, err)
-	var servingToDelete *workload.ModelServing
-	for i := range servings.Items {
-		for _, owner := range servings.Items[i].OwnerReferences {
-			if owner.Name == model.Name {
-				servingToDelete = &servings.Items[i]
-				break
-			}
-		}
-	}
-	require.NotNil(t, servingToDelete, "Expected at least one ModelServing to be generated for the model")
+	// Fetch the generated ModelServing deterministically by name
+	servingToDelete, err := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Get(ctx, expectedChildName, metav1.GetOptions{})
+	require.NoError(t, err, "Expected ModelServing to be generated with deterministic name")
 
 	err = kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Delete(ctx, servingToDelete.Name, metav1.DeleteOptions{})
 	require.NoError(t, err, "Failed to delete ModelServing")


### PR DESCRIPTION
**What type of PR is this?**
/kind bug 
<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:
This PR introduces a strict E2E test (TestModelBoosterSelfHealing) to validate that the controller instantly self-heals deleted child resources. the controller completely drops the deletion event for the AutoscalingPolicy. I have opened a detailed issue outlining the two architectural flaws causing this.

**Which issue(s) this PR fixes**:
Fixes #1137


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
