### PR TITLE
router: add observability metrics for prefix-cache and kvcache-aware score plugins

### DIFF
--- a/examples/observability/README.md
+++ b/examples/observability/README.md
@@ -1,0 +1,59 @@
+# Score-plugin observability
+
+Prometheus metrics and a sample Grafana dashboard for the kthena-router
+`prefix-cache` and `kvcache-aware` score plugins. See the design proposal in
+[`docs/proposal/score-plugin-observability.md`](../../docs/proposal/score-plugin-observability.md).
+
+## Metrics
+
+All metrics are exported on the router's existing `/metrics` endpoint and are
+labelled with `model` (the `kvcache-aware` error counter is additionally
+labelled with `stage`).
+
+### `prefix-cache`
+
+| Metric | Type |
+|--------|------|
+| `kthena_router_prefix_cache_hits_total` | Counter |
+| `kthena_router_prefix_cache_misses_total` | Counter |
+| `kthena_router_prefix_cache_blocks_matched` | Histogram |
+| `kthena_router_prefix_cache_evictions_total` | Counter |
+| `kthena_router_prefix_cache_entries` | Gauge |
+
+### `kvcache-aware`
+
+| Metric | Type |
+|--------|------|
+| `kthena_router_kvcache_aware_hits_total` | Counter |
+| `kthena_router_kvcache_aware_misses_total` | Counter |
+| `kthena_router_kvcache_aware_blocks_matched` | Histogram |
+| `kthena_router_kvcache_aware_redis_duration_seconds` | Histogram |
+| `kthena_router_kvcache_aware_tokenize_duration_seconds` | Histogram |
+| `kthena_router_kvcache_aware_errors_total` | Counter (`stage`: `tokenize`, `redis`) |
+
+> Total `Score()` duration is already exported generically as
+> `kthena_router_scheduler_plugin_duration_seconds{plugin="prefix-cache"|"kvcache-aware", type="score"}`,
+> so it is not duplicated here.
+
+## Scraping with kube-prometheus-stack
+
+Apply the ServiceMonitor (adjust namespace and the `release` label to match your
+Prometheus):
+
+```bash
+kubectl apply -f router-servicemonitor.yaml
+```
+
+Verify the new series are present:
+
+```bash
+kubectl -n kthena-system port-forward svc/kthena-router 8080:80 &
+curl -s localhost:8080/metrics | grep -E 'kthena_router_(prefix_cache|kvcache_aware)'
+```
+
+## Grafana dashboard
+
+Import `grafana-dashboard-score-plugins.json` (Dashboards → Import) and select
+your Prometheus data source. The dashboard has a `model` template variable and
+panels for hit rate, match-length distribution, Redis/tokenizer latency,
+eviction rate, occupancy, and error rate by stage.

--- a/examples/observability/grafana-dashboard-score-plugins.json
+++ b/examples/observability/grafana-dashboard-score-plugins.json
@@ -1,0 +1,209 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "Prometheus data source scraping the kthena-router /metrics endpoint",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {"type": "grafana", "uid": "-- Grafana --"},
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["kthena", "kthena-router", "score-plugins"],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Data source",
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "type": "datasource"
+      },
+      {
+        "current": {"selected": true, "text": "All", "value": "$__all"},
+        "datasource": {"type": "prometheus", "uid": "${datasource}"},
+        "definition": "label_values(kthena_router_prefix_cache_hits_total, model)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Model",
+        "multi": true,
+        "name": "model",
+        "query": {"query": "label_values(kthena_router_prefix_cache_hits_total, model)", "refId": "StandardVariableQuery"},
+        "refresh": 2,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {"from": "now-1h", "to": "now"},
+  "timepicker": {},
+  "timezone": "",
+  "title": "Kthena Router - Score Plugins (prefix-cache & kvcache-aware)",
+  "uid": "kthena-score-plugins",
+  "version": 1,
+  "weekStart": "",
+  "panels": [
+    {
+      "type": "row",
+      "title": "prefix-cache",
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 0},
+      "id": 100,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Prefix cache hit rate",
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "description": "Fraction of prefix-cache score calls that matched at least one pod.",
+      "gridPos": {"h": 8, "w": 8, "x": 0, "y": 1},
+      "id": 1,
+      "fieldConfig": {"defaults": {"unit": "percentunit", "min": 0, "max": 1}, "overrides": []},
+      "options": {"legend": {"displayMode": "list", "placement": "bottom"}, "tooltip": {"mode": "multi"}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "sum by (model) (rate(kthena_router_prefix_cache_hits_total{model=~\"$model\"}[5m])) / (sum by (model) (rate(kthena_router_prefix_cache_hits_total{model=~\"$model\"}[5m])) + sum by (model) (rate(kthena_router_prefix_cache_misses_total{model=~\"$model\"}[5m])))",
+          "legendFormat": "{{model}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Prefix match length (blocks) p50/p90/p99",
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "description": "Longest prefix match length per score call.",
+      "gridPos": {"h": 8, "w": 8, "x": 8, "y": 1},
+      "id": 2,
+      "fieldConfig": {"defaults": {"unit": "none", "min": 0}, "overrides": []},
+      "options": {"legend": {"displayMode": "list", "placement": "bottom"}, "tooltip": {"mode": "multi"}},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "${datasource}"}, "expr": "histogram_quantile(0.5, sum by (le) (rate(kthena_router_prefix_cache_blocks_matched_bucket{model=~\"$model\"}[5m])))", "legendFormat": "p50", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "${datasource}"}, "expr": "histogram_quantile(0.9, sum by (le) (rate(kthena_router_prefix_cache_blocks_matched_bucket{model=~\"$model\"}[5m])))", "legendFormat": "p90", "refId": "B"},
+        {"datasource": {"type": "prometheus", "uid": "${datasource}"}, "expr": "histogram_quantile(0.99, sum by (le) (rate(kthena_router_prefix_cache_blocks_matched_bucket{model=~\"$model\"}[5m])))", "legendFormat": "p99", "refId": "C"}
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Prefix cache entries & eviction rate",
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "description": "Current cached hash entries (occupancy) and capacity-driven eviction rate.",
+      "gridPos": {"h": 8, "w": 8, "x": 16, "y": 1},
+      "id": 3,
+      "fieldConfig": {"defaults": {"unit": "none", "min": 0}, "overrides": [{"matcher": {"id": "byName", "options": "evictions/s"}, "properties": [{"id": "custom.axisPlacement", "value": "right"}]}]},
+      "options": {"legend": {"displayMode": "list", "placement": "bottom"}, "tooltip": {"mode": "multi"}},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "${datasource}"}, "expr": "kthena_router_prefix_cache_entries", "legendFormat": "entries", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "${datasource}"}, "expr": "sum by (model) (rate(kthena_router_prefix_cache_evictions_total{model=~\"$model\"}[5m]))", "legendFormat": "evictions/s", "refId": "B"}
+      ]
+    },
+    {
+      "type": "row",
+      "title": "kvcache-aware",
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 9},
+      "id": 101,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "KV cache hit rate",
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "description": "Fraction of kvcache-aware score calls that matched at least one block.",
+      "gridPos": {"h": 8, "w": 8, "x": 0, "y": 10},
+      "id": 4,
+      "fieldConfig": {"defaults": {"unit": "percentunit", "min": 0, "max": 1}, "overrides": []},
+      "options": {"legend": {"displayMode": "list", "placement": "bottom"}, "tooltip": {"mode": "multi"}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "sum by (model) (rate(kthena_router_kvcache_aware_hits_total{model=~\"$model\"}[5m])) / (sum by (model) (rate(kthena_router_kvcache_aware_hits_total{model=~\"$model\"}[5m])) + sum by (model) (rate(kthena_router_kvcache_aware_misses_total{model=~\"$model\"}[5m])))",
+          "legendFormat": "{{model}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Redis lookup latency p50/p99",
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "description": "Time spent in the batched Redis lookup during scoring.",
+      "gridPos": {"h": 8, "w": 8, "x": 8, "y": 10},
+      "id": 5,
+      "fieldConfig": {"defaults": {"unit": "s", "min": 0}, "overrides": []},
+      "options": {"legend": {"displayMode": "list", "placement": "bottom"}, "tooltip": {"mode": "multi"}},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "${datasource}"}, "expr": "histogram_quantile(0.5, sum by (le) (rate(kthena_router_kvcache_aware_redis_duration_seconds_bucket{model=~\"$model\"}[5m])))", "legendFormat": "p50", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "${datasource}"}, "expr": "histogram_quantile(0.99, sum by (le) (rate(kthena_router_kvcache_aware_redis_duration_seconds_bucket{model=~\"$model\"}[5m])))", "legendFormat": "p99", "refId": "B"}
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Tokenize latency p50/p99",
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "description": "Time spent tokenizing the prompt during scoring.",
+      "gridPos": {"h": 8, "w": 8, "x": 16, "y": 10},
+      "id": 6,
+      "fieldConfig": {"defaults": {"unit": "s", "min": 0}, "overrides": []},
+      "options": {"legend": {"displayMode": "list", "placement": "bottom"}, "tooltip": {"mode": "multi"}},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "${datasource}"}, "expr": "histogram_quantile(0.5, sum by (le) (rate(kthena_router_kvcache_aware_tokenize_duration_seconds_bucket{model=~\"$model\"}[5m])))", "legendFormat": "p50", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "${datasource}"}, "expr": "histogram_quantile(0.99, sum by (le) (rate(kthena_router_kvcache_aware_tokenize_duration_seconds_bucket{model=~\"$model\"}[5m])))", "legendFormat": "p99", "refId": "B"}
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "KV cache block match length p50/p90/p99",
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "description": "Longest prefix-block match length per score call.",
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 18},
+      "id": 7,
+      "fieldConfig": {"defaults": {"unit": "none", "min": 0}, "overrides": []},
+      "options": {"legend": {"displayMode": "list", "placement": "bottom"}, "tooltip": {"mode": "multi"}},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "${datasource}"}, "expr": "histogram_quantile(0.5, sum by (le) (rate(kthena_router_kvcache_aware_blocks_matched_bucket{model=~\"$model\"}[5m])))", "legendFormat": "p50", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "${datasource}"}, "expr": "histogram_quantile(0.9, sum by (le) (rate(kthena_router_kvcache_aware_blocks_matched_bucket{model=~\"$model\"}[5m])))", "legendFormat": "p90", "refId": "B"},
+        {"datasource": {"type": "prometheus", "uid": "${datasource}"}, "expr": "histogram_quantile(0.99, sum by (le) (rate(kthena_router_kvcache_aware_blocks_matched_bucket{model=~\"$model\"}[5m])))", "legendFormat": "p99", "refId": "C"}
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "KV cache error rate by stage",
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "description": "Score calls aborted on error, split by stage (tokenize / redis).",
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 18},
+      "id": 8,
+      "fieldConfig": {"defaults": {"unit": "ops", "min": 0}, "overrides": []},
+      "options": {"legend": {"displayMode": "list", "placement": "bottom"}, "tooltip": {"mode": "multi"}},
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "${datasource}"}, "expr": "sum by (stage) (rate(kthena_router_kvcache_aware_errors_total{model=~\"$model\"}[5m]))", "legendFormat": "{{stage}}", "refId": "A"}
+      ]
+    }
+  ]
+}

--- a/examples/observability/router-servicemonitor.yaml
+++ b/examples/observability/router-servicemonitor.yaml
@@ -1,0 +1,20 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: kthena-router
+  namespace: kthena-system
+  labels:
+    # Must match the serviceMonitorSelector of your Prometheus (the
+    # kube-prometheus-stack default selects on this release label).
+    release: kube-prometheus-stack
+spec:
+  endpoints:
+    - interval: 15s
+      path: /metrics
+      port: http
+  namespaceSelector:
+    matchNames:
+      - kthena-system
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: kthena-router

--- a/pkg/kthena-router/metrics/metrics.go
+++ b/pkg/kthena-router/metrics/metrics.go
@@ -38,6 +38,11 @@ const (
 	LabelModelServer = "model_server"
 	LabelEngine      = "engine"
 	LabelUserID      = "user_id"
+	LabelStage       = "stage"
+
+	// kvcache-aware error stage values
+	StageTokenize = "tokenize"
+	StageRedis    = "redis"
 
 	// Token type values
 	TokenTypeInput  = "input"
@@ -91,6 +96,22 @@ type Metrics struct {
 
 	// Tokenizer unsupported engine metrics
 	TokenizerUnsupportedEngineTotal prometheus.CounterVec
+
+	// prefix-cache score plugin metrics
+	PrefixCacheHitsTotal       prometheus.CounterVec
+	PrefixCacheMissesTotal     prometheus.CounterVec
+	PrefixCacheBlocksMatched   prometheus.HistogramVec
+	PrefixCacheEvictionsTotal  prometheus.CounterVec
+	PrefixCacheEntries         prometheus.GaugeFunc
+	prefixCacheEntriesProvider atomic.Value // func() float64
+
+	// kvcache-aware score plugin metrics
+	KVCacheHitsTotal        prometheus.CounterVec
+	KVCacheMissesTotal      prometheus.CounterVec
+	KVCacheBlocksMatched    prometheus.HistogramVec
+	KVCacheRedisDuration    prometheus.HistogramVec
+	KVCacheTokenizeDuration prometheus.HistogramVec
+	KVCacheErrorsTotal      prometheus.CounterVec
 }
 
 // NewMetrics creates a new Metrics instance with all Prometheus metrics registered
@@ -236,6 +257,90 @@ func NewMetrics() *Metrics {
 			},
 			[]string{LabelModel, LabelEngine},
 		),
+
+		PrefixCacheHitsTotal: *promauto.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "kthena_router_prefix_cache_hits_total",
+				Help: "Number of prefix-cache score calls with at least one matching pod",
+			},
+			[]string{LabelModel},
+		),
+
+		PrefixCacheMissesTotal: *promauto.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "kthena_router_prefix_cache_misses_total",
+				Help: "Number of prefix-cache score calls that hashed a non-empty prompt but found zero matches",
+			},
+			[]string{LabelModel},
+		),
+
+		PrefixCacheBlocksMatched: *promauto.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Name:    "kthena_router_prefix_cache_blocks_matched",
+				Help:    "Longest prefix match length (in blocks) per prefix-cache score call",
+				Buckets: []float64{0, 1, 2, 4, 8, 16, 32, 64, 128},
+			},
+			[]string{LabelModel},
+		),
+
+		PrefixCacheEvictionsTotal: *promauto.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "kthena_router_prefix_cache_evictions_total",
+				Help: "Number of hash entries evicted from a pod LRU due to capacity pressure",
+			},
+			[]string{LabelModel},
+		),
+
+		KVCacheHitsTotal: *promauto.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "kthena_router_kvcache_aware_hits_total",
+				Help: "Number of kvcache-aware score calls with at least one block match",
+			},
+			[]string{LabelModel},
+		),
+
+		KVCacheMissesTotal: *promauto.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "kthena_router_kvcache_aware_misses_total",
+				Help: "Number of kvcache-aware score calls that produced block hashes but matched zero blocks",
+			},
+			[]string{LabelModel},
+		),
+
+		KVCacheBlocksMatched: *promauto.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Name:    "kthena_router_kvcache_aware_blocks_matched",
+				Help:    "Longest prefix-block match length per kvcache-aware score call",
+				Buckets: []float64{0, 1, 2, 4, 8, 16, 32, 64, 128},
+			},
+			[]string{LabelModel},
+		),
+
+		KVCacheRedisDuration: *promauto.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Name:    "kthena_router_kvcache_aware_redis_duration_seconds",
+				Help:    "Time spent in the batched Redis lookup during kvcache-aware scoring",
+				Buckets: []float64{0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5},
+			},
+			[]string{LabelModel},
+		),
+
+		KVCacheTokenizeDuration: *promauto.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Name:    "kthena_router_kvcache_aware_tokenize_duration_seconds",
+				Help:    "Time spent tokenizing the prompt during kvcache-aware scoring",
+				Buckets: []float64{0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5},
+			},
+			[]string{LabelModel},
+		),
+
+		KVCacheErrorsTotal: *promauto.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "kthena_router_kvcache_aware_errors_total",
+				Help: "Number of kvcache-aware score calls that aborted on error, by stage",
+			},
+			[]string{LabelModel, LabelStage},
+		),
 	}
 
 	m.ActiveRequests = promauto.NewGaugeFunc(
@@ -248,7 +353,65 @@ func NewMetrics() *Metrics {
 		},
 	)
 
+	m.PrefixCacheEntries = promauto.NewGaugeFunc(
+		prometheus.GaugeOpts{
+			Name: "kthena_router_prefix_cache_entries",
+			Help: "Current number of cached hash entries across all pod LRUs in the prefix-cache store",
+		},
+		func() float64 {
+			if p, ok := m.prefixCacheEntriesProvider.Load().(func() float64); ok && p != nil {
+				return p()
+			}
+			return 0
+		},
+	)
+
 	return m
+}
+
+// SetPrefixCacheEntriesProvider sets the callback read by the prefix_cache_entries gauge at scrape time.
+func (m *Metrics) SetPrefixCacheEntriesProvider(provider func() float64) {
+	m.prefixCacheEntriesProvider.Store(provider)
+}
+
+func (m *Metrics) RecordPrefixCacheHit(model string) {
+	m.PrefixCacheHitsTotal.WithLabelValues(model).Inc()
+}
+
+func (m *Metrics) RecordPrefixCacheMiss(model string) {
+	m.PrefixCacheMissesTotal.WithLabelValues(model).Inc()
+}
+
+func (m *Metrics) RecordPrefixCacheBlocksMatched(model string, blocks int) {
+	m.PrefixCacheBlocksMatched.WithLabelValues(model).Observe(float64(blocks))
+}
+
+func (m *Metrics) RecordPrefixCacheEviction(model string) {
+	m.PrefixCacheEvictionsTotal.WithLabelValues(model).Inc()
+}
+
+func (m *Metrics) RecordKVCacheHit(model string) {
+	m.KVCacheHitsTotal.WithLabelValues(model).Inc()
+}
+
+func (m *Metrics) RecordKVCacheMiss(model string) {
+	m.KVCacheMissesTotal.WithLabelValues(model).Inc()
+}
+
+func (m *Metrics) RecordKVCacheBlocksMatched(model string, blocks int) {
+	m.KVCacheBlocksMatched.WithLabelValues(model).Observe(float64(blocks))
+}
+
+func (m *Metrics) RecordKVCacheRedisDuration(model string, duration time.Duration) {
+	m.KVCacheRedisDuration.WithLabelValues(model).Observe(duration.Seconds())
+}
+
+func (m *Metrics) RecordKVCacheTokenizeDuration(model string, duration time.Duration) {
+	m.KVCacheTokenizeDuration.WithLabelValues(model).Observe(duration.Seconds())
+}
+
+func (m *Metrics) RecordKVCacheError(model, stage string) {
+	m.KVCacheErrorsTotal.WithLabelValues(model, stage).Inc()
 }
 
 // RecordRequest records a completed request with all relevant metrics
@@ -481,6 +644,42 @@ func (r *RequestMetricsRecorder) RecordSchedulerPluginDuration(pluginName, plugi
 // RecordFairnessQueueDuration records the time spent in fairness queue
 func (r *RequestMetricsRecorder) RecordFairnessQueueDuration(userID string, duration time.Duration) {
 	r.metrics.RecordFairnessQueueDuration(r.model, userID, duration)
+}
+
+func (r *RequestMetricsRecorder) RecordPrefixCacheHit() {
+	r.metrics.RecordPrefixCacheHit(r.model)
+}
+
+func (r *RequestMetricsRecorder) RecordPrefixCacheMiss() {
+	r.metrics.RecordPrefixCacheMiss(r.model)
+}
+
+func (r *RequestMetricsRecorder) RecordPrefixCacheBlocksMatched(blocks int) {
+	r.metrics.RecordPrefixCacheBlocksMatched(r.model, blocks)
+}
+
+func (r *RequestMetricsRecorder) RecordKVCacheHit() {
+	r.metrics.RecordKVCacheHit(r.model)
+}
+
+func (r *RequestMetricsRecorder) RecordKVCacheMiss() {
+	r.metrics.RecordKVCacheMiss(r.model)
+}
+
+func (r *RequestMetricsRecorder) RecordKVCacheBlocksMatched(blocks int) {
+	r.metrics.RecordKVCacheBlocksMatched(r.model, blocks)
+}
+
+func (r *RequestMetricsRecorder) RecordKVCacheRedisDuration(duration time.Duration) {
+	r.metrics.RecordKVCacheRedisDuration(r.model, duration)
+}
+
+func (r *RequestMetricsRecorder) RecordKVCacheTokenizeDuration(duration time.Duration) {
+	r.metrics.RecordKVCacheTokenizeDuration(r.model, duration)
+}
+
+func (r *RequestMetricsRecorder) RecordKVCacheError(stage string) {
+	r.metrics.RecordKVCacheError(r.model, stage)
 }
 
 // IncActiveUpstreamRequests increments the active upstream requests counter for this request

--- a/pkg/kthena-router/metrics/metrics_test.go
+++ b/pkg/kthena-router/metrics/metrics_test.go
@@ -1,0 +1,165 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+func histCount(t *testing.T, vec *prometheus.HistogramVec, lvs ...string) uint64 {
+	t.Helper()
+	obs, err := vec.GetMetricWithLabelValues(lvs...)
+	if err != nil {
+		t.Fatalf("GetMetricWithLabelValues: %v", err)
+	}
+	m := &dto.Metric{}
+	if err := obs.(prometheus.Metric).Write(m); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	return m.GetHistogram().GetSampleCount()
+}
+
+func counterVal(t *testing.T, vec *prometheus.CounterVec, lvs ...string) float64 {
+	t.Helper()
+	c, err := vec.GetMetricWithLabelValues(lvs...)
+	if err != nil {
+		t.Fatalf("GetMetricWithLabelValues: %v", err)
+	}
+	m := &dto.Metric{}
+	if err := c.Write(m); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	return m.GetCounter().GetValue()
+}
+
+func TestPrefixCacheHitMiss(t *testing.T) {
+	m := DefaultMetrics
+	const model = "metricstest-prefix-hitmiss"
+
+	hitsBefore := counterVal(t, &m.PrefixCacheHitsTotal, model)
+	missBefore := counterVal(t, &m.PrefixCacheMissesTotal, model)
+
+	m.RecordPrefixCacheHit(model)
+	m.RecordPrefixCacheHit(model)
+	m.RecordPrefixCacheMiss(model)
+
+	if got := counterVal(t, &m.PrefixCacheHitsTotal, model) - hitsBefore; got != 2 {
+		t.Errorf("prefix hits delta = %v, want 2", got)
+	}
+	if got := counterVal(t, &m.PrefixCacheMissesTotal, model) - missBefore; got != 1 {
+		t.Errorf("prefix misses delta = %v, want 1", got)
+	}
+}
+
+func TestPrefixCacheBlocksMatchedAndEviction(t *testing.T) {
+	m := DefaultMetrics
+	const model = "metricstest-prefix-blocks"
+
+	before := histCount(t, &m.PrefixCacheBlocksMatched, model)
+	m.RecordPrefixCacheBlocksMatched(model, 5)
+	if got := histCount(t, &m.PrefixCacheBlocksMatched, model) - before; got != 1 {
+		t.Errorf("blocks_matched sample count delta = %d, want 1", got)
+	}
+
+	evBefore := counterVal(t, &m.PrefixCacheEvictionsTotal, model)
+	m.RecordPrefixCacheEviction(model)
+	if got := counterVal(t, &m.PrefixCacheEvictionsTotal, model) - evBefore; got != 1 {
+		t.Errorf("evictions delta = %v, want 1", got)
+	}
+}
+
+func TestPrefixCacheEntriesProvider(t *testing.T) {
+	m := DefaultMetrics
+	m.SetPrefixCacheEntriesProvider(func() float64 { return 42 })
+
+	dm := &dto.Metric{}
+	if err := m.PrefixCacheEntries.Write(dm); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if got := dm.GetGauge().GetValue(); got != 42 {
+		t.Errorf("entries gauge = %v, want 42", got)
+	}
+}
+
+func TestKVCacheHitMissAndError(t *testing.T) {
+	m := DefaultMetrics
+	const model = "metricstest-kv-hitmiss"
+
+	hitsBefore := counterVal(t, &m.KVCacheHitsTotal, model)
+	missBefore := counterVal(t, &m.KVCacheMissesTotal, model)
+	redisErrBefore := counterVal(t, &m.KVCacheErrorsTotal, model, StageRedis)
+
+	m.RecordKVCacheHit(model)
+	m.RecordKVCacheMiss(model)
+	m.RecordKVCacheError(model, StageRedis)
+
+	if got := counterVal(t, &m.KVCacheHitsTotal, model) - hitsBefore; got != 1 {
+		t.Errorf("kvcache hits delta = %v, want 1", got)
+	}
+	if got := counterVal(t, &m.KVCacheMissesTotal, model) - missBefore; got != 1 {
+		t.Errorf("kvcache misses delta = %v, want 1", got)
+	}
+	if got := counterVal(t, &m.KVCacheErrorsTotal, model, StageRedis) - redisErrBefore; got != 1 {
+		t.Errorf("kvcache redis errors delta = %v, want 1", got)
+	}
+}
+
+func TestKVCacheDurations(t *testing.T) {
+	m := DefaultMetrics
+	const model = "metricstest-kv-durations"
+
+	redisBefore := histCount(t, &m.KVCacheRedisDuration, model)
+	tokBefore := histCount(t, &m.KVCacheTokenizeDuration, model)
+
+	m.RecordKVCacheRedisDuration(model, 3*time.Millisecond)
+	m.RecordKVCacheTokenizeDuration(model, 7*time.Millisecond)
+
+	if got := histCount(t, &m.KVCacheRedisDuration, model) - redisBefore; got != 1 {
+		t.Errorf("redis duration sample count delta = %d, want 1", got)
+	}
+	if got := histCount(t, &m.KVCacheTokenizeDuration, model) - tokBefore; got != 1 {
+		t.Errorf("tokenize duration sample count delta = %d, want 1", got)
+	}
+}
+
+func TestRequestRecorderDelegation(t *testing.T) {
+	m := DefaultMetrics
+	const model = "metricstest-recorder"
+	r := NewRequestMetricsRecorder(m, model, "/v1/chat/completions")
+
+	hitsBefore := counterVal(t, &m.PrefixCacheHitsTotal, model)
+	kvHitsBefore := counterVal(t, &m.KVCacheHitsTotal, model)
+	blocksBefore := histCount(t, &m.KVCacheBlocksMatched, model)
+
+	r.RecordPrefixCacheHit()
+	r.RecordKVCacheHit()
+	r.RecordKVCacheBlocksMatched(9)
+
+	if got := counterVal(t, &m.PrefixCacheHitsTotal, model) - hitsBefore; got != 1 {
+		t.Errorf("recorder prefix hit delta = %v, want 1", got)
+	}
+	if got := counterVal(t, &m.KVCacheHitsTotal, model) - kvHitsBefore; got != 1 {
+		t.Errorf("recorder kvcache hit delta = %v, want 1", got)
+	}
+	if got := histCount(t, &m.KVCacheBlocksMatched, model) - blocksBefore; got != 1 {
+		t.Errorf("recorder kvcache blocks_matched delta = %d, want 1", got)
+	}
+}

--- a/pkg/kthena-router/scheduler/plugins/cache/prefix_store.go
+++ b/pkg/kthena-router/scheduler/plugins/cache/prefix_store.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/volcano-sh/kthena/pkg/kthena-router/datastore"
+	"github.com/volcano-sh/kthena/pkg/kthena-router/metrics"
 )
 
 // hashModelKey represents a composite key combining hash and model name
@@ -199,6 +200,9 @@ func (s *ModelPrefixStore) Add(model string, hashes []uint64, pod *datastore.Pod
 	podLRU, exists := s.podHashes[nsName]
 	if !exists {
 		podLRU, _ = NewLRUCache(s.hashCapacity, func(key hashModelKey, value struct{}) {
+			// Only capacity-driven evictions reach this callback; pod deletion removes
+			// entries via onHashEvicted directly, so this is the right place to count them.
+			metrics.DefaultMetrics.RecordPrefixCacheEviction(key.model)
 			// onEvict callback need to acquire `modelCache.mu.Lock()` as well, so start a goroutine to run it async.
 			go s.onHashEvicted(key.model, []uint64{key.hash}, nsName)
 		})
@@ -229,6 +233,17 @@ func (s *ModelPrefixStore) Add(model string, hashes []uint64, pod *datastore.Pod
 		shard.mu.Unlock()
 		podLRU.Add(hashModelKey{hash: hash, model: model}, struct{}{})
 	}
+}
+
+// EntryCount sums cached hash entries across all pod LRUs; read by the prefix_cache_entries gauge at scrape time.
+func (s *ModelPrefixStore) EntryCount() float64 {
+	s.podHashesMu.RLock()
+	defer s.podHashesMu.RUnlock()
+	total := 0
+	for _, podLRU := range s.podHashes {
+		total += podLRU.Len()
+	}
+	return float64(total)
 }
 
 // onHashEvicted handles the eviction of a hash from a pod's LRU cache

--- a/pkg/kthena-router/scheduler/plugins/cache/prefix_store_test.go
+++ b/pkg/kthena-router/scheduler/plugins/cache/prefix_store_test.go
@@ -23,12 +23,14 @@ import (
 	"testing"
 	"time"
 
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/volcano-sh/kthena/pkg/kthena-router/datastore"
+	"github.com/volcano-sh/kthena/pkg/kthena-router/metrics"
 )
 
 func TestModelPrefixStore(t *testing.T) {
@@ -323,6 +325,62 @@ func TestModelPrefixStore(t *testing.T) {
 		// Even though pod is cached, an empty candidates list must return nothing.
 		matches := store.FindTopMatches("filter-model", []uint64{1, 2, 3}, []*datastore.PodInfo{})
 		assert.Equal(t, 0, len(matches), "empty candidate list must yield no results")
+	})
+}
+
+func prefixEvictionCount(t *testing.T, model string) float64 {
+	t.Helper()
+	c, err := metrics.DefaultMetrics.PrefixCacheEvictionsTotal.GetMetricWithLabelValues(model)
+	if err != nil {
+		t.Fatalf("GetMetricWithLabelValues: %v", err)
+	}
+	m := &dto.Metric{}
+	if err := c.Write(m); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	return m.GetCounter().GetValue()
+}
+
+func TestModelPrefixStoreEvictionMetric(t *testing.T) {
+	t.Run("Capacity eviction increments evictions_total", func(t *testing.T) {
+		mockStore := datastore.New()
+		store := NewModelPrefixStore(mockStore, 2, 5) // per-pod LRU capacity of 2
+
+		pod := &datastore.PodInfo{
+			Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "evict-pod", Namespace: "test"}},
+		}
+
+		const model = "evictmetric-capacity-model"
+		before := prefixEvictionCount(t, model)
+
+		// Fill to capacity, then add 3 more distinct hashes -> 3 capacity evictions.
+		store.Add(model, []uint64{1, 2}, pod)
+		store.Add(model, []uint64{3, 4, 5}, pod)
+
+		if got := prefixEvictionCount(t, model) - before; got != 3 {
+			t.Errorf("evictions delta = %v, want 3", got)
+		}
+	})
+
+	t.Run("Pod deletion does not count as eviction", func(t *testing.T) {
+		mockStore := datastore.New()
+		store := NewModelPrefixStore(mockStore, 10, 5) // capacity large enough to avoid eviction
+
+		podName := types.NamespacedName{Name: "del-pod", Namespace: "test"}
+		pod := &datastore.PodInfo{
+			Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: podName.Name, Namespace: podName.Namespace}},
+		}
+
+		const model = "evictmetric-deletion-model"
+		before := prefixEvictionCount(t, model)
+
+		store.Add(model, []uint64{1, 2, 3}, pod)
+		store.onPodDeleted(datastore.EventData{EventType: datastore.EventDelete, Pod: podName})
+		time.Sleep(50 * time.Millisecond)
+
+		if got := prefixEvictionCount(t, model) - before; got != 0 {
+			t.Errorf("evictions delta on pod deletion = %v, want 0", got)
+		}
 	})
 }
 

--- a/pkg/kthena-router/scheduler/plugins/kvcache_aware.go
+++ b/pkg/kthena-router/scheduler/plugins/kvcache_aware.go
@@ -37,6 +37,7 @@ import (
 
 	"github.com/redis/go-redis/v9"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/datastore"
+	"github.com/volcano-sh/kthena/pkg/kthena-router/metrics"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/scheduler/framework"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/scheduler/plugins/tokenization"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/utils"
@@ -206,8 +207,18 @@ func (t *KVCacheAware) Score(ctx *framework.Context, pods []*datastore.PodInfo) 
 	tokenizerDuration := time.Since(start)
 	klog.V(4).Infof("KVCacheAware.Score: tokenization took %v, tokens=%d, err=%v", tokenizerDuration, len(tokens), err)
 
-	if err != nil || len(tokens) == 0 {
-		klog.V(4).Infof("KVCacheAware.Score: early return — tokenization failed or empty (err=%v, tokens=%d)", err, len(tokens))
+	if err != nil {
+		if ctx.MetricsRecorder != nil {
+			ctx.MetricsRecorder.RecordKVCacheError(metrics.StageTokenize)
+		}
+		klog.V(4).Infof("KVCacheAware.Score: early return — tokenization failed (err=%v)", err)
+		return nil
+	}
+	if ctx.MetricsRecorder != nil {
+		ctx.MetricsRecorder.RecordKVCacheTokenizeDuration(tokenizerDuration)
+	}
+	if len(tokens) == 0 {
+		klog.V(4).Infof("KVCacheAware.Score: early return — empty token sequence")
 		return nil
 	}
 
@@ -223,13 +234,25 @@ func (t *KVCacheAware) Score(ctx *framework.Context, pods []*datastore.PodInfo) 
 	blockToPods, err := t.queryRedisForBlocks(blockHashes, ctx.Model)
 	redisDuration := time.Since(redisStart)
 	if err != nil {
+		if ctx.MetricsRecorder != nil {
+			ctx.MetricsRecorder.RecordKVCacheError(metrics.StageRedis)
+		}
 		klog.Warningf("KVCacheAware.Score: Redis query failed after %v: %v", redisDuration, err)
 		return nil
 	}
 	klog.V(4).Infof("KVCacheAware.Score: Redis query took %v, blocksWithHits=%d/%d",
 		redisDuration, len(blockToPods), len(blockHashes))
 
-	podScores := t.calculatePodScores(blockHashes, blockToPods)
+	podScores, longestMatch := t.calculatePodScoresAndMatch(blockHashes, blockToPods)
+	if ctx.MetricsRecorder != nil {
+		ctx.MetricsRecorder.RecordKVCacheRedisDuration(redisDuration)
+		ctx.MetricsRecorder.RecordKVCacheBlocksMatched(longestMatch)
+		if len(podScores) > 0 {
+			ctx.MetricsRecorder.RecordKVCacheHit()
+		} else {
+			ctx.MetricsRecorder.RecordKVCacheMiss()
+		}
+	}
 	scoreResults := make(map[*datastore.PodInfo]int, len(podScores))
 	for _, pod := range pods {
 		podName := pod.GetPodNamespacedName().Name
@@ -309,17 +332,23 @@ func extractPodNameFromIdentifier(podIdentifier string) string {
 }
 
 func (t *KVCacheAware) calculatePodScores(blockHashes []uint64, blockToPods map[uint64][]string) map[string]int {
+	podScores, _ := t.calculatePodScoresAndMatch(blockHashes, blockToPods)
+	return podScores
+}
+
+// calculatePodScoresAndMatch also returns the longest block match length, used for the blocks_matched metric.
+func (t *KVCacheAware) calculatePodScoresAndMatch(blockHashes []uint64, blockToPods map[uint64][]string) (map[string]int, int) {
 	podScores := make(map[string]int)
 
 	if len(blockHashes) == 0 {
 		klog.V(4).Infof("KVCacheAware.calculateScores: no block hashes to process")
-		return podScores
+		return podScores, 0
 	}
 
 	firstBlockPods, exists := blockToPods[blockHashes[0]]
 	if !exists || len(firstBlockPods) == 0 {
 		klog.V(4).Infof("KVCacheAware.calculateScores: first block hash=%d has no cached pods — all scores 0", blockHashes[0])
-		return podScores
+		return podScores, 0
 	}
 
 	klog.V(4).Infof("KVCacheAware.calculateScores: first block matched pods=%v, starting prefix matching across %d blocks",
@@ -365,6 +394,7 @@ func (t *KVCacheAware) calculatePodScores(blockHashes []uint64, blockToPods map[
 	klog.V(4).Infof("KVCacheAware.calculateScores: prefix matching ended at block %d/%d, scoring %d pods",
 		lastMatchedBlock+1, totalBlocks, len(podScores))
 
+	longestMatch := lastMatchedBlock + 1
 	for podName, matchLen := range podScores {
 		score := int((float64(matchLen) / float64(totalBlocks)) * 100)
 		podScores[podName] = score
@@ -372,7 +402,7 @@ func (t *KVCacheAware) calculatePodScores(blockHashes []uint64, blockToPods map[
 			podName, matchLen, totalBlocks, score)
 	}
 
-	return podScores
+	return podScores, longestMatch
 }
 
 func (tbp *TokenBlockProcessor) TokensToBlockHashes(tokens []uint32, maxBlocks int) []uint64 {

--- a/pkg/kthena-router/scheduler/plugins/kvcache_aware_test.go
+++ b/pkg/kthena-router/scheduler/plugins/kvcache_aware_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/volcano-sh/kthena/pkg/kthena-router/common"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/datastore"
+	"github.com/volcano-sh/kthena/pkg/kthena-router/metrics"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/scheduler/framework"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/scheduler/plugins/tokenization"
 	v1 "k8s.io/api/core/v1"
@@ -2110,5 +2111,47 @@ func TestKVCacheAware_Integration_Comprehensive_Core(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.testFunc(t)
 		})
+	}
+}
+
+func TestKVCacheAware_ScoreMetrics_TokenizeError(t *testing.T) {
+	plugin := &KVCacheAware{
+		name:             KVCacheAwarePluginName,
+		maxBlocksToMatch: 128,
+		keyPrefix:        kvCacheKeyPrefix,
+		processor:        &TokenBlockProcessor{blockSize: 128},
+		// tokenizerManager nil -> normalizeAndTokenizePrompt returns an error
+	}
+
+	const model = "kvmetrics-tokenize-error"
+	recorder := metrics.NewRequestMetricsRecorder(metrics.DefaultMetrics, model, "/v1/chat/completions")
+	ctx := &framework.Context{
+		Model:           model,
+		Prompt:          &common.ChatMessage{Text: "hello world"},
+		MetricsRecorder: recorder,
+	}
+
+	before := counterValue(t, &metrics.DefaultMetrics.KVCacheErrorsTotal, model, metrics.StageTokenize)
+	plugin.Score(ctx, createTestPods("pod1"))
+	if got := counterValue(t, &metrics.DefaultMetrics.KVCacheErrorsTotal, model, metrics.StageTokenize) - before; got != 1 {
+		t.Errorf("kvcache tokenize errors delta = %v, want 1", got)
+	}
+}
+
+func TestKVCacheAware_CalculatePodScoresAndMatch_LongestMatch(t *testing.T) {
+	plugin := &KVCacheAware{}
+	blockHashes := []uint64{1, 2, 3, 4}
+	blockToPods := map[uint64][]string{
+		1: {"pod1", "pod2"},
+		2: {"pod1", "pod2"},
+		3: {"pod1"},
+		4: {"pod1"},
+	}
+	scores, longest := plugin.calculatePodScoresAndMatch(blockHashes, blockToPods)
+	if scores["pod1"] != 100 {
+		t.Errorf("pod1 score = %d, want 100", scores["pod1"])
+	}
+	if longest != 4 {
+		t.Errorf("longest match = %d, want 4", longest)
 	}
 }

--- a/pkg/kthena-router/scheduler/plugins/prefix.go
+++ b/pkg/kthena-router/scheduler/plugins/prefix.go
@@ -79,6 +79,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/volcano-sh/kthena/pkg/kthena-router/datastore"
+	"github.com/volcano-sh/kthena/pkg/kthena-router/metrics"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/scheduler/framework"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/scheduler/plugins/cache"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/utils"
@@ -151,6 +152,7 @@ func NewPrefixCache(store datastore.Store, pluginArg runtime.RawExtension) *Pref
 		maxBlocksToMatch: prefixCacheArgs.MaxBlocksToMatch,
 	}
 	p.store = cache.NewModelPrefixStore(store, prefixCacheArgs.MaxHashCacheSize, prefixCacheArgs.TopKMatches)
+	metrics.DefaultMetrics.SetPrefixCacheEntriesProvider(p.store.EntryCount)
 	return p
 }
 
@@ -173,13 +175,26 @@ func (p *PrefixCache) Score(ctx *framework.Context, pods []*datastore.PodInfo) m
 
 	// Single pass over pods: score = cache-hit score if found, 0 otherwise.
 	totalHashes := len(hashes)
+	longestMatch := 0
 	scoreResults := make(map[*datastore.PodInfo]int, len(pods))
 	for _, pod := range pods {
 		nsName := pod.GetPodNamespacedName()
 		if matchLen, ok := matchByName[nsName]; ok {
 			scoreResults[pod] = int((float64(matchLen) / float64(totalHashes)) * 100)
+			if matchLen > longestMatch {
+				longestMatch = matchLen
+			}
 		} else {
 			scoreResults[pod] = 0
+		}
+	}
+
+	if ctx.MetricsRecorder != nil {
+		ctx.MetricsRecorder.RecordPrefixCacheBlocksMatched(longestMatch)
+		if len(matchByName) > 0 {
+			ctx.MetricsRecorder.RecordPrefixCacheHit()
+		} else {
+			ctx.MetricsRecorder.RecordPrefixCacheMiss()
 		}
 	}
 

--- a/pkg/kthena-router/scheduler/plugins/prefix_test.go
+++ b/pkg/kthena-router/scheduler/plugins/prefix_test.go
@@ -29,8 +29,12 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
 
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+
 	"github.com/volcano-sh/kthena/pkg/kthena-router/common"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/datastore"
+	"github.com/volcano-sh/kthena/pkg/kthena-router/metrics"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/scheduler/framework"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/scheduler/plugins/cache"
 )
@@ -176,6 +180,105 @@ func TestPrefixCacheScore(t *testing.T) {
 		}
 	})
 }
+
+func counterValue(t *testing.T, vec *prometheus.CounterVec, lvs ...string) float64 {
+	t.Helper()
+	c, err := vec.GetMetricWithLabelValues(lvs...)
+	if err != nil {
+		t.Fatalf("GetMetricWithLabelValues: %v", err)
+	}
+	m := &dto.Metric{}
+	if err := c.Write(m); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	return m.GetCounter().GetValue()
+}
+
+func TestPrefixCacheScoreMetrics(t *testing.T) {
+	mockDS := datastore.New()
+	prefixStore := cache.NewModelPrefixStore(mockDS, 100, 5)
+	plugin := &PrefixCache{
+		name:             PrefixCachePluginName,
+		blockSizeToHash:  64,
+		maxBlocksToMatch: 128,
+		store:            prefixStore,
+	}
+
+	pod1 := &datastore.PodInfo{Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: "ns1"}}}
+	pod2 := &datastore.PodInfo{Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod2", Namespace: "ns1"}}}
+
+	const model = "prefixmetrics-model"
+	prompt := "hello world from prefix cache metrics test"
+	hashes := plugin.hashPrompt(model, prompt)
+	prefixStore.Add(model, hashes, pod1)
+
+	recorder := metrics.NewRequestMetricsRecorder(metrics.DefaultMetrics, model, "/v1/chat/completions")
+
+	hitsBefore := counterValue(t, &metrics.DefaultMetrics.PrefixCacheHitsTotal, model)
+	missBefore := counterValue(t, &metrics.DefaultMetrics.PrefixCacheMissesTotal, model)
+
+	// Matching prompt -> hit.
+	hitCtx := &framework.Context{Model: model, Prompt: &common.ChatMessage{Text: prompt}, MetricsRecorder: recorder}
+	plugin.Score(hitCtx, []*datastore.PodInfo{pod1, pod2})
+
+	// Non-matching prompt -> miss.
+	missCtx := &framework.Context{Model: model, Prompt: &common.ChatMessage{Text: "a completely different prompt"}, MetricsRecorder: recorder}
+	plugin.Score(missCtx, []*datastore.PodInfo{pod1, pod2})
+
+	if got := counterValue(t, &metrics.DefaultMetrics.PrefixCacheHitsTotal, model) - hitsBefore; got != 1 {
+		t.Errorf("prefix cache hits delta = %v, want 1", got)
+	}
+	if got := counterValue(t, &metrics.DefaultMetrics.PrefixCacheMissesTotal, model) - missBefore; got != 1 {
+		t.Errorf("prefix cache misses delta = %v, want 1", got)
+	}
+}
+
+func TestPrefixCacheEntriesProviderRegistered(t *testing.T) {
+	mockDS := datastore.New()
+	plugin := NewPrefixCache(mockDS, runtime.RawExtension{Raw: []byte{}})
+
+	pod := &datastore.PodInfo{Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: "ns1"}}}
+	const model = "prefixentries-model"
+	hashes := plugin.hashPrompt(model, "some prompt that yields a single block")
+	plugin.store.Add(model, hashes, pod)
+
+	if got := plugin.store.EntryCount(); got < 1 {
+		t.Fatalf("EntryCount() = %v, want >= 1 after Add", got)
+	}
+}
+
+func benchmarkPrefixScore(b *testing.B, withMetrics bool) {
+	mockDS := datastore.New()
+	prefixStore := cache.NewModelPrefixStore(mockDS, 100000, 5)
+	plugin := &PrefixCache{
+		name:             PrefixCachePluginName,
+		blockSizeToHash:  64,
+		maxBlocksToMatch: 128,
+		store:            prefixStore,
+	}
+	pod1 := &datastore.PodInfo{Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: "ns1"}}}
+	pod2 := &datastore.PodInfo{Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod2", Namespace: "ns1"}}}
+	pods := []*datastore.PodInfo{pod1, pod2}
+
+	const model = "bench-prefix-model"
+	prompt := strings.Repeat("the quick brown fox jumps over the lazy dog ", 40)
+	hashes := plugin.hashPrompt(model, prompt)
+	prefixStore.Add(model, hashes, pod1)
+
+	ctx := &framework.Context{Model: model, Prompt: &common.ChatMessage{Text: prompt}}
+	if withMetrics {
+		ctx.MetricsRecorder = metrics.NewRequestMetricsRecorder(metrics.DefaultMetrics, model, "/v1/chat/completions")
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		plugin.Score(ctx, pods)
+	}
+}
+
+func BenchmarkPrefixCacheScore_NoMetrics(b *testing.B)   { benchmarkPrefixScore(b, false) }
+func BenchmarkPrefixCacheScore_WithMetrics(b *testing.B) { benchmarkPrefixScore(b, true) }
 
 func TestNewPrefixCacheWithEmptyArgs(t *testing.T) {
 	state := klog.CaptureState()


### PR DESCRIPTION
## What this does

Instruments the `prefix-cache` and `kvcache-aware` score plugins, whose runtime behavior was previously only visible via `klog`. All metrics are exported on the router's existing `/metrics` endpoint and labelled with `model`.