### PR TITLE
Proposal of merge `autoscalingPolicybingding` into `autoscalingPolicy`

### DIFF
--- a/docs/proposal/pd-disaggregated-autoscaling.md
+++ b/docs/proposal/pd-disaggregated-autoscaling.md
@@ -1,7 +1,8 @@
 ---
 title: P/D Disaggregated Autoscaling API
 authors:
-- TBD
+- @LiZhenCheng9527
+- @hzxuzhonghu
 reviewers:
 - TBD
 approvers:
@@ -17,8 +18,8 @@ creation-date: 2025-05-09
 
 This proposal redesigns the autoscaling API with two goals:
 
-1. **Merge `AutoscalingPolicyBinding` into `AutoscalingPolicy`** — today users must create two resources (policy + binding) and cross-reference them. Merging eliminates the indirection, avoids duplicating metric definitions across objects, and gives users a single resource that fully describes "what to scale, on what signal, and how."
-2. **Add first-class `DisaggregatedTarget`** — replace the generic `SubTarget` mechanism with a purpose-built structure for coordinated Prefill/Decode scaling, including independent per-role metrics, replica bounds, and a P/D ratio range constraint.
+1. **Merge `AutoscalingPolicyBinding` into `AutoscalingPolicy`** — today users must create two resources (policy + binding) and cross-reference them. Merging eliminates the indirection, removes split configuration across objects, and gives users a single resource that fully describes "what to scale, on what signal, and how."
+2. **Add first-class `DisaggregatedTarget`** — replace the generic `SubTarget` mechanism with a purpose-built structure for coordinated multi-role scaling, including independent per-role metrics, per-role metric sources (Pod or Prometheus), replica bounds, and role-to-role ratio constraints.
 
 The `AutoscalingPolicyBinding` CRD and the `SubTarget` type are removed.
 
@@ -27,14 +28,14 @@ The `AutoscalingPolicyBinding` CRD and the `SubTarget` type are removed.
 In disaggregated prefill/decode inference architectures, the prefill and decode stages have fundamentally different resource profiles:
 
 - **Prefill** is compute-bound and bursty — it processes the full prompt in one forward pass.
-- **Decode** is memory-bandwidth-bound and long-running — it generates tokens auto-regressively.
+- **Decode** is memory-bandwidth-bound and long-running — it generates tokens autoregressively.
 
 Scaling these two stages independently is essential for cost-efficient serving. However, independent scaling alone is insufficient — the P/D ratio must be coordinated. Too many prefill replicas starve decode capacity (growing queues); too many decode replicas waste GPU memory on idle KV caches. A healthy system keeps the ratio within an operator-defined range.
 
 **Problems with the current two-resource model (AutoscalingPolicy + AutoscalingPolicyBinding):**
 
 1. **Unnecessary indirection** — the user always creates a 1:1 pair (policy + binding). The binding adds a `policyRef` that points to a policy in the same namespace. This indirection provides no reuse benefit in practice (policies are rarely shared across multiple bindings) and doubles the number of objects to manage.
-2. **Metric duplication** — with per-role metrics in the binding and policy-level metrics in the policy object, `AutoscalingPolicyMetric` appears in two CRDs. This is confusing and error-prone when users need to update metric targets.
+2. **Configuration split across two resources** — metric targets live in `AutoscalingPolicy.spec.metrics`, while metric retrieval details (`Pod`/`Prometheus` query and endpoint) live in `AutoscalingPolicyBinding.spec.*.target.metricSources`. Users must keep two resources in sync (metric names in policy and map keys in binding), which is error-prone.
 3. **Fragmented view** — operators must read two resources to understand the complete autoscaling configuration for a single ModelServing.
 
 **Problems with `SubTarget` for P/D disaggregation:**
@@ -48,8 +49,8 @@ Scaling these two stages independently is essential for cost-efficient serving. 
 - Merge `AutoscalingPolicyBinding` into `AutoscalingPolicy` to provide a single-resource UX.
 - Provide a single `AutoscalingPolicy` resource that drives coordinated P/D scaling for one ModelServing.
 - Allow independent `minReplicas` / `maxReplicas` per role to set per-stage capacity boundaries.
-- Introduce a `ratioRange` constraint so the controller can enforce a healthy P/D ratio.
-- Support per-role metrics and metric endpoints (prefill and decode may scale on different signals and expose metrics on different ports/paths).
+- Introduce `ratioConstraints` so the controller can enforce healthy role-to-role ratios.
+- Support per-role metrics and per-role metric sources, reusing current `MetricSource` semantics (`Pod` and `Prometheus`).
 - Remove the `AutoscalingPolicyBinding` CRD and the generic `SubTarget` type.
 
 #### Non-Goals
@@ -69,9 +70,9 @@ As an ML platform operator, I want to define the complete autoscaling configurat
 
 As an ML platform operator, I deploy a vLLM disaggregated model with prefill and decode roles. I want the autoscaler to scale prefill replicas between 1–8 and decode replicas between 2–16, while always maintaining a P:D ratio between 1:1 and 1:4. This means if I have 2 prefill replicas, the decode replicas must be between 2 and 8.
 
-##### Story 3: Per-role metrics and endpoints
+##### Story 3: Per-role metrics and sources
 
-As a platform engineer, my prefill pods should scale based on `num_requests_waiting` (targeting 5) scraped on port 8100, while decode pods should scale based on `gpu_kv_cache_usage_percent` (targeting 80%) on port 9100. I need to configure both the scaling metrics and scraping endpoints for each role independently, all in one place.
+As a platform engineer, I want each role (for example, prefill/decode now and rerank in the future) to define its own scaling metrics and metric sources independently in one policy.
 
 ##### Story 4: Migration from Policy + Binding
 
@@ -84,7 +85,7 @@ As an existing user with an `AutoscalingPolicy` and one or more `AutoscalingPoli
 | Breaking change: removes `AutoscalingPolicyBinding` CRD | Both CRDs are alpha-level. Provide a migration guide and conversion tooling. The merged API is strictly simpler. |
 | Breaking change for users currently using `SubTarget` | `SubTarget` was alpha-level and only used for P/D roles — the replacement `DisaggregatedTarget` is strictly more capable. |
 | Loss of policy reuse across bindings | In practice policies are rarely shared. If reuse is needed, users can use templating tools (Helm, Kustomize). The UX win of a single resource outweighs the theoretical reuse loss. |
-| Ratio enforcement may conflict with per-role min/max bounds | Webhook validates that `ratioRange` is achievable given the min/max replica bounds at admission time. |
+| Ratio enforcement may conflict with per-role min/max bounds | Webhook validates that each `ratioConstraints` entry is achievable given min/max replica bounds at admission time. |
 | Increased controller complexity | Ratio enforcement is a bounded constraint-satisfaction problem; design details are deferred to the controller proposal. |
 
 ### Design Details
@@ -96,49 +97,33 @@ As an existing user with an `AutoscalingPolicy` and one or more `AutoscalingPoli
 | Delete `AutoscalingPolicyBinding` CRD | All target/binding fields move into `AutoscalingPolicy`. |
 | Delete `SubTarget` type | Replaced by `DisaggregatedTarget`. |
 | Expand `AutoscalingPolicySpec` | Add target fields (`homogeneousTarget`, `heterogeneousTarget`, `disaggregatedTarget`) directly. Metrics become the default; per-role metrics can override them. |
-| Add `DisaggregatedTarget` | New first-class P/D scaling type with `Prefill`, `Decode`, and `RatioRange`. |
+| Preserve `MetricSource` model | Keep current `MetricSource` discriminated union (`Pod` / `Prometheus`) and move per-target/per-role `metricSources` into `AutoscalingPolicy`. |
+| Add `DisaggregatedTarget` | New first-class multi-role scaling type with `roles` and `ratioConstraints`. |
 | Simplify `Target` | Remove `SubTarget` field. |
 
 ##### 1. Merged `AutoscalingPolicy`
 
 ```go
 // AutoscalingPolicySpec defines the desired state of AutoscalingPolicy.
-// +kubebuilder:validation:XValidation:rule="[has(self.heterogeneousTarget), has(self.homogeneousTarget), has(self.disaggregatedTarget)].filter(x, x).size() == 1",message="Exactly one of heterogeneousTarget, homogeneousTarget, or disaggregatedTarget must be set."
+// +kubebuilder:validation:XValidation:rule="[has(self.heterogeneousTarget), has(self.homogeneousTarget), has(self.disaggregatedTarget)].exists_one(x, x).size() == 1",message="Exactly one of heterogeneousTarget, homogeneousTarget, or disaggregatedTarget must be set."
 type AutoscalingPolicySpec struct {
-	// Metrics defines the default list of metrics used to evaluate scaling decisions.
-	// For HomogeneousTarget and HeterogeneousTarget these are the metrics used directly.
-	// For DisaggregatedTarget these serve as the fallback when a role does not specify its own metrics.
-	// +kubebuilder:validation:MinItems=1
-	Metrics []AutoscalingPolicyMetric `json:"metrics"`
+    // ...
 
-	// TolerancePercent defines the percentage of deviation tolerated before scaling actions are triggered.
-	// Scaling operations are performed only when |current - desired| >= current * tolerancePercent / 100.
-	// +optional
-	// +kubebuilder:validation:Minimum=0
-	// +kubebuilder:validation:Maximum=100
-	// +kubebuilder:default=10
-	TolerancePercent int32 `json:"tolerancePercent"`
+    // --- Target (exactly one must be set) ---
+    // HomogeneousTarget enables traditional metric-based scaling for a
+    // single ModelServing deployment (whole-deployment granularity).
+    // +optional
+    HomogeneousTarget *HomogeneousTarget `json:"homogeneousTarget,omitempty"`
 
-	// Behavior defines the scaling behavior configuration for both scale up and scale down operations.
-	// +optional
-	Behavior AutoscalingPolicyBehavior `json:"behavior"`
+    // HeterogeneousTarget enables optimization-based scaling across multiple
+    // ModelServing deployments with different hardware capabilities.
+    // +optional
+    HeterogeneousTarget *HeterogeneousTarget `json:"heterogeneousTarget,omitempty"`
 
-	// --- Target (exactly one must be set) ---
-
-	// HomogeneousTarget enables traditional metric-based scaling for a
-	// single ModelServing deployment (whole-deployment granularity).
-	// +optional
-	HomogeneousTarget *HomogeneousTarget `json:"homogeneousTarget,omitempty"`
-
-	// HeterogeneousTarget enables optimization-based scaling across multiple
-	// ModelServing deployments with different hardware capabilities.
-	// +optional
-	HeterogeneousTarget *HeterogeneousTarget `json:"heterogeneousTarget,omitempty"`
-
-	// DisaggregatedTarget enables coordinated autoscaling of prefill and decode
-	// roles within a single ModelServing that uses disaggregated serving.
-	// +optional
-	DisaggregatedTarget *DisaggregatedTarget `json:"disaggregatedTarget,omitempty"`
+    // DisaggregatedTarget enables coordinated autoscaling of roles
+    // within a single ModelServing that uses disaggregated serving.
+    // +optional
+    DisaggregatedTarget *DisaggregatedTarget `json:"disaggregatedTarget,omitempty"`
 }
 ```
 
@@ -149,112 +134,215 @@ Delete the `SubTarget` struct. `Target` is simplified to:
 ```go
 // Target defines a ModelServing deployment that can be monitored and scaled.
 type Target struct {
-	// TargetRef references the target object to be monitored and scaled.
-	TargetRef corev1.ObjectReference `json:"targetRef"`
-	// MetricEndpoint defines the configuration for scraping metrics from the target pods.
-	// +optional
-	MetricEndpoint MetricEndpoint `json:"metricEndpoint,omitempty"`
+    // TargetRef references the target object to be monitored and scaled.
+    TargetRef corev1.ObjectReference `json:"targetRef"`
+    // MetricSources declares how to fetch specific metrics for this target.
+    // Keys must match AutoscalingPolicy.spec.metrics[].name.
+    // Missing keys are treated as missing metrics for that reconcile loop.
+    // For example, a key "podinfo_rps" here must correspond to a metric named
+    // "podinfo_rps" in the referenced AutoscalingPolicy.
+    // +optional
+    MetricSources map[string]MetricSource `json:"metricSources,omitempty"`
 }
 ```
 
 `Target` remains in use by `HomogeneousTarget` (whole-ModelServing scaling) and `HeterogeneousTarget` (multi-ModelServing optimization). Both operate at the ModelServing level and never used `SubTarget` meaningfully.
 
+##### 2.1 Preserve `MetricSource` and Prometheus semantics
+
+The merged API keeps the existing metric-source model from `AutoscalingPolicyBinding` unchanged:
+
+- `MetricSource.type: Pod | Prometheus` (default `Pod`)
+- `MetricSource.pod` for direct pod scraping (`name`/`uri`/`port`/`labelSelector`)
+- `MetricSource.prometheus` for external Prometheus query (`serverURL` + `query`)
+
+`PrometheusMetricSource.auth` remains part of the API surface and continues to be reserved for follow-up runtime implementation, same as today.
+
 ##### 3. `DisaggregatedTarget` and supporting types
 
 ```go
-// DisaggregatedTarget defines coordinated autoscaling for prefill/decode
-// disaggregated serving within a single ModelServing deployment.
+// DisaggregatedTarget defines coordinated autoscaling for disaggregated
+// serving roles within a single ModelServing deployment.
 type DisaggregatedTarget struct {
-	// TargetRef references the ModelServing deployment that contains
-	// prefill and decode roles.
-	TargetRef corev1.ObjectReference `json:"targetRef"`
+    // TargetRef references the ModelServing deployment that contains
+    // all scalable roles.
+    TargetRef corev1.ObjectReference `json:"targetRef"`
 
-	// Prefill defines scaling parameters for the prefill role.
-	Prefill RoleScalingParam `json:"prefill"`
+    // Roles defines per-role scaling parameters. The map key is roleName
+    // from ModelServing.spec.template.roles[].name.
+    // +kubebuilder:validation:MinProperties=2
+    Roles map[string]RoleScalingParam `json:"roles"`
 
-	// Decode defines scaling parameters for the decode role.
-	Decode RoleScalingParam `json:"decode"`
-
-	// RatioRange defines the acceptable range for the Prefill-to-Decode
-	// replica ratio (P:D). The controller will respect this range when
-	// making scaling decisions. Both values express ratios as
-	// prefillReplicas / decodeReplicas.
-	//
-	// Example: minRatio=0.25, maxRatio=1.0 means for every decode replica,
-	// there should be between 0.25 and 1.0 prefill replicas (i.e., P:D
-	// ranges from 1:4 to 1:1).
-	//
-	// +optional
-	RatioRange *PDRatioRange `json:"ratioRange,omitempty"`
+    // RatioConstraints defines acceptable ratio ranges between role pairs.
+    // Each constraint enforces:
+    //   minRatio <= replicas[numeratorRole] / replicas[denominatorRole] <= maxRatio
+    // when denominator replicas is non-zero.
+    //
+    // +optional
+    RatioConstraints []RoleRatioConstraint `json:"ratioConstraints,omitempty"`
 }
 
-// RoleScalingParam defines the scaling configuration for a single role
-// (prefill or decode) within a disaggregated serving deployment.
+// RoleScalingParam defines the scaling configuration for one role.
 type RoleScalingParam struct {
-	// RoleName is the name of the role as defined in the ModelServing
-	// spec.template.roles[].name. Defaults to "prefill" for the prefill
-	// field and "decode" for the decode field if not specified.
-	// +optional
-	RoleName string `json:"roleName,omitempty"`
+    // MinReplicas defines the minimum number of replicas for this role.
+    // +kubebuilder:validation:Minimum=0
+    // +kubebuilder:validation:Maximum=1000000
+    MinReplicas int32 `json:"minReplicas"`
 
-	// MinReplicas defines the minimum number of replicas for this role.
-	// +kubebuilder:validation:Minimum=0
-	// +kubebuilder:validation:Maximum=1000000
-	MinReplicas int32 `json:"minReplicas"`
+    // MaxReplicas defines the maximum number of replicas for this role.
+    // +kubebuilder:validation:Minimum=1
+    // +kubebuilder:validation:Maximum=1000000
+    MaxReplicas int32 `json:"maxReplicas"`
 
-	// MaxReplicas defines the maximum number of replicas for this role.
-	// +kubebuilder:validation:Minimum=1
-	// +kubebuilder:validation:Maximum=1000000
-	MaxReplicas int32 `json:"maxReplicas"`
+    // Metrics overrides the policy-level metrics for this specific role.
+    // This allows different roles to scale on different signals.
+    // If not set, the top-level spec.metrics are used.
+    // +optional
+    // +kubebuilder:validation:MinItems=1
+    Metrics []AutoscalingPolicyMetric `json:"metrics,omitempty"`
 
-	// Metrics overrides the policy-level metrics for this specific role.
-	// This allows prefill and decode roles to scale on different signals
-	// (e.g., prefill on queue depth, decode on KV cache utilization).
-	// If not set, the top-level spec.metrics are used.
-	// +optional
-	// +kubebuilder:validation:MinItems=1
-	Metrics []AutoscalingPolicyMetric `json:"metrics,omitempty"`
-
-	// MetricEndpoint defines the configuration for scraping metrics from
-	// pods of this role. If not specified, the controller uses defaults.
-	// +optional
-	MetricEndpoint *MetricEndpoint `json:"metricEndpoint,omitempty"`
+    // MetricSources declares how each metric is fetched for this role.
+    // Keys must match role-level metrics when present, otherwise top-level
+    // spec.metrics[].name.
+    // Missing keys default to pod scraping behavior equivalent to an empty
+    // PodMetricSource (uri=/metrics, port=8100, metric name defaults to key).
+    // +optional
+    MetricSources map[string]MetricSource `json:"metricSources,omitempty"`
 }
 
-// PDRatioRange defines the acceptable range for the prefill-to-decode ratio.
-// +kubebuilder:validation:XValidation:rule="self.minRatio <= self.maxRatio",message="minRatio must be <= maxRatio"
-type PDRatioRange struct {
-	// MinRatio is the minimum allowed value of prefillReplicas / decodeReplicas.
-	// +kubebuilder:validation:Minimum=0
-	MinRatio resource.Quantity `json:"minRatio"`
+// RoleRatioConstraint defines the acceptable ratio range between two roles.
+type RoleRatioConstraint struct {
+    // NumeratorRole is the role on the numerator side of the ratio.
+    NumeratorRole string `json:"numeratorRole"`
 
-	// MaxRatio is the maximum allowed value of prefillReplicas / decodeReplicas.
-	MaxRatio resource.Quantity `json:"maxRatio"`
+    // DenominatorRole is the role on the denominator side of the ratio.
+    DenominatorRole string `json:"denominatorRole"`
+
+    // MinRatio is the minimum allowed value of
+    // replicas[numeratorRole] / replicas[denominatorRole].
+    // +kubebuilder:validation:Minimum=0
+    MinRatio resource.Quantity `json:"minRatio"`
+
+    // MaxRatio is the maximum allowed value of
+    // replicas[numeratorRole] / replicas[denominatorRole].
+    MaxRatio resource.Quantity `json:"maxRatio"`
 }
 ```
 
 > **Why `resource.Quantity` for ratios?** Kubernetes does not support native `float` fields in CRDs. `resource.Quantity` is the idiomatic way to express decimal values in the Kubernetes API (e.g., `"0.25"`, `"1"`, `"2.5"`). It avoids floating-point imprecision and is already used throughout the Kubernetes and Kthena APIs for similar purposes.
+>
+> **Caveat**: `resource.Quantity` carries unit/suffix semantics (e.g., `"250m"` is parsed as `0.25`), which can be surprising when the value is meant as a pure ratio. An integer-pair representation that avoids this ambiguity is discussed in [Alternative 5](#alternative-5-integer-pair-ratio-instead-of-resourcequantity).
 
 ##### 4. `HomogeneousTarget` (unchanged, except `SubTarget` removed from `Target`)
 
 ```go
 type HomogeneousTarget struct {
-	// Target defines the object to be monitored and scaled.
-	Target Target `json:"target,omitempty"`
-	// MinReplicas defines the minimum number of replicas to maintain.
-	// +kubebuilder:validation:Minimum=0
-	// +kubebuilder:validation:Maximum=1000000
-	MinReplicas int32 `json:"minReplicas"`
-	// MaxReplicas defines the maximum number of replicas allowed.
-	// +kubebuilder:validation:Minimum=1
-	// +kubebuilder:validation:Maximum=1000000
-	MaxReplicas int32 `json:"maxReplicas"`
+    // Target defines the object to be monitored and scaled.
+    Target Target `json:"target,omitempty"`
+    // MinReplicas defines the minimum number of replicas to maintain.
+    // +kubebuilder:validation:Minimum=0
+    // +kubebuilder:validation:Maximum=1000000
+    MinReplicas int32 `json:"minReplicas"`
+    // MaxReplicas defines the maximum number of replicas allowed.
+    // +kubebuilder:validation:Minimum=1
+    // +kubebuilder:validation:Maximum=1000000
+    MaxReplicas int32 `json:"maxReplicas"`
 }
 ```
 
 ##### 5. Delete `AutoscalingPolicyBinding` CRD
 
 The entire `AutoscalingPolicyBinding`, `AutoscalingPolicyBindingSpec`, `AutoscalingPolicyBindingStatus`, and `AutoscalingPolicyBindingList` types are removed. The `policyRef` indirection is eliminated.
+
+##### 6. `AutoscalingPolicyStatus`
+
+Because the target now lives in `AutoscalingPolicy` itself (previously the binding carried the binding-side status), `AutoscalingPolicy` needs a status subresource that reports the observed scaling state. This is especially important for `DisaggregatedTarget`, where the user must be able to observe the current per-role replica counts, the actual P/D ratio, and whether the ratio constraint forced an adjustment.
+
+```go
+// AutoscalingPolicyStatus defines the observed state of AutoscalingPolicy.
+type AutoscalingPolicyStatus struct {
+    // ObservedGeneration is the most recent generation observed by the controller.
+    // +optional
+    ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+
+    // Conditions represents the latest available observations of the policy's state.
+    // Well-known condition types include:
+    //   - "Ready":                   the policy is actively reconciled.
+    //   - "TargetFound":             the referenced ModelServing (and roles) exist.
+    //   - "RatioConstraintViolated": the desired counts could not satisfy ratioConstraints
+    //                                given the per-role min/max bounds.
+    // +optional
+    // +listType=map
+    // +listMapKey=type
+    Conditions []metav1.Condition `json:"conditions,omitempty"`
+
+    // HomogeneousStatus reports the observed state when HomogeneousTarget is used.
+    // +optional
+    HomogeneousStatus *TargetScalingStatus `json:"homogeneousStatus,omitempty"`
+
+    // DisaggregatedStatus reports the observed state when DisaggregatedTarget is used.
+    // +optional
+    DisaggregatedStatus *DisaggregatedScalingStatus `json:"disaggregatedStatus,omitempty"`
+
+    // HeterogeneousStatus reports the per-target observed state when
+    // HeterogeneousTarget is used.
+    // +optional
+    HeterogeneousStatus []TargetScalingStatus `json:"heterogeneousStatus,omitempty"`
+}
+
+// TargetScalingStatus reports the observed scaling state of a single scalable
+// unit (a whole ModelServing, or one role within it).
+type TargetScalingStatus struct {
+    // Name identifies the unit. For HomogeneousTarget it is the ModelServing
+    // name; for a role it is the role name.
+    Name string `json:"name"`
+
+    // CurrentReplicas is the number of replicas currently observed.
+    CurrentReplicas int32 `json:"currentReplicas"`
+
+    // DesiredReplicas is the number of replicas the controller computed from
+    // metrics, before ratio enforcement.
+    DesiredReplicas int32 `json:"desiredReplicas"`
+
+    // Mode reports whether the unit is currently in "Stable" or "Panic" mode.
+    // +optional
+    Mode string `json:"mode,omitempty"`
+
+    // LastScaleTime is the last time the unit was scaled by the controller.
+    // +optional
+    LastScaleTime *metav1.Time `json:"lastScaleTime,omitempty"`
+}
+
+// DisaggregatedScalingStatus reports the observed state of a DisaggregatedTarget.
+type DisaggregatedScalingStatus struct {
+    // Roles reports the observed scaling state per role.
+    Roles []TargetScalingStatus `json:"roles"`
+
+    // RatioStatuses reports the observed value per configured ratio constraint.
+    // +optional
+    RatioStatuses []RoleRatioStatus `json:"ratioStatuses,omitempty"`
+
+    // RatioAdjusted is true when the most recent reconcile had to override the
+    // metric-derived replica counts to satisfy one or more ratio constraints.
+    // +optional
+    RatioAdjusted bool `json:"ratioAdjusted,omitempty"`
+}
+
+// RoleRatioStatus reports the observed value for one ratio constraint.
+type RoleRatioStatus struct {
+  NumeratorRole   string `json:"numeratorRole"`
+  DenominatorRole string `json:"denominatorRole"`
+  CurrentRatio    string `json:"currentRatio,omitempty"`
+}
+```
+
+Recommended printer columns for `kubectl get autoscalingpolicy`:
+
+| Column | Source |
+|--------|--------|
+| `ROLES` | `len(status.disaggregatedStatus.roles)` |
+| `RATIOS` | `len(status.disaggregatedStatus.ratioStatuses)` |
+| `READY` | `status.conditions[type=Ready].status` |
 
 #### Full YAML Examples
 
@@ -270,7 +358,7 @@ spec:
   tolerancePercent: 10
   # Default metrics — used as fallback when a role doesn't specify its own
   metrics:
-    - metricName: pending_requests
+    - name: pending_requests
       targetValue: "5"
   behavior:
     scaleUp:
@@ -291,29 +379,40 @@ spec:
       kind: ModelServing
       name: llm-vllm-disagg
       apiVersion: workload.serving.volcano.sh/v1alpha1
-    prefill:
-      roleName: prefill
-      minReplicas: 1
-      maxReplicas: 8
-      metrics:                           # override default metrics for prefill
-        - metricName: num_requests_waiting
-          targetValue: "5"
-      metricEndpoint:
-        uri: /metrics
-        port: 8100
-    decode:
-      roleName: decode
-      minReplicas: 2
-      maxReplicas: 16
-      metrics:                           # override default metrics for decode
-        - metricName: gpu_kv_cache_usage_percent
-          targetValue: "80"
-      metricEndpoint:
-        uri: /metrics
-        port: 9100
-    ratioRange:
-      minRatio: "0.25"                   # P:D >= 1:4
-      maxRatio: "1"                       # P:D <= 1:1
+    roles:
+      prefill:
+        minReplicas: 1
+        maxReplicas: 8
+        metrics:                           # override default metrics for prefill
+          - name: num_requests_waiting
+            targetValue: "5"
+        metricSources:
+          num_requests_waiting:
+            type: Pod
+            pod:
+              name: num_requests_waiting
+              uri: /metrics
+              port: 8100
+              labelSelector:
+                matchLabels:
+                  role: prefill
+      decode:
+        minReplicas: 2
+        maxReplicas: 16
+        metrics:                           # override default metrics for decode
+          - name: gpu_kv_cache_usage_percent
+            targetValue: "80"
+        metricSources:
+          gpu_kv_cache_usage_percent:
+            type: Prometheus
+            prometheus:
+              serverURL: http://kube-prometheus-stack-prometheus.monitoring.svc:9090
+              query: avg(vllm_gpu_kv_cache_usage_percent{role="decode",model="llm-vllm-disagg"})
+    ratioConstraints:
+      - numeratorRole: prefill
+        denominatorRole: decode
+        minRatio: "0.25"                  # P:D >= 1:4
+        maxRatio: "1"                     # P:D <= 1:1
 ```
 
 ##### Homogeneous scaling (single resource, before vs. after)
@@ -328,7 +427,7 @@ metadata:
 spec:
   tolerancePercent: 10
   metrics:
-    - metricName: pending_requests
+    - name: pending_requests
       targetValue: "5"
   behavior: { ... }
 ---
@@ -358,7 +457,7 @@ metadata:
 spec:
   tolerancePercent: 10
   metrics:
-    - metricName: pending_requests
+    - name: pending_requests
       targetValue: "5"
   behavior: { ... }
   homogeneousTarget:
@@ -376,21 +475,25 @@ spec:
 |------|-------|
 | Exactly one of `homogeneousTarget`, `heterogeneousTarget`, `disaggregatedTarget` must be set. | `AutoscalingPolicySpec` (CEL) |
 | `spec.metrics` must have at least one entry. | `AutoscalingPolicySpec` |
+| `metricSources` keys must be a subset of the effective metric names for that scope. | `Target` / `RoleScalingParam` |
+| For each `MetricSource`, `type`/backend pairing must be valid (`Pod` -> `pod`, `Prometheus` -> `prometheus`). | `MetricSource` (CEL, preserved) |
 | `targetRef.kind` must be `ModelServing`. | `DisaggregatedTarget` |
-| `prefill.roleName` and `decode.roleName` must reference existing roles in the referenced ModelServing. | `DisaggregatedTarget` |
-| `prefill.roleName != decode.roleName` | `DisaggregatedTarget` |
-| `minReplicas <= maxReplicas` for both prefill and decode. | `RoleScalingParam` |
-| If `ratioRange` is set, `minRatio <= maxRatio`. | `PDRatioRange` (CEL) |
-| If `ratioRange` is set, the ratio range must be achievable: `prefill.minReplicas / decode.maxReplicas >= minRatio` **and** `prefill.maxReplicas / decode.minReplicas <= maxRatio` (when `decode.minReplicas > 0`). | `DisaggregatedTarget` |
+| `roles` map keys must reference existing roles in the referenced ModelServing and contain at least two entries. | `DisaggregatedTarget` |
+| `minReplicas <= maxReplicas` for each role. | `RoleScalingParam` |
+| For each `ratioConstraints` item: `numeratorRole != denominatorRole`, both roles exist in `roles`, and `minRatio <= maxRatio`. | `RoleRatioConstraint` (CEL) |
+| For each `ratioConstraints` item, bounds must be jointly achievable given role min/max replicas (when denominator min > 0). | `DisaggregatedTarget` |
+| For every constrained role pair `(A,B)`, scalable-to-zero must match: `roles[A].minReplicas == 0` **iff** `roles[B].minReplicas == 0`. | `DisaggregatedTarget` (CEL) |
 
 #### Scaling Semantics (Controller Contract)
 
 > **Note**: Controller implementation is out of scope for this proposal. These semantics define the contract the controller must honor.
 
-1. **Independent metric evaluation**: The controller evaluates metrics independently for prefill and decode, producing a desired replica count for each role. If a role defines its own `metrics`, those are used; otherwise the controller falls back to the top-level `spec.metrics`.
-2. **Per-role clamping**: Each desired count is clamped to `[minReplicas, maxReplicas]` of the corresponding role.
-3. **Ratio enforcement**: If `ratioRange` is configured, after clamping, the controller adjusts replica counts to satisfy `minRatio <= P/D <= maxRatio`. The adjustment strategy (e.g., scale up the lagging side vs. scale down the leading side) is a controller implementation detail.
-4. **Atomic patch**: The controller patches both `spec.template.roles[prefillIndex].replicas` and `spec.template.roles[decodeIndex].replicas` in a single ModelServing update to avoid intermediate states that violate the ratio.
+1. **Independent metric evaluation**: The controller evaluates metrics independently for each role in `disaggregatedTarget.roles`, producing a desired replica count per role. If a role defines its own `metrics`, those are used; otherwise the controller falls back to the top-level `spec.metrics`.
+2. **Metric source resolution**: For each effective metric name, the controller resolves `MetricSource` in this order: role-level `metricSources`, then target-level/default semantics. Resolved sources can be pod scraping or Prometheus query.
+3. **Per-role clamping**: Each desired count is clamped to `[minReplicas, maxReplicas]` of the corresponding role.
+4. **Coupled scale-to-zero (per constrained pair)**: For each pair appearing in `ratioConstraints`, both roles in that pair must reach zero together. The controller does not evaluate that pair's ratio while either side is `0`.
+5. **Ratio enforcement**: For each configured role pair, when both roles are non-zero, after clamping the controller adjusts replica counts to satisfy `minRatio <= replicas[numeratorRole]/replicas[denominatorRole] <= maxRatio`.
+6. **Atomic patch**: The controller patches all affected `spec.template.roles[*].replicas` in a single ModelServing update to avoid transient states that violate ratio constraints.
 
 #### Migration
 
@@ -399,7 +502,7 @@ spec:
 | Before | After |
 |--------|-------|
 | `AutoscalingPolicy` with metrics + behavior | Same fields stay in `AutoscalingPolicy.spec` |
-| `AutoscalingPolicyBinding` with `policyRef` + target | Target fields move into `AutoscalingPolicy.spec`; `policyRef` is deleted |
+| `AutoscalingPolicyBinding` with `policyRef` + target | Target fields (including `metricSources` with `Pod`/`Prometheus`) move into `AutoscalingPolicy.spec`; `policyRef` is deleted |
 | Two resources per scaling config | One resource |
 
 ##### From `SubTarget` P/D bindings
@@ -407,9 +510,9 @@ spec:
 | Before (policy + two bindings with SubTarget) | After (single policy) |
 |---|---|
 | Policy: metrics + behavior | `spec.metrics` + `spec.behavior` (same policy) |
-| Binding A: `homogeneousTarget.target.subTargets: {kind: Role, name: prefill}` | `spec.disaggregatedTarget.prefill.roleName: prefill` |
-| Binding B: `homogeneousTarget.target.subTargets: {kind: Role, name: decode}` | `spec.disaggregatedTarget.decode.roleName: decode` |
-| 3 resources, no ratio coordination | 1 resource, `ratioRange` provides coordination |
+| Binding A: `homogeneousTarget.target.subTargets: {kind: Role, name: prefill}` | `spec.disaggregatedTarget.roles.prefill` |
+| Binding B: `homogeneousTarget.target.subTargets: {kind: Role, name: decode}` | `spec.disaggregatedTarget.roles.decode` |
+| 3 resources, no ratio coordination | 1 resource, `ratioConstraints` provides coordination |
 
 ### Alternatives
 
@@ -417,7 +520,7 @@ spec:
 
 Keep the current two-resource model and only add `DisaggregatedTarget` to the binding.
 
-**Rejected because**: The policy/binding split provides no practical benefit — policies are not shared across bindings. It forces metric definitions to live in two places (policy-level and per-role overrides in the binding), increases the number of objects to manage, and makes the complete autoscaling configuration harder to read. Merging into one resource is simpler for both users and the controller.
+**Rejected because**: The policy/binding split provides no practical benefit — policies are not shared across bindings. It keeps metric targets and metric retrieval sources in different resources, increases the number of objects to manage, and makes the complete autoscaling configuration harder to read. Merging into one resource is simpler for both users and the controller.
 
 #### Alternative 2: Keep `SubTarget` and add ratio annotation
 
@@ -425,20 +528,73 @@ Add a `volcano.sh/pd-ratio-range` annotation to coordinate two separate bindings
 
 **Rejected because**: Annotations are untyped, unvalidated, and invisible to schema tooling. Coordination between two separate resources via annotations is fragile and hard to reason about.
 
-#### Alternative 3: Generic `roles[]` list instead of explicit `prefill` / `decode` fields
+#### Alternative 3: Generic `roles[]` list instead of `roles` map
 
 ```go
 type DisaggregatedTarget struct {
     TargetRef  corev1.ObjectReference `json:"targetRef"`
     Roles      []RoleScalingParam     `json:"roles"`
-    RatioRange *PDRatioRange          `json:"ratioRange,omitempty"`
+    RatioConstraints []RoleRatioConstraint `json:"ratioConstraints,omitempty"`
 }
 ```
 
-**Rejected because**: P/D disaggregation is inherently a two-role pattern. A generic list makes ratio semantics ambiguous (which role is the numerator?), loses schema-level defaulting for role names, and opens the door to unsupported configurations (3+ roles with ratio constraints). If future architectures require more than two roles, a new target type can be introduced.
+**Rejected because**: a list weakens key-based validation and makes patch/update operations harder (rename and merge semantics are less stable than map keys). `roles` map uses roleName as the canonical key and works better with ratio constraints that reference roles by name.
 
 #### Alternative 4: Extend `HomogeneousTarget` with optional P/D fields
 
 Add `prefill` and `decode` fields inside `HomogeneousTarget`.
 
 **Rejected because**: `HomogeneousTarget` is inherently single-target. Embedding P/D semantics overloads its purpose and creates confusing validation rules (e.g., `minReplicas`/`maxReplicas` at top level vs. per-role). A separate target type is cleaner.
+
+#### Alternative 5: Integer-pair ratio instead of `resource.Quantity`
+
+Express each ratio bound as an explicit numerator/denominator integer pair rather than a single decimal `resource.Quantity`:
+
+```go
+// RoleRatio expresses a role-to-role ratio as an integer pair N:D.
+// For example, {Numerator: 1, Denominator: 4} means ratio = 1:4 (0.25).
+type RoleRatio struct {
+    // Numerator is the numerator side of the ratio.
+    // +kubebuilder:validation:Minimum=0
+    Numerator int32 `json:"numerator"`
+    // Denominator is the denominator side of the ratio.
+    // +kubebuilder:validation:Minimum=1
+    Denominator int32 `json:"denominator"`
+}
+
+// RoleRatioConstraintIntPair defines one role-pair ratio constraint.
+type RoleRatioConstraintIntPair struct {
+    NumeratorRole   string    `json:"numeratorRole"`
+    DenominatorRole string    `json:"denominatorRole"`
+    MinRatio        RoleRatio `json:"minRatio"`
+    MaxRatio        RoleRatio `json:"maxRatio"`
+}
+```
+
+Example YAML:
+
+```yaml
+    ratioConstraints:
+      - numeratorRole: prefill
+        denominatorRole: decode
+        minRatio:                # P:D >= 1:4
+          numerator: 1
+          denominator: 4
+        maxRatio:                # P:D <= 1:1
+          numerator: 1
+          denominator: 1
+```
+
+**Pros**:
+
+- **No unit ambiguity** — integers cannot be misread the way `resource.Quantity` interprets suffixes (`"250m"` → `0.25`), removing a class of user error.
+- **Directly mirrors how operators reason** — people think and communicate in terms of "1:4", not "0.25".
+- **Exact comparison** — ratio checks become cross-multiplication of integers (`p1*d2 <= p2*d1`), avoiding any decimal parsing or rounding entirely.
+
+**Cons**:
+
+- **Two fields per bound** instead of one — slightly more verbose YAML.
+- **Diverges from existing convention** — `AutoscalingPolicyMetric.TargetValue` and other Kthena fields already use `resource.Quantity` for decimal values, so the integer pair would be the odd one out.
+- **CEL validation is marginally more complex** — comparisons require cross-multiplication rather than a direct `<=`.
+
+**Decision**: The proposal uses `resource.Quantity` for consistency with the rest of the Kthena API, mitigating the unit-ambiguity concern through documentation and webhook validation (rejecting values with non-empty suffixes). The integer-pair form is recorded here as a viable alternative should the unit ambiguity prove to be a frequent source of user error in practice.

--- a/docs/proposal/pd-disaggregated-autoscaling.md
+++ b/docs/proposal/pd-disaggregated-autoscaling.md
@@ -1,0 +1,444 @@
+---
+title: P/D Disaggregated Autoscaling API
+authors:
+- TBD
+reviewers:
+- TBD
+approvers:
+- TBD
+
+creation-date: 2025-05-09
+
+---
+
+## P/D Disaggregated Autoscaling API
+
+### Summary
+
+This proposal redesigns the autoscaling API with two goals:
+
+1. **Merge `AutoscalingPolicyBinding` into `AutoscalingPolicy`** — today users must create two resources (policy + binding) and cross-reference them. Merging eliminates the indirection, avoids duplicating metric definitions across objects, and gives users a single resource that fully describes "what to scale, on what signal, and how."
+2. **Add first-class `DisaggregatedTarget`** — replace the generic `SubTarget` mechanism with a purpose-built structure for coordinated Prefill/Decode scaling, including independent per-role metrics, replica bounds, and a P/D ratio range constraint.
+
+The `AutoscalingPolicyBinding` CRD and the `SubTarget` type are removed.
+
+### Motivation
+
+In disaggregated prefill/decode inference architectures, the prefill and decode stages have fundamentally different resource profiles:
+
+- **Prefill** is compute-bound and bursty — it processes the full prompt in one forward pass.
+- **Decode** is memory-bandwidth-bound and long-running — it generates tokens auto-regressively.
+
+Scaling these two stages independently is essential for cost-efficient serving. However, independent scaling alone is insufficient — the P/D ratio must be coordinated. Too many prefill replicas starve decode capacity (growing queues); too many decode replicas waste GPU memory on idle KV caches. A healthy system keeps the ratio within an operator-defined range.
+
+**Problems with the current two-resource model (AutoscalingPolicy + AutoscalingPolicyBinding):**
+
+1. **Unnecessary indirection** — the user always creates a 1:1 pair (policy + binding). The binding adds a `policyRef` that points to a policy in the same namespace. This indirection provides no reuse benefit in practice (policies are rarely shared across multiple bindings) and doubles the number of objects to manage.
+2. **Metric duplication** — with per-role metrics in the binding and policy-level metrics in the policy object, `AutoscalingPolicyMetric` appears in two CRDs. This is confusing and error-prone when users need to update metric targets.
+3. **Fragmented view** — operators must read two resources to understand the complete autoscaling configuration for a single ModelServing.
+
+**Problems with `SubTarget` for P/D disaggregation:**
+
+1. **No coordination** — each binding scales its target independently; there is no concept of a ratio constraint between prefill and decode.
+2. **Fragile coupling** — two bindings must manually agree on `targetRef`, and there is no validation that they reference the same ModelServing.
+3. **Generic abstraction** — `SubTarget` is a generic kind/name pair. It provides no schema-level guidance, validation, or defaulting for P/D use cases.
+
+#### Goals
+
+- Merge `AutoscalingPolicyBinding` into `AutoscalingPolicy` to provide a single-resource UX.
+- Provide a single `AutoscalingPolicy` resource that drives coordinated P/D scaling for one ModelServing.
+- Allow independent `minReplicas` / `maxReplicas` per role to set per-stage capacity boundaries.
+- Introduce a `ratioRange` constraint so the controller can enforce a healthy P/D ratio.
+- Support per-role metrics and metric endpoints (prefill and decode may scale on different signals and expose metrics on different ports/paths).
+- Remove the `AutoscalingPolicyBinding` CRD and the generic `SubTarget` type.
+
+#### Non-Goals
+
+- Controller implementation and reconciliation loop design (covered separately).
+- Multi-ModelServing (heterogeneous hardware) P/D scaling — that remains in `HeterogeneousTarget`.
+
+### Proposal
+
+#### User Stories
+
+##### Story 1: Single-resource autoscaling
+
+As an ML platform operator, I want to define the complete autoscaling configuration — metrics, behavior, and target — in a single `AutoscalingPolicy` resource instead of maintaining a policy and a separate binding that cross-reference each other.
+
+##### Story 2: Independent P/D scaling with ratio guardrails
+
+As an ML platform operator, I deploy a vLLM disaggregated model with prefill and decode roles. I want the autoscaler to scale prefill replicas between 1–8 and decode replicas between 2–16, while always maintaining a P:D ratio between 1:1 and 1:4. This means if I have 2 prefill replicas, the decode replicas must be between 2 and 8.
+
+##### Story 3: Per-role metrics and endpoints
+
+As a platform engineer, my prefill pods should scale based on `num_requests_waiting` (targeting 5) scraped on port 8100, while decode pods should scale based on `gpu_kv_cache_usage_percent` (targeting 80%) on port 9100. I need to configure both the scaling metrics and scraping endpoints for each role independently, all in one place.
+
+##### Story 4: Migration from Policy + Binding
+
+As an existing user with an `AutoscalingPolicy` and one or more `AutoscalingPolicyBinding` objects, I want to consolidate into a single `AutoscalingPolicy` resource.
+
+#### Risks and Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Breaking change: removes `AutoscalingPolicyBinding` CRD | Both CRDs are alpha-level. Provide a migration guide and conversion tooling. The merged API is strictly simpler. |
+| Breaking change for users currently using `SubTarget` | `SubTarget` was alpha-level and only used for P/D roles — the replacement `DisaggregatedTarget` is strictly more capable. |
+| Loss of policy reuse across bindings | In practice policies are rarely shared. If reuse is needed, users can use templating tools (Helm, Kustomize). The UX win of a single resource outweighs the theoretical reuse loss. |
+| Ratio enforcement may conflict with per-role min/max bounds | Webhook validates that `ratioRange` is achievable given the min/max replica bounds at admission time. |
+| Increased controller complexity | Ratio enforcement is a bounded constraint-satisfaction problem; design details are deferred to the controller proposal. |
+
+### Design Details
+
+#### API Changes Overview
+
+| Change | Description |
+|--------|-------------|
+| Delete `AutoscalingPolicyBinding` CRD | All target/binding fields move into `AutoscalingPolicy`. |
+| Delete `SubTarget` type | Replaced by `DisaggregatedTarget`. |
+| Expand `AutoscalingPolicySpec` | Add target fields (`homogeneousTarget`, `heterogeneousTarget`, `disaggregatedTarget`) directly. Metrics become the default; per-role metrics can override them. |
+| Add `DisaggregatedTarget` | New first-class P/D scaling type with `Prefill`, `Decode`, and `RatioRange`. |
+| Simplify `Target` | Remove `SubTarget` field. |
+
+##### 1. Merged `AutoscalingPolicy`
+
+```go
+// AutoscalingPolicySpec defines the desired state of AutoscalingPolicy.
+// +kubebuilder:validation:XValidation:rule="[has(self.heterogeneousTarget), has(self.homogeneousTarget), has(self.disaggregatedTarget)].filter(x, x).size() == 1",message="Exactly one of heterogeneousTarget, homogeneousTarget, or disaggregatedTarget must be set."
+type AutoscalingPolicySpec struct {
+	// Metrics defines the default list of metrics used to evaluate scaling decisions.
+	// For HomogeneousTarget and HeterogeneousTarget these are the metrics used directly.
+	// For DisaggregatedTarget these serve as the fallback when a role does not specify its own metrics.
+	// +kubebuilder:validation:MinItems=1
+	Metrics []AutoscalingPolicyMetric `json:"metrics"`
+
+	// TolerancePercent defines the percentage of deviation tolerated before scaling actions are triggered.
+	// Scaling operations are performed only when |current - desired| >= current * tolerancePercent / 100.
+	// +optional
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=100
+	// +kubebuilder:default=10
+	TolerancePercent int32 `json:"tolerancePercent"`
+
+	// Behavior defines the scaling behavior configuration for both scale up and scale down operations.
+	// +optional
+	Behavior AutoscalingPolicyBehavior `json:"behavior"`
+
+	// --- Target (exactly one must be set) ---
+
+	// HomogeneousTarget enables traditional metric-based scaling for a
+	// single ModelServing deployment (whole-deployment granularity).
+	// +optional
+	HomogeneousTarget *HomogeneousTarget `json:"homogeneousTarget,omitempty"`
+
+	// HeterogeneousTarget enables optimization-based scaling across multiple
+	// ModelServing deployments with different hardware capabilities.
+	// +optional
+	HeterogeneousTarget *HeterogeneousTarget `json:"heterogeneousTarget,omitempty"`
+
+	// DisaggregatedTarget enables coordinated autoscaling of prefill and decode
+	// roles within a single ModelServing that uses disaggregated serving.
+	// +optional
+	DisaggregatedTarget *DisaggregatedTarget `json:"disaggregatedTarget,omitempty"`
+}
+```
+
+##### 2. Remove `SubTarget` and simplify `Target`
+
+Delete the `SubTarget` struct. `Target` is simplified to:
+
+```go
+// Target defines a ModelServing deployment that can be monitored and scaled.
+type Target struct {
+	// TargetRef references the target object to be monitored and scaled.
+	TargetRef corev1.ObjectReference `json:"targetRef"`
+	// MetricEndpoint defines the configuration for scraping metrics from the target pods.
+	// +optional
+	MetricEndpoint MetricEndpoint `json:"metricEndpoint,omitempty"`
+}
+```
+
+`Target` remains in use by `HomogeneousTarget` (whole-ModelServing scaling) and `HeterogeneousTarget` (multi-ModelServing optimization). Both operate at the ModelServing level and never used `SubTarget` meaningfully.
+
+##### 3. `DisaggregatedTarget` and supporting types
+
+```go
+// DisaggregatedTarget defines coordinated autoscaling for prefill/decode
+// disaggregated serving within a single ModelServing deployment.
+type DisaggregatedTarget struct {
+	// TargetRef references the ModelServing deployment that contains
+	// prefill and decode roles.
+	TargetRef corev1.ObjectReference `json:"targetRef"`
+
+	// Prefill defines scaling parameters for the prefill role.
+	Prefill RoleScalingParam `json:"prefill"`
+
+	// Decode defines scaling parameters for the decode role.
+	Decode RoleScalingParam `json:"decode"`
+
+	// RatioRange defines the acceptable range for the Prefill-to-Decode
+	// replica ratio (P:D). The controller will respect this range when
+	// making scaling decisions. Both values express ratios as
+	// prefillReplicas / decodeReplicas.
+	//
+	// Example: minRatio=0.25, maxRatio=1.0 means for every decode replica,
+	// there should be between 0.25 and 1.0 prefill replicas (i.e., P:D
+	// ranges from 1:4 to 1:1).
+	//
+	// +optional
+	RatioRange *PDRatioRange `json:"ratioRange,omitempty"`
+}
+
+// RoleScalingParam defines the scaling configuration for a single role
+// (prefill or decode) within a disaggregated serving deployment.
+type RoleScalingParam struct {
+	// RoleName is the name of the role as defined in the ModelServing
+	// spec.template.roles[].name. Defaults to "prefill" for the prefill
+	// field and "decode" for the decode field if not specified.
+	// +optional
+	RoleName string `json:"roleName,omitempty"`
+
+	// MinReplicas defines the minimum number of replicas for this role.
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=1000000
+	MinReplicas int32 `json:"minReplicas"`
+
+	// MaxReplicas defines the maximum number of replicas for this role.
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=1000000
+	MaxReplicas int32 `json:"maxReplicas"`
+
+	// Metrics overrides the policy-level metrics for this specific role.
+	// This allows prefill and decode roles to scale on different signals
+	// (e.g., prefill on queue depth, decode on KV cache utilization).
+	// If not set, the top-level spec.metrics are used.
+	// +optional
+	// +kubebuilder:validation:MinItems=1
+	Metrics []AutoscalingPolicyMetric `json:"metrics,omitempty"`
+
+	// MetricEndpoint defines the configuration for scraping metrics from
+	// pods of this role. If not specified, the controller uses defaults.
+	// +optional
+	MetricEndpoint *MetricEndpoint `json:"metricEndpoint,omitempty"`
+}
+
+// PDRatioRange defines the acceptable range for the prefill-to-decode ratio.
+// +kubebuilder:validation:XValidation:rule="self.minRatio <= self.maxRatio",message="minRatio must be <= maxRatio"
+type PDRatioRange struct {
+	// MinRatio is the minimum allowed value of prefillReplicas / decodeReplicas.
+	// +kubebuilder:validation:Minimum=0
+	MinRatio resource.Quantity `json:"minRatio"`
+
+	// MaxRatio is the maximum allowed value of prefillReplicas / decodeReplicas.
+	MaxRatio resource.Quantity `json:"maxRatio"`
+}
+```
+
+> **Why `resource.Quantity` for ratios?** Kubernetes does not support native `float` fields in CRDs. `resource.Quantity` is the idiomatic way to express decimal values in the Kubernetes API (e.g., `"0.25"`, `"1"`, `"2.5"`). It avoids floating-point imprecision and is already used throughout the Kubernetes and Kthena APIs for similar purposes.
+
+##### 4. `HomogeneousTarget` (unchanged, except `SubTarget` removed from `Target`)
+
+```go
+type HomogeneousTarget struct {
+	// Target defines the object to be monitored and scaled.
+	Target Target `json:"target,omitempty"`
+	// MinReplicas defines the minimum number of replicas to maintain.
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=1000000
+	MinReplicas int32 `json:"minReplicas"`
+	// MaxReplicas defines the maximum number of replicas allowed.
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=1000000
+	MaxReplicas int32 `json:"maxReplicas"`
+}
+```
+
+##### 5. Delete `AutoscalingPolicyBinding` CRD
+
+The entire `AutoscalingPolicyBinding`, `AutoscalingPolicyBindingSpec`, `AutoscalingPolicyBindingStatus`, and `AutoscalingPolicyBindingList` types are removed. The `policyRef` indirection is eliminated.
+
+#### Full YAML Examples
+
+##### Disaggregated P/D scaling (single resource)
+
+```yaml
+apiVersion: workload.serving.volcano.sh/v1alpha1
+kind: AutoscalingPolicy
+metadata:
+  name: llm-pd-scaling
+  namespace: default
+spec:
+  tolerancePercent: 10
+  # Default metrics — used as fallback when a role doesn't specify its own
+  metrics:
+    - metricName: pending_requests
+      targetValue: "5"
+  behavior:
+    scaleUp:
+      stablePolicy:
+        instances: 2
+        period: 30s
+        stabilizationWindow: 60s
+      panicPolicy:
+        period: 10s
+        panicThresholdPercent: 200
+        panicModeHold: 120s
+    scaleDown:
+      instances: 1
+      period: 60s
+      stabilizationWindow: 300s
+  disaggregatedTarget:
+    targetRef:
+      kind: ModelServing
+      name: llm-vllm-disagg
+      apiVersion: workload.serving.volcano.sh/v1alpha1
+    prefill:
+      roleName: prefill
+      minReplicas: 1
+      maxReplicas: 8
+      metrics:                           # override default metrics for prefill
+        - metricName: num_requests_waiting
+          targetValue: "5"
+      metricEndpoint:
+        uri: /metrics
+        port: 8100
+    decode:
+      roleName: decode
+      minReplicas: 2
+      maxReplicas: 16
+      metrics:                           # override default metrics for decode
+        - metricName: gpu_kv_cache_usage_percent
+          targetValue: "80"
+      metricEndpoint:
+        uri: /metrics
+        port: 9100
+    ratioRange:
+      minRatio: "0.25"                   # P:D >= 1:4
+      maxRatio: "1"                       # P:D <= 1:1
+```
+
+##### Homogeneous scaling (single resource, before vs. after)
+
+Before (two resources):
+
+```yaml
+apiVersion: workload.serving.volcano.sh/v1alpha1
+kind: AutoscalingPolicy
+metadata:
+  name: my-policy
+spec:
+  tolerancePercent: 10
+  metrics:
+    - metricName: pending_requests
+      targetValue: "5"
+  behavior: { ... }
+---
+apiVersion: workload.serving.volcano.sh/v1alpha1
+kind: AutoscalingPolicyBinding
+metadata:
+  name: my-binding
+spec:
+  policyRef:
+    name: my-policy
+  homogeneousTarget:
+    target:
+      targetRef:
+        kind: ModelServing
+        name: my-model
+    minReplicas: 1
+    maxReplicas: 10
+```
+
+After (single resource):
+
+```yaml
+apiVersion: workload.serving.volcano.sh/v1alpha1
+kind: AutoscalingPolicy
+metadata:
+  name: my-policy
+spec:
+  tolerancePercent: 10
+  metrics:
+    - metricName: pending_requests
+      targetValue: "5"
+  behavior: { ... }
+  homogeneousTarget:
+    target:
+      targetRef:
+        kind: ModelServing
+        name: my-model
+    minReplicas: 1
+    maxReplicas: 10
+```
+
+#### Validation Rules (Webhook)
+
+| Rule | Scope |
+|------|-------|
+| Exactly one of `homogeneousTarget`, `heterogeneousTarget`, `disaggregatedTarget` must be set. | `AutoscalingPolicySpec` (CEL) |
+| `spec.metrics` must have at least one entry. | `AutoscalingPolicySpec` |
+| `targetRef.kind` must be `ModelServing`. | `DisaggregatedTarget` |
+| `prefill.roleName` and `decode.roleName` must reference existing roles in the referenced ModelServing. | `DisaggregatedTarget` |
+| `prefill.roleName != decode.roleName` | `DisaggregatedTarget` |
+| `minReplicas <= maxReplicas` for both prefill and decode. | `RoleScalingParam` |
+| If `ratioRange` is set, `minRatio <= maxRatio`. | `PDRatioRange` (CEL) |
+| If `ratioRange` is set, the ratio range must be achievable: `prefill.minReplicas / decode.maxReplicas >= minRatio` **and** `prefill.maxReplicas / decode.minReplicas <= maxRatio` (when `decode.minReplicas > 0`). | `DisaggregatedTarget` |
+
+#### Scaling Semantics (Controller Contract)
+
+> **Note**: Controller implementation is out of scope for this proposal. These semantics define the contract the controller must honor.
+
+1. **Independent metric evaluation**: The controller evaluates metrics independently for prefill and decode, producing a desired replica count for each role. If a role defines its own `metrics`, those are used; otherwise the controller falls back to the top-level `spec.metrics`.
+2. **Per-role clamping**: Each desired count is clamped to `[minReplicas, maxReplicas]` of the corresponding role.
+3. **Ratio enforcement**: If `ratioRange` is configured, after clamping, the controller adjusts replica counts to satisfy `minRatio <= P/D <= maxRatio`. The adjustment strategy (e.g., scale up the lagging side vs. scale down the leading side) is a controller implementation detail.
+4. **Atomic patch**: The controller patches both `spec.template.roles[prefillIndex].replicas` and `spec.template.roles[decodeIndex].replicas` in a single ModelServing update to avoid intermediate states that violate the ratio.
+
+#### Migration
+
+##### From `AutoscalingPolicy` + `AutoscalingPolicyBinding`
+
+| Before | After |
+|--------|-------|
+| `AutoscalingPolicy` with metrics + behavior | Same fields stay in `AutoscalingPolicy.spec` |
+| `AutoscalingPolicyBinding` with `policyRef` + target | Target fields move into `AutoscalingPolicy.spec`; `policyRef` is deleted |
+| Two resources per scaling config | One resource |
+
+##### From `SubTarget` P/D bindings
+
+| Before (policy + two bindings with SubTarget) | After (single policy) |
+|---|---|
+| Policy: metrics + behavior | `spec.metrics` + `spec.behavior` (same policy) |
+| Binding A: `homogeneousTarget.target.subTargets: {kind: Role, name: prefill}` | `spec.disaggregatedTarget.prefill.roleName: prefill` |
+| Binding B: `homogeneousTarget.target.subTargets: {kind: Role, name: decode}` | `spec.disaggregatedTarget.decode.roleName: decode` |
+| 3 resources, no ratio coordination | 1 resource, `ratioRange` provides coordination |
+
+### Alternatives
+
+#### Alternative 1: Keep `AutoscalingPolicyBinding` as a separate CRD
+
+Keep the current two-resource model and only add `DisaggregatedTarget` to the binding.
+
+**Rejected because**: The policy/binding split provides no practical benefit — policies are not shared across bindings. It forces metric definitions to live in two places (policy-level and per-role overrides in the binding), increases the number of objects to manage, and makes the complete autoscaling configuration harder to read. Merging into one resource is simpler for both users and the controller.
+
+#### Alternative 2: Keep `SubTarget` and add ratio annotation
+
+Add a `volcano.sh/pd-ratio-range` annotation to coordinate two separate bindings.
+
+**Rejected because**: Annotations are untyped, unvalidated, and invisible to schema tooling. Coordination between two separate resources via annotations is fragile and hard to reason about.
+
+#### Alternative 3: Generic `roles[]` list instead of explicit `prefill` / `decode` fields
+
+```go
+type DisaggregatedTarget struct {
+    TargetRef  corev1.ObjectReference `json:"targetRef"`
+    Roles      []RoleScalingParam     `json:"roles"`
+    RatioRange *PDRatioRange          `json:"ratioRange,omitempty"`
+}
+```
+
+**Rejected because**: P/D disaggregation is inherently a two-role pattern. A generic list makes ratio semantics ambiguous (which role is the numerator?), loses schema-level defaulting for role names, and opens the door to unsupported configurations (3+ roles with ratio constraints). If future architectures require more than two roles, a new target type can be introduced.
+
+#### Alternative 4: Extend `HomogeneousTarget` with optional P/D fields
+
+Add `prefill` and `decode` fields inside `HomogeneousTarget`.
+
+**Rejected because**: `HomogeneousTarget` is inherently single-target. Embedding P/D semantics overloads its purpose and creates confusing validation rules (e.g., `minReplicas`/`maxReplicas` at top level vs. per-role). A separate target type is cleaner.

--- a/docs/proposal/pd-disaggregated-autoscaling.md
+++ b/docs/proposal/pd-disaggregated-autoscaling.md
@@ -19,7 +19,7 @@ creation-date: 2025-05-09
 This proposal redesigns the autoscaling API with two goals:
 
 1. **Merge `AutoscalingPolicyBinding` into `AutoscalingPolicy`** — today users must create two resources (policy + binding) and cross-reference them. Merging eliminates the indirection, removes split configuration across objects, and gives users a single resource that fully describes "what to scale, on what signal, and how."
-2. **Add first-class `DisaggregatedTarget`** — replace the generic `SubTarget` mechanism with a purpose-built structure for coordinated multi-role scaling, including independent per-role metrics, per-role metric sources (Pod or Prometheus), replica bounds, and role-to-role ratio constraints.
+2. **Add first-class `DisaggregatedTarget`** — replace the generic `SubTarget` mechanism with a purpose-built structure for coordinated multi-role scaling, including independent per-role metrics, per-role metric sources (Pod or Prometheus), replica bounds, and a role-to-role ratio constraint.
 
 The `AutoscalingPolicyBinding` CRD and the `SubTarget` type are removed.
 
@@ -28,7 +28,7 @@ The `AutoscalingPolicyBinding` CRD and the `SubTarget` type are removed.
 In disaggregated prefill/decode inference architectures, the prefill and decode stages have fundamentally different resource profiles:
 
 - **Prefill** is compute-bound and bursty — it processes the full prompt in one forward pass.
-- **Decode** is memory-bandwidth-bound and long-running — it generates tokens autoregressively.
+- **Decode** is memory-bandwidth-bound and long-running — it generates tokens auto-regressively.
 
 Scaling these two stages independently is essential for cost-efficient serving. However, independent scaling alone is insufficient — the P/D ratio must be coordinated. Too many prefill replicas starve decode capacity (growing queues); too many decode replicas waste GPU memory on idle KV caches. A healthy system keeps the ratio within an operator-defined range.
 
@@ -49,7 +49,7 @@ Scaling these two stages independently is essential for cost-efficient serving. 
 - Merge `AutoscalingPolicyBinding` into `AutoscalingPolicy` to provide a single-resource UX.
 - Provide a single `AutoscalingPolicy` resource that drives coordinated P/D scaling for one ModelServing.
 - Allow independent `minReplicas` / `maxReplicas` per role to set per-stage capacity boundaries.
-- Introduce `ratioConstraints` so the controller can enforce healthy role-to-role ratios.
+- Introduce a `ratioConstraint` so the controller can enforce a healthy role-to-role ratio.
 - Support per-role metrics and per-role metric sources, reusing current `MetricSource` semantics (`Pod` and `Prometheus`).
 - Remove the `AutoscalingPolicyBinding` CRD and the generic `SubTarget` type.
 
@@ -85,7 +85,7 @@ As an existing user with an `AutoscalingPolicy` and one or more `AutoscalingPoli
 | Breaking change: removes `AutoscalingPolicyBinding` CRD | Both CRDs are alpha-level. Provide a migration guide and conversion tooling. The merged API is strictly simpler. |
 | Breaking change for users currently using `SubTarget` | `SubTarget` was alpha-level and only used for P/D roles — the replacement `DisaggregatedTarget` is strictly more capable. |
 | Loss of policy reuse across bindings | In practice policies are rarely shared. If reuse is needed, users can use templating tools (Helm, Kustomize). The UX win of a single resource outweighs the theoretical reuse loss. |
-| Ratio enforcement may conflict with per-role min/max bounds | Webhook validates that each `ratioConstraints` entry is achievable given min/max replica bounds at admission time. |
+| Ratio constraint may be unsatisfiable given per-role min/max bounds | The webhook validates `minRatio <= maxRatio`, that both roles exist and differ, and that the range is achievable within the role replica bounds at admission. See [Validation Rules](#validation-rules-crd--webhook). |
 | Increased controller complexity | Ratio enforcement is a bounded constraint-satisfaction problem; design details are deferred to the controller proposal. |
 
 ### Design Details
@@ -96,16 +96,16 @@ As an existing user with an `AutoscalingPolicy` and one or more `AutoscalingPoli
 |--------|-------------|
 | Delete `AutoscalingPolicyBinding` CRD | All target/binding fields move into `AutoscalingPolicy`. |
 | Delete `SubTarget` type | Replaced by `DisaggregatedTarget`. |
-| Expand `AutoscalingPolicySpec` | Add target fields (`homogeneousTarget`, `heterogeneousTarget`, `disaggregatedTarget`) directly. Metrics become the default; per-role metrics can override them. |
+| Expand `AutoscalingPolicySpec` | Add target fields (`homogeneousTarget`, `heterogeneousTarget`, `disaggregatedTarget`) directly. `spec.metrics` (uniform, applies to all roles) and per-role `metrics` are mutually exclusive. |
 | Preserve `MetricSource` model | Keep current `MetricSource` discriminated union (`Pod` / `Prometheus`) and move per-target/per-role `metricSources` into `AutoscalingPolicy`. |
-| Add `DisaggregatedTarget` | New first-class multi-role scaling type with `roles` and `ratioConstraints`. |
+| Add `DisaggregatedTarget` | New first-class multi-role scaling type with `roles` and a single `ratioConstraint`. |
 | Simplify `Target` | Remove `SubTarget` field. |
 
 ##### 1. Merged `AutoscalingPolicy`
 
 ```go
 // AutoscalingPolicySpec defines the desired state of AutoscalingPolicy.
-// +kubebuilder:validation:XValidation:rule="[has(self.heterogeneousTarget), has(self.homogeneousTarget), has(self.disaggregatedTarget)].exists_one(x, x).size() == 1",message="Exactly one of heterogeneousTarget, homogeneousTarget, or disaggregatedTarget must be set."
+// +kubebuilder:validation:XValidation:rule="(has(self.heterogeneousTarget) ? 1 : 0) + (has(self.homogeneousTarget) ? 1 : 0) + (has(self.disaggregatedTarget) ? 1 : 0) == 1",message="Exactly one of heterogeneousTarget, homogeneousTarget, or disaggregatedTarget must be set."
 type AutoscalingPolicySpec struct {
     // ...
 
@@ -146,13 +146,12 @@ type Target struct {
 }
 ```
 
-`Target` remains in use by `HomogeneousTarget` (whole-ModelServing scaling) and `HeterogeneousTarget` (multi-ModelServing optimization). Both operate at the ModelServing level and never used `SubTarget` meaningfully.
+`Target` remains in use by `HomogeneousTarget` (whole-ModelServing scaling) and `HeterogeneousTarget` (multi-ModelServing optimization). Both operate at the ModelServing level; `SubTarget` was primarily used for role-level scaling (e.g., P/D), which is superseded by `DisaggregatedTarget` in this proposal.
 
 ##### 2.1 Preserve `MetricSource` and Prometheus semantics
 
 The merged API keeps the existing metric-source model from `AutoscalingPolicyBinding` unchanged:
 
-- `MetricSource.type: Pod | Prometheus` (default `Pod`)
 - `MetricSource.pod` for direct pod scraping (`name`/`uri`/`port`/`labelSelector`)
 - `MetricSource.prometheus` for external Prometheus query (`serverURL` + `query`)
 
@@ -173,13 +172,13 @@ type DisaggregatedTarget struct {
     // +kubebuilder:validation:MinProperties=2
     Roles map[string]RoleScalingParam `json:"roles"`
 
-    // RatioConstraints defines acceptable ratio ranges between role pairs.
-    // Each constraint enforces:
+    // RatioConstraint defines the acceptable ratio range of a single role pair.
+    // It enforces:
     //   minRatio <= replicas[numeratorRole] / replicas[denominatorRole] <= maxRatio
-    // when denominator replicas is non-zero.
+    // when denominator replica is non-zero.
     //
     // +optional
-    RatioConstraints []RoleRatioConstraint `json:"ratioConstraints,omitempty"`
+    RatioConstraint *RoleRatioConstraint `json:"ratioConstraint,omitempty"`
 }
 
 // RoleScalingParam defines the scaling configuration for one role.
@@ -194,9 +193,13 @@ type RoleScalingParam struct {
     // +kubebuilder:validation:Maximum=1000000
     MaxReplicas int32 `json:"maxReplicas"`
 
-    // Metrics overrides the policy-level metrics for this specific role.
-    // This allows different roles to scale on different signals.
-    // If not set, the top-level spec.metrics are used.
+    // Metrics defines the list of metrics used to evaluate scaling decisions
+    // for this role, allowing different roles to scale on different signals.
+    //
+    // spec.metrics (policy-level) and per-role metrics are MUTUALLY EXCLUSIVE:
+    // either set spec.metrics to scale every role on the same signals, or set
+    // metrics on every role here and leave spec.metrics empty. They must not
+    // both be set (see Validation Rules).
     // +optional
     // +kubebuilder:validation:MinItems=1
     Metrics []AutoscalingPolicyMetric `json:"metrics,omitempty"`
@@ -204,13 +207,14 @@ type RoleScalingParam struct {
     // MetricSources declares how each metric is fetched for this role.
     // Keys must match role-level metrics when present, otherwise top-level
     // spec.metrics[].name.
-    // Missing keys default to pod scraping behavior equivalent to an empty
-    // PodMetricSource (uri=/metrics, port=8100, metric name defaults to key).
+    // Missing keys are treated as missing metrics for that reconcile loop.
     // +optional
     MetricSources map[string]MetricSource `json:"metricSources,omitempty"`
 }
 
 // RoleRatioConstraint defines the acceptable ratio range between two roles.
+// +kubebuilder:validation:XValidation:rule="self.minRatio <= self.maxRatio",message="minRatio must be <= maxRatio"
+// +kubebuilder:validation:XValidation:rule="self.numeratorRole != self.denominatorRole",message="numeratorRole and denominatorRole must differ"
 type RoleRatioConstraint struct {
     // NumeratorRole is the role on the numerator side of the ratio.
     NumeratorRole string `json:"numeratorRole"`
@@ -269,7 +273,7 @@ type AutoscalingPolicyStatus struct {
     // Well-known condition types include:
     //   - "Ready":                   the policy is actively reconciled.
     //   - "TargetFound":             the referenced ModelServing (and roles) exist.
-    //   - "RatioConstraintViolated": the desired counts could not satisfy ratioConstraints
+    //   - "RatioConstraintViolated": the desired counts could not satisfy ratioConstraint
     //                                given the per-role min/max bounds.
     // +optional
     // +listType=map
@@ -314,25 +318,42 @@ type TargetScalingStatus struct {
 }
 
 // DisaggregatedScalingStatus reports the observed state of a DisaggregatedTarget.
+//
+// Example: a prefill/decode target whose metrics asked for prefill=6, decode=2,
+// but the ratioConstraint prefill/decode <= 1 forced decode up to 6:
+//
+//   disaggregatedStatus:
+//     roles:
+//       - name: prefill
+//         currentReplicas: 6
+//         desiredReplicas: 6        # metric-derived, kept as-is
+//       - name: decode
+//         currentReplicas: 6
+//         desiredReplicas: 2        # metric asked for 2, ratio raised it to 6
+//     ratioStatus:
+//       numeratorRole: prefill
+//       denominatorRole: decode
+//       currentRatio: "1"         # 6/6, within [0.25, 1]
+//     ratioAdjusted: true           # decode was overridden to satisfy the ratio
 type DisaggregatedScalingStatus struct {
     // Roles reports the observed scaling state per role.
     Roles []TargetScalingStatus `json:"roles"`
 
-    // RatioStatuses reports the observed value per configured ratio constraint.
+    // RatioStatus reports the observed value of the configured ratio constraint.
     // +optional
-    RatioStatuses []RoleRatioStatus `json:"ratioStatuses,omitempty"`
+    RatioStatus *RoleRatioStatus `json:"ratioStatus,omitempty"`
 
     // RatioAdjusted is true when the most recent reconcile had to override the
-    // metric-derived replica counts to satisfy one or more ratio constraints.
+    // metric-derived replica counts to satisfy the ratio constraint.
     // +optional
     RatioAdjusted bool `json:"ratioAdjusted,omitempty"`
 }
 
-// RoleRatioStatus reports the observed value for one ratio constraint.
+// RoleRatioStatus reports the observed value for the ratio constraint.
 type RoleRatioStatus struct {
-  NumeratorRole   string `json:"numeratorRole"`
-  DenominatorRole string `json:"denominatorRole"`
-  CurrentRatio    string `json:"currentRatio,omitempty"`
+    NumeratorRole   string `json:"numeratorRole"`
+    DenominatorRole string `json:"denominatorRole"`
+    CurrentRatio    string `json:"currentRatio,omitempty"`
 }
 ```
 
@@ -341,7 +362,7 @@ Recommended printer columns for `kubectl get autoscalingpolicy`:
 | Column | Source |
 |--------|--------|
 | `ROLES` | `len(status.disaggregatedStatus.roles)` |
-| `RATIOS` | `len(status.disaggregatedStatus.ratioStatuses)` |
+| `RATIO` | `status.disaggregatedStatus.ratioStatus.currentRatio` |
 | `READY` | `status.conditions[type=Ready].status` |
 
 #### Full YAML Examples
@@ -356,10 +377,8 @@ metadata:
   namespace: default
 spec:
   tolerancePercent: 10
-  # Default metrics — used as fallback when a role doesn't specify its own
-  metrics:
-    - name: pending_requests
-      targetValue: "5"
+  # Each role defines its own metrics below, so policy-level spec.metrics is omitted
+  # (spec.metrics and per-role metrics are mutually exclusive).
   behavior:
     scaleUp:
       stablePolicy:
@@ -383,14 +402,14 @@ spec:
       prefill:
         minReplicas: 1
         maxReplicas: 8
-        metrics:                           # override default metrics for prefill
+        metrics:                           # this role's own metrics (no spec.metrics fallback)
           - name: num_requests_waiting
             targetValue: "5"
         metricSources:
           num_requests_waiting:
             type: Pod
             pod:
-              name: num_requests_waiting
+              name: deepseek-prefill
               uri: /metrics
               port: 8100
               labelSelector:
@@ -399,7 +418,7 @@ spec:
       decode:
         minReplicas: 2
         maxReplicas: 16
-        metrics:                           # override default metrics for decode
+        metrics:                           # this role's own metrics (no spec.metrics fallback)
           - name: gpu_kv_cache_usage_percent
             targetValue: "80"
         metricSources:
@@ -408,11 +427,11 @@ spec:
             prometheus:
               serverURL: http://kube-prometheus-stack-prometheus.monitoring.svc:9090
               query: avg(vllm_gpu_kv_cache_usage_percent{role="decode",model="llm-vllm-disagg"})
-    ratioConstraints:
-      - numeratorRole: prefill
-        denominatorRole: decode
-        minRatio: "0.25"                  # P:D >= 1:4
-        maxRatio: "1"                     # P:D <= 1:1
+    ratioConstraint:
+      numeratorRole: prefill
+      denominatorRole: decode
+      minRatio: "0.25"                  # P:D >= 1:4
+      maxRatio: "1"                     # P:D <= 1:1
 ```
 
 ##### Homogeneous scaling (single resource, before vs. after)
@@ -427,7 +446,7 @@ metadata:
 spec:
   tolerancePercent: 10
   metrics:
-    - name: pending_requests
+    - name: num_requests_waiting
       targetValue: "5"
   behavior: { ... }
 ---
@@ -457,7 +476,7 @@ metadata:
 spec:
   tolerancePercent: 10
   metrics:
-    - name: pending_requests
+    - name: num_requests_waiting
       targetValue: "5"
   behavior: { ... }
   homogeneousTarget:
@@ -469,248 +488,47 @@ spec:
     maxReplicas: 10
 ```
 
-#### Validation Rules (Webhook)
+#### Validation Rules (CRD + Webhook)
 
 | Rule | Scope |
 |------|-------|
 | Exactly one of `homogeneousTarget`, `heterogeneousTarget`, `disaggregatedTarget` must be set. | `AutoscalingPolicySpec` (CEL) |
-| `spec.metrics` must have at least one entry. | `AutoscalingPolicySpec` |
+| `spec.metrics` and per-role `metrics` are mutually exclusive: set `spec.metrics` (uniform) **or** set `metrics` on every role, never both. | `AutoscalingPolicySpec` / `DisaggregatedTarget` (webhook) |
+| Whichever metrics list is used (`spec.metrics` or each role's `metrics`) must have at least one entry. | `AutoscalingPolicySpec` / `RoleScalingParam` |
 | `metricSources` keys must be a subset of the effective metric names for that scope. | `Target` / `RoleScalingParam` |
 | For each `MetricSource`, `type`/backend pairing must be valid (`Pod` -> `pod`, `Prometheus` -> `prometheus`). | `MetricSource` (CEL, preserved) |
 | `targetRef.kind` must be `ModelServing`. | `DisaggregatedTarget` |
 | `roles` map keys must reference existing roles in the referenced ModelServing and contain at least two entries. | `DisaggregatedTarget` |
 | `minReplicas <= maxReplicas` for each role. | `RoleScalingParam` |
-| For each `ratioConstraints` item: `numeratorRole != denominatorRole`, both roles exist in `roles`, and `minRatio <= maxRatio`. | `RoleRatioConstraint` (CEL) |
-| No two `ratioConstraints` items may share the same `(numeratorRole, denominatorRole)` pair. | `DisaggregatedTarget` (CEL) |
-| For each inverse pair `(A→B, B→A)`, the ranges must overlap: `[minRatio, maxRatio]` of `B→A` must intersect `[1/maxRatio, 1/minRatio]` of `A→B`. | `DisaggregatedTarget` (webhook) |
-| For every cycle in the constraint graph, the product of `minRatio` values ≤ 1 and the product of `maxRatio` values ≥ 1. | `DisaggregatedTarget` (webhook) |
-| For each transitive path `A→…→C`, if an explicit `A→C` constraint exists, the implied range (product of edge ranges) must overlap with the explicit range. | `DisaggregatedTarget` (webhook) |
-| For each `ratioConstraints` item, bounds must be jointly achievable given role min/max replicas (when denominator min > 0). | `DisaggregatedTarget` |
-| For every constrained role pair `(A,B)`, scalable-to-zero must match: `roles[A].minReplicas == 0` **iff** `roles[B].minReplicas == 0`. | `DisaggregatedTarget` (CEL) |
+| If `ratioConstraint` is set: `numeratorRole != denominatorRole`, both roles exist in `roles`, and `minRatio <= maxRatio`. | `RoleRatioConstraint` (CEL) |
+| If `ratioConstraint` is set, bounds must be achievable given role min/max replicas: `numerator.minReplicas / denominator.maxReplicas <= maxRatio` **and** `numerator.maxReplicas / denominator.minReplicas >= minRatio` (when `denominator.minReplicas > 0`). | `DisaggregatedTarget` |
+| If `ratioConstraint` is set, the two referenced roles must be scalable-to-zero together: `roles[numeratorRole].minReplicas == 0` **iff** `roles[denominatorRole].minReplicas == 0`. | `DisaggregatedTarget` (CEL) |
+| `minRatio` / `maxRatio` must not carry a unit suffix (e.g., reject `"250m"`). | `RoleRatioConstraint` |
 
 #### Scaling Semantics (Controller Contract)
 
 > **Note**: Controller implementation is out of scope for this proposal. These semantics define the contract the controller must honor.
 
-1. **Independent metric evaluation**: The controller evaluates metrics independently for each role in `disaggregatedTarget.roles`, producing a desired replica count per role. If a role defines its own `metrics`, those are used; otherwise the controller falls back to the top-level `spec.metrics`.
-2. **Metric source resolution**: For each effective metric name, the controller resolves `MetricSource` in this order: role-level `metricSources`, then target-level/default semantics. Resolved sources can be pod scraping or Prometheus query.
-3. **Per-role clamping**: Each desired count is clamped to `[minReplicas, maxReplicas]` of the corresponding role.
-4. **Coupled scale-to-zero (per constrained pair)**: For each pair appearing in `ratioConstraints`, both roles in that pair must reach zero together. The controller does not evaluate that pair's ratio while either side is `0`.
-5. **Ratio enforcement**: For each configured role pair, when both roles are non-zero, after clamping the controller adjusts replica counts to satisfy `minRatio <= replicas[numeratorRole]/replicas[denominatorRole] <= maxRatio`.
-6. **Atomic patch**: The controller patches all affected `spec.template.roles[*].replicas` in a single ModelServing update to avoid transient states that violate ratio constraints.
+1. **Effective metrics per role**: `spec.metrics` and per-role `metrics` are mutually exclusive. When `spec.metrics` is set, every role is evaluated against that shared list; when per-role `metrics` are set, each role is evaluated against its own list. The controller computes a desired replica count for each role independently.
+2. **Multiple metrics combine by max**: When a role's effective list contains more than one metric, the controller computes a desired count for each metric independently and takes the **maximum** (the standard HPA rule), so the most demanding signal wins. For example, if `pending_requests` implies 1 replica but `num_requests_waiting` implies 10, the role scales to 10. This removes any ambiguity when two metrics disagree.
+3. **Metric source resolution**: For each effective metric name, the controller resolves `MetricSource` in this order: role-level `metricSources`, then target-level/default semantics. Resolved sources can be pod scraping or Prometheus query.
+4. **Per-role clamping**: Each desired count is clamped to `[minReplicas, maxReplicas]` of the corresponding role.
+5. **Coupled scale-to-zero**: When `ratioConstraint` is set, the two roles it references must reach zero together. The controller does not evaluate the ratio while either side is `0`.
+6. **Ratio enforcement**: For the configured role pair, when both roles are non-zero, after clamping the controller adjusts replica counts to satisfy `minRatio <= replicas[numeratorRole]/replicas[denominatorRole] <= maxRatio` (see [Ratio Enforcement Algorithm](#ratio-enforcement-algorithm)).
+7. **Atomic patch**: The controller patches both affected `spec.template.roles[*].replicas` in a single ModelServing update to avoid transient states that violate the ratio constraint.
 
-#### Multi-Constraint Conflict Analysis
+#### Ratio Enforcement Algorithm
 
-When `ratioConstraints` contains multiple entries, the constraints may be mutually unsatisfiable. This section enumerates all known conflict categories and specifies how the system must detect or handle each one.
+The webhook rejects an infeasible `ratioConstraint` at admission (see [Validation Rules](#validation-rules-crd--webhook)), so the controller always starts from a constraint whose feasible region is **non-empty**. Enforcement therefore reduces to *projecting* the two metric-derived replica counts into that region — never a search that might fail:
 
-##### Conflict Taxonomy
+1. **Start from clamped desire**: take `desired[numeratorRole]` and `desired[denominatorRole]`, each already clamped to its own `[minReplicas, maxReplicas]`.
+2. **Skip when either side is zero**: if either role resolved to `0`, the ratio is not evaluated (see coupled scale-to-zero above).
+3. **Scale-up–biased repair**: if the pair violates the range, fix it by *increasing* the deficient role rather than shrinking the other, so capacity is never reduced below what metrics asked for:
+   - if `num/den < minRatio`: raise `num` to `ceil(minRatio · den)`; if that exceeds `maxReplicas(num)`, instead lower `den` to `floor(num / minRatio)`.
+   - if `num/den > maxRatio`: raise `den` to `ceil(num / maxRatio)`; if that exceeds `maxReplicas(den)`, instead lower `num` to `floor(maxRatio · den)`.
+4. **Report**: set `status.disaggregatedStatus.ratioAdjusted = true` when the repair changed any metric-derived count, and record the resulting ratio in `status.disaggregatedStatus.ratioStatus`.
 
-###### Type 1: Cyclic Inconsistency
-
-When constraints form a directed cycle — for example three constraints `A→B`, `B→C`, `C→A` — the product of ratios around the cycle is a mathematical identity:
-
-$$\frac{r_A}{r_B} \times \frac{r_B}{r_C} \times \frac{r_C}{r_A} = 1$$
-
-For the cycle to be satisfiable, the product of the constraint ranges must contain `1`:
-
-- product of all `minRatio` values along the cycle ≤ 1
-- product of all `maxRatio` values along the cycle ≥ 1
-
-**Example (infeasible)**:
-
-```yaml
-ratioConstraints:
-  - numeratorRole: A
-    denominatorRole: B
-    minRatio: "0.5"          # A/B = 0.5
-    maxRatio: "0.5"
-  - numeratorRole: B
-    denominatorRole: C
-    minRatio: "0.5"          # B/C = 0.5
-    maxRatio: "0.5"
-  - numeratorRole: C
-    denominatorRole: A
-    minRatio: "0.5"          # C/A = 0.5
-    maxRatio: "0.5"
-```
-
-Product of `minRatio`: `0.5 × 0.5 × 0.5 = 0.125 < 1` ✓, but product of `maxRatio`: `0.5 × 0.5 × 0.5 = 0.125 < 1` ✗. The range `[0.125, 0.125]` does not contain `1`, so no solution exists.
-
-A consistent version would be:
-
-```yaml
-ratioConstraints:
-  - numeratorRole: A
-    denominatorRole: B
-    minRatio: "0.5"
-    maxRatio: "1"
-  - numeratorRole: B
-    denominatorRole: C
-    minRatio: "0.5"
-    maxRatio: "1"
-  - numeratorRole: C
-    denominatorRole: A
-    minRatio: "1"
-    maxRatio: "4"
-# min product = 0.5 × 0.5 × 1 = 0.25 ≤ 1  ✓
-# max product = 1 × 1 × 4 = 4 ≥ 1  ✓
-```
-
-This generalizes to any cycle length: for a cycle of `k` edges, the product condition must hold.
-
-###### Type 2: Transitive Inconsistency
-
-Two constraints `A→B` and `B→C` imply a derived range for `A→C`:
-
-$$m_{AB} \times m_{BC} \leq \frac{r_A}{r_C} \leq M_{AB} \times M_{BC}$$
-
-If the user also provides an explicit `A→C` constraint, the explicit range must overlap with the implied range. Otherwise the constraints are unsatisfiable.
-
-**Example (infeasible)**:
-
-```yaml
-ratioConstraints:
-  - numeratorRole: A
-    denominatorRole: B
-    minRatio: "2"
-    maxRatio: "3"    # A/B ∈ [2,3]
-  - numeratorRole: B
-    denominatorRole: C
-    minRatio: "2"
-    maxRatio: "3"    # B/C ∈ [2,3]
-  # Implied: A/C ∈ [4, 9]
-  - numeratorRole: A
-    denominatorRole: C
-    minRatio: "1"
-    maxRatio: "2"   # A/C ∈ [1,2] — no overlap with [4,9]
-```
-
-###### Type 3: Inverse Pair Inconsistency
-
-If both `A→B` and `B→A` constraints exist, they must be inverses. Constraint `A→B ∈ [m₁, M₁]` implies `B→A ∈ [1/M₁, 1/m₁]`. The explicit `B→A ∈ [m₂, M₂]` must overlap:
-
-$$\max(m_2,\ 1/M_1) \leq \min(M_2,\ 1/m_1)$$
-
-**Example (infeasible)**:
-
-```yaml
-ratioConstraints:
-  - numeratorRole: A
-    denominatorRole: B
-    minRatio: "2"
-    maxRatio: "3"    # A/B ∈ [2,3] → B/A ∈ [0.33,0.5]
-  - numeratorRole: B
-    denominatorRole: A
-    minRatio: "1"
-    maxRatio: "2"    # B/A ∈ [1,2] — no overlap with [0.33,0.5]
-```
-
-###### Type 4: Duplicate Pair Conflict
-
-Two constraints that reference the same ordered pair `(A, B)` with non-overlapping ranges.
-
-**Example (infeasible)**:
-
-```yaml
-ratioConstraints:
-  - numeratorRole: A
-    denominatorRole: B
-    minRatio: "1"
-    maxRatio: "2"
-  - numeratorRole: A
-    denominatorRole: B
-    minRatio: "4"
-    maxRatio: "5"
-```
-
-###### Type 5: Replica Bound–Ratio Conflict
-
-Even if ratio constraints are mathematically consistent with each other, they may be unsatisfiable given the integer `minReplicas`/`maxReplicas` bounds of each role.
-
-**Example (infeasible)**:
-
-```yaml
-roles:
-  A:
-    minReplicas: 1
-    maxReplicas: 2
-  B:
-    minReplicas: 1
-    maxReplicas: 2
-ratioConstraints:
-  - numeratorRole: A
-    denominatorRole: B
-    minRatio: "3"
-    maxRatio: "4"
-# A/B ≥ 3 requires A ≥ 3·B ≥ 3, but maxReplicas(A) = 2.
-```
-
-###### Type 6: Integer Feasibility Gap
-
-A constraint range that is satisfiable in continuous values but has no integer solution within the replica bounds.
-
-**Example (infeasible in integers)**:
-
-```yaml
-roles:
-  A:
-    minReplicas: 1
-    maxReplicas: 1
-  B:
-    minReplicas: 3
-    maxReplicas: 3
-ratioConstraints:
-  - { numeratorRole: A, denominatorRole: B, minRatio: "0.4", maxRatio: "0.45" }
-# A/B = 1/3 ≈ 0.333, outside [0.4, 0.45]. No other integer combination is possible.
-```
-
-##### Detection Strategy
-
-Conflicts are detected at **two stages**:
-
-| Stage | Checks | Mechanism |
-|-------|--------|-----------|
-| **Admission (webhook)** | Type 1 (cycle product), Type 2 (transitive overlap), Type 3 (inverse pair), Type 4 (duplicate pair), Type 5 (bound–ratio) | Webhook validates on create/update. Build a directed constraint graph, enumerate all simple cycles (bounded by role count), verify product conditions, compute transitive closures, cross-check with replica bounds. |
-| **Runtime (controller)** | Type 6 (integer feasibility), edge cases missed by continuous analysis | Controller reports `RatioConstraintViolated` condition when no integer assignment satisfies all constraints simultaneously. |
-
-Admission-time validation algorithm sketch:
-
-1. **Build constraint graph**: Nodes = role names, directed edge for each `RoleRatioConstraint` labeled with `[minRatio, maxRatio]`.
-2. **Reject duplicate pairs** (Type 4): Error if two edges share the same `(numeratorRole, denominatorRole)`.
-3. **Merge inverse pairs** (Type 3): For each edge `A→B [m, M]`, if edge `B→A [m', M']` also exists, verify `[m', M'] ∩ [1/M, 1/m] ≠ ∅`.
-4. **Cycle detection** (Type 1): Find all simple cycles using DFS. For each cycle, multiply the `minRatio` values and `maxRatio` values along the cycle. Reject if the product range does not contain `1`.
-5. **Transitive closure** (Type 2): For each pair `(A, C)` reachable via a path `A→…→C`, compute the implied range by multiplying edge ranges along the path. If an explicit `A→C` edge exists, verify overlap.
-6. **Bound feasibility** (Type 5): For each edge `A→B [m, M]`, verify: `m ≤ maxReplicas(A)/minReplicas(B)` and `M ≥ minReplicas(A)/maxReplicas(B)` (when denominators > 0).
-
-> **Complexity**: With `N` roles, the number of simple cycles is at most exponential in `N`, but in practice `N` is small (typically 2–4 roles). For `N ≤ 10`, exhaustive cycle enumeration is computationally trivial.
-
-##### Resolution Strategies
-
-When the controller encounters conflicts at runtime (Type 6 or transient inconsistencies during scaling), it must choose a resolution strategy. Three candidates are considered:
-
-**Priority-based relaxation**
-
-Each `RoleRatioConstraint` carries an optional `priority` field (higher value = higher priority, default = 0). When constraints cannot all be satisfied simultaneously, the controller drops the lowest-priority constraints first until a feasible solution exists.
-
-```go
-type RoleRatioConstraint struct {
-    NumeratorRole   string            `json:"numeratorRole"`
-    DenominatorRole string            `json:"denominatorRole"`
-    MinRatio        resource.Quantity `json:"minRatio"`
-    MaxRatio        resource.Quantity `json:"maxRatio"`
-    // Priority determines enforcement order when constraints conflict at
-    // runtime. Higher values are enforced first. Default is 0.
-    // +optional
-    // +kubebuilder:default=0
-    Priority int32 `json:"priority,omitempty"`
-}
-```
-
-**Recommendation**: Use priority-based for runtime resolution, combined with fail-closed for admission-time detected conflicts. This ensures:
-
-- Statically detectable conflicts (Types 1–5) are rejected at admission — the user must fix the spec.
-- Runtime-only conflicts (Type 6, transient states) are handled gracefully via priority relaxation.
-- The controller always reports which constraints were relaxed in `status.disaggregatedStatus.ratioStatuses`.
+Because the admission webhook guarantees a non-empty integer feasible region within the role replica bounds, the single-pair projection always succeeds in one pass. This biases the result toward the smallest replica vector that is **≥ metric demand** and satisfies the constraint, so SLOs are protected at the cost of a few extra replicas rather than risking under-provisioning.
 
 #### Migration
 
@@ -729,7 +547,7 @@ type RoleRatioConstraint struct {
 | Policy: metrics + behavior | `spec.metrics` + `spec.behavior` (same policy) |
 | Binding A: `homogeneousTarget.target.subTargets: {kind: Role, name: prefill}` | `spec.disaggregatedTarget.roles.prefill` |
 | Binding B: `homogeneousTarget.target.subTargets: {kind: Role, name: decode}` | `spec.disaggregatedTarget.roles.decode` |
-| 3 resources, no ratio coordination | 1 resource, `ratioConstraints` provides coordination |
+| 3 resources, no ratio coordination | 1 resource, `ratioConstraint` provides coordination |
 
 ### Alternatives
 
@@ -751,7 +569,7 @@ Add a `volcano.sh/pd-ratio-range` annotation to coordinate two separate bindings
 type DisaggregatedTarget struct {
     TargetRef  corev1.ObjectReference `json:"targetRef"`
     Roles      []RoleScalingParam     `json:"roles"`
-    RatioConstraints []RoleRatioConstraint `json:"ratioConstraints,omitempty"`
+    RatioConstraint *RoleRatioConstraint `json:"ratioConstraint,omitempty"`
 }
 ```
 
@@ -779,7 +597,7 @@ type RoleRatio struct {
     Denominator int32 `json:"denominator"`
 }
 
-// RoleRatioConstraintIntPair defines one role-pair ratio constraint.
+// RoleRatioConstraintIntPair defines the role-pair ratio constraint.
 type RoleRatioConstraintIntPair struct {
     NumeratorRole   string    `json:"numeratorRole"`
     DenominatorRole string    `json:"denominatorRole"`
@@ -791,15 +609,15 @@ type RoleRatioConstraintIntPair struct {
 Example YAML:
 
 ```yaml
-    ratioConstraints:
-      - numeratorRole: prefill
-        denominatorRole: decode
-        minRatio:                # P:D >= 1:4
-          numerator: 1
-          denominator: 4
-        maxRatio:                # P:D <= 1:1
-          numerator: 1
-          denominator: 1
+    ratioConstraint:
+      numeratorRole: prefill
+      denominatorRole: decode
+      minRatio:                # P:D >= 1:4
+        numerator: 1
+        denominator: 4
+      maxRatio:                # P:D <= 1:1
+        numerator: 1
+        denominator: 1
 ```
 
 **Pros**:

--- a/docs/proposal/pd-disaggregated-autoscaling.md
+++ b/docs/proposal/pd-disaggregated-autoscaling.md
@@ -481,6 +481,10 @@ spec:
 | `roles` map keys must reference existing roles in the referenced ModelServing and contain at least two entries. | `DisaggregatedTarget` |
 | `minReplicas <= maxReplicas` for each role. | `RoleScalingParam` |
 | For each `ratioConstraints` item: `numeratorRole != denominatorRole`, both roles exist in `roles`, and `minRatio <= maxRatio`. | `RoleRatioConstraint` (CEL) |
+| No two `ratioConstraints` items may share the same `(numeratorRole, denominatorRole)` pair. | `DisaggregatedTarget` (CEL) |
+| For each inverse pair `(A→B, B→A)`, the ranges must overlap: `[minRatio, maxRatio]` of `B→A` must intersect `[1/maxRatio, 1/minRatio]` of `A→B`. | `DisaggregatedTarget` (webhook) |
+| For every cycle in the constraint graph, the product of `minRatio` values ≤ 1 and the product of `maxRatio` values ≥ 1. | `DisaggregatedTarget` (webhook) |
+| For each transitive path `A→…→C`, if an explicit `A→C` constraint exists, the implied range (product of edge ranges) must overlap with the explicit range. | `DisaggregatedTarget` (webhook) |
 | For each `ratioConstraints` item, bounds must be jointly achievable given role min/max replicas (when denominator min > 0). | `DisaggregatedTarget` |
 | For every constrained role pair `(A,B)`, scalable-to-zero must match: `roles[A].minReplicas == 0` **iff** `roles[B].minReplicas == 0`. | `DisaggregatedTarget` (CEL) |
 
@@ -494,6 +498,219 @@ spec:
 4. **Coupled scale-to-zero (per constrained pair)**: For each pair appearing in `ratioConstraints`, both roles in that pair must reach zero together. The controller does not evaluate that pair's ratio while either side is `0`.
 5. **Ratio enforcement**: For each configured role pair, when both roles are non-zero, after clamping the controller adjusts replica counts to satisfy `minRatio <= replicas[numeratorRole]/replicas[denominatorRole] <= maxRatio`.
 6. **Atomic patch**: The controller patches all affected `spec.template.roles[*].replicas` in a single ModelServing update to avoid transient states that violate ratio constraints.
+
+#### Multi-Constraint Conflict Analysis
+
+When `ratioConstraints` contains multiple entries, the constraints may be mutually unsatisfiable. This section enumerates all known conflict categories and specifies how the system must detect or handle each one.
+
+##### Conflict Taxonomy
+
+###### Type 1: Cyclic Inconsistency
+
+When constraints form a directed cycle — for example three constraints `A→B`, `B→C`, `C→A` — the product of ratios around the cycle is a mathematical identity:
+
+$$\frac{r_A}{r_B} \times \frac{r_B}{r_C} \times \frac{r_C}{r_A} = 1$$
+
+For the cycle to be satisfiable, the product of the constraint ranges must contain `1`:
+
+- product of all `minRatio` values along the cycle ≤ 1
+- product of all `maxRatio` values along the cycle ≥ 1
+
+**Example (infeasible)**:
+
+```yaml
+ratioConstraints:
+  - numeratorRole: A
+    denominatorRole: B
+    minRatio: "0.5"          # A/B = 0.5
+    maxRatio: "0.5"
+  - numeratorRole: B
+    denominatorRole: C
+    minRatio: "0.5"          # B/C = 0.5
+    maxRatio: "0.5"
+  - numeratorRole: C
+    denominatorRole: A
+    minRatio: "0.5"          # C/A = 0.5
+    maxRatio: "0.5"
+```
+
+Product of `minRatio`: `0.5 × 0.5 × 0.5 = 0.125 < 1` ✓, but product of `maxRatio`: `0.5 × 0.5 × 0.5 = 0.125 < 1` ✗. The range `[0.125, 0.125]` does not contain `1`, so no solution exists.
+
+A consistent version would be:
+
+```yaml
+ratioConstraints:
+  - numeratorRole: A
+    denominatorRole: B
+    minRatio: "0.5"
+    maxRatio: "1"
+  - numeratorRole: B
+    denominatorRole: C
+    minRatio: "0.5"
+    maxRatio: "1"
+  - numeratorRole: C
+    denominatorRole: A
+    minRatio: "1"
+    maxRatio: "4"
+# min product = 0.5 × 0.5 × 1 = 0.25 ≤ 1  ✓
+# max product = 1 × 1 × 4 = 4 ≥ 1  ✓
+```
+
+This generalizes to any cycle length: for a cycle of `k` edges, the product condition must hold.
+
+###### Type 2: Transitive Inconsistency
+
+Two constraints `A→B` and `B→C` imply a derived range for `A→C`:
+
+$$m_{AB} \times m_{BC} \leq \frac{r_A}{r_C} \leq M_{AB} \times M_{BC}$$
+
+If the user also provides an explicit `A→C` constraint, the explicit range must overlap with the implied range. Otherwise the constraints are unsatisfiable.
+
+**Example (infeasible)**:
+
+```yaml
+ratioConstraints:
+  - numeratorRole: A
+    denominatorRole: B
+    minRatio: "2"
+    maxRatio: "3"    # A/B ∈ [2,3]
+  - numeratorRole: B
+    denominatorRole: C
+    minRatio: "2"
+    maxRatio: "3"    # B/C ∈ [2,3]
+  # Implied: A/C ∈ [4, 9]
+  - numeratorRole: A
+    denominatorRole: C
+    minRatio: "1"
+    maxRatio: "2"   # A/C ∈ [1,2] — no overlap with [4,9]
+```
+
+###### Type 3: Inverse Pair Inconsistency
+
+If both `A→B` and `B→A` constraints exist, they must be inverses. Constraint `A→B ∈ [m₁, M₁]` implies `B→A ∈ [1/M₁, 1/m₁]`. The explicit `B→A ∈ [m₂, M₂]` must overlap:
+
+$$\max(m_2,\ 1/M_1) \leq \min(M_2,\ 1/m_1)$$
+
+**Example (infeasible)**:
+
+```yaml
+ratioConstraints:
+  - numeratorRole: A
+    denominatorRole: B
+    minRatio: "2"
+    maxRatio: "3"    # A/B ∈ [2,3] → B/A ∈ [0.33,0.5]
+  - numeratorRole: B
+    denominatorRole: A
+    minRatio: "1"
+    maxRatio: "2"    # B/A ∈ [1,2] — no overlap with [0.33,0.5]
+```
+
+###### Type 4: Duplicate Pair Conflict
+
+Two constraints that reference the same ordered pair `(A, B)` with non-overlapping ranges.
+
+**Example (infeasible)**:
+
+```yaml
+ratioConstraints:
+  - numeratorRole: A
+    denominatorRole: B
+    minRatio: "1"
+    maxRatio: "2"
+  - numeratorRole: A
+    denominatorRole: B
+    minRatio: "4"
+    maxRatio: "5"
+```
+
+###### Type 5: Replica Bound–Ratio Conflict
+
+Even if ratio constraints are mathematically consistent with each other, they may be unsatisfiable given the integer `minReplicas`/`maxReplicas` bounds of each role.
+
+**Example (infeasible)**:
+
+```yaml
+roles:
+  A:
+    minReplicas: 1
+    maxReplicas: 2
+  B:
+    minReplicas: 1
+    maxReplicas: 2
+ratioConstraints:
+  - numeratorRole: A
+    denominatorRole: B
+    minRatio: "3"
+    maxRatio: "4"
+# A/B ≥ 3 requires A ≥ 3·B ≥ 3, but maxReplicas(A) = 2.
+```
+
+###### Type 6: Integer Feasibility Gap
+
+A constraint range that is satisfiable in continuous values but has no integer solution within the replica bounds.
+
+**Example (infeasible in integers)**:
+
+```yaml
+roles:
+  A:
+    minReplicas: 1
+    maxReplicas: 1
+  B:
+    minReplicas: 3
+    maxReplicas: 3
+ratioConstraints:
+  - { numeratorRole: A, denominatorRole: B, minRatio: "0.4", maxRatio: "0.45" }
+# A/B = 1/3 ≈ 0.333, outside [0.4, 0.45]. No other integer combination is possible.
+```
+
+##### Detection Strategy
+
+Conflicts are detected at **two stages**:
+
+| Stage | Checks | Mechanism |
+|-------|--------|-----------|
+| **Admission (webhook)** | Type 1 (cycle product), Type 2 (transitive overlap), Type 3 (inverse pair), Type 4 (duplicate pair), Type 5 (bound–ratio) | Webhook validates on create/update. Build a directed constraint graph, enumerate all simple cycles (bounded by role count), verify product conditions, compute transitive closures, cross-check with replica bounds. |
+| **Runtime (controller)** | Type 6 (integer feasibility), edge cases missed by continuous analysis | Controller reports `RatioConstraintViolated` condition when no integer assignment satisfies all constraints simultaneously. |
+
+Admission-time validation algorithm sketch:
+
+1. **Build constraint graph**: Nodes = role names, directed edge for each `RoleRatioConstraint` labeled with `[minRatio, maxRatio]`.
+2. **Reject duplicate pairs** (Type 4): Error if two edges share the same `(numeratorRole, denominatorRole)`.
+3. **Merge inverse pairs** (Type 3): For each edge `A→B [m, M]`, if edge `B→A [m', M']` also exists, verify `[m', M'] ∩ [1/M, 1/m] ≠ ∅`.
+4. **Cycle detection** (Type 1): Find all simple cycles using DFS. For each cycle, multiply the `minRatio` values and `maxRatio` values along the cycle. Reject if the product range does not contain `1`.
+5. **Transitive closure** (Type 2): For each pair `(A, C)` reachable via a path `A→…→C`, compute the implied range by multiplying edge ranges along the path. If an explicit `A→C` edge exists, verify overlap.
+6. **Bound feasibility** (Type 5): For each edge `A→B [m, M]`, verify: `m ≤ maxReplicas(A)/minReplicas(B)` and `M ≥ minReplicas(A)/maxReplicas(B)` (when denominators > 0).
+
+> **Complexity**: With `N` roles, the number of simple cycles is at most exponential in `N`, but in practice `N` is small (typically 2–4 roles). For `N ≤ 10`, exhaustive cycle enumeration is computationally trivial.
+
+##### Resolution Strategies
+
+When the controller encounters conflicts at runtime (Type 6 or transient inconsistencies during scaling), it must choose a resolution strategy. Three candidates are considered:
+
+**Priority-based relaxation**
+
+Each `RoleRatioConstraint` carries an optional `priority` field (higher value = higher priority, default = 0). When constraints cannot all be satisfied simultaneously, the controller drops the lowest-priority constraints first until a feasible solution exists.
+
+```go
+type RoleRatioConstraint struct {
+    NumeratorRole   string            `json:"numeratorRole"`
+    DenominatorRole string            `json:"denominatorRole"`
+    MinRatio        resource.Quantity `json:"minRatio"`
+    MaxRatio        resource.Quantity `json:"maxRatio"`
+    // Priority determines enforcement order when constraints conflict at
+    // runtime. Higher values are enforced first. Default is 0.
+    // +optional
+    // +kubebuilder:default=0
+    Priority int32 `json:"priority,omitempty"`
+}
+```
+
+**Recommendation**: Use priority-based for runtime resolution, combined with fail-closed for admission-time detected conflicts. This ensures:
+
+- Statically detectable conflicts (Types 1–5) are rejected at admission — the user must fix the spec.
+- Runtime-only conflicts (Type 6, transient states) are handled gracefully via priority relaxation.
+- The controller always reports which constraints were relaxed in `status.disaggregatedStatus.ratioStatuses`.
 
 #### Migration
 


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation
<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:

This proposal redesigns the autoscaling API with two goals:

1. **Merge `AutoscalingPolicyBinding` into `AutoscalingPolicy`** — today users must create two resources (policy + binding) and cross-reference them. Merging eliminates the indirection, avoids duplicating metric definitions across objects, and gives users a single resource that fully describes "what to scale, on what signal, and how."
2. **Add first-class `DisaggregatedTarget`** — replace the generic `SubTarget` mechanism with a purpose-built structure for coordinated Prefill/Decode scaling, including independent per-role metrics, replica bounds, and a P/D ratio range constraint.

The `AutoscalingPolicyBinding` CRD and the `SubTarget` type are removed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
