### PR TITLE
Fix router graceful shutdown and expose router active-requests metric

### DIFF
--- a/charts/kthena/charts/networking/templates/kthena-router/component/deployment.yaml
+++ b/charts/kthena/charts/networking/templates/kthena-router/component/deployment.yaml
@@ -114,6 +114,13 @@ spec:
               {{- end }}
             initialDelaySeconds: 1
             periodSeconds: 5
+<<<<<<< HEAD
+=======
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sleep", "5"]
+>>>>>>> 49cced6d (updated the gracefull shutown to see the current request count instead of terminating after 30sec)
           volumeMounts:
           - name: scheduler-config
             mountPath: /etc/config/routerConfiguration.yaml
@@ -144,3 +151,7 @@ spec:
             optional: true
         {{- end }}
       serviceAccountName: kthena-router
+<<<<<<< HEAD
+=======
+      terminationGracePeriodSeconds: 330
+>>>>>>> 49cced6d (updated the gracefull shutown to see the current request count instead of terminating after 30sec)

--- a/charts/kthena/charts/networking/values.yaml
+++ b/charts/kthena/charts/networking/values.yaml
@@ -34,6 +34,11 @@ kthenaRouter:
     requests:
       cpu: 100m
       memory: 128Mi
+<<<<<<< HEAD
+=======
+  # The router will drain all in-flight requests before forcefully closing connections
+  terminationGracePeriodSeconds: 330
+>>>>>>> 49cced6d (updated the gracefull shutown to see the current request count instead of terminating after 30sec)
   # fairness configuration for request scheduling
   fairness:
     # enabled controls whether fairness scheduling is active

--- a/charts/kthena/values.yaml
+++ b/charts/kthena/values.yaml
@@ -83,6 +83,11 @@ networking:
       # -- Enable Gateway API Inference Extension features.<br/>
       # Requires `gatewayAPI.enabled` to be true.
       inferenceExtension: false
+<<<<<<< HEAD
+=======
+    # The router will drain all in-flight requests before forcefully closing connections.
+    terminationGracePeriodSeconds: 330
+>>>>>>> 49cced6d (updated the gracefull shutown to see the current request count instead of terminating after 30sec)
 
 global:
   # -- Certificate Management Mode.<br/>

--- a/cmd/kthena-router/app/router.go
+++ b/cmd/kthena-router/app/router.go
@@ -157,7 +157,11 @@ func (s *Server) startDebugServer(ctx context.Context, store datastore.Store) {
 
 	go func() {
 		<-ctx.Done()
+<<<<<<< HEAD
 		// graceful shutdown
+=======
+		// graceful shutdown with timeout as it does not handle real traffic
+>>>>>>> 49cced6d (updated the gracefull shutown to see the current request count instead of terminating after 30sec)
 		klog.Info("Shutting down debug HTTP server ...")
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), gracefulShutdownTimeout)
 		defer cancel()
@@ -200,8 +204,14 @@ type listenerConfig struct {
 	tlsKeyFile    string
 	tlsMissingMsg string
 	// Default-server mode: health, metrics, /v1.
+<<<<<<< HEAD
 	defaultRouter *router.Router
 	readyCheck    func() bool
+=======
+	defaultRouter  *router.Router
+	readyCheck     func() bool
+	activeRequests func() int64
+>>>>>>> 49cced6d (updated the gracefull shutown to see the current request count instead of terminating after 30sec)
 	// Gateway mode (non-nil => use gateway branch).
 	gateway          *listenerGatewayConfig
 	startLog         string

--- a/docs/kthena/docs/reference/helm-chart-values.md
+++ b/docs/kthena/docs/reference/helm-chart-values.md
@@ -30,6 +30,7 @@ A Helm chart for deploying Kthena
 | networking.kthenaRouter.image.repository | string | `"ghcr.io/volcano-sh/kthena-router"` | Image repository for Kthena Router. |
 | networking.kthenaRouter.image.tag | string | `"latest"` | Image tag for Kthena Router. |
 | networking.kthenaRouter.port | int | `8080` | Container port for Kthena Router. |
+| networking.kthenaRouter.terminationGracePeriodSeconds | int | `330` |  |
 | networking.kthenaRouter.tls.dnsName | string | `"your-domain.com"` | DNS name to use for the certificate. |
 | networking.kthenaRouter.tls.enabled | bool | `false` | Enable TLS for Kthena Router server. |
 | networking.kthenaRouter.tls.secretName | string | `"kthena-router-tls"` | Secret name to store the certificate and key. |

--- a/pkg/kthena-router/webhook/validator.go
+++ b/pkg/kthena-router/webhook/validator.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"net"
 	"net/http"
 	"strings"
 	"time"
@@ -39,6 +40,7 @@ const timeout = 30 * time.Second
 type KthenaRouterValidator struct {
 	httpServer *http.Server
 	kubeClient kubernetes.Interface
+	readyCh    chan struct{} // Signals when the webhook server is ready to accept requests
 }
 
 // NewKthenaRouterValidator creates a new KthenaRouterValidator.
@@ -55,6 +57,7 @@ func NewKthenaRouterValidator(kubeClient kubernetes.Interface, port int) *Kthena
 	return &KthenaRouterValidator{
 		httpServer: server,
 		kubeClient: kubeClient,
+		readyCh:    make(chan struct{}),
 	}
 }
 
@@ -78,7 +81,31 @@ func (v *KthenaRouterValidator) Run(ctx context.Context, tlsCertFile, tlsPrivate
 		}
 	}()
 
-	// shutdown gracefully shuts down the server
+	// Wait for server to be ready by attempting to connect via the readiness check
+	// This ensures the TLS listener is actually accepting connections before returning
+	readyCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	for {
+		select {
+		case <-readyCtx.Done():
+			klog.Fatalf("webhook server failed to become ready within timeout")
+		case <-time.After(100 * time.Millisecond):
+			// Try to establish a connection to verify the server is listening
+			conn, err := net.DialTimeout("tcp", v.httpServer.Addr, 1*time.Second)
+			if err == nil {
+				conn.Close()
+				close(v.readyCh)
+				klog.Infof("Webhook server is ready and accepting connections")
+				break
+			}
+		}
+		// If we broke out of the loop, we're ready
+		if v.readyCh == nil {
+			break
+		}
+	}
+
+	// Wait for context cancellation
 	<-ctx.Done()
 	v.shutdown()
 }

--- a/test/e2e/router/webhook_test.go
+++ b/test/e2e/router/webhook_test.go
@@ -28,11 +28,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-//
-// The validating webhook is served by the kthena-router pod itself, not a separate
-// deployment. TestRouterConfigUpdate deliberately restarts the kthena-router pod before
-// this test runs.
-
 // TestKthenaRouterValidatingWebhook ensures the networking chart's ValidatingWebhookConfiguration
 // targets the real API group and the router webhook rejects invalid ModelRoute specs.
 // Invalid case uses an empty string in loraAdapters (CRD CEL allows non-empty list; webhook rejects item).

--- a/test/e2e/router/webhook_test.go
+++ b/test/e2e/router/webhook_test.go
@@ -29,7 +29,9 @@ import (
 )
 
 //
-// The validating webhook is served by the kthena-router pod itself, not a separate// deployment. TestRouter
+// The validating webhook is served by the kthena-router pod itself, not a separate
+// deployment. TestRouterConfigUpdate deliberately restarts the kthena-router pod before
+// this test runs.
 
 // TestKthenaRouterValidatingWebhook ensures the networking chart's ValidatingWebhookConfiguration
 // targets the real API group and the router webhook rejects invalid ModelRoute specs.


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind bug
-->

**What this PR does / why we need it**
Currently, graceful shutdown does not account for in-flight requests, causing active requests to be canceled mid-flight when the router exits. This PR fixes that by tracking in-flight requests with an atomic counter, waiting for them to drain before shutdown completes, and exposing the counter as a Prometheus gauge (kthena_router_active_requests).

**Which issue(s) this PR fixes**:
Fixes 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
Router now waits for in-flight requests to drain before shutting down and exposes a Prometheus gauge `kthena_router_active_requests`. Chart default sets `terminationGracePeriodSeconds` to 330s to align with the drain window.

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
