### PR TITLE
fix: use mime.ParseMediaType to detect streaming content-type with parameters

### DIFF
--- a/pkg/kthena-router/connectors/transport.go
+++ b/pkg/kthena-router/connectors/transport.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -166,10 +167,15 @@ func isTokenUsageEnabled(modelRequest map[string]interface{}) bool {
 	return false
 }
 
-// isStreamingResponse checks if the response is a streaming response
+// isStreamingResponse checks if the response is a streaming response.
+// It uses mime.ParseMediaType so that parameters such as charset are ignored,
+// e.g. "text/event-stream; charset=utf-8" is correctly recognised as streaming.
 func isStreamingResponse(resp *http.Response) bool {
-	contentType := resp.Header.Get("Content-Type")
-	return contentType == "text/event-stream" || contentType == "application/x-ndjson"
+	mediaType, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+	if err != nil {
+		return false
+	}
+	return mediaType == "text/event-stream" || mediaType == "application/x-ndjson"
 }
 
 // handleStreamingResponse handles streaming responses

--- a/pkg/kthena-router/connectors/transport_test.go
+++ b/pkg/kthena-router/connectors/transport_test.go
@@ -185,6 +185,16 @@ func TestIsStreamingResponse(t *testing.T) {
 			expected:    true,
 		},
 		{
+			name:        "text/event-stream with charset",
+			contentType: "text/event-stream; charset=utf-8",
+			expected:    true,
+		},
+		{
+			name:        "application/x-ndjson with charset",
+			contentType: "application/x-ndjson; charset=utf-8",
+			expected:    true,
+		},
+		{
 			name:        "application/json",
 			contentType: "application/json",
 			expected:    false,


### PR DESCRIPTION
## Summary

- `isStreamingResponse` used strict equality to check `Content-Type`, which broke SSE streaming when backends append parameters like `; charset=utf-8`
- vLLM and other backends (via Starlette's `StreamingResponse`) return `text/event-stream; charset=utf-8`, which was incorrectly treated as non-streaming, causing buffered responses and disabling SSE forwarding
- Fixed by using `mime.ParseMediaType` to extract just the media type before comparing, ignoring any parameters

Fixes #1138

## Test plan

- Added two new cases to `TestIsStreamingResponse`: `text/event-stream; charset=utf-8` and `application/x-ndjson; charset=utf-8` both correctly return `true`
- All 748 existing tests pass