### PR TITLE
feat(cli): improve get output for autoscaling-policies, autoscaling-p…

### DIFF
--- a/cli/kthena/cmd/get.go
+++ b/cli/kthena/cmd/get.go
@@ -369,16 +369,17 @@ func runGetModelServings(cmd *cobra.Command, args []string) error {
 	if len(args) > 0 {
 		nameFilter = args[0]
 	}
+	filterLower := strings.ToLower(nameFilter)
 
-	// Count matching items first
-	matchCount := 0
+	// Filter matching items
+	var filtered []workload.ModelServing
 	for _, ms := range modelServingList.Items {
-		if nameFilter == "" || strings.Contains(strings.ToLower(ms.Name), strings.ToLower(nameFilter)) {
-			matchCount++
+		if nameFilter == "" || strings.Contains(strings.ToLower(ms.Name), filterLower) {
+			filtered = append(filtered, ms)
 		}
 	}
 
-	if matchCount == 0 {
+	if len(filtered) == 0 {
 		if nameFilter != "" {
 			fmt.Printf("No ModelServings found matching '%s'.\n", nameFilter)
 		} else {
@@ -400,16 +401,14 @@ func runGetModelServings(cmd *cobra.Command, args []string) error {
 	}
 
 	// Print matching ModelServings
-	for _, ms := range modelServingList.Items {
-		if nameFilter == "" || strings.Contains(strings.ToLower(ms.Name), strings.ToLower(nameFilter)) {
-			age := time.Since(ms.CreationTimestamp.Time).Truncate(time.Second)
-			ready := fmt.Sprintf("%d/%d", ms.Status.AvailableReplicas, ms.Status.Replicas)
-			status := getModelServingStatus(ms.Status.Conditions)
-			if getAllNamespaces {
-				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", ms.Namespace, ms.Name, ready, status, age)
-			} else {
-				fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", ms.Name, ready, status, age)
-			}
+	for _, ms := range filtered {
+		age := time.Since(ms.CreationTimestamp.Time).Truncate(time.Second)
+		ready := fmt.Sprintf("%d/%d", ms.Status.AvailableReplicas, ms.Status.Replicas)
+		status := getModelServingStatus(ms.Status.Conditions)
+		if getAllNamespaces {
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", ms.Namespace, ms.Name, ready, status, age)
+		} else {
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", ms.Name, ready, status, age)
 		}
 	}
 	return w.Flush()
@@ -417,7 +416,9 @@ func runGetModelServings(cmd *cobra.Command, args []string) error {
 
 func getAutoscalingPolicyBindingTarget(binding workload.AutoscalingPolicyBinding) string {
 	if binding.Spec.HomogeneousTarget != nil {
-		return binding.Spec.HomogeneousTarget.Target.TargetRef.Name
+		if binding.Spec.HomogeneousTarget.Target.TargetRef.Name != "" {
+			return binding.Spec.HomogeneousTarget.Target.TargetRef.Name
+		}
 	}
 	if binding.Spec.HeterogeneousTarget != nil {
 		var names []string
@@ -513,18 +514,21 @@ func runGetAutoscalingPolicyBindings(cmd *cobra.Command, args []string) error {
 	// Print header
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
 	if getAllNamespaces {
-		fmt.Fprintln(w, "NAMESPACE\tNAME\tAGE")
+		fmt.Fprintln(w, "NAMESPACE\tNAME\tPOLICY\tTARGET\tMIN\tMAX\tAGE")
 	} else {
-		fmt.Fprintln(w, "NAME\tAGE")
+		fmt.Fprintln(w, "NAME\tPOLICY\tTARGET\tMIN\tMAX\tAGE")
 	}
 
 	// Print AutoscalingPolicyBindings
 	for _, binding := range bindings.Items {
 		age := time.Since(binding.CreationTimestamp.Time).Truncate(time.Second)
+		policy := binding.Spec.PolicyRef.Name
+		target := getAutoscalingPolicyBindingTarget(binding)
+		min, max := getAutoscalingPolicyBindingMinMax(binding)
 		if getAllNamespaces {
-			fmt.Fprintf(w, "%s\t%s\t%s\n", binding.Namespace, binding.Name, age)
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n", binding.Namespace, binding.Name, policy, target, min, max, age)
 		} else {
-			fmt.Fprintf(w, "%s\t%s\n", binding.Name, age)
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n", binding.Name, policy, target, min, max, age)
 		}
 	}
 

--- a/cli/kthena/cmd/get.go
+++ b/cli/kthena/cmd/get.go
@@ -439,6 +439,14 @@ func getAutoscalingPolicyBindingMinMax(binding workload.AutoscalingPolicyBinding
 		return fmt.Sprintf("%d", binding.Spec.HomogeneousTarget.MinReplicas),
 			fmt.Sprintf("%d", binding.Spec.HomogeneousTarget.MaxReplicas)
 	}
+	if binding.Spec.HeterogeneousTarget != nil {
+		var totalMin, totalMax int32
+		for _, p := range binding.Spec.HeterogeneousTarget.Params {
+			totalMin += p.MinReplicas
+			totalMax += p.MaxReplicas
+		}
+		return fmt.Sprintf("%d", totalMin), fmt.Sprintf("%d", totalMax)
+	}
 	return "-", "-"
 }
 

--- a/cli/kthena/cmd/get.go
+++ b/cli/kthena/cmd/get.go
@@ -91,10 +91,11 @@ If NAME is provided, only models containing the specified name will be displayed
 
 // getModelServingsCmd represents the get model-servings command
 var getModelServingsCmd = &cobra.Command{
-	Use:     "model-servings",
+	Use:     "model-servings [NAME]",
 	Aliases: []string{"ms", "model-serving"},
 	Short:   "List model serving workloads",
-	Long:    `List ModelServing resources in the cluster.`,
+	Long:    `List ModelServing resources in the cluster. Optionally filter by name.`,
+	Args:    cobra.MaximumNArgs(1),
 	RunE:    runGetModelServings,
 }
 
@@ -363,11 +364,29 @@ func runGetModelServings(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to list ModelServings: %v", err)
 	}
 
-	if len(modelServingList.Items) == 0 {
-		if getAllNamespaces {
-			fmt.Println("No ModelServings found across all namespaces.")
+	// Get name filter if provided
+	var nameFilter string
+	if len(args) > 0 {
+		nameFilter = args[0]
+	}
+
+	// Count matching items first
+	matchCount := 0
+	for _, ms := range modelServingList.Items {
+		if nameFilter == "" || strings.Contains(strings.ToLower(ms.Name), strings.ToLower(nameFilter)) {
+			matchCount++
+		}
+	}
+
+	if matchCount == 0 {
+		if nameFilter != "" {
+			fmt.Printf("No ModelServings found matching '%s'.\n", nameFilter)
 		} else {
-			fmt.Printf("No ModelServings found in namespace %s.\n", namespace)
+			if getAllNamespaces {
+				fmt.Println("No ModelServings found across all namespaces.")
+			} else {
+				fmt.Printf("No ModelServings found in namespace %s.\n", namespace)
+			}
 		}
 		return nil
 	}
@@ -380,18 +399,46 @@ func runGetModelServings(cmd *cobra.Command, args []string) error {
 		fmt.Fprintln(w, "NAME\tREADY\tSTATUS\tAGE")
 	}
 
-	// Print ModelServings
+	// Print matching ModelServings
 	for _, ms := range modelServingList.Items {
-		age := time.Since(ms.CreationTimestamp.Time).Truncate(time.Second)
-		ready := fmt.Sprintf("%d/%d", ms.Status.AvailableReplicas, ms.Status.Replicas)
-		status := getModelServingStatus(ms.Status.Conditions)
-		if getAllNamespaces {
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", ms.Namespace, ms.Name, ready, status, age)
-		} else {
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", ms.Name, ready, status, age)
+		if nameFilter == "" || strings.Contains(strings.ToLower(ms.Name), strings.ToLower(nameFilter)) {
+			age := time.Since(ms.CreationTimestamp.Time).Truncate(time.Second)
+			ready := fmt.Sprintf("%d/%d", ms.Status.AvailableReplicas, ms.Status.Replicas)
+			status := getModelServingStatus(ms.Status.Conditions)
+			if getAllNamespaces {
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", ms.Namespace, ms.Name, ready, status, age)
+			} else {
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", ms.Name, ready, status, age)
+			}
 		}
 	}
 	return w.Flush()
+}
+
+func getAutoscalingPolicyBindingTarget(binding workload.AutoscalingPolicyBinding) string {
+	if binding.Spec.HomogeneousTarget != nil {
+		return binding.Spec.HomogeneousTarget.Target.TargetRef.Name
+	}
+	if binding.Spec.HeterogeneousTarget != nil {
+		var names []string
+		for _, p := range binding.Spec.HeterogeneousTarget.Params {
+			if p.Target.TargetRef.Name != "" {
+				names = append(names, p.Target.TargetRef.Name)
+			}
+		}
+		if len(names) > 0 {
+			return strings.Join(names, ",")
+		}
+	}
+	return "<none>"
+}
+
+func getAutoscalingPolicyBindingMinMax(binding workload.AutoscalingPolicyBinding) (string, string) {
+	if binding.Spec.HomogeneousTarget != nil {
+		return fmt.Sprintf("%d", binding.Spec.HomogeneousTarget.MinReplicas),
+			fmt.Sprintf("%d", binding.Spec.HomogeneousTarget.MaxReplicas)
+	}
+	return "-", "-"
 }
 
 func runGetAutoscalingPolicies(cmd *cobra.Command, args []string) error {
@@ -420,18 +467,20 @@ func runGetAutoscalingPolicies(cmd *cobra.Command, args []string) error {
 	// Print header
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
 	if getAllNamespaces {
-		fmt.Fprintln(w, "NAMESPACE\tNAME\tAGE")
+		fmt.Fprintln(w, "NAMESPACE\tNAME\tMETRICS\tTOLERANCE\tAGE")
 	} else {
-		fmt.Fprintln(w, "NAME\tAGE")
+		fmt.Fprintln(w, "NAME\tMETRICS\tTOLERANCE\tAGE")
 	}
 
 	// Print AutoscalingPolicies
 	for _, policy := range policies.Items {
 		age := time.Since(policy.CreationTimestamp.Time).Truncate(time.Second)
+		metrics := len(policy.Spec.Metrics)
+		tolerance := fmt.Sprintf("%d%%", policy.Spec.TolerancePercent)
 		if getAllNamespaces {
-			fmt.Fprintf(w, "%s\t%s\t%s\n", policy.Namespace, policy.Name, age)
+			fmt.Fprintf(w, "%s\t%s\t%d\t%s\t%s\n", policy.Namespace, policy.Name, metrics, tolerance, age)
 		} else {
-			fmt.Fprintf(w, "%s\t%s\n", policy.Name, age)
+			fmt.Fprintf(w, "%s\t%d\t%s\t%s\n", policy.Name, metrics, tolerance, age)
 		}
 	}
 

--- a/cli/kthena/cmd/get_test.go
+++ b/cli/kthena/cmd/get_test.go
@@ -289,11 +289,16 @@ func TestGetAutoscalingPolicyBindingMinMax(t *testing.T) {
 			name: "HeterogeneousTarget",
 			binding: workload.AutoscalingPolicyBinding{
 				Spec: workload.AutoscalingPolicyBindingSpec{
-					HeterogeneousTarget: &workload.HeterogeneousTarget{},
+					HeterogeneousTarget: &workload.HeterogeneousTarget{
+						Params: []workload.HeterogeneousTargetParam{
+							{MinReplicas: 1, MaxReplicas: 5},
+							{MinReplicas: 2, MaxReplicas: 10},
+						},
+					},
 				},
 			},
-			expectedMin: "-",
-			expectedMax: "-",
+			expectedMin: "3",
+			expectedMax: "15",
 		},
 	}
 	for _, tt := range tests {

--- a/cli/kthena/cmd/get_test.go
+++ b/cli/kthena/cmd/get_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	workload "github.com/volcano-sh/kthena/pkg/apis/workload/v1alpha1"
@@ -199,6 +200,98 @@ func TestGetModelBoosterStatus(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := getModelBoosterStatus(tt.conditions)
 			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGetAutoscalingPolicyBindingTarget(t *testing.T) {
+	tests := []struct {
+		name     string
+		binding  workload.AutoscalingPolicyBinding
+		expected string
+	}{
+		{
+			name:     "NoTarget",
+			binding:  workload.AutoscalingPolicyBinding{},
+			expected: "<none>",
+		},
+		{
+			name: "HomogeneousTarget",
+			binding: workload.AutoscalingPolicyBinding{
+				Spec: workload.AutoscalingPolicyBindingSpec{
+					HomogeneousTarget: &workload.HomogeneousTarget{
+						Target: workload.Target{
+							TargetRef: corev1.ObjectReference{Name: "my-serving"},
+						},
+					},
+				},
+			},
+			expected: "my-serving",
+		},
+		{
+			name: "HeterogeneousTarget",
+			binding: workload.AutoscalingPolicyBinding{
+				Spec: workload.AutoscalingPolicyBindingSpec{
+					HeterogeneousTarget: &workload.HeterogeneousTarget{
+						Params: []workload.HeterogeneousTargetParam{
+							{Target: workload.Target{TargetRef: corev1.ObjectReference{Name: "serving-a"}}},
+							{Target: workload.Target{TargetRef: corev1.ObjectReference{Name: "serving-b"}}},
+						},
+					},
+				},
+			},
+			expected: "serving-a,serving-b",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, getAutoscalingPolicyBindingTarget(tt.binding))
+		})
+	}
+}
+
+func TestGetAutoscalingPolicyBindingMinMax(t *testing.T) {
+	tests := []struct {
+		name        string
+		binding     workload.AutoscalingPolicyBinding
+		expectedMin string
+		expectedMax string
+	}{
+		{
+			name:        "NoTarget",
+			binding:     workload.AutoscalingPolicyBinding{},
+			expectedMin: "-",
+			expectedMax: "-",
+		},
+		{
+			name: "HomogeneousTarget",
+			binding: workload.AutoscalingPolicyBinding{
+				Spec: workload.AutoscalingPolicyBindingSpec{
+					HomogeneousTarget: &workload.HomogeneousTarget{
+						MinReplicas: 2,
+						MaxReplicas: 10,
+					},
+				},
+			},
+			expectedMin: "2",
+			expectedMax: "10",
+		},
+		{
+			name: "HeterogeneousTarget",
+			binding: workload.AutoscalingPolicyBinding{
+				Spec: workload.AutoscalingPolicyBindingSpec{
+					HeterogeneousTarget: &workload.HeterogeneousTarget{},
+				},
+			},
+			expectedMin: "-",
+			expectedMax: "-",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			min, max := getAutoscalingPolicyBindingMinMax(tt.binding)
+			assert.Equal(t, tt.expectedMin, min)
+			assert.Equal(t, tt.expectedMax, max)
 		})
 	}
 }

--- a/cli/kthena/cmd/get_test.go
+++ b/cli/kthena/cmd/get_test.go
@@ -229,6 +229,15 @@ func TestGetAutoscalingPolicyBindingTarget(t *testing.T) {
 			expected: "my-serving",
 		},
 		{
+			name: "HomogeneousTargetEmptyName",
+			binding: workload.AutoscalingPolicyBinding{
+				Spec: workload.AutoscalingPolicyBindingSpec{
+					HomogeneousTarget: &workload.HomogeneousTarget{},
+				},
+			},
+			expected: "<none>",
+		},
+		{
 			name: "HeterogeneousTarget",
 			binding: workload.AutoscalingPolicyBinding{
 				Spec: workload.AutoscalingPolicyBindingSpec{


### PR DESCRIPTION
…olicy-bindings, and model-servings

**What type of PR is this?**
/kind enhancement
<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:
so currently `kthena get autoscaling-policies`, `kthena get autoscaling-policy-bindings`, and `kthena get model-servings` display only NAME and AGE columns, which forces operators to run a separate describe for every resource just to understand their cluster state.

 PR adds METRICS and TOLERANCE columns to `get autoscaling-policies`, adds POLICY/TARGET/MIN/MAX columns to `get autoscaling-policy-bindings`, and adds an optional NAME filter argument to `get model-servings` (consistent with how `get model-boosters` already works). 
 i also added UT's for the new additions

**Which issue(s) this PR fixes**:
Fixes #1176

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
