### PR TITLE
fix: metrics port should use ModelServer's configured workloadPort instead of hardcoded defaults

### DIFF
--- a/pkg/kthena-router/backend/backend.go
+++ b/pkg/kthena-router/backend/backend.go
@@ -28,8 +28,8 @@ import (
 )
 
 type MetricsProvider interface {
-	GetPodMetrics(pod *corev1.Pod) (map[string]*dto.MetricFamily, error)
-	GetPodModels(pod *corev1.Pod) ([]string, error)
+	GetPodMetrics(pod *corev1.Pod, metricPort uint32) (map[string]*dto.MetricFamily, error)
+	GetPodModels(pod *corev1.Pod, metricPort uint32) ([]string, error)
 	GetCountMetricsInfo(allMetrics map[string]*dto.MetricFamily) map[string]float64
 	GetHistogramPodMetrics(allMetrics map[string]*dto.MetricFamily, previousHistogram map[string]*dto.Histogram) (map[string]float64, map[string]*dto.Histogram)
 }
@@ -39,14 +39,14 @@ var engineRegistry = map[string]MetricsProvider{
 	"vLLM":   vllm.NewVllmEngine(),
 }
 
-func GetPodMetrics(engine string, pod *corev1.Pod, previousHistogram map[string]*dto.Histogram) (map[string]float64, map[string]*dto.Histogram) {
+func GetPodMetrics(engine string, pod *corev1.Pod, metricPort uint32, previousHistogram map[string]*dto.Histogram) (map[string]float64, map[string]*dto.Histogram) {
 	provider, err := GetMetricsProvider(engine)
 	if err != nil {
 		klog.Errorf("Failed to get inference engine: %v", err)
 		return nil, nil
 	}
 
-	allMetrics, err := provider.GetPodMetrics(pod)
+	allMetrics, err := provider.GetPodMetrics(pod, metricPort)
 	if err != nil {
 		klog.V(4).Infof("failed to get metrics of pod: %s/%s: %v", pod.GetNamespace(), pod.GetName(), err)
 		return nil, nil
@@ -71,12 +71,12 @@ func GetMetricsProvider(engine string) (MetricsProvider, error) {
 	return nil, fmt.Errorf("unsupported engine: %s", engine)
 }
 
-func GetPodModels(engine string, pod *corev1.Pod) ([]string, error) {
+func GetPodModels(engine string, pod *corev1.Pod, metricPort uint32) ([]string, error) {
 	provider, err := GetMetricsProvider(engine)
 	if err != nil {
 		klog.Errorf("Failed to get inference engine: %v", err)
 		return nil, nil
 	}
 
-	return provider.GetPodModels(pod)
+	return provider.GetPodModels(pod, metricPort)
 }

--- a/pkg/kthena-router/backend/sglang/metrics.go
+++ b/pkg/kthena-router/backend/sglang/metrics.go
@@ -54,21 +54,14 @@ var (
 	}
 )
 
-type sglangEngine struct {
-	// The address of sglang's query metrics is http://{model server}:MetricPort/metrics
-	// Default is 30000
-	MetricPort uint32
-}
+type sglangEngine struct{}
 
 func NewSglangEngine() *sglangEngine {
-	// TODO: Get MetricsPort from sglang configuration
-	return &sglangEngine{
-		MetricPort: 30000,
-	}
+	return &sglangEngine{}
 }
 
-func (engine *sglangEngine) GetPodMetrics(pod *corev1.Pod) (map[string]*dto.MetricFamily, error) {
-	url := metrics.PodEndpointURL(pod.Status.PodIP, engine.MetricPort, "/metrics")
+func (engine *sglangEngine) GetPodMetrics(pod *corev1.Pod, metricPort uint32) (map[string]*dto.MetricFamily, error) {
+	url := metrics.PodEndpointURL(pod.Status.PodIP, metricPort, "/metrics")
 	allMetrics, err := metrics.ParseMetricsURL(url)
 	if err != nil {
 		return nil, err
@@ -118,6 +111,6 @@ func (engine *sglangEngine) GetHistogramPodMetrics(allMetrics map[string]*dto.Me
 }
 
 // GetPodModels retrieves the list of models from a pod running the sglang engine.
-func (engine *sglangEngine) GetPodModels(pod *corev1.Pod) ([]string, error) {
-	return vllm.FetchPodModels(pod.Status.PodIP, engine.MetricPort)
+func (engine *sglangEngine) GetPodModels(pod *corev1.Pod, metricPort uint32) ([]string, error) {
+	return vllm.FetchPodModels(pod.Status.PodIP, metricPort)
 }

--- a/pkg/kthena-router/backend/vllm/metrics.go
+++ b/pkg/kthena-router/backend/vllm/metrics.go
@@ -53,21 +53,14 @@ var (
 	}
 )
 
-type vllmEngine struct {
-	// The address of vllm's query metrics is http://{model server}:MetricPort/metrics
-	// Default is 8000
-	MetricPort uint32
-}
+type vllmEngine struct{}
 
 func NewVllmEngine() *vllmEngine {
-	// TODO: Get MetricsPort from vllm configuration
-	return &vllmEngine{
-		MetricPort: 8000,
-	}
+	return &vllmEngine{}
 }
 
-func (engine *vllmEngine) GetPodMetrics(pod *corev1.Pod) (map[string]*dto.MetricFamily, error) {
-	url := metrics.PodEndpointURL(pod.Status.PodIP, engine.MetricPort, "/metrics")
+func (engine *vllmEngine) GetPodMetrics(pod *corev1.Pod, metricPort uint32) (map[string]*dto.MetricFamily, error) {
+	url := metrics.PodEndpointURL(pod.Status.PodIP, metricPort, "/metrics")
 	allMetrics, err := metrics.ParseMetricsURL(url)
 	if err != nil {
 		return nil, err

--- a/pkg/kthena-router/backend/vllm/models.go
+++ b/pkg/kthena-router/backend/vllm/models.go
@@ -65,6 +65,6 @@ func FetchPodModels(podIP string, port uint32) ([]string, error) {
 	return models, nil
 }
 
-func (engine *vllmEngine) GetPodModels(pod *corev1.Pod) ([]string, error) {
-	return FetchPodModels(pod.Status.PodIP, engine.MetricPort)
+func (engine *vllmEngine) GetPodModels(pod *corev1.Pod, metricPort uint32) ([]string, error) {
+	return FetchPodModels(pod.Status.PodIP, metricPort)
 }

--- a/pkg/kthena-router/controller/modelserver_controller_test.go
+++ b/pkg/kthena-router/controller/modelserver_controller_test.go
@@ -41,7 +41,7 @@ import (
 
 type fakePodRuntimeInspector struct{}
 
-func (fakePodRuntimeInspector) GetPodMetrics(_ string, _ *corev1.Pod, _ map[string]*dto.Histogram) (map[string]float64, map[string]*dto.Histogram) {
+func (fakePodRuntimeInspector) GetPodMetrics(_ string, _ *corev1.Pod, _ uint32, _ map[string]*dto.Histogram) (map[string]float64, map[string]*dto.Histogram) {
 	return map[string]float64{
 		utils.KVCacheUsage:      0.5,
 		utils.RequestWaitingNum: 10,
@@ -49,7 +49,7 @@ func (fakePodRuntimeInspector) GetPodMetrics(_ string, _ *corev1.Pod, _ map[stri
 	}, nil
 }
 
-func (fakePodRuntimeInspector) GetPodModels(_ string, _ *corev1.Pod) ([]string, error) {
+func (fakePodRuntimeInspector) GetPodModels(_ string, _ *corev1.Pod, _ uint32) ([]string, error) {
 	return []string{"test-model"}, nil
 }
 

--- a/pkg/kthena-router/datastore/ordering_test.go
+++ b/pkg/kthena-router/datastore/ordering_test.go
@@ -59,14 +59,14 @@ func createTestModelServer(namespace, name string, engine aiv1alpha1.InferenceEn
 
 func newStoreWithMockBackend() *store {
 	return New(WithPodRuntimeInspector(&fakePodRuntimeInspector{
-		metricsFn: func(_ string, _ *corev1.Pod, _ map[string]*dto.Histogram) (map[string]float64, map[string]*dto.Histogram) {
+		metricsFn: func(_ string, _ *corev1.Pod, _ uint32, _ map[string]*dto.Histogram) (map[string]float64, map[string]*dto.Histogram) {
 			return map[string]float64{
 				utils.KVCacheUsage:      0.5,
 				utils.RequestWaitingNum: 10,
 				utils.RequestRunningNum: 5,
 			}, nil
 		},
-		modelsFn: func(_ string, _ *corev1.Pod) ([]string, error) {
+		modelsFn: func(_ string, _ *corev1.Pod, _ uint32) ([]string, error) {
 			return []string{"test-model"}, nil
 		},
 	})).(*store)

--- a/pkg/kthena-router/datastore/store.go
+++ b/pkg/kthena-router/datastore/store.go
@@ -73,6 +73,39 @@ const (
 	onFlightSyncInterval = 50 * time.Millisecond
 )
 
+// resolveMetricPort returns the workloadPort from any associated model server with a non-zero port, or a default per engine.
+// If no model server is associated or none have a port set, returns engine defaults (vLLM 8000, SGLang 30000).
+func (s *store) resolveMetricPort(pod *PodInfo) uint32 {
+	engine := pod.GetEngine()
+	// Default by engine first
+	port := defaultMetricPort(engine)
+	msList := pod.GetModelServersList()
+	if len(msList) == 0 {
+		return port
+	}
+	// Use the first model server that has a configured workload port
+	for _, msName := range msList {
+		if value, ok := s.modelServer.Load(msName); ok {
+			srv := value.(*modelServer).getModelServer()
+			if srv != nil && srv.Spec.WorkloadPort.Port > 0 {
+				return uint32(srv.Spec.WorkloadPort.Port)
+			}
+		}
+	}
+	return port
+}
+
+func defaultMetricPort(engine string) uint32 {
+	switch strings.ToLower(engine) {
+	case strings.ToLower(string(aiv1alpha1.VLLM)):
+		return 8000
+	case strings.ToLower(string(aiv1alpha1.SGLang)):
+		return 30000
+	default:
+		return 0
+	}
+}
+
 // createTokenTracker creates a token tracker with configuration from environment variables
 func createTokenTracker() TokenTracker {
 	var opts []TokenTrackerOption
@@ -140,18 +173,18 @@ type CallbackFunc func(data EventData)
 
 // PodRuntimeInspector fetches runtime metrics and loaded models for a pod.
 type PodRuntimeInspector interface {
-	GetPodMetrics(engine string, pod *corev1.Pod, previousHistogram map[string]*dto.Histogram) (map[string]float64, map[string]*dto.Histogram)
-	GetPodModels(engine string, pod *corev1.Pod) ([]string, error)
+	GetPodMetrics(engine string, pod *corev1.Pod, metricPort uint32, previousHistogram map[string]*dto.Histogram) (map[string]float64, map[string]*dto.Histogram)
+	GetPodModels(engine string, pod *corev1.Pod, metricPort uint32) ([]string, error)
 }
 
 type realPodRuntimeInspector struct{}
 
-func (realPodRuntimeInspector) GetPodMetrics(engine string, pod *corev1.Pod, previousHistogram map[string]*dto.Histogram) (map[string]float64, map[string]*dto.Histogram) {
-	return backend.GetPodMetrics(engine, pod, previousHistogram)
+func (realPodRuntimeInspector) GetPodMetrics(engine string, pod *corev1.Pod, metricPort uint32, previousHistogram map[string]*dto.Histogram) (map[string]float64, map[string]*dto.Histogram) {
+	return backend.GetPodMetrics(engine, pod, metricPort, previousHistogram)
 }
 
-func (realPodRuntimeInspector) GetPodModels(engine string, pod *corev1.Pod) ([]string, error) {
-	return backend.GetPodModels(engine, pod)
+func (realPodRuntimeInspector) GetPodModels(engine string, pod *corev1.Pod, metricPort uint32) ([]string, error) {
+	return backend.GetPodModels(engine, pod, metricPort)
 }
 
 type Option func(*store)
@@ -1347,9 +1380,10 @@ func (s *store) updatePodMetrics(pod *PodInfo) {
 		klog.V(2).Info("failed to find pod")
 		return
 	}
+	metricPort := s.resolveMetricPort(pod)
 
 	previousHistogram := getPreviousHistogram(pod)
-	gaugeMetrics, histogramMetrics := s.getPodRuntimeInspector().GetPodMetrics(engine, podObj, previousHistogram)
+	gaugeMetrics, histogramMetrics := s.getPodRuntimeInspector().GetPodMetrics(engine, podObj, metricPort, previousHistogram)
 	if gaugeMetrics != nil {
 		updateGaugeMetricsInfo(pod, gaugeMetrics)
 	}
@@ -1369,8 +1403,9 @@ func (s *store) updatePodModels(podInfo *PodInfo) {
 		klog.V(2).Info("failed to find pod")
 		return
 	}
+	metricPort := s.resolveMetricPort(podInfo)
 
-	models, err := s.getPodRuntimeInspector().GetPodModels(engine, podObj)
+	models, err := s.getPodRuntimeInspector().GetPodModels(engine, podObj, metricPort)
 	if err != nil {
 		klog.V(4).Infof("failed to get models of pod %s/%s: %v", podObj.GetNamespace(), podObj.GetName(), err)
 		return

--- a/pkg/kthena-router/datastore/store_test.go
+++ b/pkg/kthena-router/datastore/store_test.go
@@ -96,6 +96,62 @@ func TestParseMetricsScrapeInterval(t *testing.T) {
 	}
 }
 
+func TestResolveMetricPortUsesModelServerWorkloadPort(t *testing.T) {
+	tests := []struct {
+		name   string
+		msPort int32
+		expect uint32
+	}{
+		{
+			name:   "uses_modelserver_port_when_set",
+			msPort: 9000,
+			expect: 9000,
+		},
+		{
+			name:   "falls_back_to_default_when_unset",
+			msPort: 0,
+			expect: 8000,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotPort uint32
+			s := &store{
+				modelServer: sync.Map{},
+				podRuntimeInspector: &fakePodRuntimeInspector{
+					metricsFn: func(_ string, _ *corev1.Pod, metricPort uint32, _ map[string]*dto.Histogram) (map[string]float64, map[string]*dto.Histogram) {
+						gotPort = metricPort
+						return nil, nil
+					},
+				},
+			}
+
+			msName := types.NamespacedName{Namespace: "default", Name: "model1"}
+			ms := &aiv1alpha1.ModelServer{
+				ObjectMeta: metav1.ObjectMeta{Namespace: msName.Namespace, Name: msName.Name},
+				Spec: aiv1alpha1.ModelServerSpec{
+					InferenceEngine: aiv1alpha1.VLLM,
+					WorkloadPort:    aiv1alpha1.WorkloadPort{Port: tt.msPort},
+				},
+			}
+			s.modelServer.Store(msName, newModelServer(ms))
+
+			podInfo := &PodInfo{
+				Pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "pod1"},
+				},
+				engine:      string(aiv1alpha1.VLLM),
+				modelServer: sets.New[types.NamespacedName](msName),
+			}
+
+			s.updatePodMetrics(podInfo)
+
+			assert.Equal(t, tt.expect, gotPort)
+		})
+	}
+}
+
 func TestNewStoreUsesMetricsScrapeInterval(t *testing.T) {
 	t.Setenv("METRICS_SCRAPE_INTERVAL", "2s")
 	s := New().(*store)
@@ -259,7 +315,7 @@ func TestStoreUpdatePodMetrics(t *testing.T) {
 		pods:        sync.Map{},
 		modelServer: sync.Map{},
 		podRuntimeInspector: &fakePodRuntimeInspector{
-			metricsFn: func(_ string, _ *corev1.Pod, _ map[string]*dto.Histogram) (map[string]float64, map[string]*dto.Histogram) {
+			metricsFn: func(_ string, _ *corev1.Pod, _ uint32, _ map[string]*dto.Histogram) (map[string]float64, map[string]*dto.Histogram) {
 				return map[string]float64{
 						utils.KVCacheUsage:      0.8,
 						utils.RequestWaitingNum: 15,
@@ -1533,26 +1589,26 @@ func TestStoreMatchModelServer(t *testing.T) {
 }
 
 type fakePodRuntimeInspector struct {
-	metricsFn    func(string, *corev1.Pod, map[string]*dto.Histogram) (map[string]float64, map[string]*dto.Histogram)
-	modelsFn     func(string, *corev1.Pod) ([]string, error)
+	metricsFn    func(string, *corev1.Pod, uint32, map[string]*dto.Histogram) (map[string]float64, map[string]*dto.Histogram)
+	modelsFn     func(string, *corev1.Pod, uint32) ([]string, error)
 	metricsCalls atomic.Int64
 	modelsCalls  atomic.Int64
 }
 
-func (f *fakePodRuntimeInspector) GetPodMetrics(engine string, pod *corev1.Pod, previousHistogram map[string]*dto.Histogram) (map[string]float64, map[string]*dto.Histogram) {
+func (f *fakePodRuntimeInspector) GetPodMetrics(engine string, pod *corev1.Pod, metricPort uint32, previousHistogram map[string]*dto.Histogram) (map[string]float64, map[string]*dto.Histogram) {
 	f.metricsCalls.Add(1)
 	if f.metricsFn == nil {
 		return nil, nil
 	}
-	return f.metricsFn(engine, pod, previousHistogram)
+	return f.metricsFn(engine, pod, metricPort, previousHistogram)
 }
 
-func (f *fakePodRuntimeInspector) GetPodModels(engine string, pod *corev1.Pod) ([]string, error) {
+func (f *fakePodRuntimeInspector) GetPodModels(engine string, pod *corev1.Pod, metricPort uint32) ([]string, error) {
 	f.modelsCalls.Add(1)
 	if f.modelsFn == nil {
 		return nil, nil
 	}
-	return f.modelsFn(engine, pod)
+	return f.modelsFn(engine, pod, metricPort)
 }
 
 func newStore(inspector ...PodRuntimeInspector) *store {
@@ -1670,10 +1726,10 @@ func TestAddOrUpdatePod_MetricsPreservedOnUpdate(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			inspector := &fakePodRuntimeInspector{
-				metricsFn: func(_ string, _ *corev1.Pod, _ map[string]*dto.Histogram) (map[string]float64, map[string]*dto.Histogram) {
+				metricsFn: func(_ string, _ *corev1.Pod, _ uint32, _ map[string]*dto.Histogram) (map[string]float64, map[string]*dto.Histogram) {
 					return tc.initialMetrics, tc.initialHist
 				},
-				modelsFn: func(_ string, _ *corev1.Pod) ([]string, error) {
+				modelsFn: func(_ string, _ *corev1.Pod, _ uint32) ([]string, error) {
 					return tc.initialModels, nil
 				},
 			}
@@ -1734,13 +1790,13 @@ func TestAddOrUpdatePod_MetricsPreservedOnUpdate(t *testing.T) {
 
 func TestAddOrUpdatePod_NewPodStillFetchesMetrics(t *testing.T) {
 	inspector := &fakePodRuntimeInspector{
-		metricsFn: func(_ string, _ *corev1.Pod, _ map[string]*dto.Histogram) (map[string]float64, map[string]*dto.Histogram) {
+		metricsFn: func(_ string, _ *corev1.Pod, _ uint32, _ map[string]*dto.Histogram) (map[string]float64, map[string]*dto.Histogram) {
 			return map[string]float64{
 				utils.KVCacheUsage:      0.3,
 				utils.RequestRunningNum: 2,
 			}, map[string]*dto.Histogram{}
 		},
-		modelsFn: func(_ string, _ *corev1.Pod) ([]string, error) {
+		modelsFn: func(_ string, _ *corev1.Pod, _ uint32) ([]string, error) {
 			return []string{"base-model"}, nil
 		},
 	}
@@ -1763,7 +1819,7 @@ func TestAddOrUpdatePod_NewPodStillFetchesMetrics(t *testing.T) {
 
 func TestAddOrUpdatePod_ModelServerChangePreservesMetrics(t *testing.T) {
 	inspector := &fakePodRuntimeInspector{
-		metricsFn: func(_ string, _ *corev1.Pod, _ map[string]*dto.Histogram) (map[string]float64, map[string]*dto.Histogram) {
+		metricsFn: func(_ string, _ *corev1.Pod, _ uint32, _ map[string]*dto.Histogram) (map[string]float64, map[string]*dto.Histogram) {
 			return map[string]float64{
 				utils.KVCacheUsage:      0.6,
 				utils.RequestWaitingNum: 5,
@@ -1772,7 +1828,7 @@ func TestAddOrUpdatePod_ModelServerChangePreservesMetrics(t *testing.T) {
 				utils.TTFT:              0.2,
 			}, map[string]*dto.Histogram{}
 		},
-		modelsFn: func(_ string, _ *corev1.Pod) ([]string, error) {
+		modelsFn: func(_ string, _ *corev1.Pod, _ uint32) ([]string, error) {
 			return []string{"model-a"}, nil
 		},
 	}

--- a/pkg/kthena-router/router/router_test.go
+++ b/pkg/kthena-router/router/router_test.go
@@ -32,6 +32,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"istio.io/istio/pkg/util/sets"
 	corev1 "k8s.io/api/core/v1"
@@ -59,6 +60,16 @@ func TestMain(m *testing.M) {
 	os.Exit(exitCode)
 }
 
+type mockPodRuntimeInspector struct{}
+
+func (m *mockPodRuntimeInspector) GetPodMetrics(engine string, pod *corev1.Pod, metricPort uint32, previousHistogram map[string]*dto.Histogram) (map[string]float64, map[string]*dto.Histogram) {
+	return nil, nil
+}
+
+func (m *mockPodRuntimeInspector) GetPodModels(engine string, pod *corev1.Pod, metricPort uint32) ([]string, error) {
+	return nil, nil
+}
+
 // setupTestRouter initializes a router and its dependencies for testing.
 // It uses a mock HTTP server as the backend, following the community's recommendation
 // to avoid hacky dependency injection.
@@ -66,7 +77,7 @@ func setupTestRouter(t *testing.T, backendHandler http.Handler) (*Router, datast
 	gin.SetMode(gin.TestMode)
 
 	backend := httptest.NewServer(backendHandler)
-	store := datastore.New()
+	store := datastore.New(datastore.WithPodRuntimeInspector(&mockPodRuntimeInspector{}))
 	router := NewRouter(store, "../scheduler/testdata/configmap.yaml")
 
 	return router, store, backend
@@ -1106,7 +1117,7 @@ func TestProxy_RetryBodyNotDrained(t *testing.T) {
 	backendIP := backendURL.Hostname()
 	backendPort, _ := strconv.Atoi(backendURL.Port())
 
-	store := datastore.New()
+	store := datastore.New(datastore.WithPodRuntimeInspector(&mockPodRuntimeInspector{}))
 	router := NewRouter(store, "../scheduler/testdata/configmap.yaml")
 
 	modelServer := &aiv1alpha1.ModelServer{


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->
/kind enhancement

**What this PR does / why we need it**:
Use configured workload port for metrics instead of using default ports.

**Which issue(s) this PR fixes**:
Fixes #1185 

**Special notes for your reviewer**:
Since now workload port was dynamic and correctly used for metrics scraping the number of requests to mock backend in `TestProxy_RetryBodyNotDrained`  was incrementing correctly but the test only expects 2 requests for test to pass, hence a mock pod runtime inspector was added in `router_test.go` which did not increment requests count when `AddOrUpdatePod` fires. Hence the ci was green again.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
