### PR TITLE
fix(router): forward backend client errors

### DIFF
--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -898,7 +898,7 @@ func doRequest(
 	if err != nil {
 		return nil, err
 	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+	if resp.StatusCode < 200 || resp.StatusCode >= 500 {
 		resp.Body.Close()
 		return nil, fmt.Errorf("http resp error, http code is %d", resp.StatusCode)
 	}

--- a/pkg/kthena-router/router/router_test.go
+++ b/pkg/kthena-router/router/router_test.go
@@ -727,6 +727,29 @@ func TestRouter_HandlerFunc_AggregatedMode(t *testing.T) {
 	assert.Contains(t, w.Body.String(), `"id":"response-id"`)
 }
 
+func TestProxyRequest_ForwardBackendClientError(t *testing.T) {
+	backendHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprint(w, `{"error":"bad request from model"}`)
+	})
+	backend := httptest.NewServer(backendHandler)
+	defer backend.Close()
+
+	backendURL, _ := url.Parse(backend.URL)
+	backendPort, _ := strconv.Atoi(backendURL.Port())
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	req, _ := http.NewRequest("POST", "http://kthena/v1/chat/completions", bytes.NewBufferString(`{"model":"test-model"}`))
+
+	err := proxyRequest(c, req, backendURL.Hostname(), int32(backendPort), false, nil)
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "bad request from model")
+}
+
 func TestRouter_HandlerFunc_DisaggregatedMode(t *testing.T) {
 	// 1. Setup backend mock server
 	prefillReqs := 0


### PR DESCRIPTION

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The router was treating every non-2xx backend response as a pod/proxy failure.

That hides normal backend client errors like 400/401/429 and can return `request to all pods failed` instead of the real status and error body. This keeps 5xx responses retryable, but forwards backend client errors to the caller.

**Which issue(s) this PR fixes**:
Fixes #

N/A

**Special notes for your reviewer**:

Added a regression test for forwarding a backend 400 response body. Existing 503 retry behavior is kept.

**Does this PR introduce a user-facing change?**:

```release-note
Kthena router now forwards non-5xx backend error responses, such as 400 or 429, instead of hiding them as proxy failures.