### PR TITLE
fix: avoid owner reference panic in role reconcile

### DIFF
--- a/pkg/model-serving-controller/controller/model_serving_controller.go
+++ b/pkg/model-serving-controller/controller/model_serving_controller.go
@@ -980,8 +980,15 @@ func (c *ModelServingController) manageRoleReplicas(ctx context.Context, ms *wor
 		for _, pod := range pods {
 			if !utils.IsOwnedByModelServingWithUID(pod, ms.UID) {
 				// If the pod is not owned by the ModelServing, we do not need to handle it.
+				ownerUID := types.UID("")
+				for _, ref := range pod.GetOwnerReferences() {
+					if ref.Kind == workloadv1alpha1.ModelServingKind.Kind && ref.APIVersion == workloadv1alpha1.SchemeGroupVersion.String() {
+						ownerUID = ref.UID
+						break
+					}
+				}
 				klog.Warningf("manageRoleReplicas: pod %s/%s may be left from previous same-named ModelServing %s/%s (expected UID=%s, got UID=%s), re-enqueuing",
-					pod.Namespace, pod.Name, ms.Namespace, ms.Name, ms.UID, pod.OwnerReferences[0].UID)
+					pod.Namespace, pod.Name, ms.Namespace, ms.Name, ms.UID, ownerUID)
 				c.enqueueModelServingAfter(ms, 1*time.Second)
 				break
 			}

--- a/pkg/model-serving-controller/controller/model_serving_controller_test.go
+++ b/pkg/model-serving-controller/controller/model_serving_controller_test.go
@@ -2559,6 +2559,7 @@ func TestManageRoleReplicas(t *testing.T) {
 		initialRoleIDs   []int
 		addEntryPod      bool
 		mismatchOwnerUID bool
+		clearOwnerRefs   bool
 		expectedRoleSize int
 		expectedPodCount int
 		expectRequeue    bool
@@ -2600,6 +2601,17 @@ func TestManageRoleReplicas(t *testing.T) {
 			initialRoleIDs:   []int{0},
 			addEntryPod:      true,
 			mismatchOwnerUID: true,
+			expectedRoleSize: 1,
+			expectedPodCount: 1,
+			expectRequeue:    true,
+		},
+		{
+			name:             "reenqueue when pod owner reference is missing",
+			roleReplicas:     1,
+			workerReplicas:   0,
+			initialRoleIDs:   []int{0},
+			addEntryPod:      true,
+			clearOwnerRefs:   true,
 			expectedRoleSize: 1,
 			expectedPodCount: 1,
 			expectRequeue:    true,
@@ -2667,6 +2679,9 @@ func TestManageRoleReplicas(t *testing.T) {
 				entryPod := utils.GenerateEntryPod(ms.Spec.Template.Roles[0], ms, groupName, 0, revision, "test-roleTemplateHash")
 				if tt.mismatchOwnerUID && len(entryPod.OwnerReferences) > 0 {
 					entryPod.OwnerReferences[0].UID = types.UID("mismatched-uid")
+				}
+				if tt.clearOwnerRefs {
+					entryPod.OwnerReferences = nil
 				}
 				_, err = kubeClient.CoreV1().Pods(ms.Namespace).Create(context.Background(), entryPod, metav1.CreateOptions{})
 				assert.NoError(t, err)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Avoids a panic in ModelServing role reconcile when a pod has matching role labels but no ownerReferences. The controller already treats it as not owned by the current ModelServing; this just makes the warning log handle the missing owner ref safely.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Added coverage in the existing manageRoleReplicas test.

**Does this PR introduce a user-facing change?**:

```release-note
NONE