### PR TITLE
Fix HTTPRoute parentRefs updates

### DIFF
--- a/pkg/kthena-router/controller/gateway_controller_test.go
+++ b/pkg/kthena-router/controller/gateway_controller_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayfake "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/fake"
@@ -67,23 +68,23 @@ func TestGatewayController_Lifecycle(t *testing.T) {
 
 		_, err := gatewayClient.GatewayV1().Gateways("default").Create(
 			context.Background(), gw, metav1.CreateOptions{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		if !waitForCacheSync(t, 5*time.Second, controller.gatewaySynced) {
 			t.Fatal("Failed to sync caches within timeout")
 		}
 
-		found := waitForObjectInCache(t, 2*time.Second, func() bool {
+		found := waitForObjectInCache(t, 5*time.Second, func() bool {
 			_, err := controller.gatewayLister.Gateways("default").Get("test-gateway")
 			return err == nil
 		})
-		assert.True(t, found, "Gateway should be in cache")
+		require.True(t, found, "Gateway should be in cache")
 
 		err = controller.syncHandler("default/test-gateway")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		stored := store.GetGateway("default/test-gateway")
-		assert.NotNil(t, stored)
+		require.NotNil(t, stored)
 		assert.Equal(t, "test-gateway", stored.Name)
 	})
 
@@ -92,26 +93,26 @@ func TestGatewayController_Lifecycle(t *testing.T) {
 		// informer cache and datastore after syncHandler is called
 		existing, err := gatewayClient.GatewayV1().Gateways("default").Get(
 			context.Background(), "test-gateway", metav1.GetOptions{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		updated := existing.DeepCopy()
 		updated.Spec.Listeners[0].Port = 8080
 
 		_, err = gatewayClient.GatewayV1().Gateways("default").Update(
 			context.Background(), updated, metav1.UpdateOptions{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
-		found := waitForObjectInCache(t, 2*time.Second, func() bool {
+		found := waitForObjectInCache(t, 5*time.Second, func() bool {
 			gw, err := controller.gatewayLister.Gateways("default").Get("test-gateway")
 			return err == nil && gw.Spec.Listeners[0].Port == 8080
 		})
-		assert.True(t, found, "Gateway update should be reflected in cache")
+		require.True(t, found, "Gateway update should be reflected in cache")
 
 		err = controller.syncHandler("default/test-gateway")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		stored := store.GetGateway("default/test-gateway")
-		assert.NotNil(t, stored)
+		require.NotNil(t, stored)
 		assert.Equal(t, gatewayv1.PortNumber(8080), stored.Spec.Listeners[0].Port)
 	})
 
@@ -120,16 +121,16 @@ func TestGatewayController_Lifecycle(t *testing.T) {
 		// cache and the datastore after syncHandler is called.
 		err := gatewayClient.GatewayV1().Gateways("default").Delete(
 			context.Background(), "test-gateway", metav1.DeleteOptions{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
-		found := waitForObjectInCache(t, 2*time.Second, func() bool {
+		found := waitForObjectInCache(t, 5*time.Second, func() bool {
 			_, err := controller.gatewayLister.Gateways("default").Get("test-gateway")
 			return err != nil
 		})
-		assert.True(t, found, "Gateway should be removed from cache")
+		require.True(t, found, "Gateway should be removed from cache")
 
 		err = controller.syncHandler("default/test-gateway")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		stored := store.GetGateway("default/test-gateway")
 		assert.Nil(t, stored)

--- a/pkg/kthena-router/controller/httproute_controller.go
+++ b/pkg/kthena-router/controller/httproute_controller.go
@@ -192,10 +192,12 @@ func (c *HTTPRouteController) syncHandler(key string) error {
 		gatewayKey := fmt.Sprintf("%s/%s", gatewayNamespace, string(parentRef.Name))
 		gw := c.store.GetGateway(gatewayKey)
 		if gw == nil {
-			if _, err := c.gatewayLister.Gateways(gatewayNamespace).Get(string(parentRef.Name)); err == nil {
+			informerGateway, err := c.gatewayLister.Gateways(gatewayNamespace).Get(string(parentRef.Name))
+			if err != nil {
 				gatewayPending = true
+				continue
 			}
-			continue
+			gw = informerGateway
 		}
 		if string(gw.Spec.GatewayClassName) == DefaultGatewayClassName {
 			allowed, err := c.gatewayAllowsHTTPRoute(gw, httpRoute, parentRef)

--- a/pkg/kthena-router/controller/httproute_controller_test.go
+++ b/pkg/kthena-router/controller/httproute_controller_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -47,7 +48,6 @@ func TestHTTPRouteController_EnqueueHTTPRoutesForGateway(t *testing.T) {
 	ctrl := NewHTTPRouteController(gatewayInformerFactory, kubeInformerFactory, store)
 	stop := make(chan struct{})
 	defer close(stop)
-	gatewayInformerFactory.Start(stop)
 
 	ctx := context.Background()
 	ns := "default"
@@ -99,6 +99,8 @@ func TestHTTPRouteController_EnqueueHTTPRoutesForGateway(t *testing.T) {
 	_, err = gatewayClient.GatewayV1().HTTPRoutes("other-ns").Create(ctx, httpRoute3, metav1.CreateOptions{})
 	assert.NoError(t, err)
 
+	gatewayInformerFactory.Start(stop)
+
 	gatewayInformer := gatewayInformerFactory.Gateway().V1().Gateways()
 	if !cache.WaitForCacheSync(stop, gatewayInformer.Informer().HasSynced) {
 		t.Fatal("gateway cache sync timeout")
@@ -108,7 +110,13 @@ func TestHTTPRouteController_EnqueueHTTPRoutesForGateway(t *testing.T) {
 		t.Fatal("httproute cache sync timeout")
 	}
 
-	time.Sleep(200 * time.Millisecond)
+	found := waitForObjectInCache(t, 5*time.Second, func() bool {
+		_, err1 := ctrl.httpRouteLister.HTTPRoutes(ns).Get("route-1")
+		_, err2 := ctrl.httpRouteLister.HTTPRoutes("other-ns").Get("route-3")
+		return err1 == nil && err2 == nil
+	})
+	require.True(t, found, "HTTPRoutes should be in cache")
+
 	for ctrl.workqueue.Len() > 0 {
 		obj, _ := ctrl.workqueue.Get()
 		ctrl.workqueue.Done(obj)
@@ -129,7 +137,6 @@ func TestHTTPRouteController_EnqueueHTTPRoutesForGateway_NoMatchingRoutes(t *tes
 	ctrl := NewHTTPRouteController(gatewayInformerFactory, kubeInformerFactory, store)
 	stop := make(chan struct{})
 	defer close(stop)
-	gatewayInformerFactory.Start(stop)
 
 	ctx := context.Background()
 	ns := "default"
@@ -155,11 +162,18 @@ func TestHTTPRouteController_EnqueueHTTPRoutesForGateway_NoMatchingRoutes(t *tes
 	_, err = gatewayClient.GatewayV1().HTTPRoutes(ns).Create(ctx, httpRoute, metav1.CreateOptions{})
 	assert.NoError(t, err)
 
+	gatewayInformerFactory.Start(stop)
+
 	if !cache.WaitForCacheSync(stop, gatewayInformerFactory.Gateway().V1().HTTPRoutes().Informer().HasSynced) {
 		t.Fatal("cache sync timeout")
 	}
 
-	time.Sleep(200 * time.Millisecond)
+	found := waitForObjectInCache(t, 5*time.Second, func() bool {
+		_, err := ctrl.httpRouteLister.HTTPRoutes(ns).Get("route-1")
+		return err == nil
+	})
+	require.True(t, found, "HTTPRoute should be in cache")
+
 	for ctrl.workqueue.Len() > 0 {
 		obj, _ := ctrl.workqueue.Get()
 		ctrl.workqueue.Done(obj)
@@ -359,4 +373,126 @@ func TestHTTPRouteController_MultipleParentRefs_FirstPending(t *testing.T) {
 	err = ctrl.syncHandler(ns + "/route-multi")
 	assert.NoError(t, err)
 	assert.NotNil(t, store.GetHTTPRoute(ns+"/route-multi"))
+}
+
+func TestHTTPRouteController_SyncHandler_MovesRouteWithGatewayOnlyInInformer(t *testing.T) {
+	kubeClient := kubefake.NewSimpleClientset()
+	kubeInformerFactory := kubeinformers.NewSharedInformerFactory(kubeClient, 0)
+	gatewayClient := gatewayfake.NewSimpleClientset()
+	gatewayInformerFactory := gatewayinformers.NewSharedInformerFactory(gatewayClient, 0)
+	store := datastore.New()
+
+	ctx := context.Background()
+	ns := "default"
+
+	oldRoute := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "route"},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{
+					{Kind: ptr(gatewayv1.Kind("Gateway")), Name: gatewayv1.ObjectName("gateway-a")},
+				},
+			},
+		},
+	}
+	assert.NoError(t, store.AddOrUpdateHTTPRoute(oldRoute))
+
+	gw := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "gateway-b"},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: gatewayv1.ObjectName(DefaultGatewayClassName),
+			Listeners: []gatewayv1.Listener{
+				{
+					Name:     gatewayv1.SectionName("http"),
+					Port:     gatewayv1.PortNumber(80),
+					Protocol: gatewayv1.HTTPProtocolType,
+				},
+			},
+		},
+	}
+	_, err := gatewayClient.GatewayV1().Gateways(ns).Create(ctx, gw, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	httpRoute := oldRoute.DeepCopy()
+	httpRoute.Spec.ParentRefs = []gatewayv1.ParentReference{
+		{Kind: ptr(gatewayv1.Kind("Gateway")), Name: gatewayv1.ObjectName("gateway-b")},
+	}
+	_, err = gatewayClient.GatewayV1().HTTPRoutes(ns).Create(ctx, httpRoute, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	ctrl := NewHTTPRouteController(gatewayInformerFactory, kubeInformerFactory, store)
+	stop := make(chan struct{})
+	defer close(stop)
+	gatewayInformerFactory.Start(stop)
+
+	if !cache.WaitForCacheSync(stop, gatewayInformerFactory.Gateway().V1().HTTPRoutes().Informer().HasSynced, gatewayInformerFactory.Gateway().V1().Gateways().Informer().HasSynced) {
+		t.Fatal("cache sync timeout")
+	}
+
+	err = ctrl.syncHandler(ns + "/route")
+	assert.NoError(t, err)
+	assert.Empty(t, store.GetHTTPRoutesByGateway(ns+"/gateway-a"))
+	assert.Len(t, store.GetHTTPRoutesByGateway(ns+"/gateway-b"), 1)
+}
+
+func TestHTTPRouteController_SyncHandler_WaitsForGatewayCreatedLater(t *testing.T) {
+	kubeClient := kubefake.NewSimpleClientset()
+	kubeInformerFactory := kubeinformers.NewSharedInformerFactory(kubeClient, 0)
+	gatewayClient := gatewayfake.NewSimpleClientset()
+	gatewayInformerFactory := gatewayinformers.NewSharedInformerFactory(gatewayClient, 0)
+	store := datastore.New()
+
+	ctx := context.Background()
+	ns := "default"
+	httpRoute := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "route"},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{
+					{Kind: ptr(gatewayv1.Kind("Gateway")), Name: gatewayv1.ObjectName("gateway")},
+				},
+			},
+		},
+	}
+	_, err := gatewayClient.GatewayV1().HTTPRoutes(ns).Create(ctx, httpRoute, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	ctrl := NewHTTPRouteController(gatewayInformerFactory, kubeInformerFactory, store)
+	stop := make(chan struct{})
+	defer close(stop)
+	gatewayInformerFactory.Start(stop)
+
+	if !cache.WaitForCacheSync(stop, gatewayInformerFactory.Gateway().V1().HTTPRoutes().Informer().HasSynced, gatewayInformerFactory.Gateway().V1().Gateways().Informer().HasSynced) {
+		t.Fatal("cache sync timeout")
+	}
+
+	err = ctrl.syncHandler(ns + "/route")
+	assert.Error(t, err)
+	assert.Nil(t, store.GetHTTPRoute(ns+"/route"))
+
+	gw := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "gateway"},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: gatewayv1.ObjectName(DefaultGatewayClassName),
+			Listeners: []gatewayv1.Listener{
+				{
+					Name:     gatewayv1.SectionName("http"),
+					Port:     gatewayv1.PortNumber(80),
+					Protocol: gatewayv1.HTTPProtocolType,
+				},
+			},
+		},
+	}
+	_, err = gatewayClient.GatewayV1().Gateways(ns).Create(ctx, gw, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	found := waitForObjectInCache(t, 5*time.Second, func() bool {
+		_, err := ctrl.gatewayLister.Gateways(ns).Get("gateway")
+		return err == nil
+	})
+	require.True(t, found, "Gateway should be in cache")
+
+	err = ctrl.syncHandler(ns + "/route")
+	assert.NoError(t, err)
+	assert.Len(t, store.GetHTTPRoutesByGateway(ns+"/gateway"), 1)
 }

--- a/pkg/kthena-router/datastore/store.go
+++ b/pkg/kthena-router/datastore/store.go
@@ -2182,9 +2182,29 @@ func (s *store) AddOrUpdateHTTPRoute(httpRoute *gatewayv1.HTTPRoute) error {
 	key := fmt.Sprintf("%s/%s", httpRoute.Namespace, httpRoute.Name)
 
 	s.httpRouteMutex.Lock()
+	oldRoute := s.httpRoutes[key]
 	s.httpRoutes[key] = httpRoute
 
 	// Update gateway routes mapping
+	if oldRoute != nil {
+		for _, parentRef := range oldRoute.Spec.ParentRefs {
+			if isGatewayParentRef(parentRef) {
+				gatewayName := string(parentRef.Name)
+				gatewayNamespace := oldRoute.Namespace
+				if parentRef.Namespace != nil {
+					gatewayNamespace = string(*parentRef.Namespace)
+				}
+				gatewayKey := fmt.Sprintf("%s/%s", gatewayNamespace, gatewayName)
+
+				if routeSet, exists := s.gatewayRoutes[gatewayKey]; exists {
+					routeSet.Delete(key)
+					if routeSet.IsEmpty() {
+						delete(s.gatewayRoutes, gatewayKey)
+					}
+				}
+			}
+		}
+	}
 	for _, parentRef := range httpRoute.Spec.ParentRefs {
 		if isGatewayParentRef(parentRef) {
 			gatewayName := string(parentRef.Name)

--- a/pkg/kthena-router/datastore/store_test.go
+++ b/pkg/kthena-router/datastore/store_test.go
@@ -1567,6 +1567,27 @@ func newStore(inspector ...PodRuntimeInspector) *store {
 	return New(WithPodRuntimeInspector(inspector[0])).(*store)
 }
 
+func TestAddOrUpdateHTTPRoute_UpdatesGatewayRoutes(t *testing.T) {
+	s := newStore()
+
+	route := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "route"},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{{Name: "gateway-a"}},
+			},
+		},
+	}
+	assert.NoError(t, s.AddOrUpdateHTTPRoute(route))
+
+	route = route.DeepCopy()
+	route.Spec.ParentRefs = []gatewayv1.ParentReference{{Name: "gateway-b"}}
+	assert.NoError(t, s.AddOrUpdateHTTPRoute(route))
+
+	assert.Empty(t, s.GetHTTPRoutesByGateway("default/gateway-a"))
+	assert.Len(t, s.GetHTTPRoutesByGateway("default/gateway-b"), 1)
+}
+
 func TestAddOrUpdatePod_MetricsPreservedOnUpdate(t *testing.T) {
 	sampleCount := uint64(100)
 	sampleSum := 0.42


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fixes stale HTTPRoute gateway mapping when `parentRefs` is updated.

`AddOrUpdateHTTPRoute` was adding the route to the new Gateway mapping but not removing it from the old one, so the old Gateway could still see the route after it moved.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Added a small regression test for updating an HTTPRoute from one Gateway to another.

**Does this PR introduce a user-facing change?**:

```release-note
NONE