### PR TITLE
Fix router auth panic when JWKS cache is empty

### DIFF
--- a/pkg/kthena-router/filters/auth/authentication.go
+++ b/pkg/kthena-router/filters/auth/authentication.go
@@ -86,7 +86,7 @@ func (j *JWTAuthenticator) Close() {
 func (j *JWTAuthenticator) authenticate(tokenStr string) (string, error) {
 	// Get current JWKS from rotator
 	jwksValue := j.rotator.GetJwks()
-	if jwksValue.Jwks == nil {
+	if jwksValue == nil || jwksValue.Jwks == nil {
 		return "", fmt.Errorf("no JWKS available for token validation")
 	}
 

--- a/pkg/kthena-router/filters/auth/authentication_test.go
+++ b/pkg/kthena-router/filters/auth/authentication_test.go
@@ -150,6 +150,20 @@ func TestJWTAuthenticatorValidateToken(t *testing.T) {
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "authorization header missing")
 	})
+
+	t.Run("missing jwks cache", func(t *testing.T) {
+		validator := &JWTAuthenticator{
+			enabled: true,
+			rotator: NewJWKSRotator(conf.AuthenticationConfig{
+				JwksUri: "invalid-url",
+			}),
+		}
+		c, _ := gin.CreateTestContext(httptest.NewRecorder())
+
+		err := validator.ValidateToken(context.Background(), c, "some-token")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "no JWKS available")
+	})
 }
 
 func TestJWTAuthenticatorMiddleware(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

When JWT auth is enabled but the initial JWKS fetch fails, the authenticator can keep running with an empty JWKS cache. The request path then dereferences the cache before checking it.

This adds the missing nil check and returns the existing auth error instead of panicking.

**Which issue(s) this PR fixes**:

Fixes #1218

**Special notes for your reviewer**:

NONE

**Does this PR introduce a user-facing change?**:

```release-note
NONE