### PR TITLE
autoscaler: Fix external metric aggregation

### DIFF
--- a/charts/kthena/charts/workload/crds/workload.serving.volcano.sh_autoscalingpolicies.yaml
+++ b/charts/kthena/charts/workload/crds/workload.serving.volcano.sh_autoscalingpolicies.yaml
@@ -171,6 +171,20 @@ spec:
                   description: AutoscalingPolicyMetric defines a metric and its target
                     value for scaling decisions.
                   properties:
+                    aggregation:
+                      allOf:
+                      - enum:
+                        - Sum
+                        - Avg
+                      - enum:
+                        - Sum
+                        - Avg
+                      default: Sum
+                      description: |-
+                        Aggregation defines how the metric should be aggregated across multiple instances.
+                        'Sum' is used for additive metrics like queue length or request counts.
+                        'Avg' is used for ratio/percentage metrics like GPU utilization or cache usage.
+                      type: string
                     name:
                       description: Name defines the metric key used by the scaling
                         algorithm.

--- a/charts/kthena/charts/workload/crds/workload.serving.volcano.sh_modelboosters.yaml
+++ b/charts/kthena/charts/workload/crds/workload.serving.volcano.sh_modelboosters.yaml
@@ -175,6 +175,20 @@ spec:
                       description: AutoscalingPolicyMetric defines a metric and its
                         target value for scaling decisions.
                       properties:
+                        aggregation:
+                          allOf:
+                          - enum:
+                            - Sum
+                            - Avg
+                          - enum:
+                            - Sum
+                            - Avg
+                          default: Sum
+                          description: |-
+                            Aggregation defines how the metric should be aggregated across multiple instances.
+                            'Sum' is used for additive metrics like queue length or request counts.
+                            'Avg' is used for ratio/percentage metrics like GPU utilization or cache usage.
+                          type: string
                         name:
                           description: Name defines the metric key used by the scaling
                             algorithm.

--- a/client-go/applyconfiguration/workload/v1alpha1/autoscalingpolicymetric.go
+++ b/client-go/applyconfiguration/workload/v1alpha1/autoscalingpolicymetric.go
@@ -19,14 +19,16 @@ limitations under the License.
 package v1alpha1
 
 import (
+	workloadv1alpha1 "github.com/volcano-sh/kthena/pkg/apis/workload/v1alpha1"
 	resource "k8s.io/apimachinery/pkg/api/resource"
 )
 
 // AutoscalingPolicyMetricApplyConfiguration represents a declarative configuration of the AutoscalingPolicyMetric type for use
 // with apply.
 type AutoscalingPolicyMetricApplyConfiguration struct {
-	Name        *string            `json:"name,omitempty"`
-	TargetValue *resource.Quantity `json:"targetValue,omitempty"`
+	Name        *string                           `json:"name,omitempty"`
+	TargetValue *resource.Quantity                `json:"targetValue,omitempty"`
+	Aggregation *workloadv1alpha1.AggregationType `json:"aggregation,omitempty"`
 }
 
 // AutoscalingPolicyMetricApplyConfiguration constructs a declarative configuration of the AutoscalingPolicyMetric type for use with
@@ -48,5 +50,13 @@ func (b *AutoscalingPolicyMetricApplyConfiguration) WithName(value string) *Auto
 // If called multiple times, the TargetValue field is set to the value of the last call.
 func (b *AutoscalingPolicyMetricApplyConfiguration) WithTargetValue(value resource.Quantity) *AutoscalingPolicyMetricApplyConfiguration {
 	b.TargetValue = &value
+	return b
+}
+
+// WithAggregation sets the Aggregation field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the Aggregation field is set to the value of the last call.
+func (b *AutoscalingPolicyMetricApplyConfiguration) WithAggregation(value workloadv1alpha1.AggregationType) *AutoscalingPolicyMetricApplyConfiguration {
+	b.Aggregation = &value
 	return b
 }

--- a/docs/kthena/docs/reference/crd/workload.serving.volcano.sh.md
+++ b/docs/kthena/docs/reference/crd/workload.serving.volcano.sh.md
@@ -19,6 +19,24 @@
 
 
 
+#### AggregationType
+
+_Underlying type:_ _string_
+
+AggregationType defines the strategy for aggregating external metrics across backends.
+
+_Validation:_
+- Enum: [Sum Avg]
+
+_Appears in:_
+- [AutoscalingPolicyMetric](#autoscalingpolicymetric)
+
+| Field | Description |
+| --- | --- |
+| `Sum` |  |
+| `Avg` |  |
+
+
 #### AutoscalingPolicy
 
 
@@ -180,6 +198,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `name` _string_ | Name defines the metric key used by the scaling algorithm. |  | MinLength: 1 <br /> |
 | `targetValue` _[Quantity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#quantity-resource-api)_ | TargetValue defines the target value for the metric that triggers scaling operations. |  |  |
+| `aggregation` _[AggregationType](#aggregationtype)_ | Aggregation defines how the metric should be aggregated across multiple instances.<br />'Sum' is used for additive metrics like queue length or request counts.<br />'Avg' is used for ratio/percentage metrics like GPU utilization or cache usage. | Sum | Enum: [Sum Avg] <br /> |
 
 
 #### AutoscalingPolicyPanicPolicy

--- a/pkg/apis/workload/v1alpha1/autoscalingpolicy_types.go
+++ b/pkg/apis/workload/v1alpha1/autoscalingpolicy_types.go
@@ -46,7 +46,23 @@ type AutoscalingPolicyMetric struct {
 	Name string `json:"name"`
 	// TargetValue defines the target value for the metric that triggers scaling operations.
 	TargetValue resource.Quantity `json:"targetValue"`
+	// Aggregation defines how the metric should be aggregated across multiple instances.
+	// 'Sum' is used for additive metrics like queue length or request counts.
+	// 'Avg' is used for ratio/percentage metrics like GPU utilization or cache usage.
+	// +kubebuilder:validation:Enum=Sum;Avg
+	// +kubebuilder:default="Sum"
+	// +optional
+	Aggregation AggregationType `json:"aggregation,omitempty"`
 }
+
+// AggregationType defines the strategy for aggregating external metrics across backends.
+// +kubebuilder:validation:Enum=Sum;Avg
+type AggregationType string
+
+const (
+	AggregationTypeSum AggregationType = "Sum"
+	AggregationTypeAvg AggregationType = "Avg"
+)
 
 // AutoscalingPolicyBehavior defines the scaling behavior configuration for both scale up and scale down operations.
 type AutoscalingPolicyBehavior struct {

--- a/pkg/autoscaler/autoscaler/metric_collector.go
+++ b/pkg/autoscaler/autoscaler/metric_collector.go
@@ -99,6 +99,23 @@ func GetMetricTargets(autoscalePolicy *v1alpha1.AutoscalingPolicy) algorithm.Met
 	return metricTargets
 }
 
+func GetMetricAggregations(autoscalePolicy *v1alpha1.AutoscalingPolicy) map[string]v1alpha1.AggregationType {
+	metricAggregations := make(map[string]v1alpha1.AggregationType)
+	if autoscalePolicy == nil {
+		klog.Warning("autoscalePolicy is nil, can't get metricAggregations")
+		return metricAggregations
+	}
+
+	for _, metric := range autoscalePolicy.Spec.Metrics {
+		if metric.Aggregation == "" {
+			metricAggregations[metric.Name] = v1alpha1.AggregationTypeSum
+		} else {
+			metricAggregations[metric.Name] = metric.Aggregation
+		}
+	}
+	return metricAggregations
+}
+
 func (collector *MetricCollector) UpdateMetrics(
 	ctx context.Context,
 	podLister listerv1.PodLister,

--- a/pkg/autoscaler/autoscaler/metric_collector.go
+++ b/pkg/autoscaler/autoscaler/metric_collector.go
@@ -517,11 +517,3 @@ func (collector *MetricCollector) getPrometheusAPI(serverURL string, timeout tim
 	collector.promClients[serverURL] = client
 	return prometheusv1.NewAPI(client), nil
 }
-
-func addMetric(instanceMetricMap algorithm.Metrics, metricName string, metricValue float64) {
-	if oldValue, ok := instanceMetricMap[metricName]; ok {
-		instanceMetricMap[metricName] = oldValue + metricValue
-	} else {
-		instanceMetricMap[metricName] = metricValue
-	}
-}

--- a/pkg/autoscaler/autoscaler/optimizer.go
+++ b/pkg/autoscaler/autoscaler/optimizer.go
@@ -19,7 +19,6 @@ package autoscaler
 import (
 	"context"
 	"sort"
-	"strings"
 
 	workload "github.com/volcano-sh/kthena/pkg/apis/workload/v1alpha1"
 	"github.com/volcano-sh/kthena/pkg/autoscaler/algorithm"
@@ -35,12 +34,13 @@ type Optimizer struct {
 }
 
 type OptimizerMeta struct {
-	Config        *workload.HeterogeneousTarget
-	MetricTargets map[string]float64
-	ScalingOrder  []*ReplicaBlock
-	MinReplicas   int32
-	MaxReplicas   int32
-	Scope         Scope
+	Config             *workload.HeterogeneousTarget
+	MetricTargets      map[string]float64
+	MetricAggregations map[string]workload.AggregationType
+	ScalingOrder       []*ReplicaBlock
+	MinReplicas        int32
+	MaxReplicas        int32
+	Scope              Scope
 }
 
 type ReplicaBlock struct {
@@ -133,6 +133,7 @@ func NewOptimizer(autoscalePolicy *workload.AutoscalingPolicy, binding *workload
 
 	meta := NewOptimizerMeta(binding)
 	meta.MetricTargets = metricTargets
+	meta.MetricAggregations = GetMetricAggregations(autoscalePolicy)
 	return &Optimizer{
 		Meta:       meta,
 		Collectors: collectors,
@@ -174,7 +175,8 @@ func (optimizer *Optimizer) Optimize(ctx context.Context, podLister listerv1.Pod
 		unreadyInstancesCount += currentUnreadyInstancesCount
 		readyInstancesMetrics = append(readyInstancesMetrics, currentReadyInstancesMetrics)
 		for metricName, metricValue := range currentExternalMetrics {
-			addExternalMetric(externalMetricAggregates, metricName, metricValue, currentInstancesCount)
+			aggType := optimizer.Meta.MetricAggregations[metricName]
+			addExternalMetric(externalMetricAggregates, metricName, metricValue, currentInstancesCount, aggType)
 		}
 	}
 	externalMetrics := finalizeExternalMetrics(externalMetricAggregates)
@@ -216,20 +218,21 @@ func (optimizer *Optimizer) Optimize(ctx context.Context, podLister listerv1.Pod
 }
 
 type externalMetricAggregate struct {
-	sum         float64
-	weightedSum float64
-	weight      int32
-	count       int32
+	aggregationType workload.AggregationType
+	sum             float64
+	weightedSum     float64
+	weight          int32
+	count           int32
 }
 
-func addExternalMetric(aggregates map[string]*externalMetricAggregate, metricName string, metricValue float64, replicas int32) {
+func addExternalMetric(aggregates map[string]*externalMetricAggregate, metricName string, metricValue float64, replicas int32, aggType workload.AggregationType) {
 	aggregate, ok := aggregates[metricName]
 	if !ok {
-		aggregate = &externalMetricAggregate{}
+		aggregate = &externalMetricAggregate{aggregationType: aggType}
 		aggregates[metricName] = aggregate
 	}
 	aggregate.count++
-	if averageExternalMetric(metricName) {
+	if aggType == workload.AggregationTypeAvg {
 		if replicas > 0 {
 			aggregate.weightedSum += metricValue * float64(replicas)
 			aggregate.weight += replicas
@@ -244,7 +247,7 @@ func addExternalMetric(aggregates map[string]*externalMetricAggregate, metricNam
 func finalizeExternalMetrics(aggregates map[string]*externalMetricAggregate) algorithm.Metrics {
 	metrics := make(algorithm.Metrics, len(aggregates))
 	for metricName, aggregate := range aggregates {
-		if averageExternalMetric(metricName) {
+		if aggregate.aggregationType == workload.AggregationTypeAvg {
 			if aggregate.weight > 0 {
 				metrics[metricName] = aggregate.weightedSum
 				continue
@@ -255,33 +258,4 @@ func finalizeExternalMetrics(aggregates map[string]*externalMetricAggregate) alg
 		metrics[metricName] = aggregate.sum
 	}
 	return metrics
-}
-
-func averageExternalMetric(metricName string) bool {
-	name := strings.ToLower(metricName)
-	for _, suffix := range []string{"utilization", "usage", "percent", "percentage", "ratio", "perc"} {
-		if metricNameHasSuffix(name, suffix) {
-			return true
-		}
-	}
-	return false
-}
-
-func metricNameHasSuffix(name, suffix string) bool {
-	if name == suffix {
-		return true
-	}
-	if !strings.HasSuffix(name, suffix) {
-		return false
-	}
-	beforeIdx := len(name) - len(suffix) - 1
-	if beforeIdx < 0 {
-		return false
-	}
-	switch name[beforeIdx] {
-	case '_', '-', '.', '/':
-		return true
-	default:
-		return false
-	}
 }

--- a/pkg/autoscaler/autoscaler/optimizer.go
+++ b/pkg/autoscaler/autoscaler/optimizer.go
@@ -19,6 +19,7 @@ package autoscaler
 import (
 	"context"
 	"sort"
+	"strings"
 
 	workload "github.com/volcano-sh/kthena/pkg/apis/workload/v1alpha1"
 	"github.com/volcano-sh/kthena/pkg/autoscaler/algorithm"
@@ -152,17 +153,19 @@ func (optimizer *Optimizer) Optimize(ctx context.Context, podLister listerv1.Pod
 	size := len(optimizer.Meta.Config.Params)
 	unreadyInstancesCount := int32(0)
 	readyInstancesMetrics := make([]algorithm.Metrics, 0, size)
-	externalMetrics := make(algorithm.Metrics)
+	externalMetricAggregates := make(map[string]*externalMetricAggregate)
 	instancesCountSum := int32(0)
 	// Update all model serving instances' metrics
 	for _, param := range optimizer.Meta.Config.Params {
-		collector, exists := optimizer.Collectors[param.Target.TargetRef.Name]
+		targetName := param.Target.TargetRef.Name
+		collector, exists := optimizer.Collectors[targetName]
 		if !exists {
-			klog.Warningf("collector for target %s not exists", param.Target.TargetRef.Name)
+			klog.Warningf("collector for target %s not exists", targetName)
 			continue
 		}
 
-		instancesCountSum += currentInstancesCounts[param.Target.TargetRef.Name]
+		currentInstancesCount := currentInstancesCounts[targetName]
+		instancesCountSum += currentInstancesCount
 		currentUnreadyInstancesCount, currentReadyInstancesMetrics, currentExternalMetrics, err := collector.UpdateMetrics(ctx, podLister, param.Target.MetricSources)
 		if err != nil {
 			klog.Warningf("update metrics error: %v", err)
@@ -170,15 +173,11 @@ func (optimizer *Optimizer) Optimize(ctx context.Context, podLister listerv1.Pod
 		}
 		unreadyInstancesCount += currentUnreadyInstancesCount
 		readyInstancesMetrics = append(readyInstancesMetrics, currentReadyInstancesMetrics)
-		// TODO: External metrics are aggregated with a plain sum across targets.
-		// This is correct for additive metrics (for example queue length), but it
-		// is semantically wrong for ratio metrics such as GPU utilization.
-		// Introduce per-metric aggregation strategy (sum/avg/max/weighted) in a
-		// follow-up change and apply it here instead of unconditional summation.
 		for metricName, metricValue := range currentExternalMetrics {
-			addMetric(externalMetrics, metricName, metricValue)
+			addExternalMetric(externalMetricAggregates, metricName, metricValue, currentInstancesCount)
 		}
 	}
+	externalMetrics := finalizeExternalMetrics(externalMetricAggregates)
 	// Get recommended replicas of all model serving instances
 	instancesAlgorithm := algorithm.RecommendedInstancesAlgorithm{
 		MinInstances:          optimizer.Meta.MinReplicas,
@@ -214,4 +213,75 @@ func (optimizer *Optimizer) Optimize(ctx context.Context, podLister listerv1.Pod
 
 	replicasMap := optimizer.Meta.RestoreReplicasOfEachBackend(recommendedInstances)
 	return replicasMap, nil
+}
+
+type externalMetricAggregate struct {
+	sum         float64
+	weightedSum float64
+	weight      int32
+	count       int32
+}
+
+func addExternalMetric(aggregates map[string]*externalMetricAggregate, metricName string, metricValue float64, replicas int32) {
+	aggregate, ok := aggregates[metricName]
+	if !ok {
+		aggregate = &externalMetricAggregate{}
+		aggregates[metricName] = aggregate
+	}
+	aggregate.count++
+	if averageExternalMetric(metricName) {
+		if replicas > 0 {
+			aggregate.weightedSum += metricValue * float64(replicas)
+			aggregate.weight += replicas
+			return
+		}
+		aggregate.sum += metricValue
+		return
+	}
+	aggregate.sum += metricValue
+}
+
+func finalizeExternalMetrics(aggregates map[string]*externalMetricAggregate) algorithm.Metrics {
+	metrics := make(algorithm.Metrics, len(aggregates))
+	for metricName, aggregate := range aggregates {
+		if averageExternalMetric(metricName) {
+			if aggregate.weight > 0 {
+				metrics[metricName] = aggregate.weightedSum
+				continue
+			}
+			metrics[metricName] = aggregate.sum / float64(aggregate.count)
+			continue
+		}
+		metrics[metricName] = aggregate.sum
+	}
+	return metrics
+}
+
+func averageExternalMetric(metricName string) bool {
+	name := strings.ToLower(metricName)
+	for _, suffix := range []string{"utilization", "usage", "percent", "percentage", "ratio", "perc"} {
+		if metricNameHasSuffix(name, suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+func metricNameHasSuffix(name, suffix string) bool {
+	if name == suffix {
+		return true
+	}
+	if !strings.HasSuffix(name, suffix) {
+		return false
+	}
+	beforeIdx := len(name) - len(suffix) - 1
+	if beforeIdx < 0 {
+		return false
+	}
+	switch name[beforeIdx] {
+	case '_', '-', '.', '/':
+		return true
+	default:
+		return false
+	}
 }

--- a/pkg/autoscaler/autoscaler/optimizer_test.go
+++ b/pkg/autoscaler/autoscaler/optimizer_test.go
@@ -198,6 +198,7 @@ func TestExternalMetricAggregation(t *testing.T) {
 		name    string
 		samples []struct {
 			metricName string
+			aggType    workload.AggregationType
 			value      float64
 			replicas   int32
 		}
@@ -207,11 +208,12 @@ func TestExternalMetricAggregation(t *testing.T) {
 			name: "additive metrics are summed across backends",
 			samples: []struct {
 				metricName string
+				aggType    workload.AggregationType
 				value      float64
 				replicas   int32
 			}{
-				{metricName: "num_requests_waiting", value: 10, replicas: 2},
-				{metricName: "num_requests_waiting", value: 15, replicas: 3},
+				{metricName: "num_requests_waiting", aggType: workload.AggregationTypeSum, value: 10, replicas: 2},
+				{metricName: "num_requests_waiting", aggType: workload.AggregationTypeSum, value: 15, replicas: 3},
 			},
 			want: map[string]float64{
 				"num_requests_waiting": 25,
@@ -221,39 +223,27 @@ func TestExternalMetricAggregation(t *testing.T) {
 			name: "ratio metrics use weighted sum by backend replica count",
 			samples: []struct {
 				metricName string
+				aggType    workload.AggregationType
 				value      float64
 				replicas   int32
 			}{
-				{metricName: "gpu_utilization", value: 60, replicas: 2},
-				{metricName: "gpu_utilization", value: 90, replicas: 1},
+				{metricName: "gpu_utilization", aggType: workload.AggregationTypeAvg, value: 60, replicas: 2},
+				{metricName: "gpu_utilization", aggType: workload.AggregationTypeAvg, value: 90, replicas: 1},
 			},
 			want: map[string]float64{
 				"gpu_utilization": 210,
 			},
 		},
 		{
-			name: "cache usage percent suffix uses weighted sum",
-			samples: []struct {
-				metricName string
-				value      float64
-				replicas   int32
-			}{
-				{metricName: "gpu_cache_usage_perc", value: 50, replicas: 1},
-				{metricName: "gpu_cache_usage_perc", value: 70, replicas: 1},
-			},
-			want: map[string]float64{
-				"gpu_cache_usage_perc": 120,
-			},
-		},
-		{
 			name: "ratio metrics fall back to sample average when replicas are zero",
 			samples: []struct {
 				metricName string
+				aggType    workload.AggregationType
 				value      float64
 				replicas   int32
 			}{
-				{metricName: "cache_usage", value: 40, replicas: 0},
-				{metricName: "cache_usage", value: 80, replicas: 0},
+				{metricName: "cache_usage", aggType: workload.AggregationTypeAvg, value: 40, replicas: 0},
+				{metricName: "cache_usage", aggType: workload.AggregationTypeAvg, value: 80, replicas: 0},
 			},
 			want: map[string]float64{
 				"cache_usage": 60,
@@ -265,7 +255,7 @@ func TestExternalMetricAggregation(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			aggregates := make(map[string]*externalMetricAggregate)
 			for _, sample := range tt.samples {
-				addExternalMetric(aggregates, sample.metricName, sample.value, sample.replicas)
+				addExternalMetric(aggregates, sample.metricName, sample.value, sample.replicas, sample.aggType)
 			}
 			got := finalizeExternalMetrics(aggregates)
 			for metricName, want := range tt.want {
@@ -275,29 +265,3 @@ func TestExternalMetricAggregation(t *testing.T) {
 	}
 }
 
-func TestAverageExternalMetric(t *testing.T) {
-	tests := []struct {
-		name       string
-		metricName string
-		want       bool
-	}{
-		{name: "utilization", metricName: "gpu_utilization", want: true},
-		{name: "usage", metricName: "gpu_cache_usage", want: true},
-		{name: "percent", metricName: "memory_percent", want: true},
-		{name: "percentage", metricName: "kv_cache_percentage", want: true},
-		{name: "ratio", metricName: "hit_ratio", want: true},
-		{name: "rate", metricName: "token_rate", want: false},
-		{name: "perc", metricName: "gpu_cache_usage_perc", want: true},
-		{name: "bare suffix", metricName: "usage", want: true},
-		{name: "suffix without separator", metricName: "upperperc", want: false},
-		{name: "false rate suffix", metricName: "error_crate", want: false},
-		{name: "count", metricName: "request_count", want: false},
-		{name: "waiting", metricName: "num_requests_waiting", want: false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, averageExternalMetric(tt.metricName))
-		})
-	}
-}

--- a/pkg/autoscaler/autoscaler/optimizer_test.go
+++ b/pkg/autoscaler/autoscaler/optimizer_test.go
@@ -192,3 +192,112 @@ func TestRestoreReplicasOfEachBackend(t *testing.T) {
 		})
 	}
 }
+
+func TestExternalMetricAggregation(t *testing.T) {
+	tests := []struct {
+		name    string
+		samples []struct {
+			metricName string
+			value      float64
+			replicas   int32
+		}
+		want map[string]float64
+	}{
+		{
+			name: "additive metrics are summed across backends",
+			samples: []struct {
+				metricName string
+				value      float64
+				replicas   int32
+			}{
+				{metricName: "num_requests_waiting", value: 10, replicas: 2},
+				{metricName: "num_requests_waiting", value: 15, replicas: 3},
+			},
+			want: map[string]float64{
+				"num_requests_waiting": 25,
+			},
+		},
+		{
+			name: "ratio metrics use weighted sum by backend replica count",
+			samples: []struct {
+				metricName string
+				value      float64
+				replicas   int32
+			}{
+				{metricName: "gpu_utilization", value: 60, replicas: 2},
+				{metricName: "gpu_utilization", value: 90, replicas: 1},
+			},
+			want: map[string]float64{
+				"gpu_utilization": 210,
+			},
+		},
+		{
+			name: "cache usage percent suffix uses weighted sum",
+			samples: []struct {
+				metricName string
+				value      float64
+				replicas   int32
+			}{
+				{metricName: "gpu_cache_usage_perc", value: 50, replicas: 1},
+				{metricName: "gpu_cache_usage_perc", value: 70, replicas: 1},
+			},
+			want: map[string]float64{
+				"gpu_cache_usage_perc": 120,
+			},
+		},
+		{
+			name: "ratio metrics fall back to sample average when replicas are zero",
+			samples: []struct {
+				metricName string
+				value      float64
+				replicas   int32
+			}{
+				{metricName: "cache_usage", value: 40, replicas: 0},
+				{metricName: "cache_usage", value: 80, replicas: 0},
+			},
+			want: map[string]float64{
+				"cache_usage": 60,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			aggregates := make(map[string]*externalMetricAggregate)
+			for _, sample := range tt.samples {
+				addExternalMetric(aggregates, sample.metricName, sample.value, sample.replicas)
+			}
+			got := finalizeExternalMetrics(aggregates)
+			for metricName, want := range tt.want {
+				assert.InDelta(t, want, got[metricName], 0.001)
+			}
+		})
+	}
+}
+
+func TestAverageExternalMetric(t *testing.T) {
+	tests := []struct {
+		name       string
+		metricName string
+		want       bool
+	}{
+		{name: "utilization", metricName: "gpu_utilization", want: true},
+		{name: "usage", metricName: "gpu_cache_usage", want: true},
+		{name: "percent", metricName: "memory_percent", want: true},
+		{name: "percentage", metricName: "kv_cache_percentage", want: true},
+		{name: "ratio", metricName: "hit_ratio", want: true},
+		{name: "rate", metricName: "token_rate", want: false},
+		{name: "perc", metricName: "gpu_cache_usage_perc", want: true},
+		{name: "bare suffix", metricName: "usage", want: true},
+		{name: "suffix without separator", metricName: "upperperc", want: false},
+		{name: "false rate suffix", metricName: "error_crate", want: false},
+		{name: "count", metricName: "request_count", want: false},
+		{name: "waiting", metricName: "num_requests_waiting", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, averageExternalMetric(tt.metricName))
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The heterogeneous optimizer was summing all external metrics across backends. That is correct for additive metrics such as queue length, but it is wrong for ratio-like metrics such as GPU utilization or cache usage. For example, two backends reporting 60% and 70% utilization should not become 130% utilization after aggregation.

This PR keeps additive external metrics as sums and averages ratio-like external metrics by backend replica count. It uses the short-term heuristic from the issue: metric names ending in utilization, usage, percent, percentage, ratio, rate, or perc are treated as ratio-like metrics. Metrics without those suffixes keep the existing sum behavior.

**Which issue(s) this PR fixes**:

Fixes #1202

**Special notes for your reviewer**:

N/A

Tested with:
- `go test ./pkg/autoscaler/...`
- `go test $(go list ./... | grep -v /test/e2e | grep -v /client-go)`
- `go build ./cmd/kthena-controller-manager ./cmd/kthena-router ./cli/kthena`

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```