### PR TITLE
fix:- ModelServer's configure WorkloadPort instead of hardcode Defaults

### DIFF
--- a/pkg/kthena-router/backend/backend.go
+++ b/pkg/kthena-router/backend/backend.go
@@ -28,8 +28,8 @@ import (
 )
 
 type MetricsProvider interface {
-	GetPodMetrics(pod *corev1.Pod) (map[string]*dto.MetricFamily, error)
-	GetPodModels(pod *corev1.Pod) ([]string, error)
+	GetPodMetrics(pod *corev1.Pod, port uint32) (map[string]*dto.MetricFamily, error)
+	GetPodModels(pod *corev1.Pod, port uint32) ([]string, error)
 	GetCountMetricsInfo(allMetrics map[string]*dto.MetricFamily) map[string]float64
 	GetHistogramPodMetrics(allMetrics map[string]*dto.MetricFamily, previousHistogram map[string]*dto.Histogram) (map[string]float64, map[string]*dto.Histogram)
 }
@@ -39,14 +39,14 @@ var engineRegistry = map[string]MetricsProvider{
 	"vLLM":   vllm.NewVllmEngine(),
 }
 
-func GetPodMetrics(engine string, pod *corev1.Pod, previousHistogram map[string]*dto.Histogram) (map[string]float64, map[string]*dto.Histogram) {
+func GetPodMetrics(engine string, pod *corev1.Pod, port uint32, previousHistogram map[string]*dto.Histogram) (map[string]float64, map[string]*dto.Histogram) {
 	provider, err := GetMetricsProvider(engine)
 	if err != nil {
 		klog.Errorf("Failed to get inference engine: %v", err)
 		return nil, nil
 	}
 
-	allMetrics, err := provider.GetPodMetrics(pod)
+	allMetrics, err := provider.GetPodMetrics(pod, port)
 	if err != nil {
 		klog.V(4).Infof("failed to get metrics of pod: %s/%s: %v", pod.GetNamespace(), pod.GetName(), err)
 		return nil, nil
@@ -71,12 +71,12 @@ func GetMetricsProvider(engine string) (MetricsProvider, error) {
 	return nil, fmt.Errorf("unsupported engine: %s", engine)
 }
 
-func GetPodModels(engine string, pod *corev1.Pod) ([]string, error) {
+func GetPodModels(engine string, pod *corev1.Pod, port uint32) ([]string, error) {
 	provider, err := GetMetricsProvider(engine)
 	if err != nil {
 		klog.Errorf("Failed to get inference engine: %v", err)
 		return nil, nil
 	}
 
-	return provider.GetPodModels(pod)
+	return provider.GetPodModels(pod, port)
 }

--- a/pkg/kthena-router/backend/sglang/metrics.go
+++ b/pkg/kthena-router/backend/sglang/metrics.go
@@ -55,20 +55,20 @@ var (
 )
 
 type sglangEngine struct {
-	// The address of sglang's query metrics is http://{model server}:MetricPort/metrics
-	// Default is 30000
-	MetricPort uint32
+	// The address of sglang's query metrics is http://{model server}:port/metrics
+	// Default is 30000 if not specified
+
 }
 
 func NewSglangEngine() *sglangEngine {
-	// TODO: Get MetricsPort from sglang configuration
-	return &sglangEngine{
-		MetricPort: 30000,
-	}
+	return &sglangEngine{}
 }
 
-func (engine *sglangEngine) GetPodMetrics(pod *corev1.Pod) (map[string]*dto.MetricFamily, error) {
-	url := metrics.PodEndpointURL(pod.Status.PodIP, engine.MetricPort, "/metrics")
+func (engine *sglangEngine) GetPodMetrics(pod *corev1.Pod, port uint32) (map[string]*dto.MetricFamily, error) {
+	if port == 0 {
+		port = 30000
+	}
+	url := metrics.PodEndpointURL(pod.Status.PodIP, port, "/metrics")
 	allMetrics, err := metrics.ParseMetricsURL(url)
 	if err != nil {
 		return nil, err
@@ -118,6 +118,9 @@ func (engine *sglangEngine) GetHistogramPodMetrics(allMetrics map[string]*dto.Me
 }
 
 // GetPodModels retrieves the list of models from a pod running the sglang engine.
-func (engine *sglangEngine) GetPodModels(pod *corev1.Pod) ([]string, error) {
-	return vllm.FetchPodModels(pod.Status.PodIP, engine.MetricPort)
+func (engine *sglangEngine) GetPodModels(pod *corev1.Pod, port uint32) ([]string, error) {
+	if port == 0 {
+		port = 30000
+	}
+	return vllm.FetchPodModels(pod.Status.PodIP, port)
 }

--- a/pkg/kthena-router/backend/vllm/metrics.go
+++ b/pkg/kthena-router/backend/vllm/metrics.go
@@ -54,20 +54,20 @@ var (
 )
 
 type vllmEngine struct {
-	// The address of vllm's query metrics is http://{model server}:MetricPort/metrics
-	// Default is 8000
-	MetricPort uint32
+	// The address of vllm's query metrics is http://{model server}:port/metrics
+	// This is now provided by the user via Model.SErver.Spec.WorkloadPort
+	// Default is 8000 if not specified
 }
 
 func NewVllmEngine() *vllmEngine {
-	// TODO: Get MetricsPort from vllm configuration
-	return &vllmEngine{
-		MetricPort: 8000,
-	}
+	return &vllmEngine{}
 }
 
-func (engine *vllmEngine) GetPodMetrics(pod *corev1.Pod) (map[string]*dto.MetricFamily, error) {
-	url := metrics.PodEndpointURL(pod.Status.PodIP, engine.MetricPort, "/metrics")
+func (engine *vllmEngine) GetPodMetrics(pod *corev1.Pod, port uint32) (map[string]*dto.MetricFamily, error) {
+	if port == 0 {
+		port = 8000
+	}
+	url := metrics.PodEndpointURL(pod.Status.PodIP, port, "/metrics")
 	allMetrics, err := metrics.ParseMetricsURL(url)
 	if err != nil {
 		return nil, err

--- a/pkg/kthena-router/backend/vllm/metrics.go
+++ b/pkg/kthena-router/backend/vllm/metrics.go
@@ -55,7 +55,7 @@ var (
 
 type vllmEngine struct {
 	// The address of vllm's query metrics is http://{model server}:port/metrics
-	// This is now provided by the user via Model.SErver.Spec.WorkloadPort
+	// This is now provided by the user via Model.Server.Spec.WorkloadPort
 	// Default is 8000 if not specified
 }
 

--- a/pkg/kthena-router/backend/vllm/models.go
+++ b/pkg/kthena-router/backend/vllm/models.go
@@ -65,6 +65,9 @@ func FetchPodModels(podIP string, port uint32) ([]string, error) {
 	return models, nil
 }
 
-func (engine *vllmEngine) GetPodModels(pod *corev1.Pod) ([]string, error) {
-	return FetchPodModels(pod.Status.PodIP, engine.MetricPort)
+func (engine *vllmEngine) GetPodModels(pod *corev1.Pod, port uint32) ([]string, error) {
+	if port == 0 {
+		port = 8000
+	}
+	return FetchPodModels(pod.Status.PodIP, port)
 }

--- a/pkg/kthena-router/controller/modelserver_controller_test.go
+++ b/pkg/kthena-router/controller/modelserver_controller_test.go
@@ -41,7 +41,7 @@ import (
 
 type fakePodRuntimeInspector struct{}
 
-func (fakePodRuntimeInspector) GetPodMetrics(_ string, _ *corev1.Pod, _ map[string]*dto.Histogram) (map[string]float64, map[string]*dto.Histogram) {
+func (fakePodRuntimeInspector) GetPodMetrics(_ string, _ *corev1.Pod, _ uint32, _ map[string]*dto.Histogram) (map[string]float64, map[string]*dto.Histogram) {
 	return map[string]float64{
 		utils.KVCacheUsage:      0.5,
 		utils.RequestWaitingNum: 10,
@@ -49,7 +49,7 @@ func (fakePodRuntimeInspector) GetPodMetrics(_ string, _ *corev1.Pod, _ map[stri
 	}, nil
 }
 
-func (fakePodRuntimeInspector) GetPodModels(_ string, _ *corev1.Pod) ([]string, error) {
+func (fakePodRuntimeInspector) GetPodModels(_ string, _ *corev1.Pod, _ uint32) ([]string, error) {
 	return []string{"test-model"}, nil
 }
 

--- a/pkg/kthena-router/datastore/ordering_test.go
+++ b/pkg/kthena-router/datastore/ordering_test.go
@@ -59,14 +59,14 @@ func createTestModelServer(namespace, name string, engine aiv1alpha1.InferenceEn
 
 func newStoreWithMockBackend() *store {
 	return New(WithPodRuntimeInspector(&fakePodRuntimeInspector{
-		metricsFn: func(_ string, _ *corev1.Pod, _ map[string]*dto.Histogram) (map[string]float64, map[string]*dto.Histogram) {
+		metricsFn: func(_ string, _ *corev1.Pod, _ uint32, _ map[string]*dto.Histogram) (map[string]float64, map[string]*dto.Histogram) {
 			return map[string]float64{
 				utils.KVCacheUsage:      0.5,
 				utils.RequestWaitingNum: 10,
 				utils.RequestRunningNum: 5,
 			}, nil
 		},
-		modelsFn: func(_ string, _ *corev1.Pod) ([]string, error) {
+		modelsFn: func(_ string, _ *corev1.Pod, _ uint32) ([]string, error) {
 			return []string{"test-model"}, nil
 		},
 	})).(*store)

--- a/pkg/kthena-router/datastore/store.go
+++ b/pkg/kthena-router/datastore/store.go
@@ -140,18 +140,18 @@ type CallbackFunc func(data EventData)
 
 // PodRuntimeInspector fetches runtime metrics and loaded models for a pod.
 type PodRuntimeInspector interface {
-	GetPodMetrics(engine string, pod *corev1.Pod, previousHistogram map[string]*dto.Histogram) (map[string]float64, map[string]*dto.Histogram)
-	GetPodModels(engine string, pod *corev1.Pod) ([]string, error)
+	GetPodMetrics(engine string, pod *corev1.Pod, port uint32, previousHistogram map[string]*dto.Histogram) (map[string]float64, map[string]*dto.Histogram)
+	GetPodModels(engine string, pod *corev1.Pod, port uint32) ([]string, error)
 }
 
 type realPodRuntimeInspector struct{}
 
-func (realPodRuntimeInspector) GetPodMetrics(engine string, pod *corev1.Pod, previousHistogram map[string]*dto.Histogram) (map[string]float64, map[string]*dto.Histogram) {
-	return backend.GetPodMetrics(engine, pod, previousHistogram)
+func (realPodRuntimeInspector) GetPodMetrics(engine string, pod *corev1.Pod, port uint32, previousHistogram map[string]*dto.Histogram) (map[string]float64, map[string]*dto.Histogram) {
+	return backend.GetPodMetrics(engine, pod, port, previousHistogram)
 }
 
-func (realPodRuntimeInspector) GetPodModels(engine string, pod *corev1.Pod) ([]string, error) {
-	return backend.GetPodModels(engine, pod)
+func (realPodRuntimeInspector) GetPodModels(engine string, pod *corev1.Pod, port uint32) ([]string, error) {
+	return backend.GetPodModels(engine, pod, port)
 }
 
 type Option func(*store)
@@ -1348,8 +1348,9 @@ func (s *store) updatePodMetrics(pod *PodInfo) {
 		return
 	}
 
+	port := s.getPodWorkloadPort(pod)
 	previousHistogram := getPreviousHistogram(pod)
-	gaugeMetrics, histogramMetrics := s.getPodRuntimeInspector().GetPodMetrics(engine, podObj, previousHistogram)
+	gaugeMetrics, histogramMetrics := s.getPodRuntimeInspector().GetPodMetrics(engine, podObj, port, previousHistogram)
 	if gaugeMetrics != nil {
 		updateGaugeMetricsInfo(pod, gaugeMetrics)
 	}
@@ -1370,13 +1371,27 @@ func (s *store) updatePodModels(podInfo *PodInfo) {
 		return
 	}
 
-	models, err := s.getPodRuntimeInspector().GetPodModels(engine, podObj)
+	port := s.getPodWorkloadPort(podInfo)
+	models, err := s.getPodRuntimeInspector().GetPodModels(engine, podObj, port)
 	if err != nil {
 		klog.V(4).Infof("failed to get models of pod %s/%s: %v", podObj.GetNamespace(), podObj.GetName(), err)
 		return
 	}
 
 	podInfo.UpdateModels(models)
+}
+
+func (s *store) getPodWorkloadPort(podInfo *PodInfo) uint32 {
+	modelServers := podInfo.GetModelServers()
+	for msName := range modelServers {
+		if msValue, ok := s.modelServer.Load(msName); ok {
+			ms := msValue.(*modelServer).getModelServer()
+			if ms != nil && ms.Spec.WorkloadPort.Port > 0 {
+				return uint32(ms.Spec.WorkloadPort.Port)
+			}
+		}
+	}
+	return 0
 }
 
 func getPreviousHistogram(podinfo *PodInfo) map[string]*dto.Histogram {

--- a/pkg/kthena-router/datastore/store.go
+++ b/pkg/kthena-router/datastore/store.go
@@ -1348,6 +1348,9 @@ func (s *store) updatePodMetrics(pod *PodInfo) {
 		return
 	}
 
+	if podObj.Status.PodIP == "" {
+		return
+	}
 	port := s.getPodWorkloadPort(pod)
 	previousHistogram := getPreviousHistogram(pod)
 	gaugeMetrics, histogramMetrics := s.getPodRuntimeInspector().GetPodMetrics(engine, podObj, port, previousHistogram)
@@ -1371,6 +1374,9 @@ func (s *store) updatePodModels(podInfo *PodInfo) {
 		return
 	}
 
+	if podObj.Status.PodIP == "" {
+		return
+	}
 	port := s.getPodWorkloadPort(podInfo)
 	models, err := s.getPodRuntimeInspector().GetPodModels(engine, podObj, port)
 	if err != nil {

--- a/pkg/kthena-router/datastore/store_test.go
+++ b/pkg/kthena-router/datastore/store_test.go
@@ -259,7 +259,7 @@ func TestStoreUpdatePodMetrics(t *testing.T) {
 		pods:        sync.Map{},
 		modelServer: sync.Map{},
 		podRuntimeInspector: &fakePodRuntimeInspector{
-			metricsFn: func(_ string, _ *corev1.Pod, _ map[string]*dto.Histogram) (map[string]float64, map[string]*dto.Histogram) {
+			metricsFn: func(_ string, _ *corev1.Pod, _ uint32, _ map[string]*dto.Histogram) (map[string]float64, map[string]*dto.Histogram) {
 				return map[string]float64{
 						utils.KVCacheUsage:      0.8,
 						utils.RequestWaitingNum: 15,
@@ -1533,26 +1533,26 @@ func TestStoreMatchModelServer(t *testing.T) {
 }
 
 type fakePodRuntimeInspector struct {
-	metricsFn    func(string, *corev1.Pod, map[string]*dto.Histogram) (map[string]float64, map[string]*dto.Histogram)
-	modelsFn     func(string, *corev1.Pod) ([]string, error)
+	metricsFn    func(string, *corev1.Pod, uint32, map[string]*dto.Histogram) (map[string]float64, map[string]*dto.Histogram)
+	modelsFn     func(string, *corev1.Pod, uint32) ([]string, error)
 	metricsCalls atomic.Int64
 	modelsCalls  atomic.Int64
 }
 
-func (f *fakePodRuntimeInspector) GetPodMetrics(engine string, pod *corev1.Pod, previousHistogram map[string]*dto.Histogram) (map[string]float64, map[string]*dto.Histogram) {
+func (f *fakePodRuntimeInspector) GetPodMetrics(engine string, pod *corev1.Pod, port uint32, previousHistogram map[string]*dto.Histogram) (map[string]float64, map[string]*dto.Histogram) {
 	f.metricsCalls.Add(1)
 	if f.metricsFn == nil {
 		return nil, nil
 	}
-	return f.metricsFn(engine, pod, previousHistogram)
+	return f.metricsFn(engine, pod, port, previousHistogram)
 }
 
-func (f *fakePodRuntimeInspector) GetPodModels(engine string, pod *corev1.Pod) ([]string, error) {
+func (f *fakePodRuntimeInspector) GetPodModels(engine string, pod *corev1.Pod, port uint32) ([]string, error) {
 	f.modelsCalls.Add(1)
 	if f.modelsFn == nil {
 		return nil, nil
 	}
-	return f.modelsFn(engine, pod)
+	return f.modelsFn(engine, pod, port)
 }
 
 func newStore(inspector ...PodRuntimeInspector) *store {
@@ -1670,10 +1670,10 @@ func TestAddOrUpdatePod_MetricsPreservedOnUpdate(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			inspector := &fakePodRuntimeInspector{
-				metricsFn: func(_ string, _ *corev1.Pod, _ map[string]*dto.Histogram) (map[string]float64, map[string]*dto.Histogram) {
+				metricsFn: func(_ string, _ *corev1.Pod, _ uint32, _ map[string]*dto.Histogram) (map[string]float64, map[string]*dto.Histogram) {
 					return tc.initialMetrics, tc.initialHist
 				},
-				modelsFn: func(_ string, _ *corev1.Pod) ([]string, error) {
+				modelsFn: func(_ string, _ *corev1.Pod, _ uint32) ([]string, error) {
 					return tc.initialModels, nil
 				},
 			}
@@ -1734,13 +1734,13 @@ func TestAddOrUpdatePod_MetricsPreservedOnUpdate(t *testing.T) {
 
 func TestAddOrUpdatePod_NewPodStillFetchesMetrics(t *testing.T) {
 	inspector := &fakePodRuntimeInspector{
-		metricsFn: func(_ string, _ *corev1.Pod, _ map[string]*dto.Histogram) (map[string]float64, map[string]*dto.Histogram) {
+		metricsFn: func(_ string, _ *corev1.Pod, _ uint32, _ map[string]*dto.Histogram) (map[string]float64, map[string]*dto.Histogram) {
 			return map[string]float64{
 				utils.KVCacheUsage:      0.3,
 				utils.RequestRunningNum: 2,
 			}, map[string]*dto.Histogram{}
 		},
-		modelsFn: func(_ string, _ *corev1.Pod) ([]string, error) {
+		modelsFn: func(_ string, _ *corev1.Pod, _ uint32) ([]string, error) {
 			return []string{"base-model"}, nil
 		},
 	}
@@ -1763,7 +1763,7 @@ func TestAddOrUpdatePod_NewPodStillFetchesMetrics(t *testing.T) {
 
 func TestAddOrUpdatePod_ModelServerChangePreservesMetrics(t *testing.T) {
 	inspector := &fakePodRuntimeInspector{
-		metricsFn: func(_ string, _ *corev1.Pod, _ map[string]*dto.Histogram) (map[string]float64, map[string]*dto.Histogram) {
+		metricsFn: func(_ string, _ *corev1.Pod, _ uint32, _ map[string]*dto.Histogram) (map[string]float64, map[string]*dto.Histogram) {
 			return map[string]float64{
 				utils.KVCacheUsage:      0.6,
 				utils.RequestWaitingNum: 5,
@@ -1772,7 +1772,7 @@ func TestAddOrUpdatePod_ModelServerChangePreservesMetrics(t *testing.T) {
 				utils.TTFT:              0.2,
 			}, map[string]*dto.Histogram{}
 		},
-		modelsFn: func(_ string, _ *corev1.Pod) ([]string, error) {
+		modelsFn: func(_ string, _ *corev1.Pod, _ uint32) ([]string, error) {
 			return []string{"model-a"}, nil
 		},
 	}

--- a/pkg/kthena-router/datastore/store_test.go
+++ b/pkg/kthena-router/datastore/store_test.go
@@ -235,7 +235,11 @@ func TestStoreUpdatePodMetrics(t *testing.T) {
 	sum2 := float64(2)
 	count2 := uint64(2)
 	podinfo := PodInfo{
-		Pod:    &corev1.Pod{},
+		Pod: &corev1.Pod{
+			Status: corev1.PodStatus{
+				PodIP: "10.0.0.1",
+			},
+		},
 		engine: "vLLM",
 		TimePerOutputToken: &dto.Histogram{
 			SampleSum:   &sum1,
@@ -1680,9 +1684,15 @@ func TestAddOrUpdatePod_MetricsPreservedOnUpdate(t *testing.T) {
 			s := newStore(inspector)
 
 			ms := createTestModelServer("default", "ms1", aiv1alpha1.VLLM)
+			ms.Spec.WorkloadPort.Port = 8000
 			s.AddOrUpdateModelServer(ms, sets.New[types.NamespacedName]())
 
 			pod := createTestPod("default", "pod1")
+			pod.Status.PodIP = "10.0.0.1"
+			if pod.Annotations == nil {
+				pod.Annotations = make(map[string]string)
+			}
+			pod.Annotations["kthena.io/engine"] = "vLLM"
 			err := s.AddOrUpdatePod(pod, []*aiv1alpha1.ModelServer{ms})
 			assert.NoError(t, err)
 			assert.Equal(t, int64(1), inspector.metricsCalls.Load(), "backend metrics should be fetched on initial pod add")
@@ -1747,9 +1757,15 @@ func TestAddOrUpdatePod_NewPodStillFetchesMetrics(t *testing.T) {
 	s := newStore(inspector)
 
 	ms := createTestModelServer("default", "ms1", aiv1alpha1.VLLM)
+	ms.Spec.WorkloadPort.Port = 8000
 	s.AddOrUpdateModelServer(ms, sets.New[types.NamespacedName]())
 
 	pod := createTestPod("default", "fresh-pod")
+	pod.Status.PodIP = "10.0.0.1"
+	if pod.Annotations == nil {
+		pod.Annotations = make(map[string]string)
+	}
+	pod.Annotations["kthena.io/engine"] = "vLLM"
 	err := s.AddOrUpdatePod(pod, []*aiv1alpha1.ModelServer{ms})
 	assert.NoError(t, err)
 
@@ -1779,11 +1795,18 @@ func TestAddOrUpdatePod_ModelServerChangePreservesMetrics(t *testing.T) {
 	s := newStore(inspector)
 
 	ms1 := createTestModelServer("default", "ms1", aiv1alpha1.VLLM)
+	ms1.Spec.WorkloadPort.Port = 8000
 	ms2 := createTestModelServer("default", "ms2", aiv1alpha1.VLLM)
+	ms2.Spec.WorkloadPort.Port = 8000
 	s.AddOrUpdateModelServer(ms1, sets.New[types.NamespacedName]())
 	s.AddOrUpdateModelServer(ms2, sets.New[types.NamespacedName]())
 
 	pod := createTestPod("default", "pod1")
+	pod.Status.PodIP = "10.0.0.1"
+	if pod.Annotations == nil {
+		pod.Annotations = make(map[string]string)
+	}
+	pod.Annotations["kthena.io/engine"] = "vLLM"
 	err := s.AddOrUpdatePod(pod, []*aiv1alpha1.ModelServer{ms1})
 	assert.NoError(t, err)
 	assert.Equal(t, int64(1), inspector.metricsCalls.Load(), "backend metrics should be fetched on initial pod add")

--- a/pkg/kthena-router/router/router_test.go
+++ b/pkg/kthena-router/router/router_test.go
@@ -59,13 +59,33 @@ func TestMain(m *testing.M) {
 	os.Exit(exitCode)
 }
 
+func withMetricsEndpoint(handler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/metrics" {
+			w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+			fmt.Fprint(w, "# TYPE up gauge\nup 1\n")
+			return
+		}
+		if r.URL.Path == "/v1/models" {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"data":[]}`)
+			return
+		}
+		if r.URL.Path != "/v1/chat/completions" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		handler.ServeHTTP(w, r)
+	})
+}
+
 // setupTestRouter initializes a router and its dependencies for testing.
 // It uses a mock HTTP server as the backend, following the community's recommendation
 // to avoid hacky dependency injection.
 func setupTestRouter(t *testing.T, backendHandler http.Handler) (*Router, datastore.Store, *httptest.Server) {
 	gin.SetMode(gin.TestMode)
 
-	backend := httptest.NewServer(backendHandler)
+	backend := httptest.NewServer(withMetricsEndpoint(backendHandler))
 	store := datastore.New()
 	router := NewRouter(store, "../scheduler/testdata/configmap.yaml")
 
@@ -1091,6 +1111,17 @@ func TestProxy_RetryBodyNotDrained(t *testing.T) {
 	// Single backend: returns 503 on the first call, 200 on the second.
 	// Both pods in the test point to this same server so we can observe both attempts.
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/metrics" {
+			w.Header().Set("Content-Type", "text/plain; version=0.0.4")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, "")
+			return
+		}
+		if r.URL.Path == "/v1/models" {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"data":[]}`)
+			return
+		}
 		body, _ := io.ReadAll(r.Body)
 		receivedBodies = append(receivedBodies, string(body))
 		if len(receivedBodies) == 1 {


### PR DESCRIPTION
… default

**What type of PR is this?**
/kind enhancement
<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:
Implemented support for configurable metric ports by propagating ModelServer.WorkloadPort through backend, datastore, and runtime inspection layers. Refactored vLLM and sGLang engines to remove hardcoded ports and use runtime-provided ports with default fallbacks for backward compatibility. Updated MetricsProvider and PodRuntimeInspector interfaces to pass port information for metrics and model discovery. Added workload port resolution logic in the datastore and fixed all affected unit, controller, and integration tests to align with the new interface changes.
**Which issue(s) this PR fixes**:
Fixes #1185 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
