### PR TITLE
fix: remove unnecessary goroutine in ModelPrefixStore LRU eviction callback

### DIFF
--- a/pkg/kthena-router/scheduler/plugins/cache/prefix_store.go
+++ b/pkg/kthena-router/scheduler/plugins/cache/prefix_store.go
@@ -199,8 +199,8 @@ func (s *ModelPrefixStore) Add(model string, hashes []uint64, pod *datastore.Pod
 	podLRU, exists := s.podHashes[nsName]
 	if !exists {
 		podLRU, _ = NewLRUCache(s.hashCapacity, func(key hashModelKey, value struct{}) {
-			// onEvict callback need to acquire `modelCache.mu.Lock()` as well, so start a goroutine to run it async.
-			go s.onHashEvicted(key.model, []uint64{key.hash}, nsName)
+			// Safe to call synchronously: podLRU.Add() is invoked after shard.mu.Unlock().
+			s.onHashEvicted(key.model, []uint64{key.hash}, nsName)
 		})
 		s.podHashes[nsName] = podLRU
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The LRU eviction callback in `ModelPrefixStore.Add()` was spawning a new goroutine for every evicted hash:

```go
podLRU, _ = NewLRUCache(s.hashCapacity, func(key hashModelKey, value struct{}) {
    go s.onHashEvicted(key.model, []uint64{key.hash}, nsName)
})
```

The goroutine was originally added to avoid a deadlock when `onHashEvicted` tried to acquire `shard.mu`. However, `podLRU.Add()` is now called after `shard.mu.Unlock()`, so the callback is safe to run synchronously. Removing the `go` eliminates a goroutine explosion under large prompts, a single 8k-token request was spawning 1,000+ goroutines instantaneously.

**Which issue(s) this PR fixes**:

Fixes #1240

**Special notes for your reviewer**:

One-line change. The lock ordering confirms no deadlock risk: `shard.mu` and `entriesMu` are both released before `podLRU.Add()` is called in the `Add()` loop.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
