### PR TITLE
autoscaler: fix ratio metric aggregation across heterogeneous backends

### DIFF
--- a/pkg/autoscaler/autoscaler/metric_collector.go
+++ b/pkg/autoscaler/autoscaler/metric_collector.go
@@ -536,11 +536,3 @@ func (collector *MetricCollector) getPrometheusAPI(serverURL string, timeout tim
 	collector.promClients[serverURL] = client
 	return prometheusv1.NewAPI(client), nil
 }
-
-func addMetric(instanceMetricMap algorithm.Metrics, metricName string, metricValue float64) {
-	if oldValue, ok := instanceMetricMap[metricName]; ok {
-		instanceMetricMap[metricName] = oldValue + metricValue
-	} else {
-		instanceMetricMap[metricName] = metricValue
-	}
-}

--- a/pkg/autoscaler/autoscaler/optimizer.go
+++ b/pkg/autoscaler/autoscaler/optimizer.go
@@ -19,6 +19,7 @@ package autoscaler
 import (
 	"context"
 	"sort"
+	"strings"
 
 	workload "github.com/volcano-sh/kthena/pkg/apis/workload/v1alpha1"
 	"github.com/volcano-sh/kthena/pkg/autoscaler/algorithm"
@@ -150,7 +151,9 @@ func (optimizer *Optimizer) Optimize(ctx context.Context, podLister listerv1.Pod
 	size := len(optimizer.Meta.Config.Params)
 	unreadyInstancesCount := int32(0)
 	readyInstancesMetrics := make([]algorithm.Metrics, 0, size)
-	externalMetrics := make(algorithm.Metrics)
+	// externalSamples accumulates per-backend (value, replicas) pairs for each
+	// external metric so that the correct aggregation can be applied afterwards.
+	externalSamples := make(map[string][]backendExternalSample)
 	instancesCountSum := int32(0)
 	// Update all model serving instances' metrics
 	for _, param := range optimizer.Meta.Config.Params {
@@ -160,7 +163,8 @@ func (optimizer *Optimizer) Optimize(ctx context.Context, podLister listerv1.Pod
 			continue
 		}
 
-		instancesCountSum += currentInstancesCounts[param.Target.TargetRef.Name]
+		backendReplicas := currentInstancesCounts[param.Target.TargetRef.Name]
+		instancesCountSum += backendReplicas
 		currentUnreadyInstancesCount, currentReadyInstancesMetrics, currentExternalMetrics, err := collector.UpdateMetrics(ctx, podLister, param.Target.MetricSources)
 		if err != nil {
 			klog.Warningf("update metrics error: %v", err)
@@ -168,14 +172,20 @@ func (optimizer *Optimizer) Optimize(ctx context.Context, podLister listerv1.Pod
 		}
 		unreadyInstancesCount += currentUnreadyInstancesCount
 		readyInstancesMetrics = append(readyInstancesMetrics, currentReadyInstancesMetrics)
-		// TODO: External metrics are aggregated with a plain sum across targets.
-		// This is correct for additive metrics (for example queue length), but it
-		// is semantically wrong for ratio metrics such as GPU utilization.
-		// Introduce per-metric aggregation strategy (sum/avg/max/weighted) in a
-		// follow-up change and apply it here instead of unconditional summation.
 		for metricName, metricValue := range currentExternalMetrics {
-			addMetric(externalMetrics, metricName, metricValue)
+			externalSamples[metricName] = append(externalSamples[metricName], backendExternalSample{
+				value:    metricValue,
+				replicas: backendReplicas,
+			})
 		}
+	}
+	// Aggregate external metrics using the semantics appropriate for each metric
+	// type: additive metrics are summed; ratio metrics use a replica-weighted
+	// average so that heterogeneous backends (different replica counts) do not
+	// distort the result.
+	externalMetrics := make(algorithm.Metrics, len(externalSamples))
+	for name, samples := range externalSamples {
+		externalMetrics[name] = aggregateExternalSamples(name, samples)
 	}
 	// Get recommended replicas of all model serving instances
 	instancesAlgorithm := algorithm.RecommendedInstancesAlgorithm{
@@ -212,4 +222,64 @@ func (optimizer *Optimizer) Optimize(ctx context.Context, podLister listerv1.Pod
 
 	replicasMap := optimizer.Meta.RestoreReplicasOfEachBackend(recommendedInstances)
 	return replicasMap, nil
+}
+
+// backendExternalSample pairs an external metric value with the replica count
+// of the backend that reported it.
+type backendExternalSample struct {
+	value    float64
+	replicas int32
+}
+
+// isRatioMetric reports whether name represents a ratio (bounded) metric that
+// must be aggregated as a weighted average across backends rather than summed.
+// Recognised suffixes: _utilization, _usage, _ratio, _percent, _saturation.
+// The "rate" suffix is intentionally excluded: throughput and request-rate
+// metrics are additive across backends.
+func isRatioMetric(name string) bool {
+	lowerName := strings.ToLower(name)
+	for _, sfx := range []string{"_utilization", "_usage", "_ratio", "_percent", "_saturation"} {
+		if strings.HasSuffix(lowerName, sfx) {
+			return true
+		}
+	}
+	return false
+}
+
+// aggregateExternalSamples combines per-backend metric samples into a single
+// value using the semantics appropriate for the metric:
+//
+//   - Additive metrics (queue length, request count, …): sum across backends.
+//   - Ratio metrics (utilization, usage, …): replica-count weighted average,
+//     Σ(value_i × replicas_i) / Σ(replicas_i), matching Kubernetes HPA
+//     semantics for cross-instance metric aggregation.
+//
+// When all backend replica counts are zero the function falls back to a plain
+// unweighted average so that ratio metrics are never silently dropped.
+func aggregateExternalSamples(name string, samples []backendExternalSample) float64 {
+	if !isRatioMetric(name) {
+		total := 0.0
+		for _, s := range samples {
+			total += s.value
+		}
+		return total
+	}
+
+	// Weighted average: Σ(value_i × replicas_i) / Σ(replicas_i)
+	weightedSum := 0.0
+	totalReplicas := int32(0)
+	for _, s := range samples {
+		weightedSum += s.value * float64(s.replicas)
+		totalReplicas += s.replicas
+	}
+	if totalReplicas == 0 {
+		// Replica counts are unavailable; fall back to unweighted average so
+		// the metric still influences scaling decisions.
+		sum := 0.0
+		for _, s := range samples {
+			sum += s.value
+		}
+		return sum / float64(len(samples))
+	}
+	return weightedSum / float64(totalReplicas)
 }

--- a/pkg/autoscaler/autoscaler/optimizer_test.go
+++ b/pkg/autoscaler/autoscaler/optimizer_test.go
@@ -28,6 +28,150 @@ import (
 	workload "github.com/volcano-sh/kthena/pkg/apis/workload/v1alpha1"
 )
 
+// ---------------------------------------------------------------------------
+// isRatioMetric
+// ---------------------------------------------------------------------------
+
+func TestIsRatioMetric(t *testing.T) {
+	ratio := []string{
+		"gpu_utilization",
+		"cpu_utilization",
+		"memory_utilization",
+		"cache_usage",
+		"disk_usage",
+		"fill_ratio",
+		"load_percent",
+		"queue_saturation",
+		// Mixed-case and uppercase Prometheus metric names must also be detected.
+		"GPU_utilization",
+		"CPU_UTILIZATION",
+		"Cache_Usage",
+	}
+	for _, name := range ratio {
+		assert.True(t, isRatioMetric(name), "expected %q to be a ratio metric", name)
+	}
+
+	additive := []string{
+		"queue_length",
+		"request_count",
+		"token_rate",
+		"request_rate",
+		"throughput_rate",
+		"pending_requests",
+		"gpu_utilization_rate", // "rate" suffix wins over inner "_utilization"
+	}
+	for _, name := range additive {
+		assert.False(t, isRatioMetric(name), "expected %q to be an additive metric", name)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// aggregateExternalSamples
+// ---------------------------------------------------------------------------
+
+func TestAggregateExternalSamples_Additive(t *testing.T) {
+	samples := []backendExternalSample{
+		{value: 100, replicas: 3},
+		{value: 200, replicas: 1},
+	}
+	got := aggregateExternalSamples("queue_length", samples)
+	assert.Equal(t, 300.0, got, "additive metrics must be summed")
+}
+
+func TestAggregateExternalSamples_AdditiveRateNotAverage(t *testing.T) {
+	// request_rate ends with "_rate" and must be summed, not averaged.
+	samples := []backendExternalSample{
+		{value: 50, replicas: 2},
+		{value: 70, replicas: 2},
+	}
+	got := aggregateExternalSamples("request_rate", samples)
+	assert.Equal(t, 120.0, got)
+}
+
+func TestAggregateExternalSamples_RatioWeightedAverage(t *testing.T) {
+	// Backend A: gpu_utilization=60%, 3 replicas
+	// Backend B: gpu_utilization=70%, 1 replica
+	// Expected: (60*3 + 70*1) / (3+1) = (180+70)/4 = 250/4 = 62.5
+	samples := []backendExternalSample{
+		{value: 60, replicas: 3},
+		{value: 70, replicas: 1},
+	}
+	got := aggregateExternalSamples("gpu_utilization", samples)
+	assert.InDelta(t, 62.5, got, 1e-9)
+}
+
+func TestAggregateExternalSamples_RatioEqualReplicas(t *testing.T) {
+	// Equal replica counts reduce to a simple average.
+	// Backend A: 60%, 2 replicas; Backend B: 70%, 2 replicas → (60+70)/2 = 65
+	samples := []backendExternalSample{
+		{value: 60, replicas: 2},
+		{value: 70, replicas: 2},
+	}
+	got := aggregateExternalSamples("memory_utilization", samples)
+	assert.InDelta(t, 65.0, got, 1e-9)
+}
+
+func TestAggregateExternalSamples_RatioHeterogeneousWeights(t *testing.T) {
+	// Reproduces the issue example: 60%+70% must NOT equal 130%.
+	// Backend A: 60%, 4 replicas; Backend B: 70%, 6 replicas
+	// Expected: (60*4 + 70*6) / (4+6) = (240+420)/10 = 66
+	samples := []backendExternalSample{
+		{value: 60, replicas: 4},
+		{value: 70, replicas: 6},
+	}
+	got := aggregateExternalSamples("gpu_utilization", samples)
+	assert.InDelta(t, 66.0, got, 1e-9)
+	assert.Less(t, got, 100.0, "ratio metric must never exceed 100%%")
+}
+
+func TestAggregateExternalSamples_RatioZeroReplicasFallback(t *testing.T) {
+	// When all backends report zero replicas the function falls back to the
+	// unweighted average so that the metric is not silently dropped.
+	samples := []backendExternalSample{
+		{value: 60, replicas: 0},
+		{value: 80, replicas: 0},
+	}
+	got := aggregateExternalSamples("cache_usage", samples)
+	assert.InDelta(t, 70.0, got, 1e-9)
+}
+
+func TestAggregateExternalSamples_RatioOneBackendZeroReplicas(t *testing.T) {
+	// One backend has replicas, one has zero.
+	// Only the backend with replicas contributes weight.
+	// (60*0 + 80*5) / (0+5) = 80
+	samples := []backendExternalSample{
+		{value: 60, replicas: 0},
+		{value: 80, replicas: 5},
+	}
+	got := aggregateExternalSamples("gpu_utilization", samples)
+	assert.InDelta(t, 80.0, got, 1e-9)
+}
+
+func TestAggregateExternalSamples_SingleBackendAdditive(t *testing.T) {
+	samples := []backendExternalSample{{value: 42, replicas: 3}}
+	got := aggregateExternalSamples("pending_requests", samples)
+	assert.Equal(t, 42.0, got)
+}
+
+func TestAggregateExternalSamples_SingleBackendRatio(t *testing.T) {
+	samples := []backendExternalSample{{value: 75, replicas: 2}}
+	got := aggregateExternalSamples("gpu_utilization", samples)
+	assert.InDelta(t, 75.0, got, 1e-9)
+}
+
+func TestAggregateExternalSamples_BackwardCompatAdditive(t *testing.T) {
+	// Existing additive metrics must continue to be summed regardless of
+	// replica counts, preserving pre-fix behaviour for queue-length style
+	// metrics.
+	samples := []backendExternalSample{
+		{value: 10, replicas: 1},
+		{value: 20, replicas: 4},
+		{value: 30, replicas: 2},
+	}
+	got := aggregateExternalSamples("queue_length", samples)
+	assert.Equal(t, 60.0, got)
+}
+
 func makePolicy(uid string, namespace string, costExpansionRate int32, params []workload.HeterogeneousTargetParam) *workload.AutoscalingPolicy {
 	return &workload.AutoscalingPolicy{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it

The heterogeneous autoscaler currently aggregates all external metrics across backends using plain summation. While this is correct for additive metrics (for example, queue length or request count), it is incorrect for ratio-based metrics such as GPU utilization or cache usage. Summing ratio metrics can produce values greater than 100%, leading to unnecessary scale-up decisions, especially in heterogeneous Prefill/Decode deployments.

This PR updates the aggregation logic with a two-phase approach:

1. Collect `(metric value, backend replica count)` pairs for each external metric.
2. Aggregate metrics according to their semantics:
   - **Additive metrics** continue to use the existing sum behavior.
   - **Ratio metrics** (`*_utilization`, `*_usage`, `*_ratio`, `*_percent`, `*_saturation`) are aggregated using a replica-weighted average:

     `Σ(metric × replicas) / Σ(replicas)`

     If all replica counts are zero or unavailable, the implementation falls back to an unweighted average so that metrics are never silently dropped.

The `_rate` suffix is intentionally **not** treated as a ratio metric because metrics such as `request_rate` and `token_rate` are additive throughput metrics.

This implementation keeps the change minimal:
- No API or CRD changes
- No Helm chart updates
- No generated client changes
- Existing behavior for additive metrics remains unchanged

Additionally, the unused `addMetric()` helper has been removed.

Comprehensive unit tests have been added covering:
- Additive metric aggregation
- Ratio metric weighted averaging
- Heterogeneous replica counts
- Equal replica counts
- Zero-replica fallback
- Single-backend scenarios
- `_rate` metrics remaining additive
- Backward compatibility

## Which issue(s) this PR fixes

Fixes #1202

## Special notes for your reviewer

- The aggregation heuristic intentionally excludes the `_rate` suffix to avoid misclassifying throughput metrics.
- The implementation is localized to the autoscaler and does not introduce any API or CRD changes.
- All existing autoscaler tests continue to pass, and new unit tests verify the new aggregation behavior.

## Does this PR introduce a user-facing change?

```release-note
NONE
```