### PR TITLE
Fix stale KV cache ownership

### DIFF
--- a/pkg/kthena-router/scheduler/plugins/kvcache_aware.go
+++ b/pkg/kthena-router/scheduler/plugins/kvcache_aware.go
@@ -32,6 +32,7 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -68,6 +69,12 @@ const (
 
 	// defaultSGLangTokenizerPort is the upstream-default port for sglang
 	defaultSGLangTokenizerPort = 30000
+
+	// kvCacheFieldFreshDuration matches the runtime mapping key expiry
+	kvCacheFieldFreshDuration = 24 * time.Hour
+
+	kvCacheGCInterval = time.Hour
+	kvCacheGCScanSize = int64(100)
 )
 
 type KVCacheAwareArgs struct {
@@ -86,6 +93,7 @@ type KVCacheAware struct {
 	redisClient      *redis.Client
 	processor        *TokenBlockProcessor
 	tokenizerManager *tokenization.TokenizerManager
+	gcCursor         uint64
 }
 
 var _ framework.ScorePlugin = &KVCacheAware{}
@@ -161,7 +169,7 @@ func NewKVCacheAware(pluginArg runtime.RawExtension) *KVCacheAware {
 		klog.Infof("KVCacheAware: Redis client initialized successfully")
 	}
 
-	return &KVCacheAware{
+	plugin := &KVCacheAware{
 		name:             KVCacheAwarePluginName,
 		maxBlocksToMatch: maxBlocksToMatch,
 		keyPrefix:        kvCacheKeyPrefix,
@@ -169,6 +177,8 @@ func NewKVCacheAware(pluginArg runtime.RawExtension) *KVCacheAware {
 		processor:        &TokenBlockProcessor{blockSize: blockSizeToHash},
 		tokenizerManager: manager,
 	}
+	plugin.startGC()
+	return plugin
 }
 
 func (t *KVCacheAware) Name() string {
@@ -271,8 +281,9 @@ func (t *KVCacheAware) Score(ctx *framework.Context, pods []*datastore.PodInfo) 
 	}
 	scoreResults := make(map[*datastore.PodInfo]int, len(podScores))
 	for _, pod := range pods {
-		podName := pod.GetPodNamespacedName().Name
-		if score, exists := podScores[podName]; exists {
+		podName := pod.GetPodNamespacedName()
+		podScoreKey := fmt.Sprintf("%s.%s", podName.Name, podName.Namespace)
+		if score, exists := podScores[podScoreKey]; exists {
 			scoreResults[pod] = score
 		}
 	}
@@ -327,17 +338,74 @@ func (t *KVCacheAware) queryRedisForBlocks(blockHashes []uint64, modelName strin
 
 		klog.V(2).Infof("KVCacheAware.queryRedis: block[%d] hash=%d key=%s matched pods=%v", i, blockHashes[i], keys[i], pods)
 
-		podNames := make([]string, 0, len(pods))
-		for _, pod := range pods {
-			// Redis field is pod identifier (e.g., "pod-name.namespace")
-			podName := extractPodNameFromIdentifier(pod)
-			podNames = append(podNames, podName)
-		}
-		blockToPods[blockHashes[i]] = podNames
+		blockToPods[blockHashes[i]] = pods
 	}
 
 	klog.V(4).Infof("KVCacheAware.queryRedis: total blocks with hits: %d/%d", len(blockToPods), len(blockHashes))
 	return blockToPods, nil
+}
+
+func (t *KVCacheAware) startGC() {
+	if t.redisClient == nil {
+		return
+	}
+	go t.runGC()
+}
+
+func (t *KVCacheAware) runGC() {
+	ticker := time.NewTicker(kvCacheGCInterval)
+	defer ticker.Stop()
+	for range ticker.C {
+		t.gcStaleFields()
+	}
+}
+
+func (t *KVCacheAware) gcStaleFields() {
+	if t.redisClient == nil {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	keys, nextCursor, err := t.redisClient.Scan(ctx, t.gcCursor, t.keyPrefix+"*", kvCacheGCScanSize).Result()
+	if err != nil {
+		klog.V(4).Infof("KVCacheAware.gcStaleFields: scan failed: %v", err)
+		return
+	}
+	t.gcCursor = nextCursor
+
+	now := time.Now()
+	staleFields := make(map[string][]string)
+	for _, key := range keys {
+		podTimes, err := t.redisClient.HGetAll(ctx, key).Result()
+		if err != nil {
+			klog.V(4).Infof("KVCacheAware.gcStaleFields: failed to read %s: %v", key, err)
+			continue
+		}
+		for pod, ts := range podTimes {
+			updatedAt, err := strconv.ParseInt(ts, 10, 64)
+			if err == nil && now.Sub(time.Unix(updatedAt, 0)) > kvCacheFieldFreshDuration {
+				staleFields[key] = append(staleFields[key], pod)
+			}
+		}
+	}
+	if len(staleFields) > 0 {
+		t.deleteStaleFields(staleFields)
+	}
+}
+
+func (t *KVCacheAware) deleteStaleFields(staleFields map[string][]string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	pipe := t.redisClient.Pipeline()
+	for key, pods := range staleFields {
+		pipe.HDel(ctx, key, pods...)
+	}
+	if _, err := pipe.Exec(ctx); err != nil {
+		klog.V(4).Infof("KVCacheAware.gcStaleFields: failed to delete stale fields: %v", err)
+	}
 }
 
 func extractPodNameFromIdentifier(podIdentifier string) string {

--- a/pkg/kthena-router/scheduler/plugins/kvcache_aware_test.go
+++ b/pkg/kthena-router/scheduler/plugins/kvcache_aware_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package plugins
 
 import (
+	"context"
 	"encoding/binary"
 	"fmt"
 	"reflect"
@@ -24,6 +25,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/common"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/datastore"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/metrics"
@@ -377,6 +380,18 @@ func TestKVCacheAware_CalculatePodScores_Core(t *testing.T) {
 				"pod2": 25, // 1/4 * 100 (only block 1, then stops at missing block 2)
 			},
 		},
+		{
+			name:        "Namespaced pods stay distinct",
+			blockHashes: []uint64{1, 2},
+			blockToPods: map[uint64][]string{
+				1: {"pod1.default", "pod1.other"},
+				2: {"pod1.default"},
+			},
+			expected: map[string]int{
+				"pod1.default": 100,
+				"pod1.other":   50,
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -387,6 +402,144 @@ func TestKVCacheAware_CalculatePodScores_Core(t *testing.T) {
 				t.Errorf("Expected %v, got %v", tt.expected, result)
 			}
 		})
+	}
+}
+
+func TestKVCacheAware_QueryRedisForBlocks_ReturnsRedisOwners(t *testing.T) {
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("failed to start miniredis: %v", err)
+	}
+	defer mr.Close()
+
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer client.Close()
+
+	plugin := &KVCacheAware{
+		keyPrefix:   kvCacheKeyPrefix,
+		redisClient: client,
+	}
+
+	ctx := context.Background()
+	hash := uint64(111)
+	key := KVCacheAwareBlock{ModelName: "qwen", ChunkHash: hash}.String(kvCacheKeyPrefix)
+	now := fmt.Sprintf("%d", time.Now().Unix())
+	if err := client.HSet(ctx, key,
+		"pod-1", now,
+		"pod-1.default", now,
+		"pod-2.default", now,
+	).Err(); err != nil {
+		t.Fatalf("failed to seed redis: %v", err)
+	}
+
+	result, err := plugin.queryRedisForBlocks([]uint64{hash}, "qwen")
+	if err != nil {
+		t.Fatalf("queryRedisForBlocks returned error: %v", err)
+	}
+	gotPods := make(map[string]bool, len(result[hash]))
+	for _, pod := range result[hash] {
+		gotPods[pod] = true
+	}
+	for _, pod := range []string{"pod-1", "pod-1.default", "pod-2.default"} {
+		if !gotPods[pod] {
+			t.Errorf("expected %s in result, got %v", pod, result[hash])
+		}
+	}
+}
+
+func TestKVCacheAware_QueryRedisForBlocks_KeepsNamespacedOwners(t *testing.T) {
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("failed to start miniredis: %v", err)
+	}
+	defer mr.Close()
+
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer client.Close()
+
+	plugin := &KVCacheAware{
+		keyPrefix:   kvCacheKeyPrefix,
+		redisClient: client,
+	}
+
+	ctx := context.Background()
+	hash := uint64(333)
+	key := KVCacheAwareBlock{ModelName: "qwen", ChunkHash: hash}.String(kvCacheKeyPrefix)
+	now := fmt.Sprintf("%d", time.Now().Unix())
+	if err := client.HSet(ctx, key,
+		"pod-1.default", now,
+		"pod-1.other", now,
+	).Err(); err != nil {
+		t.Fatalf("failed to seed redis: %v", err)
+	}
+
+	result, err := plugin.queryRedisForBlocks([]uint64{hash}, "qwen")
+	if err != nil {
+		t.Fatalf("queryRedisForBlocks returned error: %v", err)
+	}
+
+	gotPods := make(map[string]bool, len(result[hash]))
+	for _, pod := range result[hash] {
+		gotPods[pod] = true
+	}
+	for _, pod := range []string{"pod-1.default", "pod-1.other"} {
+		if !gotPods[pod] {
+			t.Errorf("expected %s in result, got %v", pod, result[hash])
+		}
+	}
+
+	scores, _ := plugin.calculatePodScores([]uint64{hash}, result)
+	if scores["pod-1.default"] != 100 || scores["pod-1.other"] != 100 {
+		t.Errorf("expected namespaced scores to stay separate, got %v", scores)
+	}
+}
+
+func TestKVCacheAware_GCStaleFields(t *testing.T) {
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("failed to start miniredis: %v", err)
+	}
+	defer mr.Close()
+
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer client.Close()
+
+	plugin := &KVCacheAware{
+		keyPrefix:   kvCacheKeyPrefix,
+		redisClient: client,
+	}
+
+	ctx := context.Background()
+	hash := uint64(444)
+	key := KVCacheAwareBlock{ModelName: "qwen", ChunkHash: hash}.String(kvCacheKeyPrefix)
+	now := fmt.Sprintf("%d", time.Now().Unix())
+	stale := fmt.Sprintf("%d", time.Now().Add(-25*time.Hour).Unix())
+	if err := client.HSet(ctx, key,
+		"pod-1", now,
+		"pod-1.default", now,
+		"pod-2.default", now,
+		"pod-3.default", stale,
+	).Err(); err != nil {
+		t.Fatalf("failed to seed redis: %v", err)
+	}
+
+	plugin.gcStaleFields()
+
+	exists, err := client.HExists(ctx, key, "pod-3.default").Result()
+	if err != nil {
+		t.Fatalf("failed to check pod-3.default: %v", err)
+	}
+	if exists {
+		t.Errorf("expected pod-3.default to be removed")
+	}
+	for _, pod := range []string{"pod-1", "pod-1.default", "pod-2.default"} {
+		exists, err := client.HExists(ctx, key, pod).Result()
+		if err != nil {
+			t.Fatalf("failed to check %s: %v", pod, err)
+		}
+		if !exists {
+			t.Errorf("expected %s to remain", pod)
+		}
 	}
 }
 


### PR DESCRIPTION

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fix stale KV cache ownership in Redis.

The router now reads matrix KV ownership with HGetAll, ignores stale ownership timestamps, and keeps Redis owner matching on the same `name.namespace` format used by runtime/scoring.

Stale or unknown owner fields are cleaned by a fixed-interval GC loop, using live store pods for the logical model so valid owners from sibling ModelServers are not removed.

Tests added for stale timestamps, deleted pod fields, namespaced owners, and GC cleanup.

**Which issue(s) this PR fixes**:

Fixes #1223

**Special notes for your reviewer**:

NONE

**Does this PR introduce a user-facing change?**:

```release-note
NONE