### PR TITLE
add gpu-usage plugin e2e test

### DIFF
--- a/test/e2e/router/plugins_helpers.go
+++ b/test/e2e/router/plugins_helpers.go
@@ -17,9 +17,11 @@ limitations under the License.
 package router
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -27,7 +29,9 @@ import (
 	backendmetrics "github.com/volcano-sh/kthena/pkg/kthena-router/backend/metrics"
 	plugincontext "github.com/volcano-sh/kthena/test/e2e/router/router-plugins/context"
 	"github.com/volcano-sh/kthena/test/e2e/utils"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -35,6 +39,11 @@ const (
 	pluginMockReplicaCount         = 3
 	leastRequestMaxWaitingRequests = 1
 	leastRequestLoadWaitTimeout    = 60 * time.Second
+	gpuCacheUsageBusyMin           = 0.1
+	gpuCacheUsageIdleMax           = 0.05
+	gpuCacheUsageLoadWaitTimeout   = 90 * time.Second
+	gpuCacheUsageLoadConcurrency   = 6
+	gpuCacheUsageLoadMaxTokens     = 256
 )
 
 func listReadyMockPods(t *testing.T, kube kubernetes.Interface, namespace string) []corev1.Pod {
@@ -42,6 +51,59 @@ func listReadyMockPods(t *testing.T, kube kubernetes.Interface, namespace string
 	ready := utils.ListReadyPodsByLabel(t, kube, namespace, "app="+plugincontext.DeploymentName)
 	require.NotEmpty(t, ready, "no ready mock pods")
 	return ready
+}
+
+var pluginMockKVCacheSimArgs = []string{
+	"--model=kthena-plugin-mock",
+	"--served-model-name=router-plugin-model",
+	"--port=8000",
+	"--mode=echo",
+	"--enable-kvcache=true",
+	"--force-dummy-tokenizer=true",
+	"--kv-cache-size=8",
+	"--block-size=8",
+	"--max-num-seqs=2",
+	"--time-to-first-token=2s",
+	"--inter-token-latency=200ms",
+}
+
+// applyPluginMockKVCacheProfile patches the shared plugin mock deployment for gpu-usage e2e
+// and restores the baseline LLM-Mock-plugins.yaml spec on cleanup.
+func applyPluginMockKVCacheProfile(t *testing.T, kube kubernetes.Interface, namespace string) {
+	t.Helper()
+	ctx := context.Background()
+	baseline := utils.LoadYAMLFromFile[appsv1.Deployment](filepath.Join(plugincontext.TestDataDir, "LLM-Mock-plugins.yaml"))
+	baseline.Namespace = namespace
+
+	dep, err := kube.AppsV1().Deployments(namespace).Get(ctx, plugincontext.DeploymentName, metav1.GetOptions{})
+	require.NoError(t, err, "get plugin mock deployment")
+
+	container := &dep.Spec.Template.Spec.Containers[0]
+	container.Args = append([]string(nil), pluginMockKVCacheSimArgs...)
+	container.Env = []corev1.EnvVar{{
+		Name: "POD_IP",
+		ValueFrom: &corev1.EnvVarSource{
+			FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.podIP"},
+		},
+	}}
+
+	_, err = kube.AppsV1().Deployments(namespace).Update(ctx, dep, metav1.UpdateOptions{})
+	require.NoError(t, err, "patch plugin mock deployment for kv-cache simulation")
+	require.NoError(t, utils.WaitForDeploymentReadyE(ctx, kube, namespace, plugincontext.DeploymentName, 5*time.Minute),
+		"wait for kv-cache plugin mock rollout")
+
+	t.Cleanup(func() {
+		cleanupCtx := context.Background()
+		latest, err := kube.AppsV1().Deployments(namespace).Get(cleanupCtx, plugincontext.DeploymentName, metav1.GetOptions{})
+		if err != nil {
+			return
+		}
+		latest.Spec = *baseline.Spec.DeepCopy()
+		if _, err := kube.AppsV1().Deployments(namespace).Update(cleanupCtx, latest, metav1.UpdateOptions{}); err != nil {
+			return
+		}
+		_ = utils.WaitForDeploymentReadyE(cleanupCtx, kube, namespace, plugincontext.DeploymentName, 5*time.Minute)
+	})
 }
 
 func waitForSchedulerPluginInMetrics(t *testing.T, metricsURL, pluginName, pluginType string) {
@@ -59,6 +121,7 @@ func waitForSchedulerPluginInMetrics(t *testing.T, metricsURL, pluginName, plugi
 }
 
 type routerPodMetricsSnapshot struct {
+	GPUCacheUsage     float64
 	RequestWaitingNum float64
 	RequestRunningNum float64
 }
@@ -77,6 +140,7 @@ func fetchRouterPodMetricsViaDebug(t *testing.T, debugBaseURL string, pod corev1
 	}
 	var parsed struct {
 		Metrics *struct {
+			GPUCacheUsage     float64 `json:"gpuCacheUsage"`
 			RequestWaitingNum float64 `json:"requestWaitingNum"`
 			RequestRunningNum float64 `json:"requestRunningNum"`
 		} `json:"metrics"`
@@ -85,6 +149,7 @@ func fetchRouterPodMetricsViaDebug(t *testing.T, debugBaseURL string, pod corev1
 		return routerPodMetricsSnapshot{}, false
 	}
 	return routerPodMetricsSnapshot{
+		GPUCacheUsage:     parsed.Metrics.GPUCacheUsage,
 		RequestWaitingNum: parsed.Metrics.RequestWaitingNum,
 		RequestRunningNum: parsed.Metrics.RequestRunningNum,
 	}, true
@@ -130,6 +195,46 @@ func waitForLeastRequestLoadSeparation(t *testing.T, kube kubernetes.Interface, 
 	}, leastRequestLoadWaitTimeout, 2*time.Second,
 		"all busy pods should have request_waiting >= %d and idle pod %s should have request_waiting < %d",
 		maxWaitingRequests, idlePod.Name, maxWaitingRequests)
+}
+
+func waitForGPUCacheUsageSeparation(t *testing.T, kube kubernetes.Interface, kthenaNamespace string, busyPods []corev1.Pod, idlePod corev1.Pod) {
+	t.Helper()
+	require.NotEmpty(t, busyPods)
+
+	routerPod := utils.GetRouterPod(t, kube, kthenaNamespace)
+	localPort := utils.AllocateLocalPort(t)
+	pf, err := utils.SetupPortForwardToPod(routerPod.Namespace, routerPod.Name, localPort, utils.RouterDebugPort)
+	require.NoError(t, err, "port-forward to router debug API")
+	defer pf.Close()
+
+	debugBaseURL := fmt.Sprintf("http://127.0.0.1:%s", localPort)
+	require.Eventually(t, func() bool {
+		allBusyHot := true
+		for _, busyPod := range busyPods {
+			busy, okBusy := fetchRouterPodMetricsViaDebug(t, debugBaseURL, busyPod)
+			if !okBusy || busy.GPUCacheUsage < gpuCacheUsageBusyMin {
+				allBusyHot = false
+				break
+			}
+		}
+		idle, okIdle := fetchRouterPodMetricsViaDebug(t, debugBaseURL, idlePod)
+		if !okIdle {
+			return false
+		}
+		idleCool := idle.GPUCacheUsage < gpuCacheUsageIdleMax
+		if allBusyHot && idleCool {
+			for _, busyPod := range busyPods {
+				busy, _ := fetchRouterPodMetricsViaDebug(t, debugBaseURL, busyPod)
+				t.Logf("gpu-usage load ready: busy %s kv_cache=%.3f waiting=%.0f running=%.0f",
+					busyPod.Name, busy.GPUCacheUsage, busy.RequestWaitingNum, busy.RequestRunningNum)
+			}
+			t.Logf("gpu-usage load ready: idle %s kv_cache=%.3f waiting=%.0f running=%.0f",
+				idlePod.Name, idle.GPUCacheUsage, idle.RequestWaitingNum, idle.RequestRunningNum)
+		}
+		return allBusyHot && idleCool
+	}, gpuCacheUsageLoadWaitTimeout, 2*time.Second,
+		"all busy pods should have gpu cache usage >= %.2f and idle pod %s should have gpu cache usage < %.2f",
+		gpuCacheUsageBusyMin, idlePod.Name, gpuCacheUsageIdleMax)
 }
 
 const (
@@ -195,5 +300,15 @@ const (
     Score:
       enabled:
         - name: random
+          weight: 1`
+
+	schedulerOnlyGPUCacheUsage = `scheduler:
+  pluginConfig: []
+  plugins:
+    Filter:
+      enabled: []
+    Score:
+      enabled:
+        - name: gpu-usage
           weight: 1`
 )

--- a/test/e2e/router/plugins_helpers.go
+++ b/test/e2e/router/plugins_helpers.go
@@ -44,7 +44,7 @@ const (
 	gpuCacheUsageBusyMin           = 0.1
 	gpuCacheUsageIdleMax           = 0.05
 	gpuCacheUsageLoadWaitTimeout   = 90 * time.Second
-	gpuCacheUsageLoadConcurrency   = 6
+	gpuCacheUsageLoadConcurrency   = 2
 	gpuCacheUsageLoadMaxTokens     = 256
 )
 
@@ -55,6 +55,9 @@ func listReadyMockPods(t *testing.T, kube kubernetes.Interface, namespace string
 	return ready
 }
 
+// pluginMockKVCacheSimArgs enables KV-cache simulation with the same fast latency as
+// LLM-Mock-plugins.yaml so probe traffic stays quick; sustained long streaming load
+// keeps busy replicas hot without slow per-token delays.
 var pluginMockKVCacheSimArgs = []string{
 	"--model=kthena-plugin-mock",
 	"--served-model-name=router-plugin-model",
@@ -65,8 +68,8 @@ var pluginMockKVCacheSimArgs = []string{
 	"--kv-cache-size=8",
 	"--block-size=8",
 	"--max-num-seqs=2",
-	"--time-to-first-token=2s",
-	"--inter-token-latency=200ms",
+	"--time-to-first-token=50ms",
+	"--inter-token-latency=10ms",
 }
 
 // applyPluginMockKVCacheProfile patches the shared plugin mock deployment for gpu-usage e2e

--- a/test/e2e/router/plugins_helpers.go
+++ b/test/e2e/router/plugins_helpers.go
@@ -27,6 +27,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 	backendmetrics "github.com/volcano-sh/kthena/pkg/kthena-router/backend/metrics"
+	"github.com/volcano-sh/kthena/pkg/kthena-router/backend/vllm"
+	routerutils "github.com/volcano-sh/kthena/pkg/kthena-router/utils"
 	plugincontext "github.com/volcano-sh/kthena/test/e2e/router/router-plugins/context"
 	"github.com/volcano-sh/kthena/test/e2e/utils"
 	appsv1 "k8s.io/api/apps/v1"
@@ -121,7 +123,6 @@ func waitForSchedulerPluginInMetrics(t *testing.T, metricsURL, pluginName, plugi
 }
 
 type routerPodMetricsSnapshot struct {
-	GPUCacheUsage     float64
 	RequestWaitingNum float64
 	RequestRunningNum float64
 }
@@ -140,7 +141,6 @@ func fetchRouterPodMetricsViaDebug(t *testing.T, debugBaseURL string, pod corev1
 	}
 	var parsed struct {
 		Metrics *struct {
-			GPUCacheUsage     float64 `json:"gpuCacheUsage"`
 			RequestWaitingNum float64 `json:"requestWaitingNum"`
 			RequestRunningNum float64 `json:"requestRunningNum"`
 		} `json:"metrics"`
@@ -149,10 +149,80 @@ func fetchRouterPodMetricsViaDebug(t *testing.T, debugBaseURL string, pod corev1
 		return routerPodMetricsSnapshot{}, false
 	}
 	return routerPodMetricsSnapshot{
-		GPUCacheUsage:     parsed.Metrics.GPUCacheUsage,
 		RequestWaitingNum: parsed.Metrics.RequestWaitingNum,
 		RequestRunningNum: parsed.Metrics.RequestRunningNum,
 	}, true
+}
+
+type mockPodMetricsPortForward struct {
+	pod     corev1.Pod
+	metrics string
+	close   func()
+}
+
+func setupMockPodMetricsPortForward(t *testing.T, pod corev1.Pod) mockPodMetricsPortForward {
+	t.Helper()
+	localPort := utils.AllocateLocalPort(t)
+	pf, err := utils.SetupPortForwardToPod(pod.Namespace, pod.Name, localPort, "8000")
+	require.NoError(t, err, "port-forward to mock pod %s for /metrics", pod.Name)
+	return mockPodMetricsPortForward{
+		pod:     pod,
+		metrics: fmt.Sprintf("http://127.0.0.1:%s/metrics", localPort),
+		close:   func() { pf.Close() },
+	}
+}
+
+func fetchMockPodKVCacheUsage(metricsURL string) (float64, bool) {
+	allMetrics, err := backendmetrics.ParseMetricsURL(metricsURL)
+	if err != nil {
+		return 0, false
+	}
+	countMetrics := vllm.NewVllmEngine().GetCountMetricsInfo(allMetrics)
+	kvUsage, ok := countMetrics[routerutils.KVCacheUsage]
+	return kvUsage, ok
+}
+
+func waitForMockPodKVCacheSeparation(t *testing.T, busyPods []corev1.Pod, idlePod corev1.Pod) {
+	t.Helper()
+	require.NotEmpty(t, busyPods)
+
+	forwards := make([]mockPodMetricsPortForward, 0, len(busyPods)+1)
+	for _, pod := range busyPods {
+		forwards = append(forwards, setupMockPodMetricsPortForward(t, pod))
+	}
+	forwards = append(forwards, setupMockPodMetricsPortForward(t, idlePod))
+	defer func() {
+		for _, forward := range forwards {
+			forward.close()
+		}
+	}()
+
+	require.Eventually(t, func() bool {
+		allBusyHot := true
+		for _, forward := range forwards[:len(busyPods)] {
+			kvUsage, ok := fetchMockPodKVCacheUsage(forward.metrics)
+			if !ok || kvUsage < gpuCacheUsageBusyMin {
+				allBusyHot = false
+				break
+			}
+		}
+		idleForward := forwards[len(forwards)-1]
+		idleUsage, okIdle := fetchMockPodKVCacheUsage(idleForward.metrics)
+		if !okIdle {
+			return false
+		}
+		idleCool := idleUsage < gpuCacheUsageIdleMax
+		if allBusyHot && idleCool {
+			for _, forward := range forwards[:len(busyPods)] {
+				kvUsage, _ := fetchMockPodKVCacheUsage(forward.metrics)
+				t.Logf("gpu-usage load ready: busy %s kv_cache=%.3f (mock /metrics)", forward.pod.Name, kvUsage)
+			}
+			t.Logf("gpu-usage load ready: idle %s kv_cache=%.3f (mock /metrics)", idleForward.pod.Name, idleUsage)
+		}
+		return allBusyHot && idleCool
+	}, gpuCacheUsageLoadWaitTimeout, 2*time.Second,
+		"all busy pods should report kv_cache_usage_perc >= %.2f and idle pod %s should report < %.2f on mock /metrics",
+		gpuCacheUsageBusyMin, idlePod.Name, gpuCacheUsageIdleMax)
 }
 
 func waitForLeastRequestLoadSeparation(t *testing.T, kube kubernetes.Interface, kthenaNamespace string, busyPods []corev1.Pod, idlePod corev1.Pod, maxWaitingRequests int) {
@@ -195,46 +265,6 @@ func waitForLeastRequestLoadSeparation(t *testing.T, kube kubernetes.Interface, 
 	}, leastRequestLoadWaitTimeout, 2*time.Second,
 		"all busy pods should have request_waiting >= %d and idle pod %s should have request_waiting < %d",
 		maxWaitingRequests, idlePod.Name, maxWaitingRequests)
-}
-
-func waitForGPUCacheUsageSeparation(t *testing.T, kube kubernetes.Interface, kthenaNamespace string, busyPods []corev1.Pod, idlePod corev1.Pod) {
-	t.Helper()
-	require.NotEmpty(t, busyPods)
-
-	routerPod := utils.GetRouterPod(t, kube, kthenaNamespace)
-	localPort := utils.AllocateLocalPort(t)
-	pf, err := utils.SetupPortForwardToPod(routerPod.Namespace, routerPod.Name, localPort, utils.RouterDebugPort)
-	require.NoError(t, err, "port-forward to router debug API")
-	defer pf.Close()
-
-	debugBaseURL := fmt.Sprintf("http://127.0.0.1:%s", localPort)
-	require.Eventually(t, func() bool {
-		allBusyHot := true
-		for _, busyPod := range busyPods {
-			busy, okBusy := fetchRouterPodMetricsViaDebug(t, debugBaseURL, busyPod)
-			if !okBusy || busy.GPUCacheUsage < gpuCacheUsageBusyMin {
-				allBusyHot = false
-				break
-			}
-		}
-		idle, okIdle := fetchRouterPodMetricsViaDebug(t, debugBaseURL, idlePod)
-		if !okIdle {
-			return false
-		}
-		idleCool := idle.GPUCacheUsage < gpuCacheUsageIdleMax
-		if allBusyHot && idleCool {
-			for _, busyPod := range busyPods {
-				busy, _ := fetchRouterPodMetricsViaDebug(t, debugBaseURL, busyPod)
-				t.Logf("gpu-usage load ready: busy %s kv_cache=%.3f waiting=%.0f running=%.0f",
-					busyPod.Name, busy.GPUCacheUsage, busy.RequestWaitingNum, busy.RequestRunningNum)
-			}
-			t.Logf("gpu-usage load ready: idle %s kv_cache=%.3f waiting=%.0f running=%.0f",
-				idlePod.Name, idle.GPUCacheUsage, idle.RequestWaitingNum, idle.RequestRunningNum)
-		}
-		return allBusyHot && idleCool
-	}, gpuCacheUsageLoadWaitTimeout, 2*time.Second,
-		"all busy pods should have gpu cache usage >= %.2f and idle pod %s should have gpu cache usage < %.2f",
-		gpuCacheUsageBusyMin, idlePod.Name, gpuCacheUsageIdleMax)
 }
 
 const (

--- a/test/e2e/router/plugins_helpers.go
+++ b/test/e2e/router/plugins_helpers.go
@@ -17,11 +17,9 @@ limitations under the License.
 package router
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -31,9 +29,7 @@ import (
 	routerutils "github.com/volcano-sh/kthena/pkg/kthena-router/utils"
 	plugincontext "github.com/volcano-sh/kthena/test/e2e/router/router-plugins/context"
 	"github.com/volcano-sh/kthena/test/e2e/utils"
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -53,62 +49,6 @@ func listReadyMockPods(t *testing.T, kube kubernetes.Interface, namespace string
 	ready := utils.ListReadyPodsByLabel(t, kube, namespace, "app="+plugincontext.DeploymentName)
 	require.NotEmpty(t, ready, "no ready mock pods")
 	return ready
-}
-
-// pluginMockKVCacheSimArgs enables KV-cache simulation with the same fast latency as
-// LLM-Mock-plugins.yaml so probe traffic stays quick; sustained long streaming load
-// keeps busy replicas hot without slow per-token delays.
-var pluginMockKVCacheSimArgs = []string{
-	"--model=kthena-plugin-mock",
-	"--served-model-name=router-plugin-model",
-	"--port=8000",
-	"--mode=echo",
-	"--enable-kvcache=true",
-	"--force-dummy-tokenizer=true",
-	"--kv-cache-size=8",
-	"--block-size=8",
-	"--max-num-seqs=2",
-	"--time-to-first-token=50ms",
-	"--inter-token-latency=10ms",
-}
-
-// applyPluginMockKVCacheProfile patches the shared plugin mock deployment for gpu-usage e2e
-// and restores the baseline LLM-Mock-plugins.yaml spec on cleanup.
-func applyPluginMockKVCacheProfile(t *testing.T, kube kubernetes.Interface, namespace string) {
-	t.Helper()
-	ctx := context.Background()
-	baseline := utils.LoadYAMLFromFile[appsv1.Deployment](filepath.Join(plugincontext.TestDataDir, "LLM-Mock-plugins.yaml"))
-	baseline.Namespace = namespace
-
-	dep, err := kube.AppsV1().Deployments(namespace).Get(ctx, plugincontext.DeploymentName, metav1.GetOptions{})
-	require.NoError(t, err, "get plugin mock deployment")
-
-	container := &dep.Spec.Template.Spec.Containers[0]
-	container.Args = append([]string(nil), pluginMockKVCacheSimArgs...)
-	container.Env = []corev1.EnvVar{{
-		Name: "POD_IP",
-		ValueFrom: &corev1.EnvVarSource{
-			FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.podIP"},
-		},
-	}}
-
-	_, err = kube.AppsV1().Deployments(namespace).Update(ctx, dep, metav1.UpdateOptions{})
-	require.NoError(t, err, "patch plugin mock deployment for kv-cache simulation")
-	require.NoError(t, utils.WaitForDeploymentReadyE(ctx, kube, namespace, plugincontext.DeploymentName, 5*time.Minute),
-		"wait for kv-cache plugin mock rollout")
-
-	t.Cleanup(func() {
-		cleanupCtx := context.Background()
-		latest, err := kube.AppsV1().Deployments(namespace).Get(cleanupCtx, plugincontext.DeploymentName, metav1.GetOptions{})
-		if err != nil {
-			return
-		}
-		latest.Spec = *baseline.Spec.DeepCopy()
-		if _, err := kube.AppsV1().Deployments(namespace).Update(cleanupCtx, latest, metav1.UpdateOptions{}); err != nil {
-			return
-		}
-		_ = utils.WaitForDeploymentReadyE(cleanupCtx, kube, namespace, plugincontext.DeploymentName, 5*time.Minute)
-	})
 }
 
 func waitForSchedulerPluginInMetrics(t *testing.T, metricsURL, pluginName, pluginType string) {

--- a/test/e2e/router/plugins_test.go
+++ b/test/e2e/router/plugins_test.go
@@ -105,6 +105,50 @@ func TestSchedulerPluginLeastRequest(t *testing.T) {
 	waitForSchedulerPluginInMetrics(t, metricsURL, plugins.LeastRequestPluginName, "filter")
 }
 
+// TestSchedulerPluginGPUCacheUsage verifies gpu-usage prefers replicas with lower KV cache
+// utilization. Two backends are kept hot with sustained long requests under enable-kvcache;
+// probe traffic should land on the idle replica.
+func TestSchedulerPluginGPUCacheUsage(t *testing.T) {
+	ctx := context.Background()
+	applyPluginMockKVCacheProfile(t, testCtx.KubeClient, testNamespace)
+
+	chatURL, metricsURL, restoreCfg := utils.ApplySchedulerConfig(t, testCtx.KubeClient, testCtx.KthenaClient, kthenaNamespace, testNamespace, schedulerOnlyGPUCacheUsage, plugincontext.ModelServerName, plugincontext.ModelName)
+	t.Cleanup(restoreCfg)
+
+	route := utils.CreateModelRouteFromFile(t, ctx, testCtx.KthenaClient, plugincontext.TestDataDir, testNamespace, "ModelRoute-plugins.yaml")
+	model := route.Spec.ModelName
+
+	pods := listReadyMockPods(t, testCtx.KubeClient, testNamespace)
+	require.Len(t, pods, pluginMockReplicaCount, "gpu-usage test needs %d mock pods", pluginMockReplicaCount)
+	busyPods := pods[:pluginMockReplicaCount-1]
+	idlePod := pods[pluginMockReplicaCount-1]
+
+	for i, busyPod := range busyPods {
+		stopLoad := utils.StartSustainedLongRequestsToPod(t, busyPod, model,
+			fmt.Sprintf("kthena-router-plugin-e2e-fixed-prompt-gpu-usage-busy-load-%d with many tokens to consume kv cache blocks for gpu usage plugin testing", i),
+			gpuCacheUsageLoadConcurrency, gpuCacheUsageLoadMaxTokens)
+		t.Cleanup(stopLoad)
+	}
+	waitForGPUCacheUsageSeparation(t, testCtx.KubeClient, kthenaNamespace, busyPods, idlePod)
+
+	since := metav1.NewTime(time.Now())
+	utils.SendRouterChatRequests(t, chatURL, model, "kthena-router-plugin-e2e-fixed-prompt-gpu-usage-route", 200)
+	time.Sleep(2 * time.Second)
+
+	busyCount := utils.CountSelectedPodsInRouterLogs(t, testCtx.KubeClient, kthenaNamespace, since, busyPods)
+	idleCount := utils.CountSelectedPodInRouterLogs(t, testCtx.KubeClient, kthenaNamespace, idlePod.Name, since)
+	routed := busyCount + idleCount
+	t.Logf("gpu-usage: busy pool %d, idle pod %s %d (of %d log lines)", busyCount, idlePod.Name, idleCount, routed)
+	require.GreaterOrEqual(t, routed, 200/2, "expected access logs for routed requests")
+	require.Greater(t, idleCount, busyCount, "gpu-usage should prefer the idle pod over kv-cache-hot pods")
+	require.GreaterOrEqual(t, float64(idleCount)/float64(routed), 0.9,
+		"gpu-usage should route at least 90%% to the idle pod")
+	require.LessOrEqual(t, float64(busyCount)/float64(routed), 0.1,
+		"gpu-usage should route at most 10%% to kv-cache-hot pods")
+
+	waitForSchedulerPluginInMetrics(t, metricsURL, plugins.GPUCacheUsagePluginName, "score")
+}
+
 // TestSchedulerPluginLeastLatency verifies least-latency prefers the intrinsically faster
 // backend when both pools are idle and scored by observed TTFT/TPOT only.
 func TestSchedulerPluginLeastLatency(t *testing.T) {

--- a/test/e2e/router/plugins_test.go
+++ b/test/e2e/router/plugins_test.go
@@ -19,7 +19,6 @@ package router
 import (
 	"context"
 	"fmt"
-	"sync"
 	"testing"
 	"time"
 
@@ -167,21 +166,11 @@ func TestSchedulerPluginLeastLatency(t *testing.T) {
 	route := utils.CreateModelRouteFromFile(t, ctx, testCtx.KthenaClient, plugincontext.TestDataDir, testNamespace, "ModelRoute-plugins-latency.yaml")
 	model := route.Spec.ModelName
 
-	// Prime both backends while idle so the router records TTFT/TPOT; parallelize to cut wall time.
-	const primeRequests = 40
-	const primeConcurrency = 5
-	var primeWG sync.WaitGroup
-	primeWG.Add(2)
-	go func() {
-		defer primeWG.Done()
-		utils.DirectChatToPodConcurrent(t, fastPods[0], model, "kthena-router-plugin-e2e-fixed-prompt-latency-fast-prime", primeRequests, primeConcurrency)
-	}()
-	go func() {
-		defer primeWG.Done()
-		utils.DirectChatToPodConcurrent(t, slowPods[0], model, "kthena-router-plugin-e2e-fixed-prompt-latency-slow-prime", primeRequests, primeConcurrency)
-	}()
-	primeWG.Wait()
-	time.Sleep(3 * time.Second)
+	// Prime slow pool only: fast pods already have TTFT/TPOT from earlier plugin tests; an
+	// unprimed slow pod reports TTFT=0 and would incorrectly win least-latency scoring.
+	const slowPrimeRequests = 8
+	utils.DirectChatToPod(t, slowPods[0], model, "kthena-router-plugin-e2e-fixed-prompt-latency-slow-prime", slowPrimeRequests)
+	time.Sleep(2 * time.Second) // allow router to scrape updated slow-pool metrics
 
 	since := metav1.NewTime(time.Now())
 	utils.SendRouterChatRequests(t, chatURL, model, "kthena-router-plugin-e2e-fixed-prompt-latency-route", 200)

--- a/test/e2e/router/plugins_test.go
+++ b/test/e2e/router/plugins_test.go
@@ -106,8 +106,8 @@ func TestSchedulerPluginLeastRequest(t *testing.T) {
 }
 
 // TestSchedulerPluginGPUCacheUsage verifies gpu-usage prefers replicas with lower KV cache
-// utilization. Two backends are kept hot with sustained long requests under enable-kvcache;
-// probe traffic should land on the idle replica.
+// utilization. Two backends are kept hot with sustained long streaming load under
+// enable-kvcache; probe traffic uses the same fast mock latency as other plugin tests.
 func TestSchedulerPluginGPUCacheUsage(t *testing.T) {
 	ctx := context.Background()
 	applyPluginMockKVCacheProfile(t, testCtx.KubeClient, testNamespace)

--- a/test/e2e/router/plugins_test.go
+++ b/test/e2e/router/plugins_test.go
@@ -19,6 +19,7 @@ package router
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -166,10 +167,20 @@ func TestSchedulerPluginLeastLatency(t *testing.T) {
 	route := utils.CreateModelRouteFromFile(t, ctx, testCtx.KthenaClient, plugincontext.TestDataDir, testNamespace, "ModelRoute-plugins-latency.yaml")
 	model := route.Spec.ModelName
 
-	// Prime both backends while idle so the router records TTFT/TPOT; do not saturate either pool.
+	// Prime both backends while idle so the router records TTFT/TPOT; parallelize to cut wall time.
 	const primeRequests = 40
-	utils.DirectChatToPod(t, fastPods[0], model, "kthena-router-plugin-e2e-fixed-prompt-latency-fast-prime", primeRequests)
-	utils.DirectChatToPod(t, slowPods[0], model, "kthena-router-plugin-e2e-fixed-prompt-latency-slow-prime", primeRequests)
+	const primeConcurrency = 5
+	var primeWG sync.WaitGroup
+	primeWG.Add(2)
+	go func() {
+		defer primeWG.Done()
+		utils.DirectChatToPodConcurrent(t, fastPods[0], model, "kthena-router-plugin-e2e-fixed-prompt-latency-fast-prime", primeRequests, primeConcurrency)
+	}()
+	go func() {
+		defer primeWG.Done()
+		utils.DirectChatToPodConcurrent(t, slowPods[0], model, "kthena-router-plugin-e2e-fixed-prompt-latency-slow-prime", primeRequests, primeConcurrency)
+	}()
+	primeWG.Wait()
 	time.Sleep(3 * time.Second)
 
 	since := metav1.NewTime(time.Now())

--- a/test/e2e/router/plugins_test.go
+++ b/test/e2e/router/plugins_test.go
@@ -106,11 +106,10 @@ func TestSchedulerPluginLeastRequest(t *testing.T) {
 }
 
 // TestSchedulerPluginGPUCacheUsage verifies gpu-usage prefers replicas with lower KV cache
-// utilization. Two backends are kept hot with sustained long streaming load under
-// enable-kvcache; probe traffic uses the same fast mock latency as other plugin tests.
+// utilization. Mock backends run with enable-kvcache (see LLM-Mock-plugins.yaml); two
+// replicas are kept hot with sustained long streaming load and probe traffic lands on idle.
 func TestSchedulerPluginGPUCacheUsage(t *testing.T) {
 	ctx := context.Background()
-	applyPluginMockKVCacheProfile(t, testCtx.KubeClient, testNamespace)
 
 	chatURL, metricsURL, restoreCfg := utils.ApplySchedulerConfig(t, testCtx.KubeClient, testCtx.KthenaClient, kthenaNamespace, testNamespace, schedulerOnlyGPUCacheUsage, plugincontext.ModelServerName, plugincontext.ModelName)
 	t.Cleanup(restoreCfg)

--- a/test/e2e/router/plugins_test.go
+++ b/test/e2e/router/plugins_test.go
@@ -129,7 +129,8 @@ func TestSchedulerPluginGPUCacheUsage(t *testing.T) {
 			gpuCacheUsageLoadConcurrency, gpuCacheUsageLoadMaxTokens)
 		t.Cleanup(stopLoad)
 	}
-	waitForGPUCacheUsageSeparation(t, testCtx.KubeClient, kthenaNamespace, busyPods, idlePod)
+	waitForMockPodKVCacheSeparation(t, busyPods, idlePod)
+	time.Sleep(3 * time.Second) // allow router to scrape updated mock metrics before probe traffic
 
 	since := metav1.NewTime(time.Now())
 	utils.SendRouterChatRequests(t, chatURL, model, "kthena-router-plugin-e2e-fixed-prompt-gpu-usage-route", 200)

--- a/test/e2e/router/router-plugins/testdata/LLM-Mock-plugins-slow.yaml
+++ b/test/e2e/router/router-plugins/testdata/LLM-Mock-plugins-slow.yaml
@@ -23,8 +23,8 @@ spec:
             - --served-model-name=router-plugin-model
             - --port=8000
             - --mode=echo
-            - --time-to-first-token=5s
-            - --inter-token-latency=80ms
+            - --time-to-first-token=500ms
+            - --inter-token-latency=20ms
           ports:
             - containerPort: 8000
           readinessProbe:

--- a/test/e2e/router/router-plugins/testdata/LLM-Mock-plugins.yaml
+++ b/test/e2e/router/router-plugins/testdata/LLM-Mock-plugins.yaml
@@ -34,8 +34,8 @@ spec:
             - --kv-cache-size=8
             - --block-size=8
             - --max-num-seqs=2
-            - --time-to-first-token=50ms
-            - --inter-token-latency=10ms
+            - --time-to-first-token=20ms
+            - --inter-token-latency=5ms
           ports:
             - containerPort: 8000
           readinessProbe:

--- a/test/e2e/router/router-plugins/testdata/LLM-Mock-plugins.yaml
+++ b/test/e2e/router/router-plugins/testdata/LLM-Mock-plugins.yaml
@@ -1,4 +1,5 @@
 # Mock vLLM backends for router scheduler plugin e2e tests.
+# KV-cache simulation is enabled for gpu-usage; other plugin tests only use their own scheduler plugins.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -18,11 +19,21 @@ spec:
         - name: llm-engine
           image: ghcr.io/llm-d/llm-d-inference-sim:latest
           imagePullPolicy: IfNotPresent
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
           args:
             - --model=kthena-plugin-mock
             - --served-model-name=router-plugin-model
             - --port=8000
             - --mode=echo
+            - --enable-kvcache=true
+            - --force-dummy-tokenizer=true
+            - --kv-cache-size=8
+            - --block-size=8
+            - --max-num-seqs=2
             - --time-to-first-token=50ms
             - --inter-token-latency=10ms
           ports:

--- a/test/e2e/utils/chat.go
+++ b/test/e2e/utils/chat.go
@@ -24,7 +24,6 @@ import (
 	"io"
 	"net/http"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -279,49 +278,29 @@ func SendRouterChatRequests(t *testing.T, routerChatURL, modelName, prompt strin
 // DirectChatToPod sends count streaming chat requests directly to a pod via port-forward.
 func DirectChatToPod(t *testing.T, pod corev1.Pod, model, prompt string, count int) {
 	t.Helper()
-	DirectChatToPodConcurrent(t, pod, model, prompt, count, 1)
-}
-
-// DirectChatToPodConcurrent sends count streaming requests with up to concurrency in flight.
-func DirectChatToPodConcurrent(t *testing.T, pod corev1.Pod, model, prompt string, count, concurrency int) {
-	t.Helper()
-	if concurrency < 1 {
-		concurrency = 1
-	}
 	localPort := AllocateLocalPort(t)
 	pf, err := SetupPortForwardToPod(pod.Namespace, pod.Name, localPort, "8000")
 	require.NoError(t, err)
 	defer pf.Close()
 
 	url := fmt.Sprintf("http://127.0.0.1:%s/v1/chat/completions", localPort)
-	body, err := json.Marshal(map[string]interface{}{
+	body, _ := json.Marshal(map[string]interface{}{
 		"model":      model,
 		"messages":   []map[string]string{{"role": "user", "content": prompt}},
 		"max_tokens": 32,
 		"stream":     true,
 	})
-	require.NoError(t, err)
-
-	sem := make(chan struct{}, concurrency)
-	var wg sync.WaitGroup
+	client := &http.Client{Timeout: 30 * time.Second}
 	for i := 0; i < count; i++ {
-		wg.Add(1)
-		sem <- struct{}{}
-		go func() {
-			defer wg.Done()
-			defer func() { <-sem }()
-			client := &http.Client{Timeout: 2 * time.Minute}
-			req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
-			require.NoError(t, err)
-			req.Header.Set("Content-Type", "application/json")
-			resp, err := client.Do(req)
-			require.NoError(t, err)
-			_, _ = io.Copy(io.Discard, resp.Body)
-			resp.Body.Close()
-			require.Equal(t, http.StatusOK, resp.StatusCode)
-		}()
+		req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		_, _ = io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
 	}
-	wg.Wait()
 }
 
 // StartSustainedLongRequestsToPod keeps concurrent long requests on one pod via port-forward.

--- a/test/e2e/utils/chat.go
+++ b/test/e2e/utils/chat.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -278,29 +279,49 @@ func SendRouterChatRequests(t *testing.T, routerChatURL, modelName, prompt strin
 // DirectChatToPod sends count streaming chat requests directly to a pod via port-forward.
 func DirectChatToPod(t *testing.T, pod corev1.Pod, model, prompt string, count int) {
 	t.Helper()
+	DirectChatToPodConcurrent(t, pod, model, prompt, count, 1)
+}
+
+// DirectChatToPodConcurrent sends count streaming requests with up to concurrency in flight.
+func DirectChatToPodConcurrent(t *testing.T, pod corev1.Pod, model, prompt string, count, concurrency int) {
+	t.Helper()
+	if concurrency < 1 {
+		concurrency = 1
+	}
 	localPort := AllocateLocalPort(t)
 	pf, err := SetupPortForwardToPod(pod.Namespace, pod.Name, localPort, "8000")
 	require.NoError(t, err)
 	defer pf.Close()
 
 	url := fmt.Sprintf("http://127.0.0.1:%s/v1/chat/completions", localPort)
-	body, _ := json.Marshal(map[string]interface{}{
+	body, err := json.Marshal(map[string]interface{}{
 		"model":      model,
 		"messages":   []map[string]string{{"role": "user", "content": prompt}},
 		"max_tokens": 32,
 		"stream":     true,
 	})
-	client := &http.Client{Timeout: 30 * time.Second}
+	require.NoError(t, err)
+
+	sem := make(chan struct{}, concurrency)
+	var wg sync.WaitGroup
 	for i := 0; i < count; i++ {
-		req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
-		require.NoError(t, err)
-		req.Header.Set("Content-Type", "application/json")
-		resp, err := client.Do(req)
-		require.NoError(t, err)
-		_, _ = io.Copy(io.Discard, resp.Body)
-		resp.Body.Close()
-		require.Equal(t, http.StatusOK, resp.StatusCode)
+		wg.Add(1)
+		sem <- struct{}{}
+		go func() {
+			defer wg.Done()
+			defer func() { <-sem }()
+			client := &http.Client{Timeout: 2 * time.Minute}
+			req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+			resp, err := client.Do(req)
+			require.NoError(t, err)
+			_, _ = io.Copy(io.Discard, resp.Body)
+			resp.Body.Close()
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+		}()
 	}
+	wg.Wait()
 }
 
 // StartSustainedLongRequestsToPod keeps concurrent long requests on one pod via port-forward.


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

After https://github.com/volcano-sh/kthena/issues/1178 we already get 5 plugin e2e test.But still lack of `gpu-usage` and `kvcache-aware` plugin. This pr implement the `gpu-usage` e2e test

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
