### PR TITLE
fix(router): respect Gateway allowedRoutes

### DIFF
--- a/charts/kthena/charts/networking/templates/kthena-router/rbac/cluster-role.yaml
+++ b/charts/kthena/charts/networking/templates/kthena-router/rbac/cluster-role.yaml
@@ -78,6 +78,14 @@ rules:
   {{- end }}
   {{- if .Values.kthenaRouter.gatewayAPI.inferenceExtension }}
   - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - inference.networking.k8s.io
     resources:
       - inferencepools

--- a/cmd/kthena-router/app/controller.go
+++ b/cmd/kthena-router/app/controller.go
@@ -116,14 +116,17 @@ func startControllers(store datastore.Store, stop <-chan struct{}, enableGateway
 		)
 
 		if enableGatewayAPIInferenceExtension {
-			httpRouteController = controller.NewHTTPRouteController(gatewayInformerFactory, store)
+			httpRouteController = controller.NewHTTPRouteController(gatewayInformerFactory, kubeInformerFactory, store)
 			dynamicClient, err := dynamic.NewForConfig(cfg)
 			if err != nil {
 				klog.Fatalf("Error building dynamic client: %s", err.Error())
 			}
 			dynamicInformerFactory := dynamicinformer.NewDynamicSharedInformerFactory(dynamicClient, 0)
 			inferencePoolController = controller.NewInferencePoolController(dynamicInformerFactory, store)
-			cacheSyncs = append(cacheSyncs, dynamicInformerFactory.ForResource(inferencev1.SchemeGroupVersion.WithResource("inferencepools")).Informer().HasSynced)
+			cacheSyncs = append(cacheSyncs,
+				kubeInformerFactory.Core().V1().Namespaces().Informer().HasSynced,
+				dynamicInformerFactory.ForResource(inferencev1.SchemeGroupVersion.WithResource("inferencepools")).Informer().HasSynced,
+			)
 			dynamicInformerFactory.Start(stop)
 		}
 		gatewayInformerFactory.Start(stop)
@@ -258,6 +261,8 @@ func ensureDefaultGateway(gatewayClient gatewayclientset.Interface, defaultPort 
 		return fmt.Errorf("failed to check Gateway %s/%s: %w", namespace, name, err)
 	}
 
+	namespacesFromAll := gatewayv1.NamespacesFromAll
+
 	// Create the default Gateway
 	gateway := &gatewayv1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{
@@ -271,6 +276,9 @@ func ensureDefaultGateway(gatewayClient gatewayclientset.Interface, defaultPort 
 					Name:     gatewayv1.SectionName("default"),
 					Port:     gatewayv1.PortNumber(port),
 					Protocol: gatewayv1.HTTPProtocolType,
+					AllowedRoutes: &gatewayv1.AllowedRoutes{
+						Namespaces: &gatewayv1.RouteNamespaces{From: &namespacesFromAll},
+					},
 					// Hostname is nil, meaning match all hostnames
 				},
 			},

--- a/pkg/kthena-router/controller/httproute_controller.go
+++ b/pkg/kthena-router/controller/httproute_controller.go
@@ -22,9 +22,12 @@ import (
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/informers"
+	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
@@ -38,7 +41,9 @@ import (
 type HTTPRouteController struct {
 	httpRouteLister gatewaylisters.HTTPRouteLister
 	gatewayLister   gatewaylisters.GatewayLister
+	namespaceLister corelisters.NamespaceLister
 	httpRouteSynced cache.InformerSynced
+	namespaceSynced cache.InformerSynced
 	registration    cache.ResourceEventHandlerRegistration
 
 	workqueue   workqueue.TypedRateLimitingInterface[any]
@@ -48,15 +53,19 @@ type HTTPRouteController struct {
 
 func NewHTTPRouteController(
 	gatewayInformerFactory gatewayinformers.SharedInformerFactory,
+	kubeInformerFactory informers.SharedInformerFactory,
 	store datastore.Store,
 ) *HTTPRouteController {
 	httpRouteInformer := gatewayInformerFactory.Gateway().V1().HTTPRoutes()
 	gatewayInformer := gatewayInformerFactory.Gateway().V1().Gateways()
+	namespaceInformer := kubeInformerFactory.Core().V1().Namespaces()
 
 	controller := &HTTPRouteController{
 		httpRouteLister: httpRouteInformer.Lister(),
 		gatewayLister:   gatewayInformer.Lister(),
+		namespaceLister: namespaceInformer.Lister(),
 		httpRouteSynced: httpRouteInformer.Informer().HasSynced,
+		namespaceSynced: namespaceInformer.Informer().HasSynced,
 		workqueue:       workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[any]()),
 		initialSync:     &atomic.Bool{},
 		store:           store,
@@ -86,6 +95,12 @@ func NewHTTPRouteController(
 	}
 	_, _ = gatewayInformer.Informer().AddEventHandler(gatewayFilter)
 
+	_, _ = namespaceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    controller.enqueueHTTPRoutesForNamespace,
+		UpdateFunc: func(_, new interface{}) { controller.enqueueHTTPRoutesForNamespace(new) },
+		DeleteFunc: controller.enqueueHTTPRoutesForNamespace,
+	})
+
 	return controller
 }
 
@@ -93,7 +108,7 @@ func (c *HTTPRouteController) Run(stopCh <-chan struct{}) error {
 	defer utilruntime.HandleCrash()
 	defer c.workqueue.ShutDown()
 
-	if ok := cache.WaitForCacheSync(stopCh, c.httpRouteSynced); !ok {
+	if ok := cache.WaitForCacheSync(stopCh, c.httpRouteSynced, c.namespaceSynced); !ok {
 		return fmt.Errorf("failed to wait for caches to sync")
 	}
 	c.workqueue.Add(initialSyncSignal)
@@ -167,7 +182,7 @@ func (c *HTTPRouteController) syncHandler(key string) error {
 	// Check all parentRefs - process immediately if any matches, retry only if no match and a Gateway is pending
 	var gatewayPending bool
 	for _, parentRef := range httpRoute.Spec.ParentRefs {
-		if parentRef.Kind == nil || *parentRef.Kind != "Gateway" {
+		if !isGatewayParentRef(parentRef) {
 			continue
 		}
 		gatewayNamespace := httpRoute.Namespace
@@ -183,7 +198,13 @@ func (c *HTTPRouteController) syncHandler(key string) error {
 			continue
 		}
 		if string(gw.Spec.GatewayClassName) == DefaultGatewayClassName {
-			return c.store.AddOrUpdateHTTPRoute(httpRoute)
+			allowed, err := c.gatewayAllowsHTTPRoute(gw, httpRoute, parentRef)
+			if err != nil {
+				return err
+			}
+			if allowed {
+				return c.store.AddOrUpdateHTTPRoute(httpRoute)
+			}
 		}
 	}
 	if gatewayPending {
@@ -216,7 +237,7 @@ func (c *HTTPRouteController) enqueueHTTPRoutesForGateway(obj interface{}) {
 	}
 	for _, route := range routes {
 		for _, parentRef := range route.Spec.ParentRefs {
-			if parentRef.Kind != nil && *parentRef.Kind == "Gateway" {
+			if isGatewayParentRef(parentRef) {
 				ns := route.Namespace
 				if parentRef.Namespace != nil {
 					ns = string(*parentRef.Namespace)
@@ -227,5 +248,106 @@ func (c *HTTPRouteController) enqueueHTTPRoutesForGateway(obj interface{}) {
 				}
 			}
 		}
+	}
+}
+
+func isGatewayParentRef(parentRef gatewayv1.ParentReference) bool {
+	if parentRef.Group != nil && string(*parentRef.Group) != gatewayv1.GroupName {
+		return false
+	}
+	return parentRef.Kind == nil || *parentRef.Kind == "Gateway"
+}
+
+func (c *HTTPRouteController) gatewayAllowsHTTPRoute(gw *gatewayv1.Gateway, httpRoute *gatewayv1.HTTPRoute, parentRef gatewayv1.ParentReference) (bool, error) {
+	for _, listener := range gw.Spec.Listeners {
+		if !parentRefSelectsListener(parentRef, listener) {
+			continue
+		}
+		if !listenerAllowsHTTPRouteKind(listener) {
+			continue
+		}
+		allowed, err := c.listenerAllowsRouteNamespace(listener, gw.Namespace, httpRoute.Namespace)
+		if err != nil {
+			return false, err
+		}
+		if allowed {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func parentRefSelectsListener(parentRef gatewayv1.ParentReference, listener gatewayv1.Listener) bool {
+	if parentRef.SectionName != nil && *parentRef.SectionName != listener.Name {
+		return false
+	}
+	if parentRef.Port != nil && *parentRef.Port != listener.Port {
+		return false
+	}
+	return true
+}
+
+func listenerAllowsHTTPRouteKind(listener gatewayv1.Listener) bool {
+	if listener.AllowedRoutes == nil || len(listener.AllowedRoutes.Kinds) == 0 {
+		return listener.Protocol == gatewayv1.HTTPProtocolType || listener.Protocol == gatewayv1.HTTPSProtocolType
+	}
+
+	for _, kind := range listener.AllowedRoutes.Kinds {
+		if kind.Group != nil && string(*kind.Group) != gatewayv1.GroupName {
+			continue
+		}
+		if kind.Kind == "HTTPRoute" {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *HTTPRouteController) listenerAllowsRouteNamespace(listener gatewayv1.Listener, gatewayNamespace, routeNamespace string) (bool, error) {
+	if listener.AllowedRoutes == nil || listener.AllowedRoutes.Namespaces == nil || listener.AllowedRoutes.Namespaces.From == nil {
+		return gatewayNamespace == routeNamespace, nil
+	}
+
+	switch *listener.AllowedRoutes.Namespaces.From {
+	case gatewayv1.NamespacesFromAll:
+		return true, nil
+	case gatewayv1.NamespacesFromSame:
+		return gatewayNamespace == routeNamespace, nil
+	case gatewayv1.NamespacesFromSelector:
+		if listener.AllowedRoutes.Namespaces.Selector == nil {
+			return false, nil
+		}
+		selector, err := metav1.LabelSelectorAsSelector(listener.AllowedRoutes.Namespaces.Selector)
+		if err != nil {
+			return false, err
+		}
+		namespace, err := c.namespaceLister.Get(routeNamespace)
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		if err != nil {
+			return false, err
+		}
+		return selector.Matches(labels.Set(namespace.Labels)), nil
+	default:
+		return false, nil
+	}
+}
+
+func (c *HTTPRouteController) enqueueHTTPRoutesForNamespace(obj interface{}) {
+	if d, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+		obj = d.Obj
+	}
+	ns, ok := obj.(metav1.Object)
+	if !ok {
+		return
+	}
+	routes, err := c.httpRouteLister.HTTPRoutes(ns.GetName()).List(labels.Everything())
+	if err != nil {
+		klog.Errorf("failed to list HTTPRoutes for namespace %s: %v", ns.GetName(), err)
+		return
+	}
+	for _, route := range routes {
+		c.workqueue.Add(fmt.Sprintf("%s/%s", route.Namespace, route.Name))
 	}
 }

--- a/pkg/kthena-router/controller/httproute_controller_test.go
+++ b/pkg/kthena-router/controller/httproute_controller_test.go
@@ -22,7 +22,11 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kubeinformers "k8s.io/client-go/informers"
+	kubefake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayfake "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/fake"
@@ -34,11 +38,13 @@ import (
 func ptr[T any](v T) *T { return &v }
 
 func TestHTTPRouteController_EnqueueHTTPRoutesForGateway(t *testing.T) {
+	kubeClient := kubefake.NewSimpleClientset()
+	kubeInformerFactory := kubeinformers.NewSharedInformerFactory(kubeClient, 0)
 	gatewayClient := gatewayfake.NewSimpleClientset()
 	gatewayInformerFactory := gatewayinformers.NewSharedInformerFactory(gatewayClient, 0)
 	store := datastore.New()
 
-	ctrl := NewHTTPRouteController(gatewayInformerFactory, store)
+	ctrl := NewHTTPRouteController(gatewayInformerFactory, kubeInformerFactory, store)
 	stop := make(chan struct{})
 	defer close(stop)
 	gatewayInformerFactory.Start(stop)
@@ -114,11 +120,13 @@ func TestHTTPRouteController_EnqueueHTTPRoutesForGateway(t *testing.T) {
 }
 
 func TestHTTPRouteController_EnqueueHTTPRoutesForGateway_NoMatchingRoutes(t *testing.T) {
+	kubeClient := kubefake.NewSimpleClientset()
+	kubeInformerFactory := kubeinformers.NewSharedInformerFactory(kubeClient, 0)
 	gatewayClient := gatewayfake.NewSimpleClientset()
 	gatewayInformerFactory := gatewayinformers.NewSharedInformerFactory(gatewayClient, 0)
 	store := datastore.New()
 
-	ctrl := NewHTTPRouteController(gatewayInformerFactory, store)
+	ctrl := NewHTTPRouteController(gatewayInformerFactory, kubeInformerFactory, store)
 	stop := make(chan struct{})
 	defer close(stop)
 	gatewayInformerFactory.Start(stop)
@@ -162,9 +170,146 @@ func TestHTTPRouteController_EnqueueHTTPRoutesForGateway_NoMatchingRoutes(t *tes
 	assert.Equal(t, 0, ctrl.workqueue.Len(), "no HTTPRoutes reference gateway-1")
 }
 
+func TestHTTPRouteController_AllowedRoutesNamespaces(t *testing.T) {
+	nsFromAll := gatewayv1.NamespacesFromAll
+	nsFromSame := gatewayv1.NamespacesFromSame
+	nsFromSelector := gatewayv1.NamespacesFromSelector
+
+	tests := []struct {
+		name          string
+		routeNS       string
+		routeLabels   map[string]string
+		allowedRoutes *gatewayv1.AllowedRoutes
+		defaultParent bool
+		wantStored    bool
+	}{
+		{
+			name:          "default same namespace allows same namespace",
+			routeNS:       "default",
+			defaultParent: true,
+			wantStored:    true,
+		},
+		{
+			name:       "default same namespace blocks cross namespace",
+			routeNS:    "other",
+			wantStored: false,
+		},
+		{
+			name:    "all allows cross namespace",
+			routeNS: "other",
+			allowedRoutes: &gatewayv1.AllowedRoutes{
+				Namespaces: &gatewayv1.RouteNamespaces{From: &nsFromAll},
+			},
+			wantStored: true,
+		},
+		{
+			name:        "selector allows matching namespace",
+			routeNS:     "selected",
+			routeLabels: map[string]string{"team": "inference"},
+			allowedRoutes: &gatewayv1.AllowedRoutes{
+				Namespaces: &gatewayv1.RouteNamespaces{
+					From:     &nsFromSelector,
+					Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"team": "inference"}},
+				},
+			},
+			wantStored: true,
+		},
+		{
+			name:        "selector blocks non matching namespace",
+			routeNS:     "blocked",
+			routeLabels: map[string]string{"team": "other"},
+			allowedRoutes: &gatewayv1.AllowedRoutes{
+				Namespaces: &gatewayv1.RouteNamespaces{
+					From:     &nsFromSelector,
+					Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"team": "inference"}},
+				},
+			},
+			wantStored: false,
+		},
+		{
+			name:    "explicit same namespace blocks cross namespace",
+			routeNS: "other",
+			allowedRoutes: &gatewayv1.AllowedRoutes{
+				Namespaces: &gatewayv1.RouteNamespaces{From: &nsFromSame},
+			},
+			wantStored: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			namespaces := []runtime.Object{
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
+			}
+			if tt.routeNS != "default" {
+				namespaces = append(namespaces, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: tt.routeNS, Labels: tt.routeLabels}})
+			}
+			kubeClient := kubefake.NewSimpleClientset(namespaces...)
+			kubeInformerFactory := kubeinformers.NewSharedInformerFactory(kubeClient, 0)
+			gatewayClient := gatewayfake.NewSimpleClientset()
+			gatewayInformerFactory := gatewayinformers.NewSharedInformerFactory(gatewayClient, 0)
+			store := datastore.New()
+
+			gw := &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "gateway"},
+				Spec: gatewayv1.GatewaySpec{
+					GatewayClassName: gatewayv1.ObjectName(DefaultGatewayClassName),
+					Listeners: []gatewayv1.Listener{
+						{
+							Name:          gatewayv1.SectionName("http"),
+							Port:          gatewayv1.PortNumber(80),
+							Protocol:      gatewayv1.HTTPProtocolType,
+							AllowedRoutes: tt.allowedRoutes,
+						},
+					},
+				},
+			}
+			assert.NoError(t, store.AddOrUpdateGateway(gw))
+
+			parentRef := gatewayv1.ParentReference{
+				Namespace: ptr(gatewayv1.Namespace("default")),
+				Name:      gatewayv1.ObjectName("gateway"),
+			}
+			if !tt.defaultParent {
+				parentRef.Kind = ptr(gatewayv1.Kind("Gateway"))
+			}
+			httpRoute := &gatewayv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{Namespace: tt.routeNS, Name: "route"},
+				Spec: gatewayv1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{
+						ParentRefs: []gatewayv1.ParentReference{parentRef},
+					},
+				},
+			}
+			_, err := gatewayClient.GatewayV1().HTTPRoutes(tt.routeNS).Create(context.Background(), httpRoute, metav1.CreateOptions{})
+			assert.NoError(t, err)
+
+			ctrl := NewHTTPRouteController(gatewayInformerFactory, kubeInformerFactory, store)
+			stop := make(chan struct{})
+			defer close(stop)
+			kubeInformerFactory.Start(stop)
+			gatewayInformerFactory.Start(stop)
+
+			if !cache.WaitForCacheSync(stop,
+				kubeInformerFactory.Core().V1().Namespaces().Informer().HasSynced,
+				gatewayInformerFactory.Gateway().V1().HTTPRoutes().Informer().HasSynced,
+			) {
+				t.Fatal("cache sync timeout")
+			}
+
+			err = ctrl.syncHandler(tt.routeNS + "/route")
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantStored, store.GetHTTPRoute(tt.routeNS+"/route") != nil)
+			assert.Equal(t, tt.wantStored, len(store.GetHTTPRoutesByGateway("default/gateway")) > 0)
+		})
+	}
+}
+
 // TestHTTPRouteController_MultipleParentRefs_FirstPending verifies that when the first parentRef
 // references a Gateway not in store, we still process if a later parentRef matches.
 func TestHTTPRouteController_MultipleParentRefs_FirstPending(t *testing.T) {
+	kubeClient := kubefake.NewSimpleClientset()
+	kubeInformerFactory := kubeinformers.NewSharedInformerFactory(kubeClient, 0)
 	gatewayClient := gatewayfake.NewSimpleClientset()
 	gatewayInformerFactory := gatewayinformers.NewSharedInformerFactory(gatewayClient, 0)
 	store := datastore.New()
@@ -175,6 +320,13 @@ func TestHTTPRouteController_MultipleParentRefs_FirstPending(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "gateway-2"},
 		Spec: gatewayv1.GatewaySpec{
 			GatewayClassName: gatewayv1.ObjectName(DefaultGatewayClassName),
+			Listeners: []gatewayv1.Listener{
+				{
+					Name:     gatewayv1.SectionName("http"),
+					Port:     gatewayv1.PortNumber(80),
+					Protocol: gatewayv1.HTTPProtocolType,
+				},
+			},
 		},
 	}
 	_, err := gatewayClient.GatewayV1().Gateways(ns).Create(ctx, gw2, metav1.CreateOptions{})
@@ -195,7 +347,7 @@ func TestHTTPRouteController_MultipleParentRefs_FirstPending(t *testing.T) {
 	_, err = gatewayClient.GatewayV1().HTTPRoutes(ns).Create(ctx, httpRoute, metav1.CreateOptions{})
 	assert.NoError(t, err)
 
-	ctrl := NewHTTPRouteController(gatewayInformerFactory, store)
+	ctrl := NewHTTPRouteController(gatewayInformerFactory, kubeInformerFactory, store)
 	stop := make(chan struct{})
 	defer close(stop)
 	gatewayInformerFactory.Start(stop)

--- a/pkg/kthena-router/datastore/store.go
+++ b/pkg/kthena-router/datastore/store.go
@@ -2006,7 +2006,7 @@ func (s *store) AddOrUpdateHTTPRoute(httpRoute *gatewayv1.HTTPRoute) error {
 
 	// Update gateway routes mapping
 	for _, parentRef := range httpRoute.Spec.ParentRefs {
-		if parentRef.Kind != nil && *parentRef.Kind == "Gateway" {
+		if isGatewayParentRef(parentRef) {
 			gatewayName := string(parentRef.Name)
 			gatewayNamespace := httpRoute.Namespace
 			if parentRef.Namespace != nil {
@@ -2025,6 +2025,13 @@ func (s *store) AddOrUpdateHTTPRoute(httpRoute *gatewayv1.HTTPRoute) error {
 
 	klog.V(4).Infof("Added or updated HTTPRoute: %s", key)
 	return nil
+}
+
+func isGatewayParentRef(parentRef gatewayv1.ParentReference) bool {
+	if parentRef.Group != nil && string(*parentRef.Group) != gatewayv1.GroupName {
+		return false
+	}
+	return parentRef.Kind == nil || *parentRef.Kind == "Gateway"
 }
 
 func (s *store) DeleteHTTPRoute(key string) error {

--- a/test/e2e/router/gateway-inference-extension/e2e_test.go
+++ b/test/e2e/router/gateway-inference-extension/e2e_test.go
@@ -383,12 +383,20 @@ func TestGatewayCreatedLaterThanHTTPRoute(t *testing.T) {
 
 	// 3. Create Gateway (triggers HTTPRoute re-enqueue)
 	t.Log("Creating Gateway...")
+	namespacesFromAll := gatewayv1.NamespacesFromAll
 	gateway := &gatewayv1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{Name: gatewayName, Namespace: kthenaNamespace},
 		Spec: gatewayv1.GatewaySpec{
 			GatewayClassName: gatewayv1.ObjectName("kthena-router"),
 			Listeners: []gatewayv1.Listener{
-				{Name: gatewayv1.SectionName("http"), Port: gatewayv1.PortNumber(8082), Protocol: gatewayv1.HTTPProtocolType},
+				{
+					Name:     gatewayv1.SectionName("http"),
+					Port:     gatewayv1.PortNumber(8082),
+					Protocol: gatewayv1.HTTPProtocolType,
+					AllowedRoutes: &gatewayv1.AllowedRoutes{
+						Namespaces: &gatewayv1.RouteNamespaces{From: &namespacesFromAll},
+					},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

HTTPRoutes were accepted for a Gateway even when the selected listener did not allow routes from that namespace.

This makes the HTTPRoute controller respect Gateway `allowedRoutes` before storing the route, including the default same-namespace behavior and selector-based namespace matching.

**Which issue(s) this PR fixes**:
Fixes #1132

**Special notes for your reviewer**:

Also handles default Gateway parentRefs where `group`/`kind` are omitted.

**Does this PR introduce a user-facing change?**:

```release-note
Kthena router now respects Gateway listener allowedRoutes when accepting HTTPRoutes.