### PR TITLE
Fix concurrent graceMap check/store race in handleErrorPod

### DIFF
--- a/pkg/model-serving-controller/controller/model_serving_controller.go
+++ b/pkg/model-serving-controller/controller/model_serving_controller.go
@@ -1336,14 +1336,13 @@ func (c *ModelServingController) handleReadyPod(ms *workloadv1alpha1.ModelServin
 
 func (c *ModelServingController) handleErrorPod(ms *workloadv1alpha1.ModelServing, servingGroupName string, errPod *corev1.Pod) error {
 	// pod is already in the grace period and does not need to be processed for the time being.
-	_, exists := c.graceMap.Load(utils.GetNamespaceName(errPod))
+	key := utils.GetNamespaceName(errPod)
 	now := time.Now()
-	if exists {
-		klog.V(4).Infof("Pod %v failed, waiting for grace time", utils.GetNamespaceName(errPod))
+	_, loaded := c.graceMap.LoadOrStore(key, now)
+	if loaded {
+		klog.V(4).Infof("Pod %v already in grace period", key)
 		return nil
 	}
-	// add pod to the grace period map
-	c.graceMap.Store(utils.GetNamespaceName(errPod), now)
 	c.store.DeleteRunningPodFromServingGroup(types.NamespacedName{
 		Namespace: ms.Namespace,
 		Name:      ms.Name,


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR fixes a potential race condition in `handleErrorPod()` caused by the non-atomic `Load()` + `Store()` access pattern on `graceMap`.

Previously, concurrent goroutines could both observe a missing entry before either stored the key, resulting in duplicate grace-period handling for the same error pod.

The fix replaces the check-then-store flow with atomic `LoadOrStore()` usage to guarantee that only one goroutine proceeds with pod recovery handling.

**Which issue(s) this PR fixes**:
Fixes #<issue-number>

**Special notes for your reviewer**:

The previous implementation was functionally correct in most cases, but still exposed a TOCTOU race window during concurrent pod failure handling. Using `LoadOrStore()` removes the overlap window and aligns the flow with idiomatic concurrent map access patterns in Go.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
