### PR TITLE
fix(modelbooster): handle missing optional worker config

### DIFF
--- a/cli/kthena/cmd/create.go
+++ b/cli/kthena/cmd/create.go
@@ -28,6 +28,7 @@ import (
 	workloadv1alpha1 "github.com/volcano-sh/kthena/pkg/apis/workload/v1alpha1"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/engine"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -287,7 +288,7 @@ func applyKthenaResource(ctx context.Context, client *versioned.Clientset, obj *
 	// Convert unstructured to the appropriate typed resource
 	switch gvk.Kind {
 	case "ModelServing":
-		fmt.Printf("  Creating ModelServing: %s in namespace %s\n", resourceName, resourceNamespace)
+		fmt.Printf("  Applying ModelServing: %s in namespace %s\n", resourceName, resourceNamespace)
 		modelInfer := &workloadv1alpha1.ModelServing{}
 		err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, modelInfer)
 		if err != nil {
@@ -296,11 +297,23 @@ func applyKthenaResource(ctx context.Context, client *versioned.Clientset, obj *
 
 		_, err = client.WorkloadV1alpha1().ModelServings(resourceNamespace).Create(ctx, modelInfer, metav1.CreateOptions{})
 		if err != nil {
-			return fmt.Errorf("failed to create ModelServing: %v", err)
+			if apierrors.IsAlreadyExists(err) {
+				existing, getErr := client.WorkloadV1alpha1().ModelServings(resourceNamespace).Get(ctx, resourceName, metav1.GetOptions{})
+				if getErr != nil {
+					return fmt.Errorf("failed to get existing ModelServing: %v", getErr)
+				}
+				modelInfer.ResourceVersion = existing.ResourceVersion
+				_, updateErr := client.WorkloadV1alpha1().ModelServings(resourceNamespace).Update(ctx, modelInfer, metav1.UpdateOptions{})
+				if updateErr != nil {
+					return fmt.Errorf("failed to update ModelServing: %v", updateErr)
+				}
+			} else {
+				return fmt.Errorf("failed to create ModelServing: %v", err)
+			}
 		}
 
 	case "ModelBooster":
-		fmt.Printf("  Creating ModelBooster: %s in namespace %s\n", resourceName, resourceNamespace)
+		fmt.Printf("  Applying ModelBooster: %s in namespace %s\n", resourceName, resourceNamespace)
 		model := &workloadv1alpha1.ModelBooster{}
 		err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, model)
 		if err != nil {
@@ -309,11 +322,23 @@ func applyKthenaResource(ctx context.Context, client *versioned.Clientset, obj *
 
 		_, err = client.WorkloadV1alpha1().ModelBoosters(resourceNamespace).Create(ctx, model, metav1.CreateOptions{})
 		if err != nil {
-			return fmt.Errorf("failed to create ModelBooster: %v", err)
+			if apierrors.IsAlreadyExists(err) {
+				existing, getErr := client.WorkloadV1alpha1().ModelBoosters(resourceNamespace).Get(ctx, resourceName, metav1.GetOptions{})
+				if getErr != nil {
+					return fmt.Errorf("failed to get existing ModelBooster: %v", getErr)
+				}
+				model.ResourceVersion = existing.ResourceVersion
+				_, updateErr := client.WorkloadV1alpha1().ModelBoosters(resourceNamespace).Update(ctx, model, metav1.UpdateOptions{})
+				if updateErr != nil {
+					return fmt.Errorf("failed to update ModelBooster: %v", updateErr)
+				}
+			} else {
+				return fmt.Errorf("failed to create ModelBooster: %v", err)
+			}
 		}
 
 	case "AutoscalingPolicy":
-		fmt.Printf("  Creating AutoscalingPolicy: %s in namespace %s\n", resourceName, resourceNamespace)
+		fmt.Printf("  Applying AutoscalingPolicy: %s in namespace %s\n", resourceName, resourceNamespace)
 		policy := &workloadv1alpha1.AutoscalingPolicy{}
 		err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, policy)
 		if err != nil {
@@ -322,7 +347,19 @@ func applyKthenaResource(ctx context.Context, client *versioned.Clientset, obj *
 
 		_, err = client.WorkloadV1alpha1().AutoscalingPolicies(resourceNamespace).Create(ctx, policy, metav1.CreateOptions{})
 		if err != nil {
-			return fmt.Errorf("failed to create AutoscalingPolicy: %v", err)
+			if apierrors.IsAlreadyExists(err) {
+				existing, getErr := client.WorkloadV1alpha1().AutoscalingPolicies(resourceNamespace).Get(ctx, resourceName, metav1.GetOptions{})
+				if getErr != nil {
+					return fmt.Errorf("failed to get existing AutoscalingPolicy: %v", getErr)
+				}
+				policy.ResourceVersion = existing.ResourceVersion
+				_, updateErr := client.WorkloadV1alpha1().AutoscalingPolicies(resourceNamespace).Update(ctx, policy, metav1.UpdateOptions{})
+				if updateErr != nil {
+					return fmt.Errorf("failed to update AutoscalingPolicy: %v", updateErr)
+				}
+			} else {
+				return fmt.Errorf("failed to create AutoscalingPolicy: %v", err)
+			}
 		}
 
 	default:

--- a/cmd/kthena-controller-manager/main.go
+++ b/cmd/kthena-controller-manager/main.go
@@ -230,7 +230,11 @@ func setupWebhook(ctx context.Context, wc webhookConfig) error {
 
 // getNamespace returns the current pod namespace or "default".
 func getNamespace() string {
-	return os.Getenv("POD_NAMESPACE")
+	ns := os.Getenv("POD_NAMESPACE")
+	if ns == "" {
+		ns = "default"
+	}
+	return ns
 }
 
 // fileExists returns true if the file exists.

--- a/cmd/kthena-router/main.go
+++ b/cmd/kthena-router/main.go
@@ -212,7 +212,11 @@ func waitForCertsReady(keyFile, CertFile string) bool {
 
 // getNamespace returns the current pod namespace or "default".
 func getNamespace() string {
-	return os.Getenv("POD_NAMESPACE")
+	ns := os.Getenv("POD_NAMESPACE")
+	if ns == "" {
+		ns = "default"
+	}
+	return ns
 }
 
 // fileExists returns true if the file exists.

--- a/pkg/kthena-router/backend/metrics/metrics.go
+++ b/pkg/kthena-router/backend/metrics/metrics.go
@@ -66,6 +66,9 @@ func ParseMetricsURL(url string) (map[string]*dto.MetricFamily, error) {
 }
 
 func LastPeriodAvg(previous, current *dto.Histogram) float64 {
+	if previous == nil || current == nil {
+		return 0
+	}
 	previousSum := previous.GetSampleSum()
 	previousCount := previous.GetSampleCount()
 

--- a/pkg/kthena-router/datastore/model_server.go
+++ b/pkg/kthena-router/datastore/model_server.go
@@ -78,6 +78,11 @@ func (m *modelServer) categorizePodForPDGroup(podName types.NamespacedName, podL
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
+	m.categorizePodForPDGroupNoLock(podName, podLabels)
+}
+
+// categorizePodForPDGroupNoLock categorizes a pod without acquiring the mutex lock (caller must hold Lock).
+func (m *modelServer) categorizePodForPDGroupNoLock(podName types.NamespacedName, podLabels map[string]string) {
 	pdGroupValue := m.getPDGroupName(podLabels)
 	if pdGroupValue == "" {
 		return
@@ -117,12 +122,7 @@ func (m *modelServer) removePodFromPDGroups(podName types.NamespacedName, labels
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
-	pdGroupName := m.getPDGroupName(labels)
-	if pdGroupName == "" {
-		return
-	}
-
-	if pdGroup, ok := m.pdGroups[pdGroupName]; ok {
+	for pdGroupName, pdGroup := range m.pdGroups {
 		pdGroup.RemovePod(podName)
 		// Clean up empty PDGroupPods
 		if pdGroup.IsEmpty() {

--- a/pkg/kthena-router/datastore/pdgroup_pods_test.go
+++ b/pkg/kthena-router/datastore/pdgroup_pods_test.go
@@ -19,6 +19,7 @@ package datastore
 import (
 	"testing"
 
+	"istio.io/istio/pkg/util/sets"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -282,5 +283,107 @@ func TestPDGroupPodRemoval(t *testing.T) {
 
 	if len(decodePods) != 0 {
 		t.Errorf("Expected 0 decode pods after deletion, got %d", len(decodePods))
+	}
+}
+
+func TestPDGroupSpecChangeRecategorization(t *testing.T) {
+	store := New()
+
+	modelServerName := types.NamespacedName{
+		Namespace: "default",
+		Name:      "test-model",
+	}
+
+	// 1. Create ModelServer with initial PDGroup config
+	modelServer := &aiv1alpha1.ModelServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-model",
+			Namespace: "default",
+		},
+		Spec: aiv1alpha1.ModelServerSpec{
+			WorkloadSelector: &aiv1alpha1.WorkloadSelector{
+				PDGroup: &aiv1alpha1.PDGroup{
+					GroupKey: "pd-group",
+					PrefillLabels: map[string]string{
+						"role": "prefill",
+					},
+					DecodeLabels: map[string]string{
+						"role": "decode",
+					},
+				},
+			},
+		},
+	}
+
+	err := store.AddOrUpdateModelServer(modelServer, nil)
+	if err != nil {
+		t.Fatalf("Failed to add model server: %v", err)
+	}
+
+	// 2. Create and add a pod
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+			Labels: map[string]string{
+				"pd-group": "group-a",
+				"role":     "prefill",
+			},
+		},
+		Status: corev1.PodStatus{
+			PodIP: "10.0.0.1",
+		},
+	}
+
+	err = store.AddOrUpdatePod(pod, []*aiv1alpha1.ModelServer{modelServer})
+	if err != nil {
+		t.Fatalf("Failed to add pod: %v", err)
+	}
+
+	// Verify pod is categorized as a prefill pod
+	prefillPods, err := store.GetPrefillPods(modelServerName)
+	if err != nil {
+		t.Fatalf("Failed to get prefill pods: %v", err)
+	}
+	if len(prefillPods) != 1 {
+		t.Errorf("Expected 1 prefill pod, got %d", len(prefillPods))
+	}
+
+	// 3. Update ModelServer PDGroup config, changing prefill label requirements while keeping the same GroupKey
+	updatedModelServer := &aiv1alpha1.ModelServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-model",
+			Namespace: "default",
+		},
+		Spec: aiv1alpha1.ModelServerSpec{
+			WorkloadSelector: &aiv1alpha1.WorkloadSelector{
+				PDGroup: &aiv1alpha1.PDGroup{
+					GroupKey: "pd-group",
+					PrefillLabels: map[string]string{
+						"role": "prefill-new", // changed
+					},
+					DecodeLabels: map[string]string{
+						"role": "decode",
+					},
+				},
+			},
+		},
+	}
+
+	// Associated pods inside modelServer object
+	podsSet := sets.New(types.NamespacedName{Namespace: "default", Name: "test-pod"})
+
+	err = store.AddOrUpdateModelServer(updatedModelServer, podsSet)
+	if err != nil {
+		t.Fatalf("Failed to update model server: %v", err)
+	}
+
+	// Verify that the old prefill categorization has been cleared, and the pod is no longer categorized as prefill
+	prefillPods, err = store.GetPrefillPods(modelServerName)
+	if err != nil {
+		t.Fatalf("Failed to get prefill pods after update: %v", err)
+	}
+	if len(prefillPods) != 0 {
+		t.Errorf("Expected 0 prefill pods after PDGroup prefill label update, got %d", len(prefillPods))
 	}
 }

--- a/pkg/kthena-router/datastore/store.go
+++ b/pkg/kthena-router/datastore/store.go
@@ -23,6 +23,7 @@ import (
 	"math/rand"
 	"net/http"
 	"os"
+	"reflect"
 	"regexp"
 	"sort"
 	"strconv"
@@ -687,7 +688,14 @@ func (s *store) AddOrUpdateModelServer(ms *aiv1alpha1.ModelServer, pods sets.Set
 		hasOldPDGroup := oldPDGroup != nil
 		hasNewPDGroup := newPDGroup != nil
 
-		if hasOldPDGroup && (!hasNewPDGroup || oldPDGroup.GroupKey != newPDGroup.GroupKey) {
+		pdGroupChanged := false
+		if hasOldPDGroup != hasNewPDGroup {
+			pdGroupChanged = true
+		} else if hasOldPDGroup && hasNewPDGroup {
+			pdGroupChanged = !reflect.DeepEqual(oldPDGroup, newPDGroup)
+		}
+
+		if hasOldPDGroup && pdGroupChanged {
 			// PDGroup configuration was removed or modified, clear the existing map
 			modelServerObj.pdGroups = make(map[string]*PDGroupPods)
 		}
@@ -698,7 +706,7 @@ func (s *store) AddOrUpdateModelServer(ms *aiv1alpha1.ModelServer, pods sets.Set
 			modelServerObj.pods = pods
 		}
 
-		if hasNewPDGroup && (!hasOldPDGroup || oldPDGroup.GroupKey != newPDGroup.GroupKey) {
+		if hasNewPDGroup && pdGroupChanged {
 			// Recategorize all existing pods
 			for podName := range modelServerObj.pods {
 				if value, ok := s.pods.Load(podName); ok {

--- a/pkg/kthena-router/datastore/store.go
+++ b/pkg/kthena-router/datastore/store.go
@@ -674,11 +674,40 @@ func (s *store) AddOrUpdateModelServer(ms *aiv1alpha1.ModelServer, pods sets.Set
 		// Existing object — concurrent readers may access modelServer and pods,
 		// so we must hold the lock to prevent data races.
 		modelServerObj.mutex.Lock()
+
+		var oldPDGroup *aiv1alpha1.PDGroup
+		if modelServerObj.modelServer.Spec.WorkloadSelector != nil {
+			oldPDGroup = modelServerObj.modelServer.Spec.WorkloadSelector.PDGroup
+		}
+		var newPDGroup *aiv1alpha1.PDGroup
+		if ms.Spec.WorkloadSelector != nil {
+			newPDGroup = ms.Spec.WorkloadSelector.PDGroup
+		}
+
+		hasOldPDGroup := oldPDGroup != nil
+		hasNewPDGroup := newPDGroup != nil
+
+		if hasOldPDGroup && (!hasNewPDGroup || oldPDGroup.GroupKey != newPDGroup.GroupKey) {
+			// PDGroup configuration was removed or modified, clear the existing map
+			modelServerObj.pdGroups = make(map[string]*PDGroupPods)
+		}
+
 		modelServerObj.modelServer = ms
 		if len(pods) != 0 {
 			// do not operate s.pods here, which are done within pod handler
 			modelServerObj.pods = pods
 		}
+
+		if hasNewPDGroup && (!hasOldPDGroup || oldPDGroup.GroupKey != newPDGroup.GroupKey) {
+			// Recategorize all existing pods
+			for podName := range modelServerObj.pods {
+				if value, ok := s.pods.Load(podName); ok {
+					podInfo := value.(*PodInfo)
+					modelServerObj.categorizePodForPDGroupNoLock(podName, podInfo.GetPodLabels())
+				}
+			}
+		}
+
 		modelServerObj.mutex.Unlock()
 	}
 	s.modelServer.Store(name, modelServerObj)
@@ -1313,8 +1342,6 @@ func selectFromWeightedSlice(weights []uint32) (int, error) {
 		return 0, fmt.Errorf("no weights provided")
 	}
 
-	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
-
 	totalWeight := 0
 	for _, weight := range weights {
 		totalWeight += int(weight)
@@ -1324,7 +1351,7 @@ func selectFromWeightedSlice(weights []uint32) (int, error) {
 		return 0, fmt.Errorf("total weight is zero")
 	}
 
-	randomNum := rng.Intn(totalWeight)
+	randomNum := rand.Intn(totalWeight)
 
 	for i, weight := range weights {
 		randomNum -= int(weight)

--- a/pkg/kthena-router/scheduler/plugins/random.go
+++ b/pkg/kthena-router/scheduler/plugins/random.go
@@ -18,7 +18,6 @@ package plugins
 
 import (
 	"math/rand"
-	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -36,18 +35,11 @@ var _ framework.ScorePlugin = &Random{}
 // It is primarily intended for testing purposes to validate scheduler behavior with random pod selection.
 type Random struct {
 	name string
-	rng  *rand.Rand
 }
 
 func NewRandom(pluginArg runtime.RawExtension) *Random {
-	// Create a new random number generator with a time-based seed
-	// to ensure different random sequences across different instances
-	source := rand.NewSource(time.Now().UnixNano())
-	rng := rand.New(source)
-
 	return &Random{
 		name: RandomPluginName,
-		rng:  rng,
 	}
 }
 
@@ -65,7 +57,7 @@ func (r *Random) Score(ctx *framework.Context, pods []*datastore.PodInfo) map[*d
 
 	// Assign random scores between 0 and 100 to each pod
 	for _, pod := range pods {
-		score := r.rng.Intn(101) // Generate random number between 0-100 (inclusive)
+		score := rand.Intn(101) // Generate random number between 0-100 (inclusive)
 		scoreResults[pod] = score
 	}
 

--- a/pkg/model-booster-controller/convert/model_server.go
+++ b/pkg/model-booster-controller/convert/model_server.go
@@ -99,6 +99,10 @@ func getKvConnectorSpec(backend workload.ModelBackend) (*networking.KVConnectorS
 			continue
 		}
 
+		if len(worker.Config.Raw) == 0 {
+			continue
+		}
+
 		kvTransferConfig, err := utils.TryGetField(worker.Config.Raw, "kv-transfer-config")
 		if err != nil {
 			return nil, fmt.Errorf("failed to get kv-transfer-config for worker %s: %w", worker.Type, err)
@@ -166,6 +170,9 @@ func getServedModelName(model *workload.ModelBooster, backend workload.ModelBack
 	for _, worker := range backend.Workers {
 		if worker.Type == workload.ModelWorkerTypeServer ||
 			worker.Type == workload.ModelWorkerTypeDecode {
+			if len(worker.Config.Raw) == 0 {
+				continue
+			}
 			valStr, err := utils.TryGetField(worker.Config.Raw, "served-model-name")
 			if err != nil {
 				return servedModelName

--- a/pkg/model-booster-controller/convert/model_server_test.go
+++ b/pkg/model-booster-controller/convert/model_server_test.go
@@ -28,10 +28,11 @@ import (
 
 func TestBuildModelServer(t *testing.T) {
 	tests := []struct {
-		name         string
-		input        *registry.ModelBooster
-		expected     []*networking.ModelServer
-		expectErrMsg string
+		name              string
+		input             *registry.ModelBooster
+		expected          []*networking.ModelServer
+		expectedModelName string
+		expectErrMsg      string
 	}{
 		{
 			name:     "normal case with VLLM backend",
@@ -59,6 +60,66 @@ func TestBuildModelServer(t *testing.T) {
 			},
 			expectErrMsg: "not support InvalidType backend yet",
 		},
+		{
+			name: "empty config on first worker fallback to second worker's served-model-name",
+			input: &registry.ModelBooster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-model",
+					Namespace: "default",
+				},
+				Spec: registry.ModelBoosterSpec{
+					Backend: registry.ModelBackend{
+						Name: "test-backend",
+						Type: registry.ModelBackendTypeVLLM,
+						Workers: []registry.ModelWorker{
+							{
+								Type: registry.ModelWorkerTypeServer,
+								Config: apiextensionsv1.JSON{
+									Raw: nil,
+								},
+							},
+							{
+								Type: registry.ModelWorkerTypeServer,
+								Config: apiextensionsv1.JSON{
+									Raw: []byte(`{"served-model-name":"custom-name"}`),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedModelName: "custom-name",
+		},
+		{
+			name: "all worker configs empty defaults to model name",
+			input: &registry.ModelBooster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-model",
+					Namespace: "default",
+				},
+				Spec: registry.ModelBoosterSpec{
+					Backend: registry.ModelBackend{
+						Name: "test-backend",
+						Type: registry.ModelBackendTypeVLLM,
+						Workers: []registry.ModelWorker{
+							{
+								Type: registry.ModelWorkerTypeServer,
+								Config: apiextensionsv1.JSON{
+									Raw: nil,
+								},
+							},
+							{
+								Type: registry.ModelWorkerTypeServer,
+								Config: apiextensionsv1.JSON{
+									Raw: []byte{},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedModelName: "test-model",
+		},
 	}
 
 	for _, tt := range tests {
@@ -70,7 +131,12 @@ func TestBuildModelServer(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
-			assert.Equal(t, tt.expected, got)
+			if tt.expected != nil {
+				assert.Equal(t, tt.expected, got)
+			}
+			if tt.expectedModelName != "" {
+				assert.Equal(t, tt.expectedModelName, *got[0].Spec.Model)
+			}
 		})
 	}
 }
@@ -165,6 +231,30 @@ func TestGetKvConnectorSpec(t *testing.T) {
 				},
 			},
 			expectErrMsg: "failed to get kv-transfer-config for worker prefill",
+		},
+		{
+			name: "worker config is nil (empty raw)",
+			workers: []registry.ModelWorker{
+				{
+					Type: registry.ModelWorkerTypePrefill,
+					Config: apiextensionsv1.JSON{
+						Raw: nil,
+					},
+				},
+			},
+			expected: nil,
+		},
+		{
+			name: "worker config has empty raw bytes",
+			workers: []registry.ModelWorker{
+				{
+					Type: registry.ModelWorkerTypePrefill,
+					Config: apiextensionsv1.JSON{
+						Raw: []byte{},
+					},
+				},
+			},
+			expected: nil,
 		},
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
Currently, if you create a `ModelBooster` and leave the `config` field empty on any of the model workers, the controller manager fails to reconcile and marks the model as `Failed`. This is because the code tries to parse `worker.Config.Raw` even when it is empty, which triggers a JSON unmarshal error.

Since the `config` field is optional, it shouldn't cause failures when omitted. I've added a check to skip configuration parsing if the raw bytes are empty, and added unit tests to cover this scenario.

**Which issue(s) this PR fixes**:
Fixes #1252

**Special notes for your reviewer**:
The change is very simple and only adds safe checks to handle optional config files. All unit tests pass cleanly.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE

