### PR TITLE
fix: guard PodInfo access against data races

### DIFF
--- a/pkg/kthena-router/controller/modelserver_controller.go
+++ b/pkg/kthena-router/controller/modelserver_controller.go
@@ -219,14 +219,18 @@ func (c *ModelServerController) syncModelServerHandler(key string) error {
 	// Build a set of existing pod names that are already bound to the model server
 	existingPodNames := sets.New[types.NamespacedName]()
 	for _, podInfo := range existingPods {
+		pod := podInfo.GetPod()
+		if pod == nil {
+			continue
+		}
 		if !podInfo.HasModelServer(utils.GetNamespaceName(ms)) {
 			// If the pod is not bound to the model server, establish the binding
-			if err := c.store.AppendModelServerToPod(podInfo.Pod, []*aiv1alpha1.ModelServer{ms}); err != nil {
-				klog.Warningf("failed to append modelserver %s/%s to pod %s/%s: %v", ms.Namespace, ms.Name, podInfo.Pod.Namespace, podInfo.Pod.Name, err)
+			if err := c.store.AppendModelServerToPod(pod, []*aiv1alpha1.ModelServer{ms}); err != nil {
+				klog.Warningf("failed to append modelserver %s/%s to pod %s/%s: %v", ms.Namespace, ms.Name, pod.Namespace, pod.Name, err)
 				continue
 			}
 		}
-		existingPodNames.Insert(utils.GetNamespaceName(podInfo.Pod))
+		existingPodNames.Insert(utils.GetNamespaceName(pod))
 	}
 
 	// Add new pods that are not yet bound to the store

--- a/pkg/kthena-router/datastore/model_server.go
+++ b/pkg/kthena-router/datastore/model_server.go
@@ -166,7 +166,7 @@ func (m *modelServer) getPrefillPodsForDecodeGroup(pod *PodInfo) []types.Namespa
 	}
 
 	pdGroup := m.modelServer.Spec.WorkloadSelector.PDGroup
-	pdGroupValue, hasPDGroupKey := pod.Pod.Labels[pdGroup.GroupKey]
+	pdGroupValue, hasPDGroupKey := pod.GetPodLabels()[pdGroup.GroupKey]
 	if !hasPDGroupKey {
 		return nil
 	}

--- a/pkg/kthena-router/datastore/store.go
+++ b/pkg/kthena-router/datastore/store.go
@@ -40,10 +40,11 @@ import (
 	"k8s.io/klog/v2"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	inferencev1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
+
 	aiv1alpha1 "github.com/volcano-sh/kthena/pkg/apis/networking/v1alpha1"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/backend"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/utils"
-	inferencev1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 )
 
 var (
@@ -298,7 +299,7 @@ type PodInfo struct {
 	// kept in sync with the global Redis counter so it reflects cross-router traffic.
 	onFlightRequestNum atomic.Int64
 
-	mutex sync.RWMutex // Protects concurrent access to metrics, models and modelServer fields
+	mutex sync.RWMutex // Protects concurrent access to Pod, engine, metrics, models and modelServer fields
 	// Protected fields - use accessor methods for thread-safe access
 	models      sets.Set[string]               // running models. Including base model and lora adapters.
 	modelServer sets.Set[types.NamespacedName] // The modelservers this pod belongs to
@@ -808,20 +809,17 @@ func (s *store) AddOrUpdatePod(pod *corev1.Pod, modelServers []*aiv1alpha1.Model
 		oldPodInfo := value.(*PodInfo)
 		oldModelServers := oldPodInfo.GetModelServers()
 		// Handle the case where the pod no longer belongs to some model servers
+		oldPodLabels := oldPodInfo.GetPodLabels()
 		for msName := range oldModelServers.Difference(newModelServers) {
 			if value, ok := s.modelServer.Load(msName); ok {
 				ms := value.(*modelServer)
 				ms.deletePod(podName)
 				// Remove from PDGroup categorizations
-				ms.removePodFromPDGroups(podName, oldPodInfo.Pod.Labels)
+				ms.removePodFromPDGroups(podName, oldPodLabels)
 			}
 		}
 
-		oldPodInfo.mutex.Lock()
-		oldPodInfo.Pod = pod
-		oldPodInfo.engine = engine
-		oldPodInfo.modelServer = newModelServers
-		oldPodInfo.mutex.Unlock()
+		oldPodInfo.UpdatePod(pod, engine, newModelServers)
 		return nil
 	}
 
@@ -858,8 +856,8 @@ func (s *store) AppendModelServerToPod(pod *corev1.Pod, modelServers []*aiv1alph
 		if !podInfo.HasModelServer(modelServerName) {
 			podInfo.AddModelServer(modelServerName)
 			// NOTE: even if a pod belongs to multiple model servers, the backend should be the same
-			if podInfo.engine == "" {
-				podInfo.engine = string(ms.Spec.InferenceEngine)
+			if podInfo.GetEngine() == "" {
+				podInfo.SetEngine(string(ms.Spec.InferenceEngine))
 			}
 
 			// Update modelServer object to include this pod
@@ -880,12 +878,13 @@ func (s *store) DeletePod(podName types.NamespacedName) error {
 	if value, ok := s.pods.Load(podName); ok {
 		pod := value.(*PodInfo)
 		modelServers := pod.GetModelServers()
+		podLabels := pod.GetPodLabels()
 		for modelServerName := range modelServers {
 			if value, ok := s.modelServer.Load(modelServerName); ok {
 				ms := value.(*modelServer)
 				ms.deletePod(podName)
 				// Remove from PDGroup categorizations
-				ms.removePodFromPDGroups(podName, pod.Pod.Labels)
+				ms.removePodFromPDGroups(podName, podLabels)
 			} else {
 				klog.V(4).Infof("model server %s not found for pod %s, maybe already deleted", modelServerName, podName)
 			}
@@ -1324,13 +1323,19 @@ func selectFromWeightedSlice(weights []uint32) (int, error) {
 }
 
 func (s *store) updatePodMetrics(pod *PodInfo) {
-	if pod.engine == "" {
+	engine := pod.GetEngine()
+	if engine == "" {
 		klog.V(2).Info("failed to find backend in pod")
+		return
+	}
+	podObj := pod.GetPod()
+	if podObj == nil {
+		klog.V(2).Info("failed to find pod")
 		return
 	}
 
 	previousHistogram := getPreviousHistogram(pod)
-	gaugeMetrics, histogramMetrics := s.getPodRuntimeInspector().GetPodMetrics(pod.engine, pod.Pod, previousHistogram)
+	gaugeMetrics, histogramMetrics := s.getPodRuntimeInspector().GetPodMetrics(engine, podObj, previousHistogram)
 	if gaugeMetrics != nil {
 		updateGaugeMetricsInfo(pod, gaugeMetrics)
 	}
@@ -1340,14 +1345,20 @@ func (s *store) updatePodMetrics(pod *PodInfo) {
 }
 
 func (s *store) updatePodModels(podInfo *PodInfo) {
-	if podInfo.engine == "" {
+	engine := podInfo.GetEngine()
+	if engine == "" {
 		klog.V(2).Info("failed to find backend in pod")
 		return
 	}
+	podObj := podInfo.GetPod()
+	if podObj == nil {
+		klog.V(2).Info("failed to find pod")
+		return
+	}
 
-	models, err := s.getPodRuntimeInspector().GetPodModels(podInfo.engine, podInfo.Pod)
+	models, err := s.getPodRuntimeInspector().GetPodModels(engine, podObj)
 	if err != nil {
-		klog.V(4).Infof("failed to get models of pod %s/%s: %v", podInfo.Pod.GetNamespace(), podInfo.Pod.GetName(), err)
+		klog.V(4).Infof("failed to get models of pod %s/%s: %v", podObj.GetNamespace(), podObj.GetName(), err)
 		return
 	}
 
@@ -1355,6 +1366,9 @@ func (s *store) updatePodModels(podInfo *PodInfo) {
 }
 
 func getPreviousHistogram(podinfo *PodInfo) map[string]*dto.Histogram {
+	podinfo.mutex.RLock()
+	defer podinfo.mutex.RUnlock()
+
 	previousHistogram := make(map[string]*dto.Histogram)
 	if podinfo.TimePerOutputToken != nil {
 		previousHistogram[utils.TPOT] = podinfo.TimePerOutputToken
@@ -1440,7 +1454,43 @@ func (s *store) triggerCallbacks(kind string, data EventData) {
 	}
 }
 
-// PodInfo methods for thread-safe access to models and modelServer fields
+// PodInfo methods for thread-safe access to mutable fields
+
+// GetPod returns the current pod pointer. The returned object must be treated as read-only.
+func (p *PodInfo) GetPod() *corev1.Pod {
+	p.mutex.RLock()
+	defer p.mutex.RUnlock()
+	return p.Pod
+}
+
+// GetPodLabels returns the current pod labels. The returned map must be treated as read-only.
+func (p *PodInfo) GetPodLabels() map[string]string {
+	p.mutex.RLock()
+	defer p.mutex.RUnlock()
+	if p.Pod == nil || len(p.Pod.Labels) == 0 {
+		return nil
+	}
+	return p.Pod.Labels
+}
+
+// GetPodNamespacedName returns the current pod namespace/name.
+func (p *PodInfo) GetPodNamespacedName() types.NamespacedName {
+	p.mutex.RLock()
+	defer p.mutex.RUnlock()
+	if p.Pod == nil {
+		return types.NamespacedName{}
+	}
+	return types.NamespacedName{Namespace: p.Pod.Namespace, Name: p.Pod.Name}
+}
+
+// UpdatePod replaces pod metadata tracked by PodInfo while preserving runtime metrics and models.
+func (p *PodInfo) UpdatePod(pod *corev1.Pod, engine string, modelServers sets.Set[types.NamespacedName]) {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+	p.Pod = pod
+	p.engine = engine
+	p.modelServer = modelServers
+}
 
 // GetModels returns a copy of the models set
 func (p *PodInfo) GetModels() sets.Set[string] {
@@ -1554,7 +1604,16 @@ func (p *PodInfo) GetModelServersList() []types.NamespacedName {
 
 // GetEngine returns the inference engine name
 func (p *PodInfo) GetEngine() string {
+	p.mutex.RLock()
+	defer p.mutex.RUnlock()
 	return p.engine
+}
+
+// SetEngine updates the inference engine name.
+func (p *PodInfo) SetEngine(engine string) {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+	p.engine = engine
 }
 
 // GetGPUCacheUsage returns the GPU cache usage
@@ -1892,7 +1951,8 @@ func (s *store) GetPodsByInferencePool(name types.NamespacedName) ([]*PodInfo, e
 	var pods []*PodInfo
 	s.pods.Range(func(key, value interface{}) bool {
 		podInfo := value.(*PodInfo)
-		if podInfo.Pod.Namespace == name.Namespace && selector.Matches(labels.Set(podInfo.Pod.Labels)) {
+		pod := podInfo.GetPod()
+		if pod != nil && pod.Namespace == name.Namespace && selector.Matches(labels.Set(podInfo.GetPodLabels())) {
 			pods = append(pods, podInfo)
 		}
 		return true

--- a/pkg/kthena-router/datastore/store_test.go
+++ b/pkg/kthena-router/datastore/store_test.go
@@ -29,13 +29,14 @@ import (
 
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
-	aiv1alpha1 "github.com/volcano-sh/kthena/pkg/apis/networking/v1alpha1"
-	"github.com/volcano-sh/kthena/pkg/kthena-router/utils"
 	"istio.io/istio/pkg/util/sets"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	aiv1alpha1 "github.com/volcano-sh/kthena/pkg/apis/networking/v1alpha1"
+	"github.com/volcano-sh/kthena/pkg/kthena-router/utils"
 )
 
 // ptr is a helper function to get pointer to a value
@@ -170,6 +171,7 @@ func TestStoreUpdatePodMetrics(t *testing.T) {
 	sum2 := float64(2)
 	count2 := uint64(2)
 	podinfo := PodInfo{
+		Pod:    &corev1.Pod{},
 		engine: "vLLM",
 		TimePerOutputToken: &dto.Histogram{
 			SampleSum:   &sum1,
@@ -1469,12 +1471,12 @@ func TestStoreMatchModelServer(t *testing.T) {
 type fakePodRuntimeInspector struct {
 	metricsFn    func(string, *corev1.Pod, map[string]*dto.Histogram) (map[string]float64, map[string]*dto.Histogram)
 	modelsFn     func(string, *corev1.Pod) ([]string, error)
-	metricsCalls int
-	modelsCalls  int
+	metricsCalls atomic.Int64
+	modelsCalls  atomic.Int64
 }
 
 func (f *fakePodRuntimeInspector) GetPodMetrics(engine string, pod *corev1.Pod, previousHistogram map[string]*dto.Histogram) (map[string]float64, map[string]*dto.Histogram) {
-	f.metricsCalls++
+	f.metricsCalls.Add(1)
 	if f.metricsFn == nil {
 		return nil, nil
 	}
@@ -1482,7 +1484,7 @@ func (f *fakePodRuntimeInspector) GetPodMetrics(engine string, pod *corev1.Pod, 
 }
 
 func (f *fakePodRuntimeInspector) GetPodModels(engine string, pod *corev1.Pod) ([]string, error) {
-	f.modelsCalls++
+	f.modelsCalls.Add(1)
 	if f.modelsFn == nil {
 		return nil, nil
 	}
@@ -1619,10 +1621,10 @@ func TestAddOrUpdatePod_MetricsPreservedOnUpdate(t *testing.T) {
 			pod := createTestPod("default", "pod1")
 			err := s.AddOrUpdatePod(pod, []*aiv1alpha1.ModelServer{ms})
 			assert.NoError(t, err)
-			assert.Equal(t, 1, inspector.metricsCalls, "backend metrics should be fetched on initial pod add")
-			assert.Equal(t, 1, inspector.modelsCalls, "backend models should be fetched on initial pod add")
-			inspector.metricsCalls = 0
-			inspector.modelsCalls = 0
+			assert.Equal(t, int64(1), inspector.metricsCalls.Load(), "backend metrics should be fetched on initial pod add")
+			assert.Equal(t, int64(1), inspector.modelsCalls.Load(), "backend models should be fetched on initial pod add")
+			inspector.metricsCalls.Store(0)
+			inspector.modelsCalls.Store(0)
 
 			// Simulate a pod update (e.g. label change)
 			updatedPod := pod.DeepCopy()
@@ -1632,8 +1634,8 @@ func TestAddOrUpdatePod_MetricsPreservedOnUpdate(t *testing.T) {
 
 			err = s.AddOrUpdatePod(updatedPod, []*aiv1alpha1.ModelServer{ms})
 			assert.NoError(t, err)
-			assert.Equal(t, 0, inspector.metricsCalls, "backend.GetPodMetrics must not be called on pod update")
-			assert.Equal(t, 0, inspector.modelsCalls, "backend.GetPodModels must not be called on pod update")
+			assert.Equal(t, int64(0), inspector.metricsCalls.Load(), "backend.GetPodMetrics must not be called on pod update")
+			assert.Equal(t, int64(0), inspector.modelsCalls.Load(), "backend.GetPodModels must not be called on pod update")
 
 			podInfo := s.GetPodInfo(utils.GetNamespaceName(updatedPod))
 			assert.NotNil(t, podInfo)
@@ -1687,8 +1689,8 @@ func TestAddOrUpdatePod_NewPodStillFetchesMetrics(t *testing.T) {
 	err := s.AddOrUpdatePod(pod, []*aiv1alpha1.ModelServer{ms})
 	assert.NoError(t, err)
 
-	assert.Equal(t, 1, inspector.metricsCalls, "backend.GetPodMetrics must be called for new pods")
-	assert.Equal(t, 1, inspector.modelsCalls, "backend.GetPodModels must be called for new pods")
+	assert.Equal(t, int64(1), inspector.metricsCalls.Load(), "backend.GetPodMetrics must be called for new pods")
+	assert.Equal(t, int64(1), inspector.modelsCalls.Load(), "backend.GetPodModels must be called for new pods")
 
 	podInfo := s.GetPodInfo(utils.GetNamespaceName(pod))
 	assert.InDelta(t, 0.3, podInfo.GetGPUCacheUsage(), 1e-9)
@@ -1720,16 +1722,16 @@ func TestAddOrUpdatePod_ModelServerChangePreservesMetrics(t *testing.T) {
 	pod := createTestPod("default", "pod1")
 	err := s.AddOrUpdatePod(pod, []*aiv1alpha1.ModelServer{ms1})
 	assert.NoError(t, err)
-	assert.Equal(t, 1, inspector.metricsCalls, "backend metrics should be fetched on initial pod add")
-	assert.Equal(t, 1, inspector.modelsCalls, "backend models should be fetched on initial pod add")
-	inspector.metricsCalls = 0
-	inspector.modelsCalls = 0
+	assert.Equal(t, int64(1), inspector.metricsCalls.Load(), "backend metrics should be fetched on initial pod add")
+	assert.Equal(t, int64(1), inspector.modelsCalls.Load(), "backend models should be fetched on initial pod add")
+	inspector.metricsCalls.Store(0)
+	inspector.modelsCalls.Store(0)
 
 	// Move pod from ms1 to ms2
 	err = s.AddOrUpdatePod(pod, []*aiv1alpha1.ModelServer{ms2})
 	assert.NoError(t, err)
-	assert.Equal(t, 0, inspector.metricsCalls, "backend.GetPodMetrics must not be called on pod update")
-	assert.Equal(t, 0, inspector.modelsCalls, "backend.GetPodModels must not be called on pod update")
+	assert.Equal(t, int64(0), inspector.metricsCalls.Load(), "backend.GetPodMetrics must not be called on pod update")
+	assert.Equal(t, int64(0), inspector.modelsCalls.Load(), "backend.GetPodModels must not be called on pod update")
 
 	podInfo := s.GetPodInfo(utils.GetNamespaceName(pod))
 	assert.InDelta(t, 0.6, podInfo.GetGPUCacheUsage(), 1e-9,

--- a/pkg/kthena-router/debug/handlers.go
+++ b/pkg/kthena-router/debug/handlers.go
@@ -153,8 +153,8 @@ func (h *DebugHandler) ListModelServers(c *gin.Context) {
 		if pods, err := h.store.GetPodsByModelServer(namespacedName); err == nil {
 			var podNames []string
 			for _, pod := range pods {
-				if pod.Pod != nil {
-					podNames = append(podNames, pod.Pod.Namespace+"/"+pod.Pod.Name)
+				if podName := pod.GetPodNamespacedName(); podName.Name != "" {
+					podNames = append(podNames, podName.Namespace+"/"+podName.Name)
 				}
 			}
 			response.AssociatedPods = podNames
@@ -164,8 +164,8 @@ func (h *DebugHandler) ListModelServers(c *gin.Context) {
 		if decodePods, err := h.store.GetDecodePods(namespacedName); err == nil {
 			var decodePodNames []string
 			for _, pod := range decodePods {
-				if pod.Pod != nil {
-					decodePodNames = append(decodePodNames, pod.Pod.Namespace+"/"+pod.Pod.Name)
+				if podName := pod.GetPodNamespacedName(); podName.Name != "" {
+					decodePodNames = append(decodePodNames, podName.Namespace+"/"+podName.Name)
 				}
 			}
 			response.DecodePods = decodePodNames
@@ -175,8 +175,8 @@ func (h *DebugHandler) ListModelServers(c *gin.Context) {
 		if prefillPods, err := h.store.GetPrefillPods(namespacedName); err == nil {
 			var prefillPodNames []string
 			for _, pod := range prefillPods {
-				if pod.Pod != nil {
-					prefillPodNames = append(prefillPodNames, pod.Pod.Namespace+"/"+pod.Pod.Name)
+				if podName := pod.GetPodNamespacedName(); podName.Name != "" {
+					prefillPodNames = append(prefillPodNames, podName.Namespace+"/"+podName.Name)
 				}
 			}
 			response.PrefillPods = prefillPodNames
@@ -321,8 +321,8 @@ func (h *DebugHandler) GetModelServer(c *gin.Context) {
 	if pods, err := h.store.GetPodsByModelServer(namespacedName); err == nil {
 		var podNames []string
 		for _, pod := range pods {
-			if pod.Pod != nil {
-				podNames = append(podNames, pod.Pod.Namespace+"/"+pod.Pod.Name)
+			if podName := pod.GetPodNamespacedName(); podName.Name != "" {
+				podNames = append(podNames, podName.Namespace+"/"+podName.Name)
 			}
 		}
 		response.AssociatedPods = podNames
@@ -332,8 +332,8 @@ func (h *DebugHandler) GetModelServer(c *gin.Context) {
 	if decodePods, err := h.store.GetDecodePods(namespacedName); err == nil {
 		var decodePodNames []string
 		for _, pod := range decodePods {
-			if pod.Pod != nil {
-				decodePodNames = append(decodePodNames, pod.Pod.Namespace+"/"+pod.Pod.Name)
+			if podName := pod.GetPodNamespacedName(); podName.Name != "" {
+				decodePodNames = append(decodePodNames, podName.Namespace+"/"+podName.Name)
 			}
 		}
 		response.DecodePods = decodePodNames
@@ -343,8 +343,8 @@ func (h *DebugHandler) GetModelServer(c *gin.Context) {
 	if prefillPods, err := h.store.GetPrefillPods(namespacedName); err == nil {
 		var prefillPodNames []string
 		for _, pod := range prefillPods {
-			if pod.Pod != nil {
-				prefillPodNames = append(prefillPodNames, pod.Pod.Namespace+"/"+pod.Pod.Name)
+			if podName := pod.GetPodNamespacedName(); podName.Name != "" {
+				prefillPodNames = append(prefillPodNames, podName.Namespace+"/"+podName.Name)
 			}
 		}
 		response.PrefillPods = prefillPodNames
@@ -482,24 +482,24 @@ func (h *DebugHandler) convertPodInfoToResponse(namespacedName types.NamespacedN
 
 	// Add metrics
 	response.Metrics = &Metrics{
-		GPUCacheUsage:     podInfo.GPUCacheUsage,
-		RequestWaitingNum: podInfo.RequestWaitingNum,
-		RequestRunningNum: podInfo.RequestRunningNum,
-		TPOT:              podInfo.TPOT,
-		TTFT:              podInfo.TTFT,
+		GPUCacheUsage:     podInfo.GetGPUCacheUsage(),
+		RequestWaitingNum: podInfo.GetRequestWaitingNum(),
+		RequestRunningNum: podInfo.GetRequestRunningNum(),
+		TPOT:              podInfo.GetTPOT(),
+		TTFT:              podInfo.GetTTFT(),
 	}
 
 	// Add pod info if details are requested
-	if includeDetails && podInfo.Pod != nil {
+	if pod := podInfo.GetPod(); includeDetails && pod != nil {
 		response.PodInfo = &PodInfo{
-			PodIP:    podInfo.Pod.Status.PodIP,
-			NodeName: podInfo.Pod.Spec.NodeName,
-			Phase:    string(podInfo.Pod.Status.Phase),
-			Labels:   podInfo.Pod.Labels,
+			PodIP:    pod.Status.PodIP,
+			NodeName: pod.Spec.NodeName,
+			Phase:    string(pod.Status.Phase),
+			Labels:   podInfo.GetPodLabels(),
 		}
 
-		if podInfo.Pod.Status.StartTime != nil {
-			response.PodInfo.StartTime = podInfo.Pod.Status.StartTime.Format("2006-01-02T15:04:05Z")
+		if pod.Status.StartTime != nil {
+			response.PodInfo.StartTime = pod.Status.StartTime.Format("2006-01-02T15:04:05Z")
 		}
 	}
 

--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -465,8 +465,8 @@ func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest) {
 		c.Set("modelRouteName", modelRouteName)
 	}
 
-	if len(ctx.BestPods) > 0 && ctx.BestPods[0].Pod != nil {
-		selectedPod := ctx.BestPods[0].Pod.Name
+	if len(ctx.BestPods) > 0 {
+		selectedPod := ctx.BestPods[0].GetPodNamespacedName().Name
 		accesslog.SetRequestRouting(c, modelRouteName, modelServerFullName, selectedPod)
 	} else {
 		// Set routing info even if no pod is selected (for error cases)
@@ -743,7 +743,8 @@ func (r *Router) proxy(
 	for i := 0; i < len(ctx.BestPods); i++ {
 		req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
 		pod := ctx.BestPods[i]
-		podName := types.NamespacedName{Namespace: pod.Pod.Namespace, Name: pod.Pod.Name}
+		podObj := pod.GetPod()
+		podName := types.NamespacedName{Namespace: podObj.Namespace, Name: podObj.Name}
 
 		// Track this request as in-flight to the chosen pod. This is instant and
 		// feeds the scheduler immediately, avoiding the ~1 s engine-metrics lag.
@@ -753,7 +754,7 @@ func (r *Router) proxy(
 		r.metrics.IncActiveUpstreamRequests(modelServerName, modelRouteName)
 
 		// Request dispatched to the pod.
-		err := proxyRequest(c, req, pod.Pod.Status.PodIP, port, stream, onUsage)
+		err := proxyRequest(c, req, podObj.Status.PodIP, port, stream, onUsage)
 
 		// Decrement upstream request count when request completes
 		r.metrics.DecActiveUpstreamRequests(modelServerName, modelRouteName)
@@ -1081,17 +1082,19 @@ func (r *Router) proxyToPDDisaggregated(
 		if ctx.PrefillPods[i] == nil || ctx.DecodePods[i] == nil {
 			continue
 		}
+		prefillPod := ctx.PrefillPods[i].GetPod()
+		decodePod := ctx.DecodePods[i].GetPod()
 
 		// Build addresses for prefill and decode pods
-		prefillAddr := net.JoinHostPort(ctx.PrefillPods[i].Pod.Status.PodIP, strconv.Itoa(int(port)))
-		decodeAddr := net.JoinHostPort(ctx.DecodePods[i].Pod.Status.PodIP, strconv.Itoa(int(port)))
+		prefillAddr := net.JoinHostPort(prefillPod.Status.PodIP, strconv.Itoa(int(port)))
+		decodeAddr := net.JoinHostPort(decodePod.Status.PodIP, strconv.Itoa(int(port)))
 
 		klog.V(4).Infof("Attempting PD disaggregated request: prefill=%s, decode=%s", prefillAddr, decodeAddr)
 
 		// Build on-flight hooks so the connector can update the per-pod counters
 		// at the precise point each phase starts and ends.
-		prefillPodName := types.NamespacedName{Namespace: ctx.PrefillPods[i].Pod.Namespace, Name: ctx.PrefillPods[i].Pod.Name}
-		decodePodName := types.NamespacedName{Namespace: ctx.DecodePods[i].Pod.Namespace, Name: ctx.DecodePods[i].Pod.Name}
+		prefillPodName := types.NamespacedName{Namespace: prefillPod.Namespace, Name: prefillPod.Name}
+		decodePodName := types.NamespacedName{Namespace: decodePod.Namespace, Name: decodePod.Name}
 		hooks := &connectors.OnFlightHooks{
 			IncrPrefill: func() { r.store.IncrPodOnFlightRequests(prefillPodName) },
 			DecrPrefill: func() { r.store.DecrPodOnFlightRequests(prefillPodName) },
@@ -1104,7 +1107,7 @@ func (r *Router) proxyToPDDisaggregated(
 
 		if err != nil {
 			klog.Errorf("proxy failed for prefill pod %s, decode pod %s: %v",
-				ctx.PrefillPods[i].Pod.Name, ctx.DecodePods[i].Pod.Name, err)
+				prefillPod.Name, decodePod.Name, err)
 			continue
 		}
 
@@ -1122,7 +1125,7 @@ func (r *Router) proxyToPDDisaggregated(
 		r.scheduler.RunPostHooks(ctx, i)
 
 		klog.V(4).Infof("kv connector run successful for prefill pod %s, decode pod %s, output tokens: %d",
-			ctx.PrefillPods[i].Pod.Name, ctx.DecodePods[i].Pod.Name, outputTokens)
+			prefillPod.Name, decodePod.Name, outputTokens)
 
 		return nil
 	}

--- a/pkg/kthena-router/scheduler/plugins/cache/prefix_store.go
+++ b/pkg/kthena-router/scheduler/plugins/cache/prefix_store.go
@@ -151,10 +151,7 @@ func (s *ModelPrefixStore) FindTopMatches(model string, hashes []uint64, pods []
 	// pods in the scheduling candidate pool are returned.
 	candidatePods := sets.New[types.NamespacedName]()
 	for _, pod := range pods {
-		candidatePods.Insert(types.NamespacedName{
-			Namespace: pod.Pod.Namespace,
-			Name:      pod.Pod.Name,
-		})
+		candidatePods.Insert(pod.GetPodNamespacedName())
 	}
 
 	matches := make(map[types.NamespacedName]int, s.topK)
@@ -196,10 +193,7 @@ func (s *ModelPrefixStore) FindTopMatches(model string, hashes []uint64, pods []
 
 // Add adds new hash->pod mappings to cache, using LRU for eviction
 func (s *ModelPrefixStore) Add(model string, hashes []uint64, pod *datastore.PodInfo) {
-	nsName := types.NamespacedName{
-		Namespace: pod.Pod.Namespace,
-		Name:      pod.Pod.Name,
-	}
+	nsName := pod.GetPodNamespacedName()
 
 	s.podHashesMu.Lock()
 	podLRU, exists := s.podHashes[nsName]

--- a/pkg/kthena-router/scheduler/plugins/kvcache_aware.go
+++ b/pkg/kthena-router/scheduler/plugins/kvcache_aware.go
@@ -190,7 +190,7 @@ func (t *KVCacheAware) Score(ctx *framework.Context, pods []*datastore.PodInfo) 
 
 	podNames := make([]string, 0, len(pods))
 	for _, p := range pods {
-		podNames = append(podNames, p.Pod.Name)
+		podNames = append(podNames, p.GetPodNamespacedName().Name)
 	}
 	klog.V(4).Infof("KVCacheAware.Score: called for model=%q, pods=%v, promptTextLen=%d, messagesLen=%d",
 		ctx.Model, podNames, len(ctx.Prompt.Text), len(ctx.Prompt.Messages))
@@ -232,7 +232,7 @@ func (t *KVCacheAware) Score(ctx *framework.Context, pods []*datastore.PodInfo) 
 	podScores := t.calculatePodScores(blockHashes, blockToPods)
 	scoreResults := make(map[*datastore.PodInfo]int, len(podScores))
 	for _, pod := range pods {
-		podName := pod.Pod.Name
+		podName := pod.GetPodNamespacedName().Name
 		if score, exists := podScores[podName]; exists {
 			scoreResults[pod] = score
 		}

--- a/pkg/kthena-router/scheduler/plugins/prefix.go
+++ b/pkg/kthena-router/scheduler/plugins/prefix.go
@@ -75,7 +75,6 @@ import (
 
 	"github.com/cespare/xxhash"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/yaml"
 
@@ -176,7 +175,7 @@ func (p *PrefixCache) Score(ctx *framework.Context, pods []*datastore.PodInfo) m
 	totalHashes := len(hashes)
 	scoreResults := make(map[*datastore.PodInfo]int, len(pods))
 	for _, pod := range pods {
-		nsName := types.NamespacedName{Namespace: pod.Pod.Namespace, Name: pod.Pod.Name}
+		nsName := pod.GetPodNamespacedName()
 		if matchLen, ok := matchByName[nsName]; ok {
 			scoreResults[pod] = int((float64(matchLen) / float64(totalHashes)) * 100)
 		} else {

--- a/pkg/kthena-router/scheduler/plugins/tokenization/tokenizer_manager.go
+++ b/pkg/kthena-router/scheduler/plugins/tokenization/tokenizer_manager.go
@@ -67,19 +67,23 @@ func (m *TokenizerManager) createTokenizerFromPods(model string, pods []*datasto
 	for i := 0; i < len(pods); i++ {
 		podIdx := (startIdx + i) % len(pods)
 		podInfo := pods[podIdx]
+		pod := podInfo.GetPod()
+		if pod == nil {
+			continue
+		}
 
 		engine, err := normalizeEngine(podInfo.GetEngine())
 		if err != nil {
-			klog.Warningf("TokenizerManager: invalid engine for pod %s: %v", podInfo.Pod.Name, err)
+			klog.Warningf("TokenizerManager: invalid engine for pod %s: %v", pod.Name, err)
 			unsupportedEngines[podInfo.GetEngine()] = struct{}{}
 			continue
 		}
 		template, ok := m.config.EndpointTemplates[engine]
 		if !ok || template == "" {
-			klog.Warningf("TokenizerManager: no endpoint template for engine %q, skipping pod %s", engine, podInfo.Pod.Name)
+			klog.Warningf("TokenizerManager: no endpoint template for engine %q, skipping pod %s", engine, pod.Name)
 			continue
 		}
-		endpoint := fmt.Sprintf(template, podInfo.Pod.Status.PodIP)
+		endpoint := fmt.Sprintf(template, pod.Status.PodIP)
 
 		config := RemoteTokenizerConfig{
 			Engine:             engine,

--- a/pkg/kthena-router/scheduler/scheduler_impl.go
+++ b/pkg/kthena-router/scheduler/scheduler_impl.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 
 	"github.com/volcano-sh/kthena/pkg/kthena-router/datastore"
@@ -155,14 +154,14 @@ func (s *SchedulerImpl) Schedule(ctx *framework.Context, pods []*datastore.PodIn
 		validPairs := 0
 
 		for i, decodePod := range ctx.DecodePods {
+			decodePodName := decodePod.GetPodNamespacedName()
+			if decodePodName.Name == "" {
+				continue
+			}
 			// Get prefill pods for the same PD group as the decode pod (O(1) lookup)
-			selectedPods, err := s.store.GetPrefillPodsForDecodeGroup(ctx.ModelServerName,
-				types.NamespacedName{
-					Namespace: decodePod.Pod.Namespace,
-					Name:      decodePod.Pod.Name,
-				})
+			selectedPods, err := s.store.GetPrefillPodsForDecodeGroup(ctx.ModelServerName, decodePodName)
 			if err != nil || len(selectedPods) == 0 {
-				klog.V(4).InfoS("prefill pods for decode group not found", "decode instance", klog.KObj(decodePod.Pod), "error", err)
+				klog.V(4).InfoS("prefill pods for decode group not found", "decode instance", decodePodName, "error", err)
 				continue
 			}
 
@@ -171,7 +170,7 @@ func (s *SchedulerImpl) Schedule(ctx *framework.Context, pods []*datastore.PodIn
 			bestPrefillPod := TopNPodInfos(scores, 1)
 			if len(bestPrefillPod) == 0 {
 				klog.V(4).InfoS("no valid prefill pods after scoring, skipping",
-					"decode instance", klog.KObj(decodePod.Pod))
+					"decode instance", decodePodName)
 				continue
 			}
 			prefillPods[i] = bestPrefillPod[0]
@@ -226,8 +225,8 @@ func (s *SchedulerImpl) RunScorePlugins(pods []*datastore.PodInfo, ctx *framewor
 
 		klog.V(4).Infof("ScorePlugin: %s", scorePlugin.plugin.Name())
 		for k, v := range scores {
-			if k.Pod != nil {
-				klog.V(4).Infof("Pod: %s/%s, Score: %d", k.Pod.Namespace, k.Pod.Name, v)
+			if podName := k.GetPodNamespacedName(); podName.Name != "" {
+				klog.V(4).Infof("Pod: %s/%s, Score: %d", podName.Namespace, podName.Name, v)
 			}
 			if _, ok := res[k]; !ok {
 				res[k] = v * scorePlugin.weight
@@ -240,8 +239,8 @@ func (s *SchedulerImpl) RunScorePlugins(pods []*datastore.PodInfo, ctx *framewor
 	if klog.V(4).Enabled() {
 		klog.Info("Final Pod Scores:")
 		for k, v := range res {
-			if k.Pod != nil {
-				klog.Infof("  Pod: %s/%s, Final Score: %d", k.Pod.Namespace, k.Pod.Name, v)
+			if podName := k.GetPodNamespacedName(); podName.Name != "" {
+				klog.Infof("  Pod: %s/%s, Final Score: %d", podName.Namespace, podName.Name, v)
 			}
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->
/kind bug

**What this PR does / why we need it**:
This PR fixes a data race in the router datastore by making `PodInfo` access consistently synchronized.

`PodInfo.Pod` and `PodInfo.engine` can be updated by pod lifecycle events while other goroutines read the same `PodInfo` for deletion cleanup, metric refresh, scheduling, routing, and debug output. Previously, some writes were protected by `PodInfo.mutex`, but several read paths accessed these fields directly.

Running the existing datastore concurrency test with the race detector exposed concurrent access between:
- `AddOrUpdatePod`, writing `PodInfo.Pod`
- `DeletePod`, reading `PodInfo.Pod.Labels`

**Which issue(s) this PR fixes**:
Fixes #1168 

**Special notes for your reviewer**:
go test -race ./pkg/kthena-router/datastore
<img width="2214" height="972" alt="image" src="https://github.com/user-attachments/assets/d9790042-291b-47bd-996d-6c80127c4c0e" />


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
