### PR TITLE
Improve multi-round conversation fairness

### DIFF
--- a/docs/kthena/docs/user-guide/fairness-scheduling.md
+++ b/docs/kthena/docs/user-guide/fairness-scheduling.md
@@ -59,6 +59,7 @@ The queue also supports the following runtime protections:
 - **Client disconnect handling**: cancelled requests are skipped instead of being sent downstream later.
 - **Dequeue-time priority refresh**: when `FAIRNESS_PRIORITY_REFRESH_RETRIES > 0`, the priority of the candidate request (the heap root) is recalculated against current usage before it is released. If a fresher priority would put it behind another waiting request, it is reinserted and the next candidate is tried instead.
 - **Heap rebuild fallback**: when dequeue-time refresh retries are exhausted *and* the current queue depth is at or below `FAIRNESS_REBUILD_THRESHOLD`, all queued item priorities are recalculated from current usage and the heap is fully rebuilt. This bounds the staleness of the entire queue while protecting against expensive rebuilds on large queues.
+- **Session affinity**: requests with the same `x-session-id` can be released consecutively to improve multi-round conversation cache locality, bounded by `FAIRNESS_MAX_CONSECUTIVE_SESSION_REQUESTS`.
 
 ## Prerequisites
 
@@ -113,6 +114,8 @@ env:
   value: "2"
 - name: FAIRNESS_REBUILD_THRESHOLD
   value: "64"
+- name: FAIRNESS_MAX_CONSECUTIVE_SESSION_REQUESTS
+  value: "2"
 ```
 
 ## Configuration Reference
@@ -135,6 +138,7 @@ env:
 | `FAIRNESS_MAX_QPS` | Maximum dequeue rate in QPS mode | `100` | Used only when `FAIRNESS_MAX_CONCURRENT=0` |
 | `FAIRNESS_PRIORITY_REFRESH_RETRIES` | Max dequeue-time refresh/reinsert attempts before heap rebuild | `0` | `0` disables dequeue-time refresh |
 | `FAIRNESS_REBUILD_THRESHOLD` | Queue size threshold controlling when heap rebuild is allowed | `64` | Helps bound rebuild cost |
+| `FAIRNESS_MAX_CONSECUTIVE_SESSION_REQUESTS` | Maximum consecutive requests released for the same `x-session-id` | `2` | `0` disables same-session lifting |
 
 ### Priority Score Settings
 

--- a/pkg/kthena-router/datastore/fairness_queue.go
+++ b/pkg/kthena-router/datastore/fairness_queue.go
@@ -49,17 +49,21 @@ type FairnessQueueConfig struct {
 
 	// RequestNumWeight is the request-count weight in the composite priority score.
 	RequestNumWeight float64
+
+	// MaxConsecutiveSessionRequests bounds consecutive dispatches from the same session.
+	MaxConsecutiveSessionRequests int
 }
 
 // DefaultFairnessQueueConfig returns backward-compatible defaults.
 func DefaultFairnessQueueConfig() FairnessQueueConfig {
 	return FairnessQueueConfig{
-		MaxConcurrent:             0,
-		MaxQPS:                    100,
-		MaxPriorityRefreshRetries: 0,
-		RebuildThreshold:          64,
-		TokenWeight:               1.0,
-		RequestNumWeight:          0.0,
+		MaxConcurrent:                 0,
+		MaxQPS:                        100,
+		MaxPriorityRefreshRetries:     0,
+		RebuildThreshold:              64,
+		TokenWeight:                   1.0,
+		RequestNumWeight:              0.0,
+		MaxConsecutiveSessionRequests: 2,
 	}
 }
 
@@ -92,11 +96,13 @@ type Request struct {
 	ReqID       string
 	UserID      string  // User ID for fairness scheduling
 	ModelName   string  // Target model for per-model fair queuing
+	SessionID   string  // Session ID for multi-round conversation affinity
 	Priority    float64 // Priority (lower value means higher priority)
 	RequestTime time.Time
 	NotifyChan  chan struct{}
 	CancelCh    <-chan struct{} // Request-scoped cancellation signal
 	Release     func()          // Set by the queue when a permit is acquired
+	Complete    func()          // Called after the request is processed
 }
 
 // RequestPriorityQueue implements the heap.Interface
@@ -113,6 +119,9 @@ type RequestPriorityQueue struct {
 
 	// Priority refresh (Phase 2)
 	tokenTracker TokenTracker // Optional; when set, enables dequeue-time priority refresh
+
+	lastSessionID         string
+	lastSessionRequestNum int
 }
 
 var _ heap.Interface = &RequestPriorityQueue{}
@@ -205,7 +214,7 @@ func (pq *RequestPriorityQueue) popWhenAvailable(ctx context.Context) (*Request,
 	for {
 		pq.mu.Lock()
 		if len(pq.heap) > 0 {
-			req := heap.Pop(pq).(*Request)
+			req, sessionLifted := pq.popNextRequestLocked()
 
 			// Skip cancelled/timed-out requests
 			if req.isCancelled() {
@@ -220,7 +229,7 @@ func (pq *RequestPriorityQueue) popWhenAvailable(ctx context.Context) (*Request,
 			}
 
 			// Bounded priority refresh: re-evaluate root priority at dequeue time
-			if pq.tokenTracker != nil && pq.config.MaxPriorityRefreshRetries > 0 {
+			if !sessionLifted && pq.tokenTracker != nil && pq.config.MaxPriorityRefreshRetries > 0 {
 				newPri, err := CalculateFairnessPriority(
 					pq.tokenTracker,
 					req.UserID,
@@ -263,6 +272,7 @@ func (pq *RequestPriorityQueue) popWhenAvailable(ctx context.Context) (*Request,
 				pq.metrics.RecordFairnessQueueDuration(req.ModelName, req.UserID, queueDuration)
 				pq.metrics.IncFairnessQueueDequeue(req.ModelName, req.UserID)
 			}
+			pq.setCompleteLocked(req)
 
 			pq.mu.Unlock()
 			return req, nil
@@ -280,6 +290,58 @@ func (pq *RequestPriorityQueue) popWhenAvailable(ctx context.Context) (*Request,
 			continue
 		}
 	}
+}
+
+func (pq *RequestPriorityQueue) popNextRequestLocked() (*Request, bool) {
+	if pq.config.MaxConsecutiveSessionRequests > 0 &&
+		pq.lastSessionID != "" &&
+		pq.lastSessionRequestNum < pq.config.MaxConsecutiveSessionRequests {
+		if index := pq.findSessionRequestLocked(pq.lastSessionID); index >= 0 {
+			return heap.Remove(pq, index).(*Request), true
+		}
+	}
+	return heap.Pop(pq).(*Request), false
+}
+
+func (pq *RequestPriorityQueue) findSessionRequestLocked(sessionID string) int {
+	index := -1
+	for i, req := range pq.heap {
+		if req.SessionID != sessionID {
+			continue
+		}
+		if index == -1 || req.RequestTime.Before(pq.heap[index].RequestTime) {
+			index = i
+		}
+	}
+	return index
+}
+
+func (pq *RequestPriorityQueue) setCompleteLocked(req *Request) {
+	if pq.config.MaxConsecutiveSessionRequests <= 0 {
+		return
+	}
+	completeOnce := sync.Once{}
+	req.Complete = func() {
+		completeOnce.Do(func() {
+			pq.recordSession(req)
+		})
+	}
+}
+
+func (pq *RequestPriorityQueue) recordSession(req *Request) {
+	pq.mu.Lock()
+	defer pq.mu.Unlock()
+	if req.SessionID == "" {
+		pq.lastSessionID = ""
+		pq.lastSessionRequestNum = 0
+		return
+	}
+	if req.SessionID == pq.lastSessionID {
+		pq.lastSessionRequestNum++
+		return
+	}
+	pq.lastSessionID = req.SessionID
+	pq.lastSessionRequestNum = 1
 }
 
 func (r *Request) isCancelled() bool {

--- a/pkg/kthena-router/datastore/fairness_queue_test.go
+++ b/pkg/kthena-router/datastore/fairness_queue_test.go
@@ -137,6 +137,75 @@ func TestFairnessSameUser(t *testing.T) {
 	}
 }
 
+func TestFairnessSameSessionLift(t *testing.T) {
+	cfg := DefaultFairnessQueueConfig()
+	cfg.MaxConsecutiveSessionRequests = 2
+	pq := NewRequestPriorityQueueWithConfig(nil, cfg, nil)
+	defer pq.Close()
+
+	now := time.Now()
+	requests := []*Request{
+		{ReqID: "session-first", UserID: "user1", SessionID: "session-a", Priority: 1.0, RequestTime: now},
+		{ReqID: "other-session", UserID: "user2", SessionID: "session-b", Priority: 2.0, RequestTime: now.Add(time.Second)},
+		{ReqID: "session-next", UserID: "user3", SessionID: "session-a", Priority: 100.0, RequestTime: now.Add(2 * time.Second)},
+	}
+
+	for _, req := range requests {
+		if err := pq.PushRequest(req); err != nil {
+			t.Fatalf("PushRequest failed: %v", err)
+		}
+	}
+
+	expectedOrder := []string{"session-first", "session-next", "other-session"}
+	for i, expected := range expectedOrder {
+		req, err := pq.popWhenAvailable(context.Background())
+		if err != nil {
+			t.Fatalf("PopRequest failed at index %d: %v", i, err)
+		}
+		if req.ReqID != expected {
+			t.Errorf("Expected ReqID %s at index %d, got %s", expected, i, req.ReqID)
+		}
+		if req.Complete != nil {
+			req.Complete()
+		}
+	}
+}
+
+func TestFairnessSameSessionLiftLimit(t *testing.T) {
+	cfg := DefaultFairnessQueueConfig()
+	cfg.MaxConsecutiveSessionRequests = 2
+	pq := NewRequestPriorityQueueWithConfig(nil, cfg, nil)
+	defer pq.Close()
+
+	now := time.Now()
+	requests := []*Request{
+		{ReqID: "session-first", UserID: "user1", SessionID: "session-a", Priority: 1.0, RequestTime: now},
+		{ReqID: "other-session", UserID: "user2", SessionID: "session-b", Priority: 2.0, RequestTime: now.Add(time.Second)},
+		{ReqID: "session-second", UserID: "user3", SessionID: "session-a", Priority: 100.0, RequestTime: now.Add(2 * time.Second)},
+		{ReqID: "session-third", UserID: "user4", SessionID: "session-a", Priority: 101.0, RequestTime: now.Add(3 * time.Second)},
+	}
+
+	for _, req := range requests {
+		if err := pq.PushRequest(req); err != nil {
+			t.Fatalf("PushRequest failed: %v", err)
+		}
+	}
+
+	expectedOrder := []string{"session-first", "session-second", "other-session", "session-third"}
+	for i, expected := range expectedOrder {
+		req, err := pq.popWhenAvailable(context.Background())
+		if err != nil {
+			t.Fatalf("PopRequest failed at index %d: %v", i, err)
+		}
+		if req.ReqID != expected {
+			t.Errorf("Expected ReqID %s at index %d, got %s", expected, i, req.ReqID)
+		}
+		if req.Complete != nil {
+			req.Complete()
+		}
+	}
+}
+
 func TestPopWhenAvailable(t *testing.T) {
 	pq := NewRequestPriorityQueue(nil)
 	defer pq.Close()

--- a/pkg/kthena-router/datastore/store.go
+++ b/pkg/kthena-router/datastore/store.go
@@ -460,6 +460,14 @@ func createFairnessQueueConfig() FairnessQueueConfig {
 		}
 	}
 
+	if v := os.Getenv("FAIRNESS_MAX_CONSECUTIVE_SESSION_REQUESTS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			cfg.MaxConsecutiveSessionRequests = n
+		} else {
+			klog.Warningf("Invalid FAIRNESS_MAX_CONSECUTIVE_SESSION_REQUESTS: %q, using default %d", v, cfg.MaxConsecutiveSessionRequests)
+		}
+	}
+
 	return cfg
 }
 

--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -1049,6 +1049,7 @@ func (r *Router) handleFairnessScheduling(c *gin.Context, modelRequest ModelRequ
 		ReqID:       requestID,
 		UserID:      userId,
 		ModelName:   modelName,
+		SessionID:   strings.TrimSpace(c.Request.Header.Get("x-session-id")),
 		Priority:    pri,
 		RequestTime: time.Now(),
 		NotifyChan:  make(chan struct{}),
@@ -1064,6 +1065,9 @@ func (r *Router) handleFairnessScheduling(c *gin.Context, modelRequest ModelRequ
 	case <-queueReq.NotifyChan:
 		if queueReq.Release != nil {
 			defer queueReq.Release()
+		}
+		if queueReq.Complete != nil {
+			defer queueReq.Complete()
 		}
 		r.doLoadbalance(c, modelRequest)
 		return nil


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement

**What this PR does / why we need it**:

Improves fairness scheduling for multi-round conversations by allowing requests from the same session to be picked again after the previous session request finishes. This helps agent-style conversations keep better KV cache locality while still limiting consecutive same-session dispatches.

**Which issue(s) this PR fixes**:

Fixes #1190

**Special notes for your reviewer**:

Session is read from `x-session-id` header or `session_id` request field. Consecutive same-session dispatches are bounded by `FAIRNESS_MAX_CONSECUTIVE_SESSION_REQUESTS`.

**Does this PR introduce a user-facing change?**:

```release-note
Improve fairness scheduling for multi-round conversation sessions.