### PR TITLE
Validate ModelRoute rule fields

### DIFF
--- a/pkg/kthena-router/webhook/validator.go
+++ b/pkg/kthena-router/webhook/validator.go
@@ -21,6 +21,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net/http"
+	"regexp"
 	"strings"
 	"time"
 
@@ -179,6 +180,36 @@ func (v *KthenaRouterValidator) validateModelRoute(modelRoute *networkingv1alpha
 		ruleField := rulesField.Index(i)
 		if len(rule.TargetModels) == 0 {
 			allErrs = append(allErrs, field.Required(ruleField.Child("targetModels"), "each rule must have at least one target model"))
+			continue
+		}
+		totalWeight := uint32(0)
+		for j, targetModel := range rule.TargetModels {
+			targetModelField := ruleField.Child("targetModels").Index(j)
+			if targetModel.ModelServerName == "" {
+				allErrs = append(allErrs, field.Invalid(targetModelField.Child("modelServerName"), targetModel.ModelServerName, "modelServerName cannot be an empty string"))
+			}
+			if targetModel.Weight != nil {
+				totalWeight += *targetModel.Weight
+			} else {
+				totalWeight += 100
+			}
+		}
+		if totalWeight == 0 {
+			allErrs = append(allErrs, field.Invalid(ruleField.Child("targetModels"), totalWeight, "total weight must be greater than zero"))
+		}
+		if rule.ModelMatch != nil {
+			for key, sm := range rule.ModelMatch.Headers {
+				if sm != nil && sm.Regex != nil {
+					if _, err := regexp.Compile(*sm.Regex); err != nil {
+						allErrs = append(allErrs, field.Invalid(ruleField.Child("modelMatch").Child("headers").Key(key).Child("regex"), *sm.Regex, err.Error()))
+					}
+				}
+			}
+			if rule.ModelMatch.Uri != nil && rule.ModelMatch.Uri.Regex != nil {
+				if _, err := regexp.Compile(*rule.ModelMatch.Uri.Regex); err != nil {
+					allErrs = append(allErrs, field.Invalid(ruleField.Child("modelMatch").Child("uri").Child("regex"), *rule.ModelMatch.Uri.Regex, err.Error()))
+				}
+			}
 		}
 	}
 

--- a/pkg/kthena-router/webhook/validator_test.go
+++ b/pkg/kthena-router/webhook/validator_test.go
@@ -27,6 +27,10 @@ import (
 )
 
 func TestValidateModelRoute(t *testing.T) {
+	weight0 := uint32(0)
+	invalidHeaderRegex := "["
+	invalidURIRegex := "["
+
 	tests := []struct {
 		name           string
 		modelRoute     *networkingv1alpha1.ModelRoute
@@ -108,6 +112,32 @@ func TestValidateModelRoute(t *testing.T) {
 								{
 									ModelServerName: "test-server",
 								},
+							},
+						},
+					},
+				},
+			},
+			expectValid: true,
+		},
+		{
+			name: "valid model route with default and zero weights",
+			modelRoute: &networkingv1alpha1.ModelRoute{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "networking.serving.volcano.sh/v1alpha1",
+					Kind:       "ModelRoute",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "default",
+				},
+				Spec: networkingv1alpha1.ModelRouteSpec{
+					ModelName: "test-model",
+					Rules: []*networkingv1alpha1.Rule{
+						{
+							Name: "test-rule",
+							TargetModels: []*networkingv1alpha1.TargetModel{
+								{ModelServerName: "test-server-1"},
+								{ModelServerName: "test-server-2", Weight: &weight0},
 							},
 						},
 					},
@@ -308,6 +338,121 @@ func TestValidateModelRoute(t *testing.T) {
 			},
 			expectValid:    false,
 			expectedReason: "validation failed:   - spec.rules[1].targetModels: Required value: each rule must have at least one target model",
+		},
+		{
+			name: "invalid model route - empty modelServerName",
+			modelRoute: &networkingv1alpha1.ModelRoute{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "networking.serving.volcano.sh/v1alpha1",
+					Kind:       "ModelRoute",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "default",
+				},
+				Spec: networkingv1alpha1.ModelRouteSpec{
+					ModelName: "test-model",
+					Rules: []*networkingv1alpha1.Rule{
+						{
+							Name: "test-rule",
+							TargetModels: []*networkingv1alpha1.TargetModel{
+								{ModelServerName: ""},
+							},
+						},
+					},
+				},
+			},
+			expectValid:    false,
+			expectedReason: "validation failed:   - spec.rules[0].targetModels[0].modelServerName: Invalid value: \"\": modelServerName cannot be an empty string",
+		},
+		{
+			name: "invalid model route - all target weights are zero",
+			modelRoute: &networkingv1alpha1.ModelRoute{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "networking.serving.volcano.sh/v1alpha1",
+					Kind:       "ModelRoute",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "default",
+				},
+				Spec: networkingv1alpha1.ModelRouteSpec{
+					ModelName: "test-model",
+					Rules: []*networkingv1alpha1.Rule{
+						{
+							Name: "test-rule",
+							TargetModels: []*networkingv1alpha1.TargetModel{
+								{ModelServerName: "test-server-1", Weight: &weight0},
+								{ModelServerName: "test-server-2", Weight: &weight0},
+							},
+						},
+					},
+				},
+			},
+			expectValid:    false,
+			expectedReason: "validation failed:   - spec.rules[0].targetModels: Invalid value: 0: total weight must be greater than zero",
+		},
+		{
+			name: "invalid model route - invalid header regex",
+			modelRoute: &networkingv1alpha1.ModelRoute{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "networking.serving.volcano.sh/v1alpha1",
+					Kind:       "ModelRoute",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "default",
+				},
+				Spec: networkingv1alpha1.ModelRouteSpec{
+					ModelName: "test-model",
+					Rules: []*networkingv1alpha1.Rule{
+						{
+							Name: "test-rule",
+							ModelMatch: &networkingv1alpha1.ModelMatch{
+								Headers: map[string]*networkingv1alpha1.StringMatch{
+									"x-user": {Regex: &invalidHeaderRegex},
+								},
+							},
+							TargetModels: []*networkingv1alpha1.TargetModel{
+								{ModelServerName: "test-server"},
+							},
+						},
+					},
+				},
+			},
+			expectValid:    false,
+			expectedReason: "validation failed:   - spec.rules[0].modelMatch.headers[x-user].regex: Invalid value: \"[\": error parsing regexp: missing closing ]: `[`",
+		},
+		{
+			name: "invalid model route - invalid uri regex",
+			modelRoute: &networkingv1alpha1.ModelRoute{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "networking.serving.volcano.sh/v1alpha1",
+					Kind:       "ModelRoute",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "default",
+				},
+				Spec: networkingv1alpha1.ModelRouteSpec{
+					ModelName: "test-model",
+					Rules: []*networkingv1alpha1.Rule{
+						{
+							Name: "test-rule",
+							ModelMatch: &networkingv1alpha1.ModelMatch{
+								Uri: &networkingv1alpha1.StringMatch{
+									Regex: &invalidURIRegex,
+								},
+							},
+							TargetModels: []*networkingv1alpha1.TargetModel{
+								{ModelServerName: "test-server"},
+							},
+						},
+					},
+				},
+			},
+			expectValid:    false,
+			expectedReason: "validation failed:   - spec.rules[0].modelMatch.uri.regex: Invalid value: \"[\": error parsing regexp: missing closing ]: `[`",
 		},
 		{
 			name: "invalid model route - nil rule",


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

This tightens ModelRoute validating webhook checks for route rules that would otherwise fail later during request routing.

The webhook now rejects:
- empty `modelServerName` in `targetModels`
- nil target model entries
- target model weights with a total of `0`
- invalid regex values in `modelMatch.headers` and `modelMatch.uri`

**Which issue(s) this PR fixes**:
Fixes #1200

**Special notes for your reviewer**:

Added focused unit coverage for the new ModelRoute validation cases.

**Does this PR introduce a user-facing change?**:

```release-note
ModelRoute validating webhook now rejects invalid route rules with empty target model names, zero total target weight, nil target entries, or invalid match regex values.