### PR TITLE
test(e2e): refactor ModelBooster controller tests and add generated resource coverage

### DIFF
--- a/pkg/model-booster-controller/controller/model_booster_controller.go
+++ b/pkg/model-booster-controller/controller/model_booster_controller.go
@@ -173,6 +173,11 @@ func (mc *ModelBoosterController) updateModelBooster(old any, new any) {
 }
 
 func (mc *ModelBoosterController) deleteModelBooster(obj any) {
+	obj, ok := unwrapTombstone(obj)
+	if !ok {
+		klog.Error("failed to unwrap tombstone when deleteModelBooster")
+		return
+	}
 	model, ok := obj.(*workload.ModelBooster)
 	if !ok {
 		klog.Error("failed to parse ModelBooster when deleteModelBooster")

--- a/test/e2e/controller-manager/model_booster_test.go
+++ b/test/e2e/controller-manager/model_booster_test.go
@@ -33,7 +33,10 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 )
 
-const testDataDir = "test/e2e/controller-manager/testdata"
+const (
+	testDataDir                   = "test/e2e/controller-manager/testdata"
+	modelBoosterTestSchedulerName = "volcano"
+)
 
 // TestModelCR creates a ModelBooster CR from YAML, waits for it to become active,
 // tests chat functionality, verifies generated child resources and ownership,
@@ -96,14 +99,13 @@ func TestModelCR(t *testing.T) {
 	require.NotEmpty(t, msRevisionBefore, "ModelServing revision label should be set")
 
 	t.Log("Testing update of ModelBooster")
-	updatedMaxReplicas := model.Spec.Backend.MaxReplicas + 1
 	require.Eventually(t, func() bool {
 		m, err := kthenaClient.WorkloadV1alpha1().ModelBoosters(testNamespace).Get(ctx, model.Name, metav1.GetOptions{})
 		if err != nil {
 			t.Logf("Get model error: %v", err)
 			return false
 		}
-		m.Spec.Backend.MaxReplicas = updatedMaxReplicas
+		m.Spec.Backend.SchedulerName = modelBoosterTestSchedulerName
 		_, err = kthenaClient.WorkloadV1alpha1().ModelBoosters(testNamespace).Update(ctx, m, metav1.UpdateOptions{})
 		if err != nil {
 			t.Logf("Update model error: %v", err)
@@ -117,7 +119,7 @@ func TestModelCR(t *testing.T) {
 		if err != nil {
 			return false
 		}
-		return m.Spec.Backend.MaxReplicas == updatedMaxReplicas
+		return m.Spec.Backend.SchedulerName == modelBoosterTestSchedulerName
 	}, 2*time.Minute, 5*time.Second, "ModelBooster update was not reflected")
 
 	// ModelServing hashes model.Spec.Backend, so backend changes should mutate the revision label.

--- a/test/e2e/controller-manager/model_booster_test.go
+++ b/test/e2e/controller-manager/model_booster_test.go
@@ -96,13 +96,14 @@ func TestModelCR(t *testing.T) {
 	require.NotEmpty(t, msRevisionBefore, "ModelServing revision label should be set")
 
 	t.Log("Testing update of ModelBooster")
+	updatedMaxReplicas := model.Spec.Backend.MaxReplicas + 1
 	require.Eventually(t, func() bool {
 		m, err := kthenaClient.WorkloadV1alpha1().ModelBoosters(testNamespace).Get(ctx, model.Name, metav1.GetOptions{})
 		if err != nil {
 			t.Logf("Get model error: %v", err)
 			return false
 		}
-		m.Spec.Backend.Workers[0].Replicas = 2
+		m.Spec.Backend.MaxReplicas = updatedMaxReplicas
 		_, err = kthenaClient.WorkloadV1alpha1().ModelBoosters(testNamespace).Update(ctx, m, metav1.UpdateOptions{})
 		if err != nil {
 			t.Logf("Update model error: %v", err)
@@ -116,10 +117,10 @@ func TestModelCR(t *testing.T) {
 		if err != nil {
 			return false
 		}
-		return m.Spec.Backend.Workers[0].Replicas == 2
+		return m.Spec.Backend.MaxReplicas == updatedMaxReplicas
 	}, 2*time.Minute, 5*time.Second, "ModelBooster update was not reflected")
 
-	// ModelServing hashes model.Spec.Backend, so replica changes should mutate the revision label.
+	// ModelServing hashes model.Spec.Backend, so backend changes should mutate the revision label.
 	t.Log("Verifying revision label changed on ModelServing after update")
 	require.Eventually(t, func() bool {
 		updatedMS, err := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Get(ctx, expectedChildName, metav1.GetOptions{})
@@ -161,6 +162,73 @@ func TestModelCR(t *testing.T) {
 		list, err := kthenaClient.NetworkingV1alpha1().ModelRoutes(testNamespace).List(ctx, listOpts)
 		return err == nil && len(list.Items) == 0
 	}, 2*time.Minute, 5*time.Second, "Orphan ModelRoutes should be garbage-collected")
+}
+
+// TestModelCRDisaggregated verifies that a vLLMDisaggregated ModelBooster is
+// reconciled into the split prefill/decode ModelServing shape.
+func TestModelCRDisaggregated(t *testing.T) {
+	ctx, kthenaClient, _ := setupControllerManagerE2ETest(t)
+
+	model := utils.LoadYAMLFromFile[workload.ModelBooster](filepath.Join(testDataDir, "ModelBooster-vllm-disaggregated.yaml"))
+	model.Namespace = testNamespace
+
+	createdModel, err := kthenaClient.WorkloadV1alpha1().ModelBoosters(testNamespace).Create(ctx, model, metav1.CreateOptions{})
+	require.NoError(t, err, "Failed to create disaggregated ModelBooster")
+	require.NotNil(t, createdModel)
+	t.Cleanup(func() {
+		if err := kthenaClient.WorkloadV1alpha1().ModelBoosters(testNamespace).Delete(context.Background(), model.Name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			t.Logf("cleanup: failed to delete ModelBooster %s: %v", model.Name, err)
+		}
+	})
+
+	expectedChildName := mbutils.GetBackendResourceName(model.Name, model.Spec.Backend.Name)
+
+	var modelServing *workload.ModelServing
+	require.Eventually(t, func() bool {
+		ms, err := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Get(ctx, expectedChildName, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		modelServing = ms
+		return true
+	}, 2*time.Minute, 2*time.Second, "Disaggregated ModelServing should be created")
+
+	assertOwnedByModelBooster(t, modelServing.OwnerReferences, createdModel)
+	assertModelBoosterLabels(t, modelServing.Labels, createdModel, model.Spec.Backend.Name)
+	require.Len(t, modelServing.Spec.Template.Roles, 2, "Disaggregated ModelServing should contain prefill and decode roles")
+	assertModelServingRoleNames(t, modelServing, workload.ModelWorkerTypePrefill, workload.ModelWorkerTypeDecode)
+
+	var modelServerLabels map[string]string
+	var modelServerOwnerReferences []metav1.OwnerReference
+	require.Eventually(t, func() bool {
+		modelServer, err := kthenaClient.NetworkingV1alpha1().ModelServers(testNamespace).Get(ctx, expectedChildName, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		modelServerOwnerReferences = modelServer.OwnerReferences
+		modelServerLabels = modelServer.Labels
+		return true
+	}, 2*time.Minute, 2*time.Second, "Disaggregated ModelServer should be created")
+	assertOwnedByModelBooster(t, modelServerOwnerReferences, createdModel)
+	assertModelBoosterLabels(t, modelServerLabels, createdModel, model.Spec.Backend.Name)
+
+	err = kthenaClient.WorkloadV1alpha1().ModelBoosters(testNamespace).Delete(ctx, model.Name, metav1.DeleteOptions{})
+	require.NoError(t, err, "Failed to delete disaggregated ModelBooster")
+
+	ownerUIDSelector := labels.SelectorFromSet(map[string]string{
+		mbutils.OwnerUIDKey: string(createdModel.UID),
+	})
+	listOpts := metav1.ListOptions{LabelSelector: ownerUIDSelector.String()}
+
+	require.Eventually(t, func() bool {
+		list, err := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).List(ctx, listOpts)
+		return err == nil && len(list.Items) == 0
+	}, 2*time.Minute, 2*time.Second, "Disaggregated ModelServing should be garbage-collected")
+
+	require.Eventually(t, func() bool {
+		list, err := kthenaClient.NetworkingV1alpha1().ModelServers(testNamespace).List(ctx, listOpts)
+		return err == nil && len(list.Items) == 0
+	}, 2*time.Minute, 2*time.Second, "Disaggregated ModelServer should be garbage-collected")
 }
 
 // TestModelBoosterSelfHealing validates that the controller instantly self-heals deleted child resources.
@@ -308,4 +376,16 @@ func assertModelBoosterLabels(t *testing.T, resourceLabels map[string]string, bo
 	assert.Equal(t, string(booster.UID), resourceLabels[mbutils.OwnerUIDKey], "label model-uid")
 	assert.Equal(t, workload.GroupName, resourceLabels[mbutils.ManageBy], "label managed-by")
 	assert.NotEmpty(t, resourceLabels[mbutils.RevisionLabelKey], "label revision should not be empty")
+}
+
+func assertModelServingRoleNames(t *testing.T, modelServing *workload.ModelServing, expectedRoles ...workload.ModelWorkerType) {
+	t.Helper()
+	actual := make(map[workload.ModelWorkerType]struct{}, len(modelServing.Spec.Template.Roles))
+	for _, role := range modelServing.Spec.Template.Roles {
+		actual[workload.ModelWorkerType(role.Name)] = struct{}{}
+	}
+	for _, expectedRole := range expectedRoles {
+		_, ok := actual[expectedRole]
+		assert.True(t, ok, "ModelServing should contain %s role", expectedRole)
+	}
 }

--- a/test/e2e/controller-manager/model_booster_test.go
+++ b/test/e2e/controller-manager/model_booster_test.go
@@ -18,48 +18,83 @@ package controller_manager
 
 import (
 	"context"
-	"fmt"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	workload "github.com/volcano-sh/kthena/pkg/apis/workload/v1alpha1"
+	mbutils "github.com/volcano-sh/kthena/pkg/model-booster-controller/utils"
 	"github.com/volcano-sh/kthena/test/e2e/utils"
-	corev1 "k8s.io/api/core/v1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
-// TestModelCR creates a ModelBooster CR, waits for it to become active, and tests chat functionality.
+const testDataDir = "test/e2e/controller-manager/testdata"
+
+// TestModelCR creates a ModelBooster CR from YAML, waits for it to become active,
+// tests chat functionality, verifies generated child resources and ownership,
+// updates the CR, and verifies cascading deletion.
 func TestModelCR(t *testing.T) {
 	ctx, kthenaClient, _ := setupControllerManagerE2ETest(t)
 
-	// Create a Model CR in the test namespace
-	model := createTestModel()
+	// Load the ModelBooster CR from YAML fixture
+	model := utils.LoadYAMLFromFile[workload.ModelBooster](filepath.Join(testDataDir, "ModelBooster-vllm.yaml"))
+	model.Namespace = testNamespace
+
 	createdModel, err := kthenaClient.WorkloadV1alpha1().ModelBoosters(testNamespace).Create(ctx, model, metav1.CreateOptions{})
 	require.NoError(t, err, "Failed to create Model CR")
-	assert.NotNil(t, createdModel)
+	require.NotNil(t, createdModel)
+	t.Cleanup(func() {
+		if err := kthenaClient.WorkloadV1alpha1().ModelBoosters(testNamespace).Delete(context.Background(), model.Name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			t.Logf("cleanup: failed to delete ModelBooster %s: %v", model.Name, err)
+		}
+	})
 	t.Logf("Created Model CR: %s/%s", createdModel.Namespace, createdModel.Name)
+
 	// Wait for the Model to be Active
 	require.Eventually(t, func() bool {
-		model, err := kthenaClient.WorkloadV1alpha1().ModelBoosters(testNamespace).Get(ctx, model.Name, metav1.GetOptions{})
+		m, err := kthenaClient.WorkloadV1alpha1().ModelBoosters(testNamespace).Get(ctx, model.Name, metav1.GetOptions{})
 		if err != nil {
 			t.Logf("Get model error: %v", err)
 			return false
 		}
-		return meta.IsStatusConditionPresentAndEqual(model.Status.Conditions,
+		return meta.IsStatusConditionPresentAndEqual(m.Status.Conditions,
 			string(workload.ModelStatusConditionTypeActive), metav1.ConditionTrue)
 	}, 5*time.Minute, 5*time.Second, "Model did not become Active")
+
 	// Test chat via port-forward
 	messages := []utils.ChatMessage{
 		utils.NewChatMessage("user", "Where is the capital of China?"),
 	}
+	utils.WaitForChatModelReady(t, utils.DefaultRouterURL, "test-model", messages, 2*time.Minute)
 	utils.CheckChatCompletions(t, "test-model", messages)
-	// Test updating ModelBooster
+
+	expectedChildName := mbutils.GetBackendResourceName(model.Name, model.Spec.Backend.Name)
+
+	ms, err := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Get(ctx, expectedChildName, metav1.GetOptions{})
+	require.NoError(t, err, "Generated ModelServing should exist")
+	assertOwnedByModelBooster(t, ms.OwnerReferences, createdModel)
+	assertModelBoosterLabels(t, ms.Labels, createdModel, model.Spec.Backend.Name)
+
+	mserver, err := kthenaClient.NetworkingV1alpha1().ModelServers(testNamespace).Get(ctx, expectedChildName, metav1.GetOptions{})
+	require.NoError(t, err, "Generated ModelServer should exist")
+	assertOwnedByModelBooster(t, mserver.OwnerReferences, createdModel)
+	assertModelBoosterLabels(t, mserver.Labels, createdModel, model.Spec.Backend.Name)
+
+	// ModelRoute expects an empty backendName
+	mroute, err := kthenaClient.NetworkingV1alpha1().ModelRoutes(testNamespace).Get(ctx, model.Name, metav1.GetOptions{})
+	require.NoError(t, err, "Generated ModelRoute should exist")
+	assertOwnedByModelBooster(t, mroute.OwnerReferences, createdModel)
+	assertModelBoosterLabels(t, mroute.Labels, createdModel, "")
+
+	// Record revision label for comparison
+	msRevisionBefore := ms.Labels[mbutils.RevisionLabelKey]
+	require.NotEmpty(t, msRevisionBefore, "ModelServing revision label should be set")
+
 	t.Log("Testing update of ModelBooster")
 	require.Eventually(t, func() bool {
 		m, err := kthenaClient.WorkloadV1alpha1().ModelBoosters(testNamespace).Get(ctx, model.Name, metav1.GetOptions{})
@@ -76,7 +111,6 @@ func TestModelCR(t *testing.T) {
 		return true
 	}, 2*time.Minute, 5*time.Second, "Failed to update ModelBooster")
 
-	// Verify the update took effect
 	require.Eventually(t, func() bool {
 		m, err := kthenaClient.WorkloadV1alpha1().ModelBoosters(testNamespace).Get(ctx, model.Name, metav1.GetOptions{})
 		if err != nil {
@@ -85,29 +119,57 @@ func TestModelCR(t *testing.T) {
 		return m.Spec.Backend.Workers[0].Replicas == 2
 	}, 2*time.Minute, 5*time.Second, "ModelBooster update was not reflected")
 
-	// Test deleting ModelBooster
-	t.Log("Testing deletion of ModelBooster")
+	// ModelServing hashes model.Spec.Backend, so replica changes should mutate the revision label.
+	t.Log("Verifying revision label changed on ModelServing after update")
+	require.Eventually(t, func() bool {
+		updatedMS, err := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Get(ctx, expectedChildName, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		return updatedMS.Labels[mbutils.RevisionLabelKey] != msRevisionBefore
+	}, 2*time.Minute, 5*time.Second, "ModelServing revision label should change after spec update")
+
+	t.Log("Testing explicit deletion of ModelBooster")
 	err = kthenaClient.WorkloadV1alpha1().ModelBoosters(testNamespace).Delete(ctx, model.Name, metav1.DeleteOptions{})
 	require.NoError(t, err, "Failed to delete Model CR")
 
 	require.Eventually(t, func() bool {
 		_, err := kthenaClient.WorkloadV1alpha1().ModelBoosters(testNamespace).Get(ctx, model.Name, metav1.GetOptions{})
 		if err != nil {
-			// We expect a NotFound error here
 			return apierrors.IsNotFound(err)
 		}
 		return false
 	}, 2*time.Minute, 5*time.Second, "ModelBooster was not deleted")
+
+	t.Log("Verifying generated resources were garbage-collected")
+	ownerUIDSelector := labels.SelectorFromSet(map[string]string{
+		mbutils.OwnerUIDKey: string(createdModel.UID),
+	})
+	listOpts := metav1.ListOptions{LabelSelector: ownerUIDSelector.String()}
+
+	require.Eventually(t, func() bool {
+		list, err := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).List(ctx, listOpts)
+		return err == nil && len(list.Items) == 0
+	}, 2*time.Minute, 5*time.Second, "Orphan ModelServings should be garbage-collected")
+
+	require.Eventually(t, func() bool {
+		list, err := kthenaClient.NetworkingV1alpha1().ModelServers(testNamespace).List(ctx, listOpts)
+		return err == nil && len(list.Items) == 0
+	}, 2*time.Minute, 5*time.Second, "Orphan ModelServers should be garbage-collected")
+
+	require.Eventually(t, func() bool {
+		list, err := kthenaClient.NetworkingV1alpha1().ModelRoutes(testNamespace).List(ctx, listOpts)
+		return err == nil && len(list.Items) == 0
+	}, 2*time.Minute, 5*time.Second, "Orphan ModelRoutes should be garbage-collected")
 }
 
 // TestModelBoosterSelfHealing validates that the controller instantly self-heals deleted child resources.
 func TestModelBoosterSelfHealing(t *testing.T) {
 	ctx, kthenaClient, _ := setupControllerManagerE2ETest(t)
 
-	// Create a Model CR in the test namespace
-	model := createTestModel()
-	model.Name = "self-healing-test-model"
-	model.Spec.Name = "self-healing-test-model"
+	// Load the ModelBooster CR with autoscaling policy from YAML fixture
+	model := utils.LoadYAMLFromFile[workload.ModelBooster](filepath.Join(testDataDir, "ModelBooster-autoscaling.yaml"))
+	model.Namespace = testNamespace
 
 	waitForWebhookReady(t, ctx, kthenaClient, model.Namespace)
 
@@ -135,17 +197,29 @@ func TestModelBoosterSelfHealing(t *testing.T) {
 
 	t.Log("Model is active. Testing self-healing of ModelServing...")
 
-	// The controller contract guarantees the child resource is named: {modelName}-{backendName}
-	expectedChildName := fmt.Sprintf("%s-%s", model.Name, model.Spec.Backend.Name)
+	expectedChildName := mbutils.GetBackendResourceName(model.Name, model.Spec.Backend.Name)
 
-	// Fetch the generated ModelServing deterministically by name
+	policyToDelete, err := kthenaClient.WorkloadV1alpha1().AutoscalingPolicies(testNamespace).Get(ctx, expectedChildName, metav1.GetOptions{})
+	require.NoError(t, err, "Expected AutoscalingPolicy to be generated with deterministic name")
+
+	err = kthenaClient.WorkloadV1alpha1().AutoscalingPolicies(testNamespace).Delete(ctx, policyToDelete.Name, metav1.DeleteOptions{})
+	require.NoError(t, err, "Failed to delete AutoscalingPolicy")
+
+	require.Eventually(t, func() bool {
+		recreated, err := kthenaClient.WorkloadV1alpha1().AutoscalingPolicies(testNamespace).Get(ctx, policyToDelete.Name, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		return recreated.UID != policyToDelete.UID
+	}, 1*time.Minute, 2*time.Second, "Controller failed to self-heal deleted AutoscalingPolicy")
+
+	t.Log("AutoscalingPolicy was successfully self-healed. Testing ModelServing...")
 	servingToDelete, err := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Get(ctx, expectedChildName, metav1.GetOptions{})
 	require.NoError(t, err, "Expected ModelServing to be generated with deterministic name")
 
 	err = kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Delete(ctx, servingToDelete.Name, metav1.DeleteOptions{})
 	require.NoError(t, err, "Failed to delete ModelServing")
 
-	// Wait for the controller to self-heal and recreate it
 	require.Eventually(t, func() bool {
 		recreated, err := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Get(ctx, servingToDelete.Name, metav1.GetOptions{})
 		if err != nil {
@@ -154,106 +228,84 @@ func TestModelBoosterSelfHealing(t *testing.T) {
 		return recreated.UID != servingToDelete.UID
 	}, 1*time.Minute, 2*time.Second, "Controller failed to self-heal deleted ModelServing")
 
-	t.Log("ModelServing was successfully self-healed. Test complete.")
+	t.Log("ModelServing was successfully self-healed. Testing ModelServer...")
+
+	serverToDelete, err := kthenaClient.NetworkingV1alpha1().ModelServers(testNamespace).Get(ctx, expectedChildName, metav1.GetOptions{})
+	require.NoError(t, err, "Expected ModelServer to be generated with deterministic name")
+
+	err = kthenaClient.NetworkingV1alpha1().ModelServers(testNamespace).Delete(ctx, serverToDelete.Name, metav1.DeleteOptions{})
+	require.NoError(t, err, "Failed to delete ModelServer")
+
+	require.Eventually(t, func() bool {
+		recreated, err := kthenaClient.NetworkingV1alpha1().ModelServers(testNamespace).Get(ctx, serverToDelete.Name, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		return recreated.UID != serverToDelete.UID
+	}, 1*time.Minute, 2*time.Second, "Controller failed to self-heal deleted ModelServer")
+
+	t.Log("ModelServer was successfully self-healed. Testing ModelRoute...")
+
+	routeToDelete, err := kthenaClient.NetworkingV1alpha1().ModelRoutes(testNamespace).Get(ctx, model.Name, metav1.GetOptions{})
+	require.NoError(t, err, "Expected ModelRoute to be generated with model name")
+
+	err = kthenaClient.NetworkingV1alpha1().ModelRoutes(testNamespace).Delete(ctx, routeToDelete.Name, metav1.DeleteOptions{})
+	require.NoError(t, err, "Failed to delete ModelRoute")
+
+	require.Eventually(t, func() bool {
+		recreated, err := kthenaClient.NetworkingV1alpha1().ModelRoutes(testNamespace).Get(ctx, routeToDelete.Name, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		return recreated.UID != routeToDelete.UID
+	}, 1*time.Minute, 2*time.Second, "Controller failed to self-heal deleted ModelRoute")
+
+	t.Log("ModelRoute was successfully self-healed. Verifying AutoscalingPolicyBinding...")
+
+	binding, err := kthenaClient.WorkloadV1alpha1().AutoscalingPolicyBindings(testNamespace).Get(ctx, expectedChildName, metav1.GetOptions{})
+	require.NoError(t, err, "Expected AutoscalingPolicyBinding to be generated")
+	assertOwnedByModelBooster(t, binding.OwnerReferences, createdModel)
+
+	t.Log("All child resources self-healed successfully. Test complete.")
 }
 
 func createValidModelBoosterForWebhookTest() *workload.ModelBooster {
-	model := createTestModel()
+	model := utils.LoadYAMLFromFile[workload.ModelBooster](filepath.Join(testDataDir, "ModelBooster-vllm.yaml"))
 	model.Name = "webhook-test-model"
 	model.Spec.Name = "webhook-test-model"
 	return model
 }
 
-func createTestModel() *workload.ModelBooster {
-	// Create a simple config as JSON
-	config := &apiextensionsv1.JSON{}
-	configRaw := `{
-		"served-model-name": "test-model",
-		"max-model-len": 32768,
-		"max-num-batched-tokens": 65536,
-		"block-size": 128,
-		"enable-prefix-caching": ""
-	}`
-	config.Raw = []byte(configRaw)
-
-	return &workload.ModelBooster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-model",
-			Namespace: testNamespace,
-		},
-		Spec: workload.ModelBoosterSpec{
-			Name: "test-model",
-			Backend: workload.ModelBackend{
-				Name:     "backend1",
-				Type:     workload.ModelBackendTypeVLLM,
-				ModelURI: "hf://Qwen/Qwen2.5-0.5B-Instruct",
-				CacheURI: "hostpath:///tmp/cache",
-				Replicas: 1,
-				Workers: []workload.ModelWorker{
-					{
-						Type:      workload.ModelWorkerTypeServer,
-						Image:     "ghcr.io/huntersman/vllm-cpu-env:latest",
-						Replicas:  1,
-						Pods:      1,
-						Config:    *config,
-						Resources: corev1ResourceRequirements(),
-					},
-				},
-			},
-		},
-	}
-}
-
 func createInvalidModel() *workload.ModelBooster {
-	// Create a simple config as JSON
-	config := &apiextensionsv1.JSON{}
-	configRaw := `{
-		"served-model-name": "invalid-model",
-		"max-model-len": 32768,
-		"max-num-batched-tokens": 65536,
-		"block-size": 128,
-		"enable-prefix-caching": ""
-	}`
-	config.Raw = []byte(configRaw)
-
-	return &workload.ModelBooster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "invalid-model",
-			Namespace: testNamespace,
-		},
-		Spec: workload.ModelBoosterSpec{
-			Name: "invalid-model",
-			Backend: workload.ModelBackend{
-				Name:     "backend1",
-				Type:     workload.ModelBackendTypeVLLM,
-				ModelURI: "hf://Qwen/Qwen2.5-0.5B-Instruct",
-				CacheURI: "hostpath:///tmp/cache",
-				Replicas: 1000001, // invalid: greater than maximum
-				Workers: []workload.ModelWorker{
-					{
-						Type:      workload.ModelWorkerTypeServer,
-						Image:     "ghcr.io/huntersman/vllm-cpu-env:latest",
-						Replicas:  1,
-						Pods:      1,
-						Config:    *config,
-						Resources: corev1ResourceRequirements(),
-					},
-				},
-			},
-		},
-	}
+	model := utils.LoadYAMLFromFile[workload.ModelBooster](filepath.Join(testDataDir, "ModelBooster-vllm.yaml"))
+	model.Name = "invalid-model"
+	model.Spec.Name = "invalid-model"
+	model.Spec.Backend.MinReplicas = 5 // invalid: greater than maxReplicas
+	return model
 }
 
-// corev1ResourceRequirements is a helper to avoid duplication and keep imports clean
-func corev1ResourceRequirements() corev1.ResourceRequirements {
-	return corev1.ResourceRequirements{
-		Requests: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("2"),
-			corev1.ResourceMemory: resource.MustParse("4Gi"),
-		},
-		Limits: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("4"),
-			corev1.ResourceMemory: resource.MustParse("16Gi"),
-		},
-	}
+// assertOwnedByModelBooster verifies that an OwnerReference list contains exactly one entry
+// pointing to the given ModelBooster with controller=true and blockOwnerDeletion=true.
+func assertOwnedByModelBooster(t *testing.T, refs []metav1.OwnerReference, booster *workload.ModelBooster) {
+	t.Helper()
+	require.Len(t, refs, 1, "Expected exactly one OwnerReference")
+	ref := refs[0]
+	assert.Equal(t, booster.Name, ref.Name, "OwnerReference name should match ModelBooster")
+	assert.Equal(t, string(booster.UID), string(ref.UID), "OwnerReference UID should match ModelBooster")
+	assert.Equal(t, workload.ModelKind.Kind, ref.Kind, "OwnerReference kind should be ModelBooster")
+	require.NotNil(t, ref.Controller, "OwnerReference controller flag should be set")
+	assert.True(t, *ref.Controller, "OwnerReference controller should be true")
+	require.NotNil(t, ref.BlockOwnerDeletion, "OwnerReference blockOwnerDeletion flag should be set")
+	assert.True(t, *ref.BlockOwnerDeletion, "OwnerReference blockOwnerDeletion should be true")
+}
+
+// assertModelBoosterLabels verifies that a resource's labels contain the expected
+// ModelBooster controller labels. backendName should be "" for ModelRoute.
+func assertModelBoosterLabels(t *testing.T, resourceLabels map[string]string, booster *workload.ModelBooster, backendName string) {
+	t.Helper()
+	assert.Equal(t, booster.Name, resourceLabels[mbutils.ModelNameLabelKey], "label model-name")
+	assert.Equal(t, backendName, resourceLabels[mbutils.BackendNameLabelKey], "label backend-name")
+	assert.Equal(t, string(booster.UID), resourceLabels[mbutils.OwnerUIDKey], "label model-uid")
+	assert.Equal(t, workload.GroupName, resourceLabels[mbutils.ManageBy], "label managed-by")
+	assert.NotEmpty(t, resourceLabels[mbutils.RevisionLabelKey], "label revision should not be empty")
 }

--- a/test/e2e/controller-manager/model_booster_test.go
+++ b/test/e2e/controller-manager/model_booster_test.go
@@ -269,21 +269,6 @@ func TestModelBoosterSelfHealing(t *testing.T) {
 
 	expectedChildName := mbutils.GetBackendResourceName(model.Name, model.Spec.Backend.Name)
 
-	policyToDelete, err := kthenaClient.WorkloadV1alpha1().AutoscalingPolicies(testNamespace).Get(ctx, expectedChildName, metav1.GetOptions{})
-	require.NoError(t, err, "Expected AutoscalingPolicy to be generated with deterministic name")
-
-	err = kthenaClient.WorkloadV1alpha1().AutoscalingPolicies(testNamespace).Delete(ctx, policyToDelete.Name, metav1.DeleteOptions{})
-	require.NoError(t, err, "Failed to delete AutoscalingPolicy")
-
-	require.Eventually(t, func() bool {
-		recreated, err := kthenaClient.WorkloadV1alpha1().AutoscalingPolicies(testNamespace).Get(ctx, policyToDelete.Name, metav1.GetOptions{})
-		if err != nil {
-			return false
-		}
-		return recreated.UID != policyToDelete.UID
-	}, 1*time.Minute, 2*time.Second, "Controller failed to self-heal deleted AutoscalingPolicy")
-
-	t.Log("AutoscalingPolicy was successfully self-healed. Testing ModelServing...")
 	servingToDelete, err := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Get(ctx, expectedChildName, metav1.GetOptions{})
 	require.NoError(t, err, "Expected ModelServing to be generated with deterministic name")
 
@@ -330,12 +315,6 @@ func TestModelBoosterSelfHealing(t *testing.T) {
 		return recreated.UID != routeToDelete.UID
 	}, 1*time.Minute, 2*time.Second, "Controller failed to self-heal deleted ModelRoute")
 
-	t.Log("ModelRoute was successfully self-healed. Verifying AutoscalingPolicyBinding...")
-
-	binding, err := kthenaClient.WorkloadV1alpha1().AutoscalingPolicyBindings(testNamespace).Get(ctx, expectedChildName, metav1.GetOptions{})
-	require.NoError(t, err, "Expected AutoscalingPolicyBinding to be generated")
-	assertOwnedByModelBooster(t, binding.OwnerReferences, createdModel)
-
 	t.Log("All child resources self-healed successfully. Test complete.")
 }
 
@@ -350,7 +329,7 @@ func createInvalidModel() *workload.ModelBooster {
 	model := utils.LoadYAMLFromFile[workload.ModelBooster](filepath.Join(testDataDir, "ModelBooster-vllm.yaml"))
 	model.Name = "invalid-model"
 	model.Spec.Name = "invalid-model"
-	model.Spec.Backend.MinReplicas = 5 // invalid: greater than maxReplicas
+	model.Spec.Backend.Replicas = 1000001 // invalid: exceeds maximum allowed replicas
 	return model
 }
 

--- a/test/e2e/controller-manager/testdata/ModelBooster-autoscaling.yaml
+++ b/test/e2e/controller-manager/testdata/ModelBooster-autoscaling.yaml
@@ -4,18 +4,12 @@ metadata:
   name: self-healing-test-model
 spec:
   name: self-healing-test-model
-  autoscalingPolicy:
-    metrics:
-    - metricName: concurrency
-      targetValue: "10"
   backend:
     name: backend1
     type: vLLM
     modelURI: hf://Qwen/Qwen2.5-0.5B-Instruct
     cacheURI: hostpath:///tmp/cache
-    minReplicas: 1
-    # maxReplicas is set to 1 since this fixture only tests ASP generation and self-healing, not autoscaling
-    maxReplicas: 1
+    replicas: 1
     workers:
     - type: server
       image: ghcr.io/huntersman/vllm-cpu-env:latest

--- a/test/e2e/controller-manager/testdata/ModelBooster-autoscaling.yaml
+++ b/test/e2e/controller-manager/testdata/ModelBooster-autoscaling.yaml
@@ -1,0 +1,36 @@
+apiVersion: workload.serving.volcano.sh/v1alpha1
+kind: ModelBooster
+metadata:
+  name: self-healing-test-model
+spec:
+  name: self-healing-test-model
+  autoscalingPolicy:
+    metrics:
+    - metricName: concurrency
+      targetValue: "10"
+  backend:
+    name: backend1
+    type: vLLM
+    modelURI: hf://Qwen/Qwen2.5-0.5B-Instruct
+    cacheURI: hostpath:///tmp/cache
+    minReplicas: 1
+    # maxReplicas is set to 1 since this fixture only tests ASP generation and self-healing, not autoscaling
+    maxReplicas: 1
+    workers:
+    - type: server
+      image: ghcr.io/huntersman/vllm-cpu-env:latest
+      replicas: 1
+      pods: 1
+      config:
+        served-model-name: "self-healing-test-model"
+        max-model-len: 32768
+        max-num-batched-tokens: 65536
+        block-size: 128
+        enable-prefix-caching: ""
+      resources:
+        requests:
+          cpu: 2
+          memory: 4Gi
+        limits:
+          cpu: 4
+          memory: 16Gi

--- a/test/e2e/controller-manager/testdata/ModelBooster-vllm-disaggregated.yaml
+++ b/test/e2e/controller-manager/testdata/ModelBooster-vllm-disaggregated.yaml
@@ -9,8 +9,7 @@ spec:
     type: vLLMDisaggregated
     modelURI: hf://dummy-repo/dummy-model
     cacheURI: hostpath:///tmp/mock-cache
-    minReplicas: 1
-    maxReplicas: 1
+    replicas: 1
     workers:
     - type: prefill
       image: alpine:3.20

--- a/test/e2e/controller-manager/testdata/ModelBooster-vllm-disaggregated.yaml
+++ b/test/e2e/controller-manager/testdata/ModelBooster-vllm-disaggregated.yaml
@@ -9,7 +9,7 @@ spec:
     type: vLLMDisaggregated
     modelURI: hf://dummy-repo/dummy-model
     cacheURI: hostpath:///tmp/mock-cache
-    minReplicas: 0
+    minReplicas: 1
     maxReplicas: 1
     workers:
     - type: prefill

--- a/test/e2e/controller-manager/testdata/ModelBooster-vllm-disaggregated.yaml
+++ b/test/e2e/controller-manager/testdata/ModelBooster-vllm-disaggregated.yaml
@@ -1,0 +1,34 @@
+apiVersion: workload.serving.volcano.sh/v1alpha1
+kind: ModelBooster
+metadata:
+  name: test-model-disaggregated
+spec:
+  name: test-model-disaggregated
+  backend:
+    name: backend1
+    type: vLLMDisaggregated
+    modelURI: hf://dummy-repo/dummy-model
+    cacheURI: hostpath:///tmp/mock-cache
+    minReplicas: 0
+    maxReplicas: 1
+    workers:
+    - type: prefill
+      image: alpine:3.20
+      replicas: 1
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+      config:
+        served-model-name: "test-model-disaggregated"
+        max-model-len: 1024
+    - type: decode
+      image: alpine:3.20
+      replicas: 1
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+      config:
+        served-model-name: "test-model-disaggregated"
+        max-model-len: 1024

--- a/test/e2e/controller-manager/testdata/ModelBooster-vllm.yaml
+++ b/test/e2e/controller-manager/testdata/ModelBooster-vllm.yaml
@@ -9,8 +9,7 @@ spec:
     type: vLLM
     modelURI: hf://Qwen/Qwen2.5-0.5B-Instruct
     cacheURI: hostpath:///tmp/cache
-    minReplicas: 1
-    maxReplicas: 1
+    replicas: 1
     workers:
     - type: server
       image: ghcr.io/huntersman/vllm-cpu-env:latest

--- a/test/e2e/controller-manager/testdata/ModelBooster-vllm.yaml
+++ b/test/e2e/controller-manager/testdata/ModelBooster-vllm.yaml
@@ -1,0 +1,31 @@
+apiVersion: workload.serving.volcano.sh/v1alpha1
+kind: ModelBooster
+metadata:
+  name: test-model
+spec:
+  name: test-model
+  backend:
+    name: backend1
+    type: vLLM
+    modelURI: hf://Qwen/Qwen2.5-0.5B-Instruct
+    cacheURI: hostpath:///tmp/cache
+    minReplicas: 1
+    maxReplicas: 1
+    workers:
+    - type: server
+      image: ghcr.io/huntersman/vllm-cpu-env:latest
+      replicas: 1
+      pods: 1
+      config:
+        served-model-name: "test-model"
+        max-model-len: 32768
+        max-num-batched-tokens: 65536
+        block-size: 128
+        enable-prefix-caching: ""
+      resources:
+        requests:
+          cpu: 2
+          memory: 4Gi
+        limits:
+          cpu: 4
+          memory: 16Gi


### PR DESCRIPTION
**What type of PR is this?**
/kind enhancement 
<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:
The ModelBooster controller lacked comprehensive E2E coverage for its core reconciliation loop. Specifically, there were no concrete assertions verifying that the controller correctly synthesized its 5 child resources, correctly wired OwnerReferences for API Server garbage collection, or instantly self-healed deleted dependents.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
