### PR TITLE
Fixed an issue where a PG was created by mistake when scaling up a Se…

### DIFF
--- a/pkg/model-serving-controller/controller/model_serving_controller.go
+++ b/pkg/model-serving-controller/controller/model_serving_controller.go
@@ -650,8 +650,10 @@ func (c *ModelServingController) syncServingGroupReplicas(ctx context.Context, m
 		klog.V(2).Infof("manageServingGroupReplicas: scaling up modelServing=%s (%d -> %d)", utils.GetNamespaceName(ms), curReplicas, expectedCount)
 		// update pod groups if needed
 		for _, servingGroup := range servingGroupList {
-			if err := c.createOrUpdatePodGroupByServingGroup(ctx, ms, servingGroup.Name); err != nil {
-				return fmt.Errorf("failed to update PodGroup for ServingGroup %s: %v", servingGroup.Name, err)
+			if servingGroup.Status != datastore.ServingGroupDeleting {
+				if err := c.createOrUpdatePodGroupByServingGroup(ctx, ms, servingGroup.Name); err != nil {
+					return fmt.Errorf("failed to update PodGroup for ServingGroup %s: %v", servingGroup.Name, err)
+				}
 			}
 		}
 		if err := c.scaleUpServingGroups(ctx, ms, servingGroupList, expectedCount, newRevision); err != nil {


### PR DESCRIPTION
…rvingGroup due to an error during SG deletion.
/kind bug
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:

Prevent the creation of a podgroup for a ServingGroup marked as ‘ServingGroupDeleting’ during a scale-up operation

**Which issue(s) this PR fixes**:
Fixes #1267 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Prevent the creation of a podgroup for a ServingGroup marked as ‘ServingGroupDeleting’ during a scale-up operation
```
