### PR TITLE
fix: resolve check-then-act data races in datastore

### DIFF
--- a/pkg/kthena-router/datastore/store.go
+++ b/pkg/kthena-router/datastore/store.go
@@ -676,17 +676,24 @@ func (s *store) DecrPodOnFlightRequests(podName types.NamespacedName) {
 	podInfo.DecrOnFlightRequests()
 }
 
+// AddOrUpdateModelServer adds or updates a model server in the datastore.
+// NOTE: This function takes ownership of the provided 'pods' set for performance reasons.
+// Callers MUST NOT mutate the 'pods' set after passing it to this function.
 func (s *store) AddOrUpdateModelServer(ms *aiv1alpha1.ModelServer, pods sets.Set[types.NamespacedName]) error {
 	name := utils.GetNamespaceName(ms)
-	var modelServerObj *modelServer
-	if value, ok := s.modelServer.Load(name); !ok {
-		modelServerObj = newModelServer(ms)
-		// New object — no concurrent access yet, safe to write without lock
+
+	actual, loaded := s.modelServer.Load(name)
+	if !loaded {
+		newObj := newModelServer(ms)
 		if len(pods) != 0 {
-			modelServerObj.pods = pods
+			newObj.pods = pods
 		}
-	} else {
-		modelServerObj = value.(*modelServer)
+		actual, loaded = s.modelServer.LoadOrStore(name, newObj)
+	}
+
+	modelServerObj := actual.(*modelServer)
+
+	if loaded {
 		// Existing object — concurrent readers may access modelServer and pods,
 		// so we must hold the lock to prevent data races.
 		modelServerObj.mutex.Lock()
@@ -697,7 +704,6 @@ func (s *store) AddOrUpdateModelServer(ms *aiv1alpha1.ModelServer, pods sets.Set
 		}
 		modelServerObj.mutex.Unlock()
 	}
-	s.modelServer.Store(name, modelServerObj)
 	return nil
 }
 
@@ -834,36 +840,38 @@ func (s *store) AddOrUpdatePod(pod *corev1.Pod, modelServers []*aiv1alpha1.Model
 		}
 	}
 
-	if value, ok := s.pods.Load(podName); ok {
-		// Update existing pod in place — preserve runtime metrics and models.
-		oldPodInfo := value.(*PodInfo)
-		oldModelServers := oldPodInfo.GetModelServers()
-		// Handle the case where the pod no longer belongs to some model servers
-		oldPodLabels := oldPodInfo.GetPodLabels()
-		for msName := range oldModelServers.Difference(newModelServers) {
-			if value, ok := s.modelServer.Load(msName); ok {
-				ms := value.(*modelServer)
-				ms.deletePod(podName)
-				// Remove from PDGroup categorizations
-				ms.removePodFromPDGroups(podName, oldPodLabels)
-			}
+	actual, loaded := s.pods.Load(podName)
+	if !loaded {
+		newPodInfo := &PodInfo{
+			Pod:         pod,
+			engine:      engine,
+			modelServer: newModelServers,
+			models:      sets.New[string](),
 		}
-
-		oldPodInfo.UpdatePod(pod, engine, newModelServers)
-		return nil
+		actual, loaded = s.pods.LoadOrStore(podName, newPodInfo)
+		if !loaded {
+			// We were the one that successfully stored the new pod
+			s.updatePodMetrics(newPodInfo)
+			s.updatePodModels(newPodInfo)
+			return nil
+		}
 	}
 
-	// New pod — create PodInfo and fetch initial metrics.
-	newPodInfo := &PodInfo{
-		Pod:         pod,
-		engine:      engine,
-		modelServer: newModelServers,
-		models:      sets.New[string](),
+	// Update existing pod in place — preserve runtime metrics and models.
+	oldPodInfo := actual.(*PodInfo)
+	oldModelServers := oldPodInfo.GetModelServers()
+	// Handle the case where the pod no longer belongs to some model servers
+	oldPodLabels := oldPodInfo.GetPodLabels()
+	for msName := range oldModelServers.Difference(newModelServers) {
+		if value, ok := s.modelServer.Load(msName); ok {
+			ms := value.(*modelServer)
+			ms.deletePod(podName)
+			// Remove from PDGroup categorizations
+			ms.removePodFromPDGroups(podName, oldPodLabels)
+		}
 	}
-	s.pods.Store(podName, newPodInfo)
-	s.updatePodMetrics(newPodInfo)
-	s.updatePodModels(newPodInfo)
 
+	oldPodInfo.UpdatePod(pod, engine, newModelServers)
 	return nil
 }
 

--- a/pkg/kthena-router/datastore/store_test.go
+++ b/pkg/kthena-router/datastore/store_test.go
@@ -2336,3 +2336,113 @@ func TestStoreRunBoundedConcurrency(t *testing.T) {
 	assert.Greater(t, maxInFlight.Load(), int32(1), "expected at least some parallelism in scrapes")
 	assert.LessOrEqual(t, maxInFlight.Load(), int32(maxConcurrentPodScrapes), "in-flight requests should never exceed the semaphore cap")
 }
+
+func TestStoreAddOrUpdateModelServer_ConcurrentAccess(t *testing.T) {
+	s := &store{
+		modelServer: sync.Map{},
+	}
+
+	msName := types.NamespacedName{Namespace: "default", Name: "concurrent-model1"}
+	msInitial := &aiv1alpha1.ModelServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: msName.Namespace,
+			Name:      msName.Name,
+		},
+	}
+	s.AddOrUpdateModelServer(msInitial, nil)
+
+	// Simulate state mutation that would be lost in a TOCTOU race
+	val, _ := s.modelServer.Load(msName)
+	msObj := val.(*modelServer)
+	msObj.mutex.Lock()
+	msObj.pdGroups["decode"] = &PDGroupPods{}
+	msObj.mutex.Unlock()
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, 100)
+	// Simulate many concurrent goroutines trying to add the same ModelServer
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ms := &aiv1alpha1.ModelServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "concurrent-model1",
+				},
+			}
+			pods := sets.New[types.NamespacedName](types.NamespacedName{Namespace: "default", Name: "pod1"})
+			errCh <- s.AddOrUpdateModelServer(ms, pods)
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		assert.NoError(t, err)
+	}
+
+	// Verify the model server is safely in the datastore and no panic occurred
+	value, ok := s.modelServer.Load(msName)
+	assert.True(t, ok)
+	msInfo := value.(*modelServer)
+	assert.NotNil(t, msInfo)
+	assert.True(t, msInfo.pods.Contains(types.NamespacedName{Namespace: "default", Name: "pod1"}))
+	assert.NotNil(t, msInfo.pdGroups["decode"], "Internal state (pdGroups) was lost due to TOCTOU overwrite!")
+}
+
+func TestStoreAddOrUpdatePod_ConcurrentAccess(t *testing.T) {
+	s := &store{
+		modelServer: sync.Map{},
+		pods:        sync.Map{},
+	}
+
+	podName := types.NamespacedName{Namespace: "default", Name: "concurrent-pod1"}
+	podInitial := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: podName.Namespace,
+			Name:      podName.Name,
+		},
+	}
+	s.AddOrUpdatePod(podInitial, nil)
+
+	// Simulate state mutation that would be lost in a TOCTOU race
+	val, _ := s.pods.Load(podName)
+	podInfoInit := val.(*PodInfo)
+	podInfoInit.IncrOnFlightRequests() // Seed a non-zero runtime field
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, 100)
+	// Simulate many concurrent goroutines trying to add the same Pod
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "concurrent-pod1",
+				},
+			}
+			ms := &aiv1alpha1.ModelServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "model1",
+				},
+			}
+			errCh <- s.AddOrUpdatePod(pod, []*aiv1alpha1.ModelServer{ms})
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		assert.NoError(t, err)
+	}
+
+	// Verify the pod is safely in the datastore and no panic occurred
+	value, ok := s.pods.Load(podName)
+	assert.True(t, ok)
+	podInfo := value.(*PodInfo)
+	assert.NotNil(t, podInfo)
+	assert.True(t, podInfo.modelServer.Contains(types.NamespacedName{Namespace: "default", Name: "model1"}))
+	assert.Equal(t, int64(1), podInfo.GetOnFlightRequestNum(), "Runtime state (IncrOnFlightRequests) was lost due to TOCTOU overwrite!")
+}


### PR DESCRIPTION
Fixes #1196

### What type of PR is this?
/kind bug

### What this PR does / why we need it:
This PR fixes the TOCTOU check-then-act data races in `AddOrUpdateModelServer` and `AddOrUpdatePod` within the router datastore (`store.go`).
It replaces the non-atomic `Load()` followed by `Store()` pattern with atomic `LoadOrStore()` operations, preventing concurrent map insertions from overwriting each other.

### Which issue(s) this PR fixes:
Fixes #1196

### Special notes for reviewer:
This applies the same fix pattern that was applied to `handleErrorPod` in PR #1157, completing the concurrency fix that was partially addressed in PR #781.

### Does this PR introduce a user-facing change?:
```release-note
NONE
```