### PR TITLE
fix: parallelize pod metrics scraping loop with bounded concurrency

### DIFF
--- a/pkg/kthena-router/datastore/store.go
+++ b/pkg/kthena-router/datastore/store.go
@@ -67,6 +67,9 @@ const (
 	defaultMetricsScrapeInterval = 1 * time.Second
 	metricsScrapeIntervalEnv     = "METRICS_SCRAPE_INTERVAL"
 
+	// maxConcurrentPodScrapes caps goroutines spawned per metrics scrape cycle.
+	maxConcurrentPodScrapes = 100
+
 	// onFlightSyncInterval caps Redis read traffic from SyncOnFlightCounts.
 	// At most one HMGET is issued per interval regardless of request rate;
 	// all other callers use the local atomic values maintained by Incr/Decr.
@@ -484,13 +487,26 @@ func (s *store) Run(ctx context.Context) {
 		ticker := time.NewTicker(s.metricsScrapeInterval)
 		defer ticker.Stop()
 		for {
+			var wg sync.WaitGroup
+			sem := make(chan struct{}, maxConcurrentPodScrapes)
 			s.pods.Range(func(key, value any) bool {
 				if p, ok := value.(*PodInfo); ok {
-					s.updatePodMetrics(p)
-					s.updatePodModels(p)
+					select {
+					case <-ctx.Done():
+						return false
+					case sem <- struct{}{}:
+					}
+					wg.Add(1)
+					go func(pod *PodInfo) {
+						defer wg.Done()
+						defer func() { <-sem }()
+						s.updatePodMetrics(pod)
+						s.updatePodModels(pod)
+					}(p)
 				}
 				return true
 			})
+			wg.Wait()
 			s.initialSynced.Store(true)
 			select {
 			case <-ctx.Done():

--- a/pkg/kthena-router/datastore/store_test.go
+++ b/pkg/kthena-router/datastore/store_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package datastore
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"net/http"
@@ -2265,4 +2266,73 @@ func TestMatchModelServer_GatewayScoped(t *testing.T) {
 			assert.Equal(t, tt.expectedServer, server)
 		})
 	}
+}
+
+func TestStoreRunBoundedConcurrency(t *testing.T) {
+	const testPodCount = 150 // > maxConcurrentPodScrapes (100)
+
+	var inFlight atomic.Int32
+	var maxInFlight atomic.Int32
+	var metricsCalls, modelsCalls atomic.Int64
+
+	s := &store{
+		pods:                  sync.Map{},
+		modelServer:           sync.Map{},
+		initialSynced:         &atomic.Bool{},
+		metricsScrapeInterval: 10 * time.Millisecond,
+		podRuntimeInspector: &fakePodRuntimeInspector{
+			metricsFn: func(_ string, _ *corev1.Pod, _ uint32, _ map[string]*dto.Histogram) (map[string]float64, map[string]*dto.Histogram) {
+				current := inFlight.Add(1)
+				defer inFlight.Add(-1)
+
+				// Track max concurrent goroutines
+				for {
+					max := maxInFlight.Load()
+					if current <= max {
+						break
+					}
+					if maxInFlight.CompareAndSwap(max, current) {
+						break
+					}
+				}
+
+				// Small sleep to ensure goroutines pile up and hit the cap
+				time.Sleep(2 * time.Millisecond)
+
+				metricsCalls.Add(1)
+				return nil, nil
+			},
+			modelsFn: func(_ string, _ *corev1.Pod, _ uint32) ([]string, error) {
+				modelsCalls.Add(1)
+				return nil, nil
+			},
+		},
+	}
+
+	for i := 0; i < testPodCount; i++ {
+		podName := types.NamespacedName{Namespace: "default", Name: fmt.Sprintf("pod%d", i)}
+		s.pods.Store(podName, &PodInfo{
+			Pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: podName.Name, Namespace: podName.Namespace},
+				Status:     corev1.PodStatus{PodIP: fmt.Sprintf("10.0.0.%d", i)},
+			},
+			engine:      "vLLM",
+			modelServer: sets.New[types.NamespacedName](types.NamespacedName{Namespace: "default", Name: "model"}),
+		})
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Start the actual Run loop
+	s.Run(ctx)
+
+	// Wait for at least one full cycle of scrapes
+	assert.Eventually(t, func() bool {
+		return metricsCalls.Load() >= int64(testPodCount) && modelsCalls.Load() >= int64(testPodCount)
+	}, 2*time.Second, 10*time.Millisecond)
+
+	// Verify the bound was respected and parallelism actually occurred
+	assert.Greater(t, maxInFlight.Load(), int32(1), "expected at least some parallelism in scrapes")
+	assert.LessOrEqual(t, maxInFlight.Load(), int32(maxConcurrentPodScrapes), "in-flight requests should never exceed the semaphore cap")
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The background scraper in `store.Run()` was doing a blocking HTTP GET for every pod sequentially. In a cluster with a lot of pods or just a few unresponsive ones timing out, the entire loop would hang. This meant O(N) scaling for scrapes, leading to stale metrics across the board if a few pods acted up.

Fixed this by firing off the scrapes concurrently with a standard `sync.WaitGroup`, capping the max concurrent goroutines at 100 to avoid exploding the scheduler:

```go
var wg sync.WaitGroup
sem := make(chan struct{}, maxConcurrentPodScrapes) // 100

s.pods.Range(func(key, value any) bool {
    if p, ok := value.(*PodInfo); ok {
        select {
        case <-ctx.Done():
            return false // Stop iterating if context is cancelled
        case sem <- struct{}{}:
        }
        wg.Add(1)
        go func(pod *PodInfo) {
            defer wg.Done()
            defer func() { <-sem }()
            s.updatePodMetrics(pod)
            s.updatePodModels(pod)
        }(p)
    }
    return true
})
wg.Wait()
```

**Which issue(s) this PR fixes**:
Fixes #1250

**Special notes for your reviewer**:

- Went with a hard cap of 100 based on the issue discussion with @hzxuzhonghu. Happy to pull it out into an env var later if we think it's needed.
- Added `TestStoreRunBoundedConcurrency` to verify correctness. Used atomic counters instead of time-based sleeps to keep the test deterministic and avoid CI flakes.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```