### PR TITLE
fix: correct docs anchor typo and validator error messages

### DIFF
--- a/docs/kthena/docs/user-guide/router-routing.md
+++ b/docs/kthena/docs/user-guide/router-routing.md
@@ -9,7 +9,7 @@ Kthena Router provides sophisticated traffic routing capabilities that enable in
 - **ModelServer**: Defines backend inference service instances with their associated pods, models, and traffic policies. It uses **workloadSelector.matchLabels** to select which pods belong to it (pods must match all given labels); this applies to every ModelServer.
 - **ModelRoute**: Defines routing rules based on request characteristics such as model name, LoRA adapters, HTTP headers, and weight distribution
 
-For a detailed definition of the ModelServer and ModelRoute CRs, please refer to the [ModelRoute and ModelRoute Reference](../reference/crd/networking.serving.volcano.sh.md) pages.
+For a detailed definition of the ModelServer and ModelRoute CRs, please refer to the [ModelServer and ModelRoute Reference](../reference/crd/networking.serving.volcano.sh.md) pages.
 
 The router supports various routing strategies, from simple model-based forwarding to complex weighted distribution, header-based routing, and PD-Disaggregated (Prefill/Decode) routing. This flexibility allows for advanced deployment patterns including canary releases, A/B testing, load balancing across heterogeneous model deployments, and PD-Disaggregated inference for lower latency and better resource utilization.
 

--- a/pkg/model-serving-controller/webhook/validator.go
+++ b/pkg/model-serving-controller/webhook/validator.go
@@ -181,7 +181,7 @@ func validatorReplicas(ms *workloadv1alpha1.ModelServing) field.ErrorList {
 		allErrs = append(allErrs, field.Invalid(
 			field.NewPath("spec").Child("replicas"),
 			ms.Spec.Replicas,
-			"replicas must be a positive integer",
+			"replicas must be a non-negative integer",
 		))
 	}
 
@@ -199,7 +199,7 @@ func validatorReplicas(ms *workloadv1alpha1.ModelServing) field.ErrorList {
 			allErrs = append(allErrs, field.Invalid(
 				field.NewPath("spec").Child("template").Child("roles").Index(i).Child("replicas"),
 				role.Replicas,
-				"role replicas must be a positive integer",
+				"role replicas must be a non-negative integer",
 			))
 		}
 	}

--- a/pkg/model-serving-controller/webhook/validator_test.go
+++ b/pkg/model-serving-controller/webhook/validator_test.go
@@ -556,7 +556,7 @@ func TestValidatorReplicas(t *testing.T) {
 				field.Invalid(
 					field.NewPath("spec").Child("replicas"),
 					int32PtrNil(),
-					"replicas must be a positive integer",
+					"replicas must be a non-negative integer",
 				),
 			},
 		},
@@ -589,7 +589,7 @@ func TestValidatorReplicas(t *testing.T) {
 				field.Invalid(
 					field.NewPath("spec").Child("replicas"),
 					int32Ptr(-1),
-					"replicas must be a positive integer",
+					"replicas must be a non-negative integer",
 				),
 			},
 		},
@@ -622,7 +622,7 @@ func TestValidatorReplicas(t *testing.T) {
 				field.Invalid(
 					field.NewPath("spec").Child("template").Child("roles").Index(0).Child("replicas"),
 					int32Ptr(-1),
-					"role replicas must be a positive integer",
+					"role replicas must be a non-negative integer",
 				),
 			},
 		},
@@ -655,7 +655,7 @@ func TestValidatorReplicas(t *testing.T) {
 				field.Invalid(
 					field.NewPath("spec").Child("template").Child("roles").Index(0).Child("replicas"),
 					int32PtrNil(),
-					"role replicas must be a positive integer",
+					"role replicas must be a non-negative integer",
 				),
 			},
 		},


### PR DESCRIPTION
## Summary

- Fix copy-paste typo in `docs/kthena/docs/user-guide/router-routing.md`: anchor text read "ModelRoute and ModelRoute" instead of "ModelServer and ModelRoute"
- Fix misleading validator error messages in `pkg/model-serving-controller/webhook/validator.go`: validation allows zero replicas (`< 0` check) but error message said "positive integer", changed to "non-negative integer" to match actual behavior

Closes #964

## Test plan

- All 52 webhook validator tests pass
- Verified the error message strings in tests match the updated validator