### PR TITLE
feat: honor HTTPRoute hostnames and matched rule selection

### DIFF
--- a/pkg/kthena-router/router/httproute_match.go
+++ b/pkg/kthena-router/router/httproute_match.go
@@ -1,0 +1,320 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package router
+
+import (
+	"net"
+	"regexp"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+const (
+	inferencePoolBackendGroup gatewayv1.Group = "inference.networking.k8s.io"
+	inferencePoolBackendKind  gatewayv1.Kind  = "InferencePool"
+)
+
+type httpRouteMatchResult struct {
+	// route is the HTTPRoute whose hostnames matched the request and whose rule
+	// supplied the best path match within that route.
+	route *gatewayv1.HTTPRoute
+	// rule is the exact rule that accepted the request path. BackendRefs and
+	// URLRewrite filters are rule-scoped, so handleHTTPRoute must use this rule
+	// instead of scanning route.Spec.Rules from the beginning again.
+	rule *gatewayv1.HTTPRouteRule
+	// matchedPrefix is the normalized PathPrefix that matched the request. It is
+	// stored in gin.Context so ReplacePrefixMatch URLRewrite can replace exactly
+	// the prefix that made this rule match.
+	matchedPrefix string
+	// path stores the path specificity used only to choose the best rule within
+	// this HTTPRoute.
+	path httpRoutePathPrecedence
+}
+
+type httpRoutePathPrecedence struct {
+	// matchType ranks path match kinds. Higher values are more specific:
+	// Exact > PathPrefix > RegularExpression.
+	matchType int
+	// characters is the length of the matched path value. It makes a longer
+	// PathPrefix such as "/chat" win over "/" when both match the request.
+	characters int
+	// ruleIndex is the rule's position in route.Spec.Rules. It is the final
+	// tie-breaker before matchIndex, preserving list order when specificity ties.
+	ruleIndex int
+	// matchIndex is the match's position inside rule.Matches. It preserves list
+	// order when two matches in the same rule have equal path specificity.
+	matchIndex int
+}
+
+// findHTTPRouteMatch keeps Kthena's lightweight HTTPRoute matching model. It
+// checks hostnames at the route level, then picks the best path match within the
+// first matching HTTPRoute and preserves that rule for backend/filter lookup. It
+// intentionally does not implement full Gateway API method/header/query matching
+// or cross-route precedence.
+func (r *Router) findHTTPRouteMatch(c *gin.Context, gatewayKey string) (httpRouteMatchResult, bool) {
+	httpRoutes := r.store.GetHTTPRoutesByGateway(gatewayKey)
+	if len(httpRoutes) == 0 {
+		return httpRouteMatchResult{}, false
+	}
+
+	for _, route := range httpRoutes {
+		if route == nil {
+			continue
+		}
+		if !matchHTTPRouteHostnames(route.Spec.Hostnames, c.Request.Host) {
+			continue
+		}
+		result, matched := findBestHTTPRouteRuleMatch(route, c.Request.URL.Path)
+		if matched {
+			return result, true
+		}
+	}
+	return httpRouteMatchResult{}, false
+}
+
+func findBestHTTPRouteRuleMatch(route *gatewayv1.HTTPRoute, requestPath string) (httpRouteMatchResult, bool) {
+	var best httpRouteMatchResult
+	found := false
+	for i := range route.Spec.Rules {
+		rule := &route.Spec.Rules[i]
+		if len(rule.Matches) == 0 {
+			// Gateway API treats an omitted matches list as a default PathPrefix
+			// "/" match. Model it explicitly so it can compete with other rules.
+			result := httpRouteMatchResult{
+				route:         route,
+				rule:          rule,
+				matchedPrefix: "/",
+				path: httpRoutePathPrecedence{
+					matchType:  httpPathPrefixPrecedence,
+					characters: 1,
+					ruleIndex:  i,
+				},
+			}
+			if !found || compareHTTPRoutePathPrecedence(result.path, best.path) < 0 {
+				best = result
+				found = true
+			}
+			continue
+		}
+		for j, match := range rule.Matches {
+			if hasUnsupportedHTTPRouteMatchPredicates(match) {
+				// Kthena currently evaluates only the path predicate. Gateway API
+				// ANDs all predicates in one HTTPRouteMatch, so silently ignoring
+				// method/header/query predicates would turn a constrained match
+				// into a path-only match and could select the wrong backend.
+				continue
+			}
+			matched, matchedPrefix, pathPrecedence := matchHTTPRoutePath(match.Path, requestPath, route)
+			if !matched {
+				continue
+			}
+			pathPrecedence.ruleIndex = i
+			pathPrecedence.matchIndex = j
+			result := httpRouteMatchResult{
+				route:         route,
+				rule:          rule,
+				matchedPrefix: matchedPrefix,
+				path:          pathPrecedence,
+			}
+			if !found || compareHTTPRoutePathPrecedence(result.path, best.path) < 0 {
+				best = result
+				found = true
+			}
+		}
+	}
+	return best, found
+}
+
+func hasUnsupportedHTTPRouteMatchPredicates(match gatewayv1.HTTPRouteMatch) bool {
+	return match.Method != nil || len(match.Headers) > 0 || len(match.QueryParams) > 0
+}
+
+func compareHTTPRoutePathPrecedence(a, b httpRoutePathPrecedence) int {
+	if a.matchType != b.matchType {
+		if a.matchType > b.matchType {
+			return -1
+		}
+		return 1
+	}
+	if a.characters != b.characters {
+		if a.characters > b.characters {
+			return -1
+		}
+		return 1
+	}
+	if a.ruleIndex != b.ruleIndex {
+		// When path specificity is equal, keep the HTTPRoute's rule order.
+		if a.ruleIndex < b.ruleIndex {
+			return -1
+		}
+		return 1
+	}
+	if a.matchIndex < b.matchIndex {
+		return -1
+	}
+	if a.matchIndex > b.matchIndex {
+		return 1
+	}
+	return 0
+}
+
+// inferencePoolFromHTTPRouteRule extracts the InferencePool backend from the
+// already matched rule. Other Gateway API backend kinds are ignored because this
+// router currently forwards only through InferencePool.
+func inferencePoolFromHTTPRouteRule(route *gatewayv1.HTTPRoute, rule *gatewayv1.HTTPRouteRule) (types.NamespacedName, bool) {
+	var inferencePoolName types.NamespacedName
+	for _, backendRef := range rule.BackendRefs {
+		if backendRef.Group != nil && *backendRef.Group == inferencePoolBackendGroup &&
+			backendRef.Kind != nil && *backendRef.Kind == inferencePoolBackendKind {
+			inferencePoolName.Namespace = route.Namespace
+			if backendRef.Namespace != nil {
+				inferencePoolName.Namespace = string(*backendRef.Namespace)
+			}
+			inferencePoolName.Name = string(backendRef.Name)
+			return inferencePoolName, true
+		}
+	}
+	return types.NamespacedName{}, false
+}
+
+// httpPathMatchType returns the Gateway API default PathPrefix type when the
+// field is omitted.
+func httpPathMatchType(path *gatewayv1.HTTPPathMatch) gatewayv1.PathMatchType {
+	if path.Type == nil {
+		return gatewayv1.PathMatchPathPrefix
+	}
+	return *path.Type
+}
+
+// httpPathMatchValue returns the Gateway API default "/" path when value is
+// omitted.
+func httpPathMatchValue(path *gatewayv1.HTTPPathMatch) string {
+	if path.Value == nil {
+		return "/"
+	}
+	return *path.Value
+}
+
+const (
+	// Higher values win in compareHTTPRoutePathPrecedence. Regex is kept below
+	// Exact and PathPrefix because Kthena's current behavior is path-oriented and
+	// this PR is not trying to implement full Gateway API precedence. A catch-all
+	// prefix such as "/" will therefore win over a regex match in the same route.
+	httpPathRegularExpressionPrecedence = iota + 1
+	httpPathPrefixPrecedence
+	httpPathExactPrecedence
+)
+
+// matchHTTPRoutePath checks only the path predicate. It returns the matched
+// prefix needed by ReplacePrefixMatch URLRewrite and the path score used to
+// compare rules inside one HTTPRoute.
+func matchHTTPRoutePath(path *gatewayv1.HTTPPathMatch, requestPath string, route *gatewayv1.HTTPRoute) (bool, string, httpRoutePathPrecedence) {
+	if path == nil {
+		return true, "/", httpRoutePathPrecedence{matchType: httpPathPrefixPrecedence, characters: 1}
+	}
+
+	pathType := httpPathMatchType(path)
+	pathValue := httpPathMatchValue(path)
+	switch pathType {
+	case gatewayv1.PathMatchExact:
+		return requestPath == pathValue, "", httpRoutePathPrecedence{matchType: httpPathExactPrecedence, characters: len(pathValue)}
+	case gatewayv1.PathMatchPathPrefix:
+		matched, matchedPrefix := matchHTTPPathPrefix(requestPath, pathValue)
+		if !matched {
+			return false, "", httpRoutePathPrecedence{}
+		}
+		return true, matchedPrefix, httpRoutePathPrecedence{matchType: httpPathPrefixPrecedence, characters: len(matchedPrefix)}
+	case gatewayv1.PathMatchRegularExpression:
+		expression, err := regexp.Compile(pathValue)
+		if err != nil {
+			klog.Warningf("Invalid regex pattern '%s' in HTTPRoute %s/%s: %v", pathValue, route.Namespace, route.Name, err)
+			return false, "", httpRoutePathPrecedence{}
+		}
+		return expression.MatchString(requestPath), "", httpRoutePathPrecedence{matchType: httpPathRegularExpressionPrecedence}
+	default:
+		return false, "", httpRoutePathPrecedence{}
+	}
+}
+
+// matchHTTPPathPrefix implements Gateway API PathPrefix semantics: matching is
+// path-segment based, and a trailing slash on the configured prefix is ignored.
+func matchHTTPPathPrefix(path, prefix string) (bool, string) {
+	normalizedPrefix := strings.TrimRight(prefix, "/")
+	if normalizedPrefix == "" {
+		return strings.HasPrefix(path, "/"), "/"
+	}
+	return path == normalizedPrefix || strings.HasPrefix(path, normalizedPrefix+"/"), normalizedPrefix
+}
+
+// matchHTTPRouteHostnames matches the request Host header against route
+// hostnames. Empty hostnames means the route matches all hosts.
+func matchHTTPRouteHostnames(hostnames []gatewayv1.Hostname, requestHost string) bool {
+	if len(hostnames) == 0 {
+		return true
+	}
+	normalizedHost := normalizeHTTPRouteHost(requestHost)
+	if normalizedHost == "" {
+		return false
+	}
+	for _, hostname := range hostnames {
+		if matchHTTPRouteHostname(string(hostname), normalizedHost) {
+			return true
+		}
+	}
+	return false
+}
+
+// normalizeHTTPRouteHost removes the optional Host header port and normalizes
+// case/trailing dots before Gateway API hostname comparison.
+func normalizeHTTPRouteHost(host string) string {
+	host = strings.TrimSpace(host)
+	if host == "" {
+		return ""
+	}
+	if hostOnly, _, err := net.SplitHostPort(host); err == nil {
+		host = hostOnly
+	} else if index := strings.LastIndex(host, ":"); index > -1 && !strings.Contains(host[:index], ":") {
+		host = host[:index]
+	}
+	host = strings.TrimPrefix(host, "[")
+	host = strings.TrimSuffix(host, "]")
+	host = strings.TrimSuffix(host, ".")
+	return strings.ToLower(host)
+}
+
+// matchHTTPRouteHostname supports exact hostnames and Gateway API wildcard
+// suffix hostnames. A wildcard such as "*.example.com" matches
+// "api.example.com" and "v1.api.example.com", but not "example.com".
+func matchHTTPRouteHostname(pattern, host string) bool {
+	pattern = strings.ToLower(strings.TrimSuffix(pattern, "."))
+	if pattern == host {
+		return true
+	}
+	if !strings.HasPrefix(pattern, "*.") {
+		return false
+	}
+	suffix := strings.TrimPrefix(pattern, "*")
+	if !strings.HasSuffix(host, suffix) {
+		return false
+	}
+	prefix := strings.TrimSuffix(host, suffix)
+	return prefix != ""
+}

--- a/pkg/kthena-router/router/httproute_match_test.go
+++ b/pkg/kthena-router/router/httproute_match_test.go
@@ -1,0 +1,275 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package router
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/volcano-sh/kthena/pkg/kthena-router/datastore"
+)
+
+func TestRouter_FindHTTPRouteMatch(t *testing.T) {
+	pathType := gatewayv1.PathMatchPathPrefix
+	kind := gatewayv1.Kind("Gateway")
+	group := inferencePoolBackendGroup
+	backendKind := inferencePoolBackendKind
+	backendRefs := func(name string) []gatewayv1.HTTPBackendRef {
+		return []gatewayv1.HTTPBackendRef{
+			{
+				BackendRef: gatewayv1.BackendRef{
+					BackendObjectReference: gatewayv1.BackendObjectReference{
+						Group: &group,
+						Kind:  &backendKind,
+						Name:  gatewayv1.ObjectName(name),
+					},
+				},
+			},
+		}
+	}
+	matchRule := func(match gatewayv1.HTTPRouteMatch, backend string) gatewayv1.HTTPRouteRule {
+		return gatewayv1.HTTPRouteRule{
+			Matches:     []gatewayv1.HTTPRouteMatch{match},
+			BackendRefs: backendRefs(backend),
+		}
+	}
+	pathMatch := func(prefix string) gatewayv1.HTTPRouteMatch {
+		return gatewayv1.HTTPRouteMatch{
+			Path: &gatewayv1.HTTPPathMatch{
+				Type:  &pathType,
+				Value: &prefix,
+			},
+		}
+	}
+	pathRule := func(prefix, backend string) gatewayv1.HTTPRouteRule {
+		return matchRule(pathMatch(prefix), backend)
+	}
+	route := func(name string, hostnames []gatewayv1.Hostname, rules []gatewayv1.HTTPRouteRule) *gatewayv1.HTTPRoute {
+		return &gatewayv1.HTTPRoute{
+			ObjectMeta: v1.ObjectMeta{Name: name, Namespace: "default"},
+			Spec: gatewayv1.HTTPRouteSpec{
+				CommonRouteSpec: gatewayv1.CommonRouteSpec{
+					ParentRefs: []gatewayv1.ParentReference{
+						{
+							Name: "gw",
+							Kind: &kind,
+						},
+					},
+				},
+				Hostnames: hostnames,
+				Rules:     rules,
+			},
+		}
+	}
+	method := gatewayv1.HTTPMethodGet
+
+	tests := []struct {
+		name           string
+		routes         []*gatewayv1.HTTPRoute
+		host           string
+		path           string
+		expectedRoute  string
+		expectedPool   string
+		expectedPrefix string
+	}{
+		{
+			name: "prefers longest prefix in a single route",
+			routes: []*gatewayv1.HTTPRoute{
+				route("route", nil, []gatewayv1.HTTPRouteRule{
+					pathRule("/", "pool-root"),
+					pathRule("/chat", "pool-chat"),
+				}),
+			},
+			host:           "api.example.com",
+			path:           "/chat/completions",
+			expectedRoute:  "route",
+			expectedPool:   "pool-chat",
+			expectedPrefix: "/chat",
+		},
+		{
+			name: "matches hostname before selecting a rule",
+			routes: []*gatewayv1.HTTPRoute{
+				route("route", []gatewayv1.Hostname{"api.example.com"}, []gatewayv1.HTTPRouteRule{
+					pathRule("/chat", "pool"),
+				}),
+			},
+			host:           "api.example.com",
+			path:           "/chat",
+			expectedRoute:  "route",
+			expectedPool:   "pool",
+			expectedPrefix: "/chat",
+		},
+		{
+			name: "returns nil when no rule matches",
+			routes: []*gatewayv1.HTTPRoute{
+				route("route", nil, []gatewayv1.HTTPRouteRule{
+					pathRule("/api", "pool"),
+				}),
+			},
+			host: "api.example.com",
+			path: "/chat",
+		},
+		{
+			name: "skips unsupported method match instead of treating it as path only",
+			routes: []*gatewayv1.HTTPRoute{
+				route("route", nil, []gatewayv1.HTTPRouteRule{
+					matchRule(gatewayv1.HTTPRouteMatch{
+						Path:   pathMatch("/chat").Path,
+						Method: &method,
+					}, "pool-method"),
+					pathRule("/", "pool-root"),
+				}),
+			},
+			host:           "api.example.com",
+			path:           "/chat/completions",
+			expectedRoute:  "route",
+			expectedPool:   "pool-root",
+			expectedPrefix: "/",
+		},
+		{
+			name: "skips unsupported header match instead of treating it as path only",
+			routes: []*gatewayv1.HTTPRoute{
+				route("route", nil, []gatewayv1.HTTPRouteRule{
+					matchRule(gatewayv1.HTTPRouteMatch{
+						Path: pathMatch("/chat").Path,
+						Headers: []gatewayv1.HTTPHeaderMatch{
+							{Name: "x-model", Value: "v1"},
+						},
+					}, "pool-header"),
+					pathRule("/", "pool-root"),
+				}),
+			},
+			host:           "api.example.com",
+			path:           "/chat/completions",
+			expectedRoute:  "route",
+			expectedPool:   "pool-root",
+			expectedPrefix: "/",
+		},
+		{
+			name: "skips unsupported query param match instead of treating it as path only",
+			routes: []*gatewayv1.HTTPRoute{
+				route("route", nil, []gatewayv1.HTTPRouteRule{
+					matchRule(gatewayv1.HTTPRouteMatch{
+						Path: pathMatch("/chat").Path,
+						QueryParams: []gatewayv1.HTTPQueryParamMatch{
+							{Name: "version", Value: "v1"},
+						},
+					}, "pool-query"),
+					pathRule("/", "pool-root"),
+				}),
+			},
+			host:           "api.example.com",
+			path:           "/chat/completions",
+			expectedRoute:  "route",
+			expectedPool:   "pool-root",
+			expectedPrefix: "/",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := datastore.New()
+			router := &Router{store: store}
+			for _, route := range tt.routes {
+				assert.NoError(t, store.AddOrUpdateHTTPRoute(route))
+			}
+
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request, _ = http.NewRequest(http.MethodPost, tt.path, nil)
+			c.Request.Host = tt.host
+
+			result, matched := router.findHTTPRouteMatch(c, "default/gw")
+			if tt.expectedRoute == "" {
+				assert.False(t, matched)
+				return
+			}
+			assert.True(t, matched)
+			assert.Equal(t, tt.expectedRoute, result.route.Name)
+			assert.Equal(t, tt.expectedPrefix, result.matchedPrefix)
+			pool, found := inferencePoolFromHTTPRouteRule(result.route, result.rule)
+			assert.True(t, found)
+			assert.Equal(t, types.NamespacedName{Namespace: "default", Name: tt.expectedPool}, pool)
+		})
+	}
+}
+
+func TestMatchHTTPRouteHostname(t *testing.T) {
+	tests := []struct {
+		name          string
+		pattern       string
+		host          string
+		expectedMatch bool
+	}{
+		{
+			name:          "exact hostname",
+			pattern:       "api.example.com",
+			host:          "api.example.com",
+			expectedMatch: true,
+		},
+		{
+			name:          "exact pattern is normalized",
+			pattern:       "API.EXAMPLE.COM.",
+			host:          "api.example.com",
+			expectedMatch: true,
+		},
+		{
+			name:          "wildcard suffix",
+			pattern:       "*.example.com",
+			host:          "api.example.com",
+			expectedMatch: true,
+		},
+		{
+			name:          "wildcard suffix matches nested subdomain",
+			pattern:       "*.example.com",
+			host:          "v1.api.example.com",
+			expectedMatch: true,
+		},
+		{
+			name:          "wildcard does not match apex",
+			pattern:       "*.example.com",
+			host:          "example.com",
+			expectedMatch: false,
+		},
+		{
+			name:          "wildcard suffix mismatch",
+			pattern:       "*.example.com",
+			host:          "api.example.net",
+			expectedMatch: false,
+		},
+		{
+			name:          "exact mismatch",
+			pattern:       "api.example.com",
+			host:          "other.example.com",
+			expectedMatch: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matched := matchHTTPRouteHostname(tt.pattern, tt.host)
+			assert.Equal(t, tt.expectedMatch, matched)
+		})
+	}
+}

--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -28,7 +28,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -519,104 +518,21 @@ func (r *Router) getPodsAndServer(modelServerName types.NamespacedName) ([]*data
 // Returns true if HTTPRoute was matched and request is being handled, false otherwise
 // Also returns the InferencePool NamespacedName if found
 func (r *Router) handleHTTPRoute(c *gin.Context, gatewayKey string) (bool, types.NamespacedName) {
-	// Find HTTPRoutes for this Gateway
-	httpRoutes := r.store.GetHTTPRoutesByGateway(gatewayKey)
-	if len(httpRoutes) == 0 {
-		return false, types.NamespacedName{}
-	}
-
-	// Match HTTPRoute by path and hostname
-	var matchedRoute *gatewayv1.HTTPRoute
-	var matchedPrefix string // Store the matched prefix for URL rewriting
-	for _, route := range httpRoutes {
-		if route == nil {
-			continue
-		}
-
-		matched := false
-		for _, rule := range route.Spec.Rules {
-			if len(rule.Matches) == 0 {
-				matched = true
-				break
-			}
-			for _, match := range rule.Matches {
-				if match.Path != nil {
-					pathType := httpPathMatchType(match.Path)
-					pathValue := httpPathMatchValue(match.Path)
-					switch pathType {
-					case gatewayv1.PathMatchExact:
-						if c.Request.URL.Path == pathValue {
-							matched = true
-							break
-						}
-					case gatewayv1.PathMatchPathPrefix:
-						if ok, prefix := matchHTTPPathPrefix(c.Request.URL.Path, pathValue); ok {
-							matched = true
-							matchedPrefix = prefix
-							break
-						}
-					case gatewayv1.PathMatchRegularExpression:
-						if regexMatched, err := regexp.MatchString(pathValue, c.Request.URL.Path); err == nil && regexMatched {
-							matched = true
-							break
-						} else if err != nil {
-							klog.Warningf("Invalid regex pattern '%s' in HTTPRoute %s/%s: %v", pathValue, route.Namespace, route.Name, err)
-						}
-					}
-				} else {
-					matched = true
-				}
-				if matched {
-					break
-				}
-			}
-			if matched {
-				matchedRoute = route
-				break
-			}
-		}
-		if matched {
-			break
-		}
-	}
-
-	if matchedRoute == nil {
+	matchResult, matched := r.findHTTPRouteMatch(c, gatewayKey)
+	if !matched {
 		return false, types.NamespacedName{}
 	}
 
 	// Record Gateway API match into access log (gatewayKey is already "namespace/name").
-	httpRouteKey := fmt.Sprintf("%s/%s", matchedRoute.Namespace, matchedRoute.Name)
+	httpRouteKey := fmt.Sprintf("%s/%s", matchResult.route.Namespace, matchResult.route.Name)
 	accesslog.SetGatewayAPIInfo(c, gatewayKey, httpRouteKey, "")
 
 	// Store the matched prefix in context for URL rewriting
-	if matchedPrefix != "" {
-		c.Set("matchedPrefix", matchedPrefix)
+	if matchResult.matchedPrefix != "" {
+		c.Set("matchedPrefix", matchResult.matchedPrefix)
 	}
 
-	// Find InferencePool backendRef and apply filters
-	var inferencePoolName types.NamespacedName
-	found := false
-	var matchedRule *gatewayv1.HTTPRouteRule
-	for i := range matchedRoute.Spec.Rules {
-		rule := &matchedRoute.Spec.Rules[i]
-		for _, backendRef := range rule.BackendRefs {
-			if backendRef.Group != nil && *backendRef.Group == "inference.networking.k8s.io" &&
-				backendRef.Kind != nil && *backendRef.Kind == "InferencePool" {
-				inferencePoolName.Namespace = matchedRoute.Namespace
-				if backendRef.Namespace != nil {
-					inferencePoolName.Namespace = string(*backendRef.Namespace)
-				}
-				inferencePoolName.Name = string(backendRef.Name)
-				found = true
-				matchedRule = rule
-				break
-			}
-		}
-		if found {
-			break
-		}
-	}
-
+	inferencePoolName, found := inferencePoolFromHTTPRouteRule(matchResult.route, matchResult.rule)
 	if !found {
 		return false, types.NamespacedName{}
 	}
@@ -625,9 +541,9 @@ func (r *Router) handleHTTPRoute(c *gin.Context, gatewayKey string) (bool, types
 	inferencePoolKey := fmt.Sprintf("%s/%s", inferencePoolName.Namespace, inferencePoolName.Name)
 	accesslog.SetGatewayAPIInfo(c, "", "", inferencePoolKey)
 
-	// Apply HTTPURLRewriteFilter if present
-	if matchedRule != nil && matchedRule.Filters != nil {
-		for _, filter := range matchedRule.Filters {
+	// Apply HTTPURLRewriteFilter from the same rule that matched the request.
+	if matchResult.rule.Filters != nil {
+		for _, filter := range matchResult.rule.Filters {
 			if filter.Type == gatewayv1.HTTPRouteFilterURLRewrite && filter.URLRewrite != nil {
 				r.applyURLRewrite(c, filter.URLRewrite)
 			}
@@ -635,28 +551,6 @@ func (r *Router) handleHTTPRoute(c *gin.Context, gatewayKey string) (bool, types
 	}
 
 	return true, inferencePoolName
-}
-
-func httpPathMatchType(path *gatewayv1.HTTPPathMatch) gatewayv1.PathMatchType {
-	if path.Type == nil {
-		return gatewayv1.PathMatchPathPrefix
-	}
-	return *path.Type
-}
-
-func httpPathMatchValue(path *gatewayv1.HTTPPathMatch) string {
-	if path.Value == nil {
-		return "/"
-	}
-	return *path.Value
-}
-
-func matchHTTPPathPrefix(path, prefix string) (bool, string) {
-	normalizedPrefix := strings.TrimRight(prefix, "/")
-	if normalizedPrefix == "" {
-		return strings.HasPrefix(path, "/"), "/"
-	}
-	return path == normalizedPrefix || strings.HasPrefix(path, normalizedPrefix+"/"), normalizedPrefix
 }
 
 // applyURLRewrite applies HTTPURLRewriteFilter to the request

--- a/pkg/kthena-router/router/router_test.go
+++ b/pkg/kthena-router/router/router_test.go
@@ -39,6 +39,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
 	aiv1alpha1 "github.com/volcano-sh/kthena/pkg/apis/networking/v1alpha1"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/accesslog"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/common"
@@ -46,7 +48,6 @@ import (
 	"github.com/volcano-sh/kthena/pkg/kthena-router/datastore"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/metrics"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/utils"
-	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 func TestMain(m *testing.M) {
@@ -74,8 +75,8 @@ func setupTestRouter(t *testing.T, backendHandler http.Handler) (*Router, datast
 func TestRouter_HandleHTTPRoute_PathPrefix(t *testing.T) {
 	pathType := gatewayv1.PathMatchPathPrefix
 	kind := gatewayv1.Kind("Gateway")
-	group := gatewayv1.Group("inference.networking.k8s.io")
-	backendKind := gatewayv1.Kind("InferencePool")
+	group := inferencePoolBackendGroup
+	backendKind := inferencePoolBackendKind
 
 	tests := []struct {
 		name           string
@@ -241,6 +242,401 @@ func TestRouter_HandleHTTPRoute_PathPrefix(t *testing.T) {
 			prefix, exists := c.Get("matchedPrefix")
 			assert.True(t, exists)
 			assert.Equal(t, tt.expectedPrefix, prefix)
+		})
+	}
+}
+
+func TestRouter_HandleHTTPRoute_UsesMatchedRuleBackend(t *testing.T) {
+	pathType := gatewayv1.PathMatchPathPrefix
+	kind := gatewayv1.Kind("Gateway")
+	group := inferencePoolBackendGroup
+	backendKind := inferencePoolBackendKind
+	prefixA := "/a"
+	prefixB := "/b"
+	store := datastore.New()
+	router := &Router{store: store}
+	route := &gatewayv1.HTTPRoute{
+		ObjectMeta: v1.ObjectMeta{Name: "route", Namespace: "default"},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{
+					{
+						Name: "gw",
+						Kind: &kind,
+					},
+				},
+			},
+			Rules: []gatewayv1.HTTPRouteRule{
+				{
+					Matches: []gatewayv1.HTTPRouteMatch{
+						{
+							Path: &gatewayv1.HTTPPathMatch{
+								Type:  &pathType,
+								Value: &prefixA,
+							},
+						},
+					},
+					BackendRefs: []gatewayv1.HTTPBackendRef{
+						{
+							BackendRef: gatewayv1.BackendRef{
+								BackendObjectReference: gatewayv1.BackendObjectReference{
+									Group: &group,
+									Kind:  &backendKind,
+									Name:  "pool-a",
+								},
+							},
+						},
+					},
+				},
+				{
+					Matches: []gatewayv1.HTTPRouteMatch{
+						{
+							Path: &gatewayv1.HTTPPathMatch{
+								Type:  &pathType,
+								Value: &prefixB,
+							},
+						},
+					},
+					BackendRefs: []gatewayv1.HTTPBackendRef{
+						{
+							BackendRef: gatewayv1.BackendRef{
+								BackendObjectReference: gatewayv1.BackendObjectReference{
+									Group: &group,
+									Kind:  &backendKind,
+									Name:  "pool-b",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	assert.NoError(t, store.AddOrUpdateHTTPRoute(route))
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request, _ = http.NewRequest(http.MethodPost, "/b/chat", nil)
+
+	matched, pool := router.handleHTTPRoute(c, "default/gw")
+	assert.True(t, matched)
+	assert.Equal(t, types.NamespacedName{Namespace: "default", Name: "pool-b"}, pool)
+}
+
+func TestRouter_HandleHTTPRoute_PrefersLongestPrefix(t *testing.T) {
+	pathType := gatewayv1.PathMatchPathPrefix
+	kind := gatewayv1.Kind("Gateway")
+	group := inferencePoolBackendGroup
+	backendKind := inferencePoolBackendKind
+	rootPrefix := "/"
+	chatPrefix := "/chat"
+	store := datastore.New()
+	router := &Router{store: store}
+	route := &gatewayv1.HTTPRoute{
+		ObjectMeta: v1.ObjectMeta{Name: "route", Namespace: "default"},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{
+					{
+						Name: "gw",
+						Kind: &kind,
+					},
+				},
+			},
+			Rules: []gatewayv1.HTTPRouteRule{
+				{
+					Matches: []gatewayv1.HTTPRouteMatch{
+						{
+							Path: &gatewayv1.HTTPPathMatch{
+								Type:  &pathType,
+								Value: &rootPrefix,
+							},
+						},
+					},
+					BackendRefs: []gatewayv1.HTTPBackendRef{
+						{
+							BackendRef: gatewayv1.BackendRef{
+								BackendObjectReference: gatewayv1.BackendObjectReference{
+									Group: &group,
+									Kind:  &backendKind,
+									Name:  "pool-root",
+								},
+							},
+						},
+					},
+				},
+				{
+					Matches: []gatewayv1.HTTPRouteMatch{
+						{
+							Path: &gatewayv1.HTTPPathMatch{
+								Type:  &pathType,
+								Value: &chatPrefix,
+							},
+						},
+					},
+					BackendRefs: []gatewayv1.HTTPBackendRef{
+						{
+							BackendRef: gatewayv1.BackendRef{
+								BackendObjectReference: gatewayv1.BackendObjectReference{
+									Group: &group,
+									Kind:  &backendKind,
+									Name:  "pool-chat",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	assert.NoError(t, store.AddOrUpdateHTTPRoute(route))
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request, _ = http.NewRequest(http.MethodPost, "/chat/completions", nil)
+
+	matched, pool := router.handleHTTPRoute(c, "default/gw")
+	assert.True(t, matched)
+	assert.Equal(t, types.NamespacedName{Namespace: "default", Name: "pool-chat"}, pool)
+	prefix, exists := c.Get("matchedPrefix")
+	assert.True(t, exists)
+	assert.Equal(t, "/chat", prefix)
+}
+
+func TestRouter_HandleHTTPRoute_UsesMatchedRuleURLRewrite(t *testing.T) {
+	pathType := gatewayv1.PathMatchPathPrefix
+	rewriteType := gatewayv1.PrefixMatchHTTPPathModifier
+	kind := gatewayv1.Kind("Gateway")
+	group := inferencePoolBackendGroup
+	backendKind := inferencePoolBackendKind
+	prefixA := "/a"
+	prefixB := "/b"
+	wrongPrefix := "/wrong"
+	rightPrefix := "/right"
+	store := datastore.New()
+	router := &Router{store: store}
+	route := &gatewayv1.HTTPRoute{
+		ObjectMeta: v1.ObjectMeta{Name: "route", Namespace: "default"},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{
+					{
+						Name: "gw",
+						Kind: &kind,
+					},
+				},
+			},
+			Rules: []gatewayv1.HTTPRouteRule{
+				{
+					Matches: []gatewayv1.HTTPRouteMatch{
+						{
+							Path: &gatewayv1.HTTPPathMatch{
+								Type:  &pathType,
+								Value: &prefixA,
+							},
+						},
+					},
+					Filters: []gatewayv1.HTTPRouteFilter{
+						{
+							Type: gatewayv1.HTTPRouteFilterURLRewrite,
+							URLRewrite: &gatewayv1.HTTPURLRewriteFilter{
+								Path: &gatewayv1.HTTPPathModifier{
+									Type:               rewriteType,
+									ReplacePrefixMatch: &wrongPrefix,
+								},
+							},
+						},
+					},
+					BackendRefs: []gatewayv1.HTTPBackendRef{
+						{
+							BackendRef: gatewayv1.BackendRef{
+								BackendObjectReference: gatewayv1.BackendObjectReference{
+									Group: &group,
+									Kind:  &backendKind,
+									Name:  "pool-a",
+								},
+							},
+						},
+					},
+				},
+				{
+					Matches: []gatewayv1.HTTPRouteMatch{
+						{
+							Path: &gatewayv1.HTTPPathMatch{
+								Type:  &pathType,
+								Value: &prefixB,
+							},
+						},
+					},
+					Filters: []gatewayv1.HTTPRouteFilter{
+						{
+							Type: gatewayv1.HTTPRouteFilterURLRewrite,
+							URLRewrite: &gatewayv1.HTTPURLRewriteFilter{
+								Path: &gatewayv1.HTTPPathModifier{
+									Type:               rewriteType,
+									ReplacePrefixMatch: &rightPrefix,
+								},
+							},
+						},
+					},
+					BackendRefs: []gatewayv1.HTTPBackendRef{
+						{
+							BackendRef: gatewayv1.BackendRef{
+								BackendObjectReference: gatewayv1.BackendObjectReference{
+									Group: &group,
+									Kind:  &backendKind,
+									Name:  "pool-b",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	assert.NoError(t, store.AddOrUpdateHTTPRoute(route))
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request, _ = http.NewRequest(http.MethodPost, "/b/chat", nil)
+
+	matched, pool := router.handleHTTPRoute(c, "default/gw")
+	assert.True(t, matched)
+	assert.Equal(t, types.NamespacedName{Namespace: "default", Name: "pool-b"}, pool)
+	assert.Equal(t, "/right/chat", c.Request.URL.Path)
+}
+
+func TestRouter_HandleHTTPRoute_HostnameMatch(t *testing.T) {
+	pathType := gatewayv1.PathMatchPathPrefix
+	kind := gatewayv1.Kind("Gateway")
+	group := inferencePoolBackendGroup
+	backendKind := inferencePoolBackendKind
+	path := "/chat"
+	route := &gatewayv1.HTTPRoute{
+		ObjectMeta: v1.ObjectMeta{Name: "route", Namespace: "default"},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{
+					{
+						Name: "gw",
+						Kind: &kind,
+					},
+				},
+			},
+			Hostnames: []gatewayv1.Hostname{"api.example.com"},
+			Rules: []gatewayv1.HTTPRouteRule{
+				{
+					Matches: []gatewayv1.HTTPRouteMatch{
+						{
+							Path: &gatewayv1.HTTPPathMatch{
+								Type:  &pathType,
+								Value: &path,
+							},
+						},
+					},
+					BackendRefs: []gatewayv1.HTTPBackendRef{
+						{
+							BackendRef: gatewayv1.BackendRef{
+								BackendObjectReference: gatewayv1.BackendObjectReference{
+									Group: &group,
+									Kind:  &backendKind,
+									Name:  "pool",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	wildcardRoute := &gatewayv1.HTTPRoute{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "wildcard-route",
+			Namespace: "default",
+		},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{
+					{
+						Name: "gw",
+						Kind: &kind,
+					},
+				},
+			},
+			Hostnames: []gatewayv1.Hostname{"*.example.com"},
+			Rules: []gatewayv1.HTTPRouteRule{
+				{
+					Matches: []gatewayv1.HTTPRouteMatch{
+						{
+							Path: &gatewayv1.HTTPPathMatch{
+								Type:  &pathType,
+								Value: &path,
+							},
+						},
+					},
+					BackendRefs: []gatewayv1.HTTPBackendRef{
+						{
+							BackendRef: gatewayv1.BackendRef{
+								BackendObjectReference: gatewayv1.BackendObjectReference{
+									Group: &group,
+									Kind:  &backendKind,
+									Name:  "pool-wildcard",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name          string
+		routes        []*gatewayv1.HTTPRoute
+		host          string
+		expectedMatch bool
+		expectedPool  types.NamespacedName
+	}{
+		{
+			name:          "hostname matches",
+			routes:        []*gatewayv1.HTTPRoute{route},
+			host:          "api.example.com:8080",
+			expectedMatch: true,
+			expectedPool:  types.NamespacedName{Namespace: "default", Name: "pool"},
+		},
+		{
+			name:          "hostname mismatch",
+			routes:        []*gatewayv1.HTTPRoute{route},
+			host:          "other.example.com",
+			expectedMatch: false,
+		},
+		{
+			name:          "wildcard hostname matches",
+			routes:        []*gatewayv1.HTTPRoute{wildcardRoute},
+			host:          "api.example.com",
+			expectedMatch: true,
+			expectedPool:  types.NamespacedName{Namespace: "default", Name: "pool-wildcard"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := datastore.New()
+			router := &Router{store: store}
+			for _, route := range tt.routes {
+				assert.NoError(t, store.AddOrUpdateHTTPRoute(route))
+			}
+
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request, _ = http.NewRequest(http.MethodPost, "/chat", nil)
+			c.Request.Host = tt.host
+
+			matched, pool := router.handleHTTPRoute(c, "default/gw")
+			assert.Equal(t, tt.expectedMatch, matched)
+			if tt.expectedMatch {
+				assert.Equal(t, tt.expectedPool, pool)
+			}
 		})
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

/kind feature

**What this PR does / why we need it**:

This PR enhances Gateway API HTTPRoute support in kthena-router.

The key change is that the router now keeps the matched HTTPRoute rule and uses that same rule consistently for backendRef selection and URLRewrite filters. This allows one HTTPRoute to safely contain multiple rules with different backends and filters.

Previously, the router first scanned `route.Spec.Rules` to determine whether the request matched an HTTPRoute, but only kept the matched route object:

```go
if matched {
    matchedRoute = route
    break
}
```

Later, backend selection scanned `matchedRoute.Spec.Rules` again from the beginning:

```go
for i := range matchedRoute.Spec.Rules {
    rule := &matchedRoute.Spec.Rules[i]
    for _, backendRef := range rule.BackendRefs {
        ...
        inferencePoolName.Name = string(backendRef.Name)
        matchedRule = rule
        break
    }
}
```

This could lose the association between a rule's `matches`, `backendRefs`, and `filters`.

For example, users may configure one HTTPRoute with two rules:

```yaml
rules:
- matches:
  - path:
      type: PathPrefix
      value: /a
  backendRefs:
  - group: inference.networking.k8s.io
    kind: InferencePool
    name: pool-a
- matches:
  - path:
      type: PathPrefix
      value: /b
  backendRefs:
  - group: inference.networking.k8s.io
    kind: InferencePool
    name: pool-b
```

A request to `/b/chat` should match the second rule and route to `pool-b`. With the previous flow, the request could match the `/b` rule during the first scan, but backend selection would scan from the first rule again and select `pool-a`.

This PR enhances kthena-router HTTPRoute handling for Kthena's current lightweight routing model.

The router now keeps the matched HTTPRoute rule and uses that same rule consistently for BackendRef selection and URLRewrite filters. This avoids selecting a backend or filter from a different rule than the one that matched the request.

This PR also adds:

- `spec.hostnames` matching, which was mentioned in the original comment but not implemented
- more specific path rule selection within one HTTPRoute, for example `/chat` winning over `/`
- concerned about the performance, this pr not implement a full gateway , which is very costy, need to match per request. safeguards so HTTPRoute matches containing unsupported method/header/query predicates are not treated as path-only matches

This PR intentionally does not implement full Gateway API matching or cross-route precedence. Method, header, and query parameter matching are not supported in this PR.

**Which issue(s) this PR fixes**:
Fixes #1175 

**Special notes for your reviewer**:

Prepared with AI assistance; I reviewed the changes and verified the behavior locally.

Verification:

```bash
go test ./pkg/kthena-router/router -run 'TestRouter_HandleHTTPRoute' -count=1
go test ./pkg/kthena-router/router -count=1
git diff --check
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->

```release-note
Enhanced kthena-router HTTPRoute handling to honor hostnames, preserve the matched rule for BackendRef and URLRewrite selection, and prefer more specific path rules within one HTTPRoute.
```