### PR TITLE
fix: use random serial numbers for webhook certificates

### DIFF
--- a/pkg/webhook/cert/generator.go
+++ b/pkg/webhook/cert/generator.go
@@ -61,8 +61,13 @@ func GenerateSelfSignedCertificate(dnsNames []string) (*CertBundle, error) {
 		return nil, fmt.Errorf("failed to generate CA key: %w", err)
 	}
 
+	caSerial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate CA serial number: %w", err)
+	}
+
 	caTemplate := &x509.Certificate{
-		SerialNumber: big.NewInt(1),
+		SerialNumber: caSerial,
 		Subject: pkix.Name{
 			CommonName:   "kthena-webhook-ca",
 			Organization: []string{"Volcano"},
@@ -85,8 +90,13 @@ func GenerateSelfSignedCertificate(dnsNames []string) (*CertBundle, error) {
 		return nil, fmt.Errorf("failed to generate server key: %w", err)
 	}
 
+	serverSerial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate server serial number: %w", err)
+	}
+
 	serverTemplate := &x509.Certificate{
-		SerialNumber: big.NewInt(2),
+		SerialNumber: serverSerial,
 		Subject: pkix.Name{
 			CommonName:   dnsNames[0],
 			Organization: []string{"Volcano"},

--- a/pkg/webhook/cert/generator_test.go
+++ b/pkg/webhook/cert/generator_test.go
@@ -110,6 +110,45 @@ func TestGenerateSelfSignedCertificate_MultipleDNSNames(t *testing.T) {
 	assert.Equal(t, dnsNames[0], serverCert.Subject.CommonName)
 }
 
+func TestGenerateSelfSignedCertificate_RandomSerialNumbers(t *testing.T) {
+	dnsNames := []string{"webhook.default.svc"}
+
+	bundle1, err := GenerateSelfSignedCertificate(dnsNames)
+	require.NoError(t, err)
+
+	bundle2, err := GenerateSelfSignedCertificate(dnsNames)
+	require.NoError(t, err)
+
+	// Parse CA certs
+	ca1Block, _ := pem.Decode(bundle1.CAPEM)
+	ca1, err := x509.ParseCertificate(ca1Block.Bytes)
+	require.NoError(t, err)
+
+	ca2Block, _ := pem.Decode(bundle2.CAPEM)
+	ca2, err := x509.ParseCertificate(ca2Block.Bytes)
+	require.NoError(t, err)
+
+	// Parse server certs
+	srv1Block, _ := pem.Decode(bundle1.CertPEM)
+	srv1, err := x509.ParseCertificate(srv1Block.Bytes)
+	require.NoError(t, err)
+
+	srv2Block, _ := pem.Decode(bundle2.CertPEM)
+	srv2, err := x509.ParseCertificate(srv2Block.Bytes)
+	require.NoError(t, err)
+
+	// Serial numbers must be positive
+	assert.True(t, ca1.SerialNumber.Sign() > 0, "CA serial must be positive")
+	assert.True(t, srv1.SerialNumber.Sign() > 0, "server serial must be positive")
+
+	// Serial numbers from different calls must differ
+	assert.NotEqual(t, ca1.SerialNumber, ca2.SerialNumber, "CA serials should differ across calls")
+	assert.NotEqual(t, srv1.SerialNumber, srv2.SerialNumber, "server serials should differ across calls")
+
+	// CA and server serials within the same bundle must differ
+	assert.NotEqual(t, ca1.SerialNumber, srv1.SerialNumber, "CA and server serials should differ")
+}
+
 func TestGenerateSelfSignedCertificate_EmptyDNSNames(t *testing.T) {
 	dnsNames := []string{}
 


### PR DESCRIPTION
## Summary

Replace fixed serial numbers (1 for CA, 2 for server) with cryptographically random 128-bit serial numbers in `GenerateSelfSignedCertificate`. This follows RFC 5280 recommendations and ensures regenerated certificates are distinguishable.

Closes #1066

## Test plan

- Added `TestGenerateSelfSignedCertificate_RandomSerialNumbers` verifying:
  - Serial numbers are positive
  - CA and server serials differ within the same bundle
  - Serial numbers differ across separate calls
- All 13 cert package tests pass