### PR TITLE
feat:  prioritize decode over prefill when scaling up in PD-separated ModelServing

### DIFF
--- a/pkg/apis/workload/v1alpha1/labels.go
+++ b/pkg/apis/workload/v1alpha1/labels.go
@@ -33,3 +33,11 @@ const (
 	// RoleTemplateHashLabelKey is the revision label for the role, used for RoleRollingUpdate strategy.
 	RoleTemplateHashLabelKey = "modelserving.volcano.sh/role-template-hash"
 )
+
+// Role name constants used in SubTarget.Name and pod labels.
+const (
+	// RoleNameDecode is the role name for decode pods in PD-separated modelServing.
+	RoleNameDecode = "decode"
+	// RoleNamePrefill is the role name for prefill pods in PD-separated modelServing.
+	RoleNamePrefill = "prefill"
+)

--- a/pkg/autoscaler/controller/autoscale_controller.go
+++ b/pkg/autoscaler/controller/autoscale_controller.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/volcano-sh/kthena/pkg/autoscaler/autoscaler"
@@ -149,6 +150,9 @@ func (ac *AutoscaleController) Reconcile(ctx context.Context) {
 			delete(ac.optimizerMap, key)
 		}
 	}
+
+	// Decode-first: process decode policies before prefill so decode pods enter the scheduler queue first
+	sortPoliciesByRolePriority(policies)
 
 	for _, policy := range policies {
 		err := ac.schedule(ctx, policy)
@@ -313,4 +317,70 @@ func formatAutoscalerMapKey(policyNamespace, policyName string, targetRef *corev
 		key += "/" + targetNamespace + "/" + targetKind + "/" + targetRef.Name
 	}
 	return key
+}
+
+// sortPoliciesByRolePriority sorts policies so that decode is processed
+// before prefill. Policies without a recognized role sort last.
+func sortPoliciesByRolePriority(policies []*workload.AutoscalingPolicy) {
+	sort.Slice(policies, func(i, j int) bool {
+		ri := roleOfPolicy(policies[i])
+		rj := roleOfPolicy(policies[j])
+		oi := roleOrder(ri)
+		oj := roleOrder(rj)
+		if oi != oj {
+			return oi < oj
+		}
+		if ri != rj {
+			// Within the same order bucket, empty role sorts last
+			if ri == "" {
+				return false
+			}
+			if rj == "" {
+				return true
+			}
+			return ri < rj
+		}
+		if policies[i].Namespace != policies[j].Namespace {
+			return policies[i].Namespace < policies[j].Namespace
+		}
+		return policies[i].Name < policies[j].Name
+	})
+}
+
+// roleOfPolicy extracts the role name from a policy's metric source label
+// selector. It scans all PodMetricSources and deterministically picks the
+// role with the highest priority (lowest roleOrder); lexicographic order
+// breaks ties. This avoids non-deterministic map iteration causing
+// inconsistent sort comparisons.
+func roleOfPolicy(policy *workload.AutoscalingPolicy) string {
+	if policy.Spec.HomogeneousTarget == nil {
+		return ""
+	}
+	bestRole := ""
+	bestOrder := 3 // higher than any valid roleOrder (max=2)
+	for _, ms := range policy.Spec.HomogeneousTarget.Target.MetricSources {
+		if ms.Pod != nil && ms.Pod.LabelSelector != nil {
+			if role, ok := ms.Pod.LabelSelector.MatchLabels[workload.RoleLabelKey]; ok {
+				o := roleOrder(role)
+				if o < bestOrder || (o == bestOrder && role < bestRole) {
+					bestOrder = o
+					bestRole = role
+				}
+			}
+		}
+	}
+	return bestRole
+}
+
+// roleOrder returns a sort key for a role name. "decode" has the highest
+// priority (0), "prefill" second (1), everything else last (2).
+func roleOrder(role string) int {
+	switch role {
+	case workload.RoleNameDecode:
+		return 0
+	case workload.RoleNamePrefill:
+		return 1
+	default:
+		return 2
+	}
 }

--- a/pkg/autoscaler/controller/autoscale_controller_test.go
+++ b/pkg/autoscaler/controller/autoscale_controller_test.go
@@ -223,6 +223,306 @@ func TestTwoBackendsHighLoad_then_DoOptimize_expect_DistributionA5B4(t *testing.
 	}
 }
 
+func TestRoleOfPolicy(t *testing.T) {
+	tests := []struct {
+		name     string
+		policy   *workload.AutoscalingPolicy
+		expected string
+	}{
+		{
+			name: "homogeneous target with decode role via MetricSources",
+			policy: &workload.AutoscalingPolicy{
+				Spec: workload.AutoscalingPolicySpec{
+					HomogeneousTarget: &workload.HomogeneousTarget{
+						Target: workload.Target{
+							MetricSources: map[string]workload.MetricSource{
+								"rps": {Pod: &workload.PodMetricSource{
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{workload.RoleLabelKey: workload.RoleNameDecode},
+									},
+								}},
+							},
+						},
+					},
+				},
+			},
+			expected: workload.RoleNameDecode,
+		},
+		{
+			name: "homogeneous target with prefill role via MetricSources",
+			policy: &workload.AutoscalingPolicy{
+				Spec: workload.AutoscalingPolicySpec{
+					HomogeneousTarget: &workload.HomogeneousTarget{
+						Target: workload.Target{
+							MetricSources: map[string]workload.MetricSource{
+								"rps": {Pod: &workload.PodMetricSource{
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{workload.RoleLabelKey: workload.RoleNamePrefill},
+									},
+								}},
+							},
+						},
+					},
+				},
+			},
+			expected: workload.RoleNamePrefill,
+		},
+		{
+			name: "homogeneous target without role in MetricSources",
+			policy: &workload.AutoscalingPolicy{
+				Spec: workload.AutoscalingPolicySpec{
+					HomogeneousTarget: &workload.HomogeneousTarget{
+						Target: workload.Target{
+							MetricSources: map[string]workload.MetricSource{
+								"rps": {Pod: &workload.PodMetricSource{
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{"app": "myapp"},
+									},
+								}},
+							},
+						},
+					},
+				},
+			},
+			expected: "",
+		},
+		{
+			name: "heterogeneous target returns empty",
+			policy: &workload.AutoscalingPolicy{
+				Spec: workload.AutoscalingPolicySpec{
+					HeterogeneousTarget: &workload.HeterogeneousTarget{
+						Params: []workload.HeterogeneousTargetParam{
+							{Target: workload.Target{}, MinReplicas: 1, MaxReplicas: 4, Cost: 10},
+						},
+					},
+				},
+			},
+			expected: "",
+		},
+		{
+			name: "MetricSources with non-Role label key returns empty",
+			policy: &workload.AutoscalingPolicy{
+				Spec: workload.AutoscalingPolicySpec{
+					HomogeneousTarget: &workload.HomogeneousTarget{
+						Target: workload.Target{
+							MetricSources: map[string]workload.MetricSource{
+								"rps": {Pod: &workload.PodMetricSource{
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{"custom-key": workload.RoleNameDecode},
+									},
+								}},
+							},
+						},
+					},
+				},
+			},
+			expected: "",
+		},
+		{
+			name: "conflicting roles deterministically picks highest priority",
+			policy: &workload.AutoscalingPolicy{
+				Spec: workload.AutoscalingPolicySpec{
+					HomogeneousTarget: &workload.HomogeneousTarget{
+						Target: workload.Target{
+							MetricSources: map[string]workload.MetricSource{
+								"queue": {Pod: &workload.PodMetricSource{
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{workload.RoleLabelKey: workload.RoleNamePrefill},
+									},
+								}},
+								"latency": {Pod: &workload.PodMetricSource{
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{workload.RoleLabelKey: workload.RoleNameDecode},
+									},
+								}},
+							},
+						},
+					},
+				},
+			},
+			expected: workload.RoleNameDecode,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := roleOfPolicy(tt.policy)
+			if got != tt.expected {
+				t.Errorf("roleOfPolicy() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestRoleOrder(t *testing.T) {
+	tests := []struct {
+		name     string
+		role     string
+		expected int
+	}{
+		{"decode", workload.RoleNameDecode, 0},
+		{"prefill", workload.RoleNamePrefill, 1},
+		{"server", "server", 2},
+		{"controller", "controller", 2},
+		{"empty string", "", 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := roleOrder(tt.role)
+			if got != tt.expected {
+				t.Errorf("roleOrder(%q) = %d, want %d", tt.role, got, tt.expected)
+			}
+		})
+	}
+
+	// Verify ordering: decode < prefill < other
+	if roleOrder(workload.RoleNameDecode) >= roleOrder(workload.RoleNamePrefill) {
+		t.Error("decode should have lower (higher priority) order than prefill")
+	}
+	if roleOrder(workload.RoleNamePrefill) >= roleOrder("server") {
+		t.Error("prefill should have lower order than server")
+	}
+}
+
+func TestReconcile_SortPutsDecodeBeforePrefill(t *testing.T) {
+	policies := []*workload.AutoscalingPolicy{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "prefill-policy", Namespace: "ns"},
+			Spec: workload.AutoscalingPolicySpec{
+				HomogeneousTarget: &workload.HomogeneousTarget{
+					Target: workload.Target{
+						MetricSources: map[string]workload.MetricSource{
+							"rps": {Pod: &workload.PodMetricSource{
+								LabelSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{workload.RoleLabelKey: workload.RoleNamePrefill},
+								},
+							}},
+						},
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "decode-policy", Namespace: "ns"},
+			Spec: workload.AutoscalingPolicySpec{
+				HomogeneousTarget: &workload.HomogeneousTarget{
+					Target: workload.Target{
+						MetricSources: map[string]workload.MetricSource{
+							"rps": {Pod: &workload.PodMetricSource{
+								LabelSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{workload.RoleLabelKey: workload.RoleNameDecode},
+								},
+							}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	sortPoliciesByRolePriority(policies)
+
+	if roleOfPolicy(policies[0]) != workload.RoleNameDecode {
+		t.Errorf("expected first policy to be decode, got %q", roleOfPolicy(policies[0]))
+	}
+	if roleOfPolicy(policies[1]) != workload.RoleNamePrefill {
+		t.Errorf("expected second policy to be prefill, got %q", roleOfPolicy(policies[1]))
+	}
+}
+
+func TestReconcile_SortPolicyWithoutRole(t *testing.T) {
+	policies := []*workload.AutoscalingPolicy{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "no-role-policy", Namespace: "ns"},
+			Spec: workload.AutoscalingPolicySpec{
+				HomogeneousTarget: &workload.HomogeneousTarget{
+					Target: workload.Target{
+						MetricSources: map[string]workload.MetricSource{
+							"rps": {Pod: &workload.PodMetricSource{
+								LabelSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{"app": "myapp"},
+								},
+							}},
+						},
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "decode-policy", Namespace: "ns"},
+			Spec: workload.AutoscalingPolicySpec{
+				HomogeneousTarget: &workload.HomogeneousTarget{
+					Target: workload.Target{
+						MetricSources: map[string]workload.MetricSource{
+							"rps": {Pod: &workload.PodMetricSource{
+								LabelSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{workload.RoleLabelKey: workload.RoleNameDecode},
+								},
+							}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	sortPoliciesByRolePriority(policies)
+
+	if roleOfPolicy(policies[0]) != workload.RoleNameDecode {
+		t.Errorf("expected first policy to be decode, got %q", roleOfPolicy(policies[0]))
+	}
+	if roleOfPolicy(policies[1]) != "" {
+		t.Errorf("expected second policy to have no role, got %q", roleOfPolicy(policies[1]))
+	}
+}
+
+func TestReconcile_SortEmptyRoleAfterOtherRole(t *testing.T) {
+	policies := []*workload.AutoscalingPolicy{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "empty-role", Namespace: "ns"},
+			Spec: workload.AutoscalingPolicySpec{
+				HomogeneousTarget: &workload.HomogeneousTarget{
+					Target: workload.Target{
+						MetricSources: map[string]workload.MetricSource{
+							"rps": {Pod: &workload.PodMetricSource{
+								LabelSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{"app": "myapp"},
+								},
+							}},
+						},
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "server-role", Namespace: "ns"},
+			Spec: workload.AutoscalingPolicySpec{
+				HomogeneousTarget: &workload.HomogeneousTarget{
+					Target: workload.Target{
+						MetricSources: map[string]workload.MetricSource{
+							"rps": {Pod: &workload.PodMetricSource{
+								LabelSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{workload.RoleLabelKey: "server"},
+								},
+							}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	sortPoliciesByRolePriority(policies)
+
+	if roleOfPolicy(policies[0]) != "server" {
+		t.Errorf("expected first policy to be server, got %q", roleOfPolicy(policies[0]))
+	}
+	if roleOfPolicy(policies[1]) != "" {
+		t.Errorf("expected second policy to have no role, got %q", roleOfPolicy(policies[1]))
+	}
+}
+
 func httpHandlerWithBody(body string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.Write([]byte(body)) })
 }


### PR DESCRIPTION
## Problem

In PD-separated modelserving, when cluster GPU resources are insufficient for both roles to scale up simultaneously, the autoscaler may scale prefill first and leave decode stuck — a completely wasteful outcome. Prefill producing KV Cache that decode can't consume doesn't improve throughput; it only wastes GPU resources.

The root cause: `Reconcile()` iterates all `AutoscalingPolicyBinding` objects in whatever order the lister returns — effectively random. There is no mechanism to ensure decode's scaling decision is applied first.

## What this PR does

Sorts bindings before the scheduling loop so that decode is always processed
before prefill:

- **decode** → priority 0 (processed first)
- **prefill** → priority 1
- **other/none** → priority 2 (processed last)

Same-role ties are broken by `namespace/name` for stable ordering.

When decode's Patch is sent first, its pods enter the Kubernetes scheduler queue ahead of prefill pods. Under resource contention, decode gets a higher chance of GPU allocation.

## Why not scale-down priority

To sort by direction (scale-up vs scale-down), the autoscaler would need to compute the scaling decision *before* applying it — requiring a two-phase refactor of `doScale()` and `doOptimize()` (split "compute" from "apply").

However, scale-down order has no practical effect:
- Two Patch operations target different fields (`roles[i].replicas`), so there is no resource competition between them.
- Scale-down is rate-limited to at most 1 pod per 15-second cycle regardless of order.

True "scale down prefill to free GPUs for decode" coordination requires cluster-level resource awareness (knowing when a terminated pod's GPU is actually released) — that is a separate problem beyond this PR's scope.

## Changes

- `autoscale_controller.go`: add `sortBindingsByRolePriority()`, `roleOfBinding()`, `roleOrder()`; call sort   before scheduling loop in `Reconcile()`
- `autoscale_controller_test.go`: unit tests for all three helpers and sort behavior