### PR TITLE
router: fix lora-only route rate limits

### DIFF
--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -104,22 +104,57 @@ func NewRouter(store datastore.Store, routerConfigPath string) *Router {
 	// Initialize tokenizer
 	tokenizerInstance := tokenizer.NewSimpleEstimateTokenizer()
 
+	hasModelRateLimit := func(model string) bool {
+		for _, route := range store.GetAllModelRoutes() {
+			if route.Spec.RateLimit == nil {
+				continue
+			}
+			if route.Spec.ModelName == model {
+				return true
+			}
+			for _, lora := range route.Spec.LoraAdapters {
+				if lora == model {
+					return true
+				}
+			}
+		}
+		return false
+	}
+
 	store.RegisterCallback("ModelRoute", func(data datastore.EventData) {
 		switch data.EventType {
 		case datastore.EventAdd, datastore.EventUpdate:
 			if data.ModelRoute == nil || data.ModelRoute.Spec.RateLimit == nil {
 				return
 			}
-			klog.Infof("add or update rate limit for model %s", data.ModelName)
 
 			// Configure the unified rate limiter for this model
-			if err := loadRateLimiter.AddOrUpdateLimiter(data.ModelName, data.ModelRoute.Spec.RateLimit); err != nil {
-				klog.Errorf("failed to configure rate limiter for model %s: %v", data.ModelName, err)
+			if data.ModelName != "" {
+				klog.Infof("add or update rate limit for model %s", data.ModelName)
+				if err := loadRateLimiter.AddOrUpdateLimiter(data.ModelName, data.ModelRoute.Spec.RateLimit); err != nil {
+					klog.Errorf("failed to configure rate limiter for model %s: %v", data.ModelName, err)
+				}
+			}
+			for _, lora := range data.ModelRoute.Spec.LoraAdapters {
+				klog.Infof("add or update rate limit for Lora Adapter %s", lora)
+				if err := loadRateLimiter.AddOrUpdateLimiter(lora, data.ModelRoute.Spec.RateLimit); err != nil {
+					klog.Errorf("failed to configure rate limiter for Lora Adapter %s: %v", lora, err)
+				}
 			}
 
 		case datastore.EventDelete:
-			klog.Infof("delete rate limit for model %s", data.ModelName)
-			loadRateLimiter.DeleteLimiter(data.ModelName)
+			if data.ModelName != "" && !hasModelRateLimit(data.ModelName) {
+				klog.Infof("delete rate limit for model %s", data.ModelName)
+				loadRateLimiter.DeleteLimiter(data.ModelName)
+			}
+			if data.ModelRoute != nil {
+				for _, lora := range data.ModelRoute.Spec.LoraAdapters {
+					if !hasModelRateLimit(lora) {
+						klog.Infof("delete rate limit for Lora Adapter %s", lora)
+						loadRateLimiter.DeleteLimiter(lora)
+					}
+				}
+			}
 		}
 	})
 

--- a/pkg/kthena-router/router/router_test.go
+++ b/pkg/kthena-router/router/router_test.go
@@ -92,6 +92,43 @@ func setupTestRouter(t *testing.T, backendHandler http.Handler) (*Router, datast
 	return router, store, backend
 }
 
+func TestRouter_ModelRouteRateLimitForLoraOnlyRoute(t *testing.T) {
+	router, store, backend := setupTestRouter(t, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	defer backend.Close()
+
+	limit := uint32(1)
+	modelRoute := &aiv1alpha1.ModelRoute{
+		ObjectMeta: v1.ObjectMeta{Name: "lora-route", Namespace: "default"},
+		Spec: aiv1alpha1.ModelRouteSpec{
+			LoraAdapters: []string{"math-lora"},
+			RateLimit:    &aiv1alpha1.RateLimit{InputTokensPerUnit: &limit, Unit: aiv1alpha1.Second},
+			Rules: []*aiv1alpha1.Rule{
+				{TargetModels: []*aiv1alpha1.TargetModel{{ModelServerName: "lora-server"}}},
+			},
+		},
+	}
+
+	assert.NoError(t, store.AddOrUpdateModelRoute(modelRoute))
+	modelRoute2 := modelRoute.DeepCopy()
+	modelRoute2.Name = "lora-route-2"
+	assert.NoError(t, store.AddOrUpdateModelRoute(modelRoute2))
+
+	prompt := "hello world"
+	assert.Eventually(t, func() bool {
+		return router.loadRateLimiter.RateLimit("math-lora", prompt) != nil
+	}, time.Second, 10*time.Millisecond)
+
+	assert.NoError(t, store.DeleteModelRoute("default/lora-route"))
+	assert.Eventually(t, func() bool {
+		return router.loadRateLimiter.RateLimit("math-lora", prompt) != nil
+	}, time.Second, 10*time.Millisecond)
+
+	assert.NoError(t, store.DeleteModelRoute("default/lora-route-2"))
+	assert.Eventually(t, func() bool {
+		return router.loadRateLimiter.RateLimit("math-lora", prompt) == nil
+	}, time.Second, 10*time.Millisecond)
+}
+
 func TestRouter_HandleHTTPRoute_PathPrefix(t *testing.T) {
 	pathType := gatewayv1.PathMatchPathPrefix
 	kind := gatewayv1.Kind("Gateway")


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

Fixes rate limits for LoRA-only ModelRoutes.

Previously the router registered the limiter only with `spec.modelName`. For a LoRA-only route, `modelName` is empty, so the limiter was added under an empty key and requests using the LoRA adapter name were not limited.

This applies the same limiter to configured `loraAdapters` too.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:

```release-note
Fix rateLimit not being applied to LoRA-only ModelRoutes.