### PR TITLE
fix: use stable sort with pod name tiebreaker in TopNPodInfos

### DIFF
--- a/pkg/kthena-router/scheduler/scheduler_impl.go
+++ b/pkg/kthena-router/scheduler/scheduler_impl.go
@@ -261,8 +261,11 @@ func TopNPodInfos(m map[*datastore.PodInfo]int, n int) []*datastore.PodInfo {
 		list = append(list, podInfoWithValue{pod: k, score: v})
 	}
 
-	sort.Slice(list, func(i, j int) bool {
-		return list[i].score > list[j].score
+	sort.SliceStable(list, func(i, j int) bool {
+		if list[i].score != list[j].score {
+			return list[i].score > list[j].score
+		}
+		return list[i].pod.Pod.Name < list[j].pod.Pod.Name
 	})
 
 	res := []*datastore.PodInfo{}

--- a/pkg/kthena-router/scheduler/scheduler_impl.go
+++ b/pkg/kthena-router/scheduler/scheduler_impl.go
@@ -265,7 +265,7 @@ func TopNPodInfos(m map[*datastore.PodInfo]int, n int) []*datastore.PodInfo {
 		if list[i].score != list[j].score {
 			return list[i].score > list[j].score
 		}
-		return list[i].pod.Pod.Name < list[j].pod.Pod.Name
+		return podKey(list[i].pod) < podKey(list[j].pod)
 	})
 
 	res := []*datastore.PodInfo{}
@@ -277,4 +277,13 @@ func TopNPodInfos(m map[*datastore.PodInfo]int, n int) []*datastore.PodInfo {
 	}
 
 	return res
+}
+
+// podKey returns a namespace/name string for deterministic sorting.
+// Returns empty string if the PodInfo or its Pod is nil.
+func podKey(p *datastore.PodInfo) string {
+	if p == nil || p.Pod == nil {
+		return ""
+	}
+	return p.Pod.Namespace + "/" + p.Pod.Name
 }

--- a/pkg/kthena-router/scheduler/scheduler_impl_test.go
+++ b/pkg/kthena-router/scheduler/scheduler_impl_test.go
@@ -117,6 +117,29 @@ func TestTopNPodInfosOrdering(t *testing.T) {
 	assert.Equal(t, "pod1", result[2].Pod.Name)
 }
 
+// TestTopNPodInfosEqualScores verifies that pods with equal scores are ordered
+// deterministically by pod name, preserving cache affinity across calls.
+func TestTopNPodInfosEqualScores(t *testing.T) {
+	podA := createTestPodInfo("pod-a")
+	podB := createTestPodInfo("pod-b")
+	podC := createTestPodInfo("pod-c")
+
+	scores := map[*datastore.PodInfo]int{
+		podA: 100,
+		podB: 100,
+		podC: 100,
+	}
+
+	// Run multiple times to confirm determinism despite map iteration order.
+	for i := 0; i < 20; i++ {
+		result := TopNPodInfos(scores, 3)
+		require.Equal(t, 3, len(result))
+		assert.Equal(t, "pod-a", result[0].Pod.Name, "iteration %d", i)
+		assert.Equal(t, "pod-b", result[1].Pod.Name, "iteration %d", i)
+		assert.Equal(t, "pod-c", result[2].Pod.Name, "iteration %d", i)
+	}
+}
+
 // TestSchedulePDGroup uses table-driven tests to validate PD scheduling behavior.
 // It covers both graceful degradation (no prefill pods) and the happy path (valid prefill pod).
 func TestSchedulePDGroup(t *testing.T) {


### PR DESCRIPTION
## Summary

`TopNPodInfos` iterates a `map[*datastore.PodInfo]int` (random order in Go) and then uses `sort.Slice` (unstable). When multiple pods have equal aggregate scores, the selected pod is non-deterministic across calls, which breaks prefix-cache affinity.

Fix:
- Switch from `sort.Slice` to `sort.SliceStable`
- Add pod name as a deterministic tiebreaker when scores are equal

Closes #1163

## Test plan

- Added `TestTopNPodInfosEqualScores`: three pods with identical scores, run 20 iterations, verify consistent alphabetical ordering by pod name
- All 291 scheduler tests pass