### PR TITLE
feat(router): make pod metrics update interval configurable

### DIFF
--- a/pkg/kthena-router/datastore/store.go
+++ b/pkg/kthena-router/datastore/store.go
@@ -63,8 +63,9 @@ var (
 
 const (
 	// Configuration constants for fairness scheduling
-	defaultQueueQPS = 100
-	uppdateInterval = 1 * time.Second
+	defaultQueueQPS          = 100
+	defaultUpdateInterval    = 1 * time.Second
+	metricsUpdateIntervalEnv = "METRICS_UPDATE_INTERVAL"
 
 	// onFlightSyncInterval caps Redis read traffic from SyncOnFlightCounts.
 	// At most one HMGET is issued per interval regardless of request rate;
@@ -355,11 +356,12 @@ type store struct {
 	// initialSynced is used to indicate whether all the resources has been processed and storred into this store.
 	initialSynced *atomic.Bool
 	// model -> RequestPriorityQueue
-	requestWaitingQueue sync.Map
-	tokenTracker        TokenTracker
-	podRuntimeInspector PodRuntimeInspector
-	rootCtx             context.Context // Lifecycle context for queue goroutines, set by Run()
-	fairnessQueueConfig FairnessQueueConfig
+	requestWaitingQueue   sync.Map
+	tokenTracker          TokenTracker
+	podRuntimeInspector   PodRuntimeInspector
+	rootCtx               context.Context // Lifecycle context for queue goroutines, set by Run()
+	fairnessQueueConfig   FairnessQueueConfig
+	metricsUpdateInterval time.Duration
 }
 
 func New(opts ...Option) Store {
@@ -378,9 +380,10 @@ func New(opts ...Option) Store {
 		initialSynced:       &atomic.Bool{},
 		requestWaitingQueue: sync.Map{},
 		// Create token tracker with environment-based configuration
-		tokenTracker:        createTokenTracker(),
-		podRuntimeInspector: realPodRuntimeInspector{},
-		fairnessQueueConfig: createFairnessQueueConfig(),
+		tokenTracker:          createTokenTracker(),
+		podRuntimeInspector:   realPodRuntimeInspector{},
+		fairnessQueueConfig:   createFairnessQueueConfig(),
+		metricsUpdateInterval: parseMetricsUpdateInterval(),
 	}
 	for _, opt := range opts {
 		if opt != nil {
@@ -456,6 +459,17 @@ func isValidFairnessWeight(value float64) bool {
 	return !math.IsNaN(value) && !math.IsInf(value, 0) && value >= 0
 }
 
+func parseMetricsUpdateInterval() time.Duration {
+	if v := os.Getenv(metricsUpdateIntervalEnv); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			return d
+		} else {
+			klog.Warningf("Invalid %s: %q, using default %v", metricsUpdateIntervalEnv, v, defaultUpdateInterval)
+		}
+	}
+	return defaultUpdateInterval
+}
+
 func (s *store) Run(ctx context.Context) {
 	s.rootCtx = ctx
 	go func() {
@@ -472,7 +486,7 @@ func (s *store) Run(ctx context.Context) {
 					return true
 				})
 				s.initialSynced.Store(true)
-				time.Sleep(uppdateInterval)
+				time.Sleep(s.metricsUpdateInterval)
 			}
 		}
 	}()

--- a/pkg/kthena-router/datastore/store.go
+++ b/pkg/kthena-router/datastore/store.go
@@ -62,10 +62,11 @@ var (
 )
 
 const (
-	// Configuration constants for fairness scheduling
-	defaultQueueQPS          = 100
-	defaultUpdateInterval    = 1 * time.Second
-	metricsUpdateIntervalEnv = "METRICS_UPDATE_INTERVAL"
+	defaultQueueQPS = 100 //nolint:unused // pre-existing constant kept for future use
+
+	// defaultMetricsUpdateInterval is the default polling interval for pod metrics.
+	defaultMetricsUpdateInterval = 1 * time.Second
+	metricsUpdateIntervalEnv     = "METRICS_UPDATE_INTERVAL"
 
 	// onFlightSyncInterval caps Redis read traffic from SyncOnFlightCounts.
 	// At most one HMGET is issued per interval regardless of request rate;
@@ -464,10 +465,10 @@ func parseMetricsUpdateInterval() time.Duration {
 		if d, err := time.ParseDuration(v); err == nil && d > 0 {
 			return d
 		} else {
-			klog.Warningf("Invalid %s: %q, using default %v", metricsUpdateIntervalEnv, v, defaultUpdateInterval)
+			klog.Warningf("Invalid %s: %q, using default %v", metricsUpdateIntervalEnv, v, defaultMetricsUpdateInterval)
 		}
 	}
-	return defaultUpdateInterval
+	return defaultMetricsUpdateInterval
 }
 
 func (s *store) Run(ctx context.Context) {

--- a/pkg/kthena-router/datastore/store.go
+++ b/pkg/kthena-router/datastore/store.go
@@ -62,8 +62,6 @@ var (
 )
 
 const (
-	defaultQueueQPS = 100 //nolint:unused // pre-existing constant kept for future use
-
 	// defaultMetricsScrapeInterval is the default polling interval for pod metrics.
 	defaultMetricsScrapeInterval = 1 * time.Second
 	metricsScrapeIntervalEnv     = "METRICS_SCRAPE_INTERVAL"
@@ -474,6 +472,8 @@ func parseMetricsScrapeInterval() time.Duration {
 func (s *store) Run(ctx context.Context) {
 	s.rootCtx = ctx
 	go func() {
+		ticker := time.NewTicker(s.metricsScrapeInterval)
+		defer ticker.Stop()
 		for {
 			s.pods.Range(func(key, value any) bool {
 				if p, ok := value.(*PodInfo); ok {
@@ -483,12 +483,10 @@ func (s *store) Run(ctx context.Context) {
 				return true
 			})
 			s.initialSynced.Store(true)
-			t := time.NewTimer(s.metricsScrapeInterval)
 			select {
 			case <-ctx.Done():
-				t.Stop()
 				return
-			case <-t.C:
+			case <-ticker.C:
 			}
 		}
 	}()

--- a/pkg/kthena-router/datastore/store.go
+++ b/pkg/kthena-router/datastore/store.go
@@ -64,9 +64,9 @@ var (
 const (
 	defaultQueueQPS = 100 //nolint:unused // pre-existing constant kept for future use
 
-	// defaultMetricsUpdateInterval is the default polling interval for pod metrics.
-	defaultMetricsUpdateInterval = 1 * time.Second
-	metricsUpdateIntervalEnv     = "METRICS_UPDATE_INTERVAL"
+	// defaultMetricsScrapeInterval is the default polling interval for pod metrics.
+	defaultMetricsScrapeInterval = 1 * time.Second
+	metricsScrapeIntervalEnv     = "METRICS_SCRAPE_INTERVAL"
 
 	// onFlightSyncInterval caps Redis read traffic from SyncOnFlightCounts.
 	// At most one HMGET is issued per interval regardless of request rate;
@@ -362,7 +362,7 @@ type store struct {
 	podRuntimeInspector   PodRuntimeInspector
 	rootCtx               context.Context // Lifecycle context for queue goroutines, set by Run()
 	fairnessQueueConfig   FairnessQueueConfig
-	metricsUpdateInterval time.Duration
+	metricsScrapeInterval time.Duration
 }
 
 func New(opts ...Option) Store {
@@ -384,7 +384,7 @@ func New(opts ...Option) Store {
 		tokenTracker:          createTokenTracker(),
 		podRuntimeInspector:   realPodRuntimeInspector{},
 		fairnessQueueConfig:   createFairnessQueueConfig(),
-		metricsUpdateInterval: parseMetricsUpdateInterval(),
+		metricsScrapeInterval: parseMetricsScrapeInterval(),
 	}
 	for _, opt := range opts {
 		if opt != nil {
@@ -460,34 +460,35 @@ func isValidFairnessWeight(value float64) bool {
 	return !math.IsNaN(value) && !math.IsInf(value, 0) && value >= 0
 }
 
-func parseMetricsUpdateInterval() time.Duration {
-	if v := os.Getenv(metricsUpdateIntervalEnv); v != "" {
+func parseMetricsScrapeInterval() time.Duration {
+	if v := os.Getenv(metricsScrapeIntervalEnv); v != "" {
 		if d, err := time.ParseDuration(v); err == nil && d > 0 {
 			return d
 		} else {
-			klog.Warningf("Invalid %s: %q, using default %v", metricsUpdateIntervalEnv, v, defaultMetricsUpdateInterval)
+			klog.Warningf("Invalid %s: %q, using default %v", metricsScrapeIntervalEnv, v, defaultMetricsScrapeInterval)
 		}
 	}
-	return defaultMetricsUpdateInterval
+	return defaultMetricsScrapeInterval
 }
 
 func (s *store) Run(ctx context.Context) {
 	s.rootCtx = ctx
 	go func() {
 		for {
+			s.pods.Range(func(key, value any) bool {
+				if p, ok := value.(*PodInfo); ok {
+					s.updatePodMetrics(p)
+					s.updatePodModels(p)
+				}
+				return true
+			})
+			s.initialSynced.Store(true)
+			t := time.NewTimer(s.metricsScrapeInterval)
 			select {
 			case <-ctx.Done():
+				t.Stop()
 				return
-			default:
-				s.pods.Range(func(key, value any) bool {
-					if p, ok := value.(*PodInfo); ok {
-						s.updatePodMetrics(p)
-						s.updatePodModels(p)
-					}
-					return true
-				})
-				s.initialSynced.Store(true)
-				time.Sleep(s.metricsUpdateInterval)
+			case <-t.C:
 			}
 		}
 	}()

--- a/pkg/kthena-router/datastore/store_test.go
+++ b/pkg/kthena-router/datastore/store_test.go
@@ -43,6 +43,71 @@ func ptr[T any](v T) *T {
 	return &v
 }
 
+func TestParseMetricsUpdateInterval(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue string
+		expected time.Duration
+	}{
+		{
+			name:     "default when env not set",
+			envValue: "",
+			expected: defaultUpdateInterval,
+		},
+		{
+			name:     "valid duration 200ms",
+			envValue: "200ms",
+			expected: 200 * time.Millisecond,
+		},
+		{
+			name:     "valid duration 500ms",
+			envValue: "500ms",
+			expected: 500 * time.Millisecond,
+		},
+		{
+			name:     "valid duration 5s",
+			envValue: "5s",
+			expected: 5 * time.Second,
+		},
+		{
+			name:     "invalid duration falls back to default",
+			envValue: "notaduration",
+			expected: defaultUpdateInterval,
+		},
+		{
+			name:     "zero duration falls back to default",
+			envValue: "0s",
+			expected: defaultUpdateInterval,
+		},
+		{
+			name:     "negative duration falls back to default",
+			envValue: "-1s",
+			expected: defaultUpdateInterval,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.envValue != "" {
+				t.Setenv("METRICS_UPDATE_INTERVAL", tc.envValue)
+			}
+			got := parseMetricsUpdateInterval()
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+func TestNewStoreUsesMetricsUpdateInterval(t *testing.T) {
+	t.Setenv("METRICS_UPDATE_INTERVAL", "2s")
+	s := New().(*store)
+	assert.Equal(t, 2*time.Second, s.metricsUpdateInterval)
+}
+
+func TestNewStoreUsesDefaultMetricsUpdateInterval(t *testing.T) {
+	s := New().(*store)
+	assert.Equal(t, defaultUpdateInterval, s.metricsUpdateInterval)
+}
+
 func TestCreateFairnessQueueConfig_RejectsInvalidWeights(t *testing.T) {
 	t.Setenv("FAIRNESS_PRIORITY_TOKEN_WEIGHT", "NaN")
 	t.Setenv("FAIRNESS_PRIORITY_REQUEST_NUM_WEIGHT", strconv.FormatFloat(math.Inf(1), 'f', -1, 64))

--- a/pkg/kthena-router/datastore/store_test.go
+++ b/pkg/kthena-router/datastore/store_test.go
@@ -50,9 +50,9 @@ func TestParseMetricsUpdateInterval(t *testing.T) {
 		expected time.Duration
 	}{
 		{
-			name:     "default when env not set",
+			name:     "default when env empty",
 			envValue: "",
-			expected: defaultUpdateInterval,
+			expected: defaultMetricsUpdateInterval,
 		},
 		{
 			name:     "valid duration 200ms",
@@ -72,17 +72,17 @@ func TestParseMetricsUpdateInterval(t *testing.T) {
 		{
 			name:     "invalid duration falls back to default",
 			envValue: "notaduration",
-			expected: defaultUpdateInterval,
+			expected: defaultMetricsUpdateInterval,
 		},
 		{
 			name:     "zero duration falls back to default",
 			envValue: "0s",
-			expected: defaultUpdateInterval,
+			expected: defaultMetricsUpdateInterval,
 		},
 		{
 			name:     "negative duration falls back to default",
 			envValue: "-1s",
-			expected: defaultUpdateInterval,
+			expected: defaultMetricsUpdateInterval,
 		},
 	}
 
@@ -104,7 +104,7 @@ func TestNewStoreUsesMetricsUpdateInterval(t *testing.T) {
 func TestNewStoreUsesDefaultMetricsUpdateInterval(t *testing.T) {
 	t.Setenv("METRICS_UPDATE_INTERVAL", "")
 	s := New().(*store)
-	assert.Equal(t, defaultUpdateInterval, s.metricsUpdateInterval)
+	assert.Equal(t, defaultMetricsUpdateInterval, s.metricsUpdateInterval)
 }
 
 func TestCreateFairnessQueueConfig_RejectsInvalidWeights(t *testing.T) {

--- a/pkg/kthena-router/datastore/store_test.go
+++ b/pkg/kthena-router/datastore/store_test.go
@@ -88,9 +88,7 @@ func TestParseMetricsUpdateInterval(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if tc.envValue != "" {
-				t.Setenv("METRICS_UPDATE_INTERVAL", tc.envValue)
-			}
+			t.Setenv("METRICS_UPDATE_INTERVAL", tc.envValue)
 			got := parseMetricsUpdateInterval()
 			assert.Equal(t, tc.expected, got)
 		})
@@ -104,6 +102,7 @@ func TestNewStoreUsesMetricsUpdateInterval(t *testing.T) {
 }
 
 func TestNewStoreUsesDefaultMetricsUpdateInterval(t *testing.T) {
+	t.Setenv("METRICS_UPDATE_INTERVAL", "")
 	s := New().(*store)
 	assert.Equal(t, defaultUpdateInterval, s.metricsUpdateInterval)
 }

--- a/pkg/kthena-router/datastore/store_test.go
+++ b/pkg/kthena-router/datastore/store_test.go
@@ -43,7 +43,7 @@ func ptr[T any](v T) *T {
 	return &v
 }
 
-func TestParseMetricsUpdateInterval(t *testing.T) {
+func TestParseMetricsScrapeInterval(t *testing.T) {
 	tests := []struct {
 		name     string
 		envValue string
@@ -52,7 +52,7 @@ func TestParseMetricsUpdateInterval(t *testing.T) {
 		{
 			name:     "default when env empty",
 			envValue: "",
-			expected: defaultMetricsUpdateInterval,
+			expected: defaultMetricsScrapeInterval,
 		},
 		{
 			name:     "valid duration 200ms",
@@ -72,39 +72,39 @@ func TestParseMetricsUpdateInterval(t *testing.T) {
 		{
 			name:     "invalid duration falls back to default",
 			envValue: "notaduration",
-			expected: defaultMetricsUpdateInterval,
+			expected: defaultMetricsScrapeInterval,
 		},
 		{
 			name:     "zero duration falls back to default",
 			envValue: "0s",
-			expected: defaultMetricsUpdateInterval,
+			expected: defaultMetricsScrapeInterval,
 		},
 		{
 			name:     "negative duration falls back to default",
 			envValue: "-1s",
-			expected: defaultMetricsUpdateInterval,
+			expected: defaultMetricsScrapeInterval,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Setenv("METRICS_UPDATE_INTERVAL", tc.envValue)
-			got := parseMetricsUpdateInterval()
+			t.Setenv("METRICS_SCRAPE_INTERVAL", tc.envValue)
+			got := parseMetricsScrapeInterval()
 			assert.Equal(t, tc.expected, got)
 		})
 	}
 }
 
-func TestNewStoreUsesMetricsUpdateInterval(t *testing.T) {
-	t.Setenv("METRICS_UPDATE_INTERVAL", "2s")
+func TestNewStoreUsesMetricsScrapeInterval(t *testing.T) {
+	t.Setenv("METRICS_SCRAPE_INTERVAL", "2s")
 	s := New().(*store)
-	assert.Equal(t, 2*time.Second, s.metricsUpdateInterval)
+	assert.Equal(t, 2*time.Second, s.metricsScrapeInterval)
 }
 
-func TestNewStoreUsesDefaultMetricsUpdateInterval(t *testing.T) {
-	t.Setenv("METRICS_UPDATE_INTERVAL", "")
+func TestNewStoreUsesDefaultMetricsScrapeInterval(t *testing.T) {
+	t.Setenv("METRICS_SCRAPE_INTERVAL", "")
 	s := New().(*store)
-	assert.Equal(t, defaultMetricsUpdateInterval, s.metricsUpdateInterval)
+	assert.Equal(t, defaultMetricsScrapeInterval, s.metricsScrapeInterval)
 }
 
 func TestCreateFairnessQueueConfig_RejectsInvalidWeights(t *testing.T) {


### PR DESCRIPTION
## Problem

The pod metrics update interval is hardcoded to `1 * time.Second` in `pkg/kthena-router/datastore/store.go`. This fixed interval may not be optimal for all deployments:

- **High-traffic environments** benefit from shorter intervals (e.g., 200ms–500ms) for fresher scheduling decisions.
- **Large-scale clusters** prefer longer intervals (e.g., 5s–10s) to reduce scraping overhead on the router.

## Summary of Changes

- Made the metrics update interval configurable via `METRICS_UPDATE_INTERVAL` environment variable (e.g., `500ms`, `5s`)
- Retains `1s` as the default for backward compatibility
- Fixed existing typo: `uppdateInterval` → `defaultMetricsUpdateInterval`
- Follows the same env-var parsing pattern used by `FAIRNESS_WINDOW_SIZE` and other `FAIRNESS_*` parameters
- Tests explicitly isolate env vars via `t.Setenv` to avoid host-dependent failures

## Testing

- Added table-driven unit tests for `parseMetricsUpdateInterval()` covering: default (empty env), valid durations (200ms, 500ms, 5s), invalid string, zero, and negative values
- Added integration tests verifying `New()` correctly wires the configured interval into the store struct
- All existing tests pass (`make test` — 157 pass)
- `make lint` passes clean
- `go fmt` verified

## Configuration Example

```bash
# Set metrics update interval to 500ms for high-traffic environments
export METRICS_UPDATE_INTERVAL=500ms

# Set to 5s for large clusters to reduce scraping overhead
export METRICS_UPDATE_INTERVAL=5s
```

Fixes #1147