### PR TITLE
test: Gate e2e tests behind build tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,32 +98,32 @@ test-e2e: ## Run all e2e tests sequentially (legacy).
 	@echo "Setting up Kind cluster for E2E tests..."
 	@./test/e2e/setup.sh
 	@echo "Running E2E tests sequentially..."
-	@KUBECONFIG=/tmp/kubeconfig-e2e go test -p 1 $$(go list ./... | grep /test/e2e) -v -timeout=15m
+	@KUBECONFIG=/tmp/kubeconfig-e2e go test -tags=e2e -p 1 $$(go list -tags=e2e ./... | grep /test/e2e) -v -timeout=15m
 	@echo "E2E tests completed"
 
 .PHONY: test-e2e-controller-manager
 test-e2e-controller-manager: ## Run controller-manager e2e tests.
 	@command -v kind >/dev/null 2>&1 || { echo "Kind is not installed."; exit 1; }
 	@TEST_CATEGORY=controller-manager ./test/e2e/setup.sh
-	@KUBECONFIG=/tmp/kubeconfig-e2e go test -v -timeout=15m ./test/e2e/controller-manager/...
+	@KUBECONFIG=/tmp/kubeconfig-e2e go test -tags=e2e -v -timeout=15m ./test/e2e/controller-manager/...
 
 .PHONY: test-e2e-router
 test-e2e-router: ## Run router e2e tests.
 	@command -v kind >/dev/null 2>&1 || { echo "Kind is not installed."; exit 1; }
 	@TEST_CATEGORY=router ./test/e2e/setup.sh
-	@KUBECONFIG=/tmp/kubeconfig-e2e go test -v -timeout=18m ./test/e2e/router
+	@KUBECONFIG=/tmp/kubeconfig-e2e go test -tags=e2e -v -timeout=18m ./test/e2e/router
 
 .PHONY: test-e2e-gateway-api
 test-e2e-gateway-api: ## Run gateway-api e2e tests.
 	@command -v kind >/dev/null 2>&1 || { echo "Kind is not installed."; exit 1; }
 	@TEST_CATEGORY=gateway-api ./test/e2e/setup.sh
-	@KUBECONFIG=/tmp/kubeconfig-e2e go test -v -timeout=10m ./test/e2e/router/gateway-api/...
+	@KUBECONFIG=/tmp/kubeconfig-e2e go test -tags=e2e -v -timeout=10m ./test/e2e/router/gateway-api/...
 
 .PHONY: test-e2e-gateway-inference-extension
 test-e2e-gateway-inference-extension: ## Run gateway-inference-extension e2e tests.
 	@command -v kind >/dev/null 2>&1 || { echo "Kind is not installed."; exit 1; }
 	@TEST_CATEGORY=gateway-inference-extension ./test/e2e/setup.sh
-	@KUBECONFIG=/tmp/kubeconfig-e2e go test -v -timeout=10m ./test/e2e/router/gateway-inference-extension/...
+	@KUBECONFIG=/tmp/kubeconfig-e2e go test -tags=e2e -v -timeout=10m ./test/e2e/router/gateway-inference-extension/...
 
 .PHONY: test-e2e-cleanup
 test-e2e-cleanup: ## Clean up the Kind cluster used for E2E tests.

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -120,7 +120,7 @@ Tests that do not require the vLLM image (like webhook validation/mutation tests
 For example, to run the controller manager webhook tests:
 
 ```bash
-go test -v ./test/e2e/controller-manager/ -run TestWebhook
+go test -tags=e2e -v ./test/e2e/controller-manager/ -run TestWebhook
 ```
 
 ## Troubleshooting

--- a/test/e2e/controller-manager/autoscaling_test.go
+++ b/test/e2e/controller-manager/autoscaling_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
 Copyright The Volcano Authors.
 

--- a/test/e2e/controller-manager/model_booster_test.go
+++ b/test/e2e/controller-manager/model_booster_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
 Copyright The Volcano Authors.
 

--- a/test/e2e/controller-manager/model_serving_test.go
+++ b/test/e2e/controller-manager/model_serving_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
 Copyright The Volcano Authors.
 
@@ -276,7 +278,7 @@ func TestModelServingRoleScaleDown(t *testing.T) {
 	t.Log("Creating ModelServing with 1 servingGroup, prefill role with 3 replicas")
 	createAndWaitForModelServing(t, ctx, kthenaClient, modelServing)
 
-	// Verify initial pods (expect 3: 1 servingGroup × 3 role replicas × 1 entry pod)
+	// Verify initial pods (expect 3: 1 servingGroup x 3 role replicas x 1 entry pod)
 	waitForRunningPodCount(t, ctx, kubeClient, modelServing.Name, 3, 3*time.Minute)
 	t.Log("Verified 3 running pods initially")
 
@@ -1798,7 +1800,7 @@ func TestModelServingControllerManagerRestart(t *testing.T) {
 	ctx, kthenaClient, kubeClient := setupControllerManagerE2ETest(t)
 
 	// Create a complicated ModelServing with multiple roles
-	// 5 serving groups × (3 pods for prefill + 2 pods for decode) = 25 pods total
+	// 5 serving groups x (3 pods for prefill + 2 pods for decode) = 25 pods total
 	prefillRole := createRole("prefill", 1, 2)
 	decodeRole := createRole("decode", 1, 1)
 	modelServing := createBasicModelServing("test-controller-restart", 5, 0, prefillRole, decodeRole)
@@ -1868,7 +1870,7 @@ func TestModelServingControllerManagerRestart(t *testing.T) {
 	require.NoError(t, err, "Failed to list ModelServing pods")
 
 	// Calculate expected pod count:
-	// 5 serving groups × (3 pods for prefill role + 2 pods for decode role) = 25 pods
+	// 5 serving groups x (3 pods for prefill role + 2 pods for decode role) = 25 pods
 	expectedPodCount := 25
 	actualPodCount := len(podList.Items)
 
@@ -2010,7 +2012,7 @@ func TestModelServingRoleBasedRollingUpdate(t *testing.T) {
 	// Monitor the role-based rolling update to ensure only prefill role pods are replaced
 	t.Log("Monitoring role-based rolling update to ensure only prefill role pods are replaced while decode role pods remain")
 
-	// It is possible that the ‘modelServing Ready’ check completed before the change in the modelServing status,
+	// It is possible that the 'modelServing Ready' check completed before the change in the modelServing status,
 	// causing subsequent checks to fail. Therefore, the checks have been retried.
 	// This has improved the robustness of the end-to-end tests.
 	require.Eventually(t, func() bool {

--- a/test/e2e/controller-manager/test_suite_test.go
+++ b/test/e2e/controller-manager/test_suite_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
 Copyright The Volcano Authors.
 

--- a/test/e2e/controller-manager/webhook_test.go
+++ b/test/e2e/controller-manager/webhook_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
 Copyright The Volcano Authors.
 

--- a/test/e2e/router/debug_test.go
+++ b/test/e2e/router/debug_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
 Copyright The Volcano Authors.
 

--- a/test/e2e/router/e2e_test.go
+++ b/test/e2e/router/e2e_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
 Copyright The Volcano Authors.
 

--- a/test/e2e/router/gateway-api/e2e_test.go
+++ b/test/e2e/router/gateway-api/e2e_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
 Copyright The Volcano Authors.
 

--- a/test/e2e/router/gateway-inference-extension/e2e_test.go
+++ b/test/e2e/router/gateway-inference-extension/e2e_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
 Copyright The Volcano Authors.
 

--- a/test/e2e/router/plugins_test.go
+++ b/test/e2e/router/plugins_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
 Copyright The Volcano Authors.
 
@@ -211,7 +213,7 @@ func TestSchedulerPluginRandom(t *testing.T) {
 	}
 	require.GreaterOrEqual(t, routed, 200/2, "expected access logs for routed requests")
 
-	// Each pod should receive roughly 1/3 of traffic (±10% absolute ratio).
+	// Each pod should receive roughly 1/3 of traffic (+/-10% absolute ratio).
 	const randomMaxRatioDeviation = 0.10
 	expectedRatio := 1.0 / float64(len(pods))
 	for i, c := range counts {

--- a/test/e2e/router/webhook_test.go
+++ b/test/e2e/router/webhook_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
 Copyright The Volcano Authors.
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Running `go test ./...` should be a quick way to run the regular Go test suite. Today it can also discover E2E packages, whose `TestMain` tries to install Kthena into a cluster with Helm. That makes a normal local test run fail on machines that are not set up for E2E testing.

This PR puts the E2E test files behind the `e2e` build tag and updates the E2E Make targets to opt in with `-tags=e2e`. The legacy all-E2E target now also uses `go list -tags=e2e`, so packages that only contain tagged test files are still included when E2E tests are requested explicitly.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

I used AI assistance while preparing this PR and reviewed the final changes locally.

Tested with:
- `go test ./...`
- `go test -tags=e2e -c ./test/e2e/controller-manager`
- `go test -tags=e2e -c ./test/e2e/router`
- `go test -tags=e2e -c ./test/e2e/router/gateway-api`
- `go test -tags=e2e -c ./test/e2e/router/gateway-inference-extension`
- `git diff --check`

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```