### PR TITLE
Fix stale ModelServer pod bindings

### DIFF
--- a/cmd/kthena-router/app/controller.go
+++ b/cmd/kthena-router/app/controller.go
@@ -131,7 +131,7 @@ func startControllers(store datastore.Store, stop <-chan struct{}, enableGateway
 				klog.Fatalf("Error building dynamic client: %s", err.Error())
 			}
 			dynamicInformerFactory := dynamicinformer.NewDynamicSharedInformerFactory(dynamicClient, 0)
-			inferencePoolController, err = controller.NewInferencePoolController(dynamicInformerFactory, store)
+			inferencePoolController, err = controller.NewInferencePoolController(dynamicInformerFactory, kubeInformerFactory, store)
 			if err != nil {
 				klog.Fatalf("Error creating inferencepool controller: %s", err.Error())
 			}

--- a/pkg/kthena-router/controller/inferencepool_controller.go
+++ b/pkg/kthena-router/controller/inferencepool_controller.go
@@ -21,10 +21,15 @@ import (
 	"sync/atomic"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/dynamic/dynamicinformer"
+	"k8s.io/client-go/informers"
+	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
@@ -35,7 +40,9 @@ import (
 
 type InferencePoolController struct {
 	inferencePoolInformer cache.SharedIndexInformer
+	podLister             corelisters.PodLister
 	inferencePoolSynced   cache.InformerSynced
+	podSynced             cache.InformerSynced
 	registration          cache.ResourceEventHandlerRegistration
 
 	workqueue   workqueue.TypedRateLimitingInterface[any]
@@ -45,14 +52,18 @@ type InferencePoolController struct {
 
 func NewInferencePoolController(
 	dynamicInformerFactory dynamicinformer.DynamicSharedInformerFactory,
+	kubeInformerFactory informers.SharedInformerFactory,
 	store datastore.Store,
 ) (*InferencePoolController, error) {
 	gvr := inferencev1.SchemeGroupVersion.WithResource("inferencepools")
 	inferencePoolInformer := dynamicInformerFactory.ForResource(gvr).Informer()
+	podInformer := kubeInformerFactory.Core().V1().Pods()
 
 	controller := &InferencePoolController{
 		inferencePoolInformer: inferencePoolInformer,
+		podLister:             podInformer.Lister(),
 		inferencePoolSynced:   inferencePoolInformer.HasSynced,
+		podSynced:             podInformer.Informer().HasSynced,
 		workqueue:             workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[any]()),
 		initialSync:           &atomic.Bool{},
 		store:                 store,
@@ -67,6 +78,14 @@ func NewInferencePoolController(
 	if err != nil {
 		return nil, fmt.Errorf("failed to add event handler for inferencepool controller: %w", err)
 	}
+	if _, err = podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: controller.enqueueInferencePoolsForPod,
+		UpdateFunc: func(old, new interface{}) {
+			controller.enqueueInferencePoolsForPod(new)
+		},
+	}); err != nil {
+		return nil, fmt.Errorf("failed to add pod event handler for inferencepool controller: %w", err)
+	}
 
 	return controller, nil
 }
@@ -75,7 +94,7 @@ func (c *InferencePoolController) Run(stopCh <-chan struct{}) error {
 	defer utilruntime.HandleCrash()
 	defer c.workqueue.ShutDown()
 
-	if ok := cache.WaitForCacheSync(stopCh, c.registration.HasSynced); !ok {
+	if ok := cache.WaitForCacheSync(stopCh, c.registration.HasSynced, c.podSynced); !ok {
 		return fmt.Errorf("failed to wait for caches to sync")
 	}
 	c.workqueue.Add(initialSyncSignal)
@@ -155,7 +174,27 @@ func (c *InferencePoolController) syncHandler(key string) error {
 		return fmt.Errorf("failed to convert unstructured to InferencePool: %w", err)
 	}
 
-	return c.store.AddOrUpdateInferencePool(inferencePool)
+	if err := c.store.AddOrUpdateInferencePool(inferencePool); err != nil {
+		return err
+	}
+
+	selector, err := getInferencePoolSelector(inferencePool)
+	if err != nil {
+		return fmt.Errorf("invalid selector: %w", err)
+	}
+	pods, err := c.podLister.Pods(inferencePool.Namespace).List(selector)
+	if err != nil {
+		return err
+	}
+	for _, pod := range pods {
+		if !isPodReady(pod) {
+			continue
+		}
+		if err := c.store.AddOrUpdateInferencePoolPod(pod); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (c *InferencePoolController) enqueueInferencePool(obj interface{}) {
@@ -165,4 +204,42 @@ func (c *InferencePoolController) enqueueInferencePool(obj interface{}) {
 		return
 	}
 	c.workqueue.Add(key)
+}
+
+func (c *InferencePoolController) enqueueInferencePoolsForPod(obj interface{}) {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok || !isPodReady(pod) {
+		return
+	}
+
+	for _, obj := range c.inferencePoolInformer.GetIndexer().List() {
+		unstructuredObj, ok := obj.(runtime.Unstructured)
+		if !ok {
+			continue
+		}
+		inferencePool := &inferencev1.InferencePool{}
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredObj.UnstructuredContent(), inferencePool); err != nil {
+			utilruntime.HandleError(err)
+			continue
+		}
+		if inferencePool.Namespace != pod.Namespace {
+			continue
+		}
+		selector, err := getInferencePoolSelector(inferencePool)
+		if err != nil {
+			utilruntime.HandleError(err)
+			continue
+		}
+		if selector.Matches(labels.Set(pod.Labels)) {
+			c.enqueueInferencePool(obj)
+		}
+	}
+}
+
+func getInferencePoolSelector(inferencePool *inferencev1.InferencePool) (labels.Selector, error) {
+	matchLabels := make(map[string]string, len(inferencePool.Spec.Selector.MatchLabels))
+	for k, v := range inferencePool.Spec.Selector.MatchLabels {
+		matchLabels[string(k)] = string(v)
+	}
+	return metav1.LabelSelectorAsSelector(&metav1.LabelSelector{MatchLabels: matchLabels})
 }

--- a/pkg/kthena-router/controller/inferencepool_controller_test.go
+++ b/pkg/kthena-router/controller/inferencepool_controller_test.go
@@ -1,0 +1,126 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/informers"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+
+	aiv1alpha1 "github.com/volcano-sh/kthena/pkg/apis/networking/v1alpha1"
+	"github.com/volcano-sh/kthena/pkg/kthena-router/utils"
+	inferencev1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
+)
+
+func TestInferencePoolControllerSyncRestoresPodAfterModelServerRemoval(t *testing.T) {
+	kubeClient := kubefake.NewSimpleClientset()
+	kubeInformerFactory := informers.NewSharedInformerFactory(kubeClient, 0)
+	dynamicClient := dynamicfake.NewSimpleDynamicClient(k8sruntime.NewScheme())
+	dynamicInformerFactory := dynamicinformer.NewDynamicSharedInformerFactory(dynamicClient, 0)
+	store := newStoreWithMockBackend()
+	controller, err := NewInferencePoolController(dynamicInformerFactory, kubeInformerFactory, store)
+	require.NoError(t, err)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "pool-pod",
+			Labels: map[string]string{
+				"pool": "chat",
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{
+				{
+					Type:   corev1.PodReady,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		},
+	}
+	ms := &aiv1alpha1.ModelServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "model1",
+		},
+		Spec: aiv1alpha1.ModelServerSpec{
+			InferenceEngine: aiv1alpha1.VLLM,
+		},
+	}
+	require.NoError(t, store.AddOrUpdateModelServer(ms, nil))
+	require.NoError(t, store.AddOrUpdatePod(pod, []*aiv1alpha1.ModelServer{ms}))
+	require.NotNil(t, store.GetPodInfo(utils.GetNamespaceName(pod)))
+	require.NoError(t, store.AddOrUpdatePod(pod, []*aiv1alpha1.ModelServer{}))
+	require.Nil(t, store.GetPodInfo(utils.GetNamespaceName(pod)))
+
+	podIndexer := kubeInformerFactory.Core().V1().Pods().Informer().GetIndexer()
+	require.NoError(t, podIndexer.Add(pod))
+
+	inferencePool := &inferencev1.InferencePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "pool1",
+		},
+		Spec: inferencev1.InferencePoolSpec{
+			Selector: inferencev1.LabelSelector{
+				MatchLabels: map[inferencev1.LabelKey]inferencev1.LabelValue{
+					"pool": "chat",
+				},
+			},
+			TargetPorts: []inferencev1.Port{{Number: 9000}},
+		},
+	}
+	obj, err := k8sruntime.DefaultUnstructuredConverter.ToUnstructured(inferencePool)
+	require.NoError(t, err)
+	u := &unstructured.Unstructured{Object: obj}
+	u.SetGroupVersionKind(inferencev1.SchemeGroupVersion.WithKind("InferencePool"))
+	poolInformer := dynamicInformerFactory.ForResource(inferencev1.SchemeGroupVersion.WithResource("inferencepools")).Informer()
+	require.NoError(t, poolInformer.GetIndexer().Add(u))
+
+	require.NoError(t, controller.syncHandler("default/pool1"))
+	pods, err := store.GetPodsByInferencePool(utils.GetNamespaceName(inferencePool))
+	require.NoError(t, err)
+	require.Len(t, pods, 1)
+	assert.Equal(t, "pool-pod", pods[0].GetPod().Name)
+
+	laterPod := pod.DeepCopy()
+	laterPod.Name = "later-pod"
+	require.NoError(t, podIndexer.Add(laterPod))
+	controller.enqueueInferencePoolsForPod(laterPod)
+
+	require.Equal(t, 1, controller.workqueue.Len())
+	item, shutdown := controller.workqueue.Get()
+	require.False(t, shutdown)
+	controller.workqueue.Done(item)
+	controller.workqueue.Forget(item)
+	require.Equal(t, "default/pool1", item)
+	require.NoError(t, controller.syncHandler(item.(string)))
+
+	pods, err = store.GetPodsByInferencePool(utils.GetNamespaceName(inferencePool))
+	require.NoError(t, err)
+	require.Len(t, pods, 2)
+}

--- a/pkg/kthena-router/controller/modelserver_controller.go
+++ b/pkg/kthena-router/controller/modelserver_controller.go
@@ -214,16 +214,40 @@ func (c *ModelServerController) syncModelServerHandler(key string) error {
 		}
 	}
 
-	_ = c.store.AddOrUpdateModelServer(ms, pods)
-
-	// Bind every ready pod selected by this ModelServer. Pods that already have
-	// an entry in the store get the binding appended so their runtime metrics and
-	// bindings to other ModelServers are preserved; brand-new pods are created
-	// with the binding. We check each pod against the store directly instead of
-	// re-reading GetPodsByModelServer, which would only echo back the pod set that
-	// AddOrUpdateModelServer just wrote and cannot distinguish existing pods from
-	// new ones.
 	msName := utils.GetNamespaceName(ms)
+	oldPods, err := c.store.GetPodsByModelServer(msName)
+	if err != nil {
+		klog.V(4).Infof("failed to get existing pods for ModelServer %s/%s: %v", ms.Namespace, ms.Name, err)
+	}
+
+	// Reconcile pods this ModelServer used to select before replacing the stored pod set.
+	for _, podInfo := range oldPods {
+		oldPod := podInfo.GetPod()
+		if oldPod == nil {
+			continue
+		}
+		podName := utils.GetNamespaceName(oldPod)
+		if pods.Contains(podName) {
+			continue
+		}
+
+		pod, err := c.podLister.Pods(podName.Namespace).Get(podName.Name)
+		if err != nil {
+			return fmt.Errorf("failed to get pod %s from lister: %v", podName, err)
+		}
+		if !isPodReady(pod) {
+			continue
+		}
+		if err := c.addOrUpdatePod(pod); err != nil {
+			return err
+		}
+	}
+
+	if err := c.store.AddOrUpdateModelServer(ms, pods); err != nil {
+		return err
+	}
+
+	// Bind the current pod set after stale bindings have been reconciled.
 	for _, pod := range podList {
 		if !isPodReady(pod) {
 			continue
@@ -286,10 +310,10 @@ func (c *ModelServerController) addOrUpdatePod(pod *corev1.Pod) error {
 		servers = append(servers, item)
 	}
 
-	if len(servers) > 0 {
-		if err := c.store.AddOrUpdatePod(pod, servers); err != nil {
-			return fmt.Errorf("failed to add or update pod %s/%s in data store: %v", pod.Namespace, pod.Name, err)
-		}
+	// Empty servers is meaningful here: the store clears stale ModelServer bindings
+	// and deletes the pod only when no other routing resource still selects it.
+	if err := c.store.AddOrUpdatePod(pod, servers); err != nil {
+		return fmt.Errorf("failed to add or update pod %s/%s in data store: %v", pod.Namespace, pod.Name, err)
 	}
 
 	return nil

--- a/pkg/kthena-router/controller/modelserver_controller_test.go
+++ b/pkg/kthena-router/controller/modelserver_controller_test.go
@@ -714,6 +714,130 @@ func TestModelServerController_PodSelectionLogic(t *testing.T) {
 	})
 }
 
+func TestModelServerController_PodLabelChangeRemovesBinding(t *testing.T) {
+	kubeClient := kubefake.NewSimpleClientset()
+	kthenaClient := kthenafake.NewSimpleClientset()
+	kubeInformerFactory := informers.NewSharedInformerFactory(kubeClient, 0)
+	kthenaInformerFactory := informersv1alpha1.NewSharedInformerFactory(kthenaClient, 0)
+	store := newStoreWithMockBackend()
+	controller, err := NewModelServerController(kthenaInformerFactory, kubeInformerFactory, store)
+	require.NoError(t, err)
+	modelServerIndexer := kthenaInformerFactory.Networking().V1alpha1().ModelServers().Informer().GetIndexer()
+
+	ms := &aiv1alpha1.ModelServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "test-modelserver-label-change",
+		},
+		Spec: aiv1alpha1.ModelServerSpec{
+			InferenceEngine: aiv1alpha1.VLLM,
+			WorkloadSelector: &aiv1alpha1.WorkloadSelector{
+				MatchLabels: map[string]string{
+					"app": "test-model",
+				},
+			},
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "test-pod-label-change",
+			Labels: map[string]string{
+				"app": "test-model",
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{
+				{
+					Type:   corev1.PodReady,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		},
+	}
+
+	require.NoError(t, modelServerIndexer.Add(ms.DeepCopy()))
+	require.NoError(t, store.AddOrUpdateModelServer(ms, nil))
+	require.NoError(t, controller.addOrUpdatePod(pod))
+
+	pods, err := store.GetPodsByModelServer(utils.GetNamespaceName(ms))
+	require.NoError(t, err)
+	require.Len(t, pods, 1)
+
+	updatedPod := pod.DeepCopy()
+	updatedPod.Labels = map[string]string{"app": "other-model"}
+	require.NoError(t, controller.addOrUpdatePod(updatedPod))
+
+	pods, err = store.GetPodsByModelServer(utils.GetNamespaceName(ms))
+	require.NoError(t, err)
+	assert.Empty(t, pods)
+	assert.Nil(t, store.GetPodInfo(utils.GetNamespaceName(updatedPod)))
+}
+
+func TestModelServerController_SelectorChangeRemovesBinding(t *testing.T) {
+	kubeClient := kubefake.NewSimpleClientset()
+	kthenaClient := kthenafake.NewSimpleClientset()
+	kubeInformerFactory := informers.NewSharedInformerFactory(kubeClient, 0)
+	kthenaInformerFactory := informersv1alpha1.NewSharedInformerFactory(kthenaClient, 0)
+	store := newStoreWithMockBackend()
+	controller, err := NewModelServerController(kthenaInformerFactory, kubeInformerFactory, store)
+	require.NoError(t, err)
+	modelServerIndexer := kthenaInformerFactory.Networking().V1alpha1().ModelServers().Informer().GetIndexer()
+	podIndexer := kubeInformerFactory.Core().V1().Pods().Informer().GetIndexer()
+
+	ms := &aiv1alpha1.ModelServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "test-modelserver-selector-change",
+		},
+		Spec: aiv1alpha1.ModelServerSpec{
+			InferenceEngine: aiv1alpha1.VLLM,
+			WorkloadSelector: &aiv1alpha1.WorkloadSelector{
+				MatchLabels: map[string]string{
+					"app": "test-model",
+				},
+			},
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "test-pod-selector-change",
+			Labels: map[string]string{
+				"app": "test-model",
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{
+				{
+					Type:   corev1.PodReady,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		},
+	}
+
+	require.NoError(t, modelServerIndexer.Add(ms.DeepCopy()))
+	require.NoError(t, podIndexer.Add(pod.DeepCopy()))
+	require.NoError(t, controller.syncModelServerHandler("default/test-modelserver-selector-change"))
+
+	pods, err := store.GetPodsByModelServer(utils.GetNamespaceName(ms))
+	require.NoError(t, err)
+	require.Len(t, pods, 1)
+
+	updatedMS := ms.DeepCopy()
+	updatedMS.Spec.WorkloadSelector.MatchLabels = map[string]string{"app": "other-model"}
+	require.NoError(t, modelServerIndexer.Update(updatedMS.DeepCopy()))
+	require.NoError(t, controller.syncModelServerHandler("default/test-modelserver-selector-change"))
+
+	pods, err = store.GetPodsByModelServer(utils.GetNamespaceName(ms))
+	require.NoError(t, err)
+	assert.Empty(t, pods)
+	assert.Nil(t, store.GetPodInfo(utils.GetNamespaceName(pod)))
+}
+
 func TestModelServerController_ComprehensiveLifecycleTest(t *testing.T) {
 	// Create a comprehensive test that tests the full workflow
 	// with proper informer setup and timing

--- a/pkg/kthena-router/datastore/ordering_test.go
+++ b/pkg/kthena-router/datastore/ordering_test.go
@@ -479,8 +479,7 @@ func TestStore_EdgeCases(t *testing.T) {
 
 	podName := utils.GetNamespaceName(pod)
 	podInfo := s.GetPodInfo(podName)
-	assert.NotNil(t, podInfo)
-	assert.Equal(t, 0, podInfo.GetModelServerCount())
+	assert.Nil(t, podInfo)
 }
 
 // Test Case 11: random operations (simulated)

--- a/pkg/kthena-router/datastore/store.go
+++ b/pkg/kthena-router/datastore/store.go
@@ -186,6 +186,7 @@ type Store interface {
 
 	// Refresh Store and ModelServer when add a new pod or update a pod
 	AddOrUpdatePod(pod *corev1.Pod, modelServer []*aiv1alpha1.ModelServer) error
+	AddOrUpdateInferencePoolPod(pod *corev1.Pod) error
 	// AppendModelServerToPod appends new modelservers to the podInfo without replacing existing ones
 	AppendModelServerToPod(pod *corev1.Pod, modelServers []*aiv1alpha1.ModelServer) error
 	// Refresh Store and ModelServer when delete a pod
@@ -841,22 +842,20 @@ func (s *store) DecrPodOnFlightRequests(podName types.NamespacedName) {
 func (s *store) AddOrUpdateModelServer(ms *aiv1alpha1.ModelServer, pods sets.Set[types.NamespacedName]) error {
 	name := utils.GetNamespaceName(ms)
 	var modelServerObj *modelServer
+	if len(pods) == 0 {
+		pods = sets.New[types.NamespacedName]()
+	}
 	if value, ok := s.modelServer.Load(name); !ok {
 		modelServerObj = newModelServer(ms)
 		// New object — no concurrent access yet, safe to write without lock
-		if len(pods) != 0 {
-			modelServerObj.pods = pods
-		}
+		modelServerObj.pods = pods
 	} else {
 		modelServerObj = value.(*modelServer)
 		// Existing object — concurrent readers may access modelServer and pods,
 		// so we must hold the lock to prevent data races.
 		modelServerObj.mutex.Lock()
 		modelServerObj.modelServer = ms
-		if len(pods) != 0 {
-			// do not operate s.pods here, which are done within pod handler
-			modelServerObj.pods = pods
-		}
+		modelServerObj.pods = pods
 		modelServerObj.mutex.Unlock()
 	}
 	s.modelServer.Store(name, modelServerObj)
@@ -997,8 +996,37 @@ func (s *store) AddOrUpdatePod(pod *corev1.Pod, modelServers []*aiv1alpha1.Model
 	}
 
 	if value, ok := s.pods.Load(podName); ok {
-		// Update existing pod in place — preserve runtime metrics and models.
+		// Update existing pod in place, preserving runtime metrics and models.
 		oldPodInfo := value.(*PodInfo)
+		if newModelServers.Len() == 0 {
+			selectedByInferencePool := false
+			s.inferencePoolMutex.RLock()
+			for _, inferencePool := range s.inferencePools {
+				if inferencePool.Namespace != pod.Namespace {
+					continue
+				}
+				matchLabels := make(map[string]string)
+				for k, v := range inferencePool.Spec.Selector.MatchLabels {
+					matchLabels[string(k)] = string(v)
+				}
+				selector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
+					MatchLabels: matchLabels,
+				})
+				if err != nil {
+					s.inferencePoolMutex.RUnlock()
+					return fmt.Errorf("invalid selector: %w", err)
+				}
+				if selector.Matches(labels.Set(pod.Labels)) {
+					selectedByInferencePool = true
+					break
+				}
+			}
+			s.inferencePoolMutex.RUnlock()
+			if !selectedByInferencePool {
+				return s.DeletePod(podName)
+			}
+			engine = oldPodInfo.GetEngine()
+		}
 		oldModelServers := oldPodInfo.GetModelServers()
 		// Handle the case where the pod no longer belongs to some model servers
 		oldPodLabels := oldPodInfo.GetPodLabels()
@@ -1014,8 +1042,11 @@ func (s *store) AddOrUpdatePod(pod *corev1.Pod, modelServers []*aiv1alpha1.Model
 		oldPodInfo.UpdatePod(pod, engine, newModelServers)
 		return nil
 	}
+	if newModelServers.Len() == 0 {
+		return nil
+	}
 
-	// New pod — create PodInfo and fetch initial metrics.
+	// New pod, create PodInfo and fetch initial metrics.
 	newPodInfo := &PodInfo{
 		Pod:         pod,
 		engine:      engine,
@@ -1026,6 +1057,19 @@ func (s *store) AddOrUpdatePod(pod *corev1.Pod, modelServers []*aiv1alpha1.Model
 	s.updatePodMetrics(newPodInfo)
 	s.updatePodModels(newPodInfo)
 
+	return nil
+}
+
+func (s *store) AddOrUpdateInferencePoolPod(pod *corev1.Pod) error {
+	podName := utils.GetNamespaceName(pod)
+	podInfo := &PodInfo{
+		Pod:         pod,
+		modelServer: sets.New[types.NamespacedName](),
+		models:      sets.New[string](),
+	}
+	if value, loaded := s.pods.LoadOrStore(podName, podInfo); loaded {
+		value.(*PodInfo).UpdatePodMetadata(pod)
+	}
 	return nil
 }
 
@@ -1573,6 +1617,30 @@ func (s *store) getPodWorkloadPort(podInfo *PodInfo) uint32 {
 			}
 		}
 	}
+	pod := podInfo.GetPod()
+	if pod == nil {
+		return 0
+	}
+	s.inferencePoolMutex.RLock()
+	defer s.inferencePoolMutex.RUnlock()
+	for _, inferencePool := range s.inferencePools {
+		if inferencePool.Namespace != pod.Namespace || len(inferencePool.Spec.TargetPorts) == 0 {
+			continue
+		}
+		matchLabels := make(map[string]string)
+		for k, v := range inferencePool.Spec.Selector.MatchLabels {
+			matchLabels[string(k)] = string(v)
+		}
+		selector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
+			MatchLabels: matchLabels,
+		})
+		if err != nil {
+			continue
+		}
+		if selector.Matches(labels.Set(podInfo.GetPodLabels())) {
+			return uint32(inferencePool.Spec.TargetPorts[0].Number)
+		}
+	}
 	return 0
 }
 
@@ -1701,6 +1769,13 @@ func (p *PodInfo) UpdatePod(pod *corev1.Pod, engine string, modelServers sets.Se
 	p.Pod = pod
 	p.engine = engine
 	p.modelServer = modelServers
+}
+
+// UpdatePodMetadata replaces the pod object without changing its routing state.
+func (p *PodInfo) UpdatePodMetadata(pod *corev1.Pod) {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+	p.Pod = pod
 }
 
 // GetModels returns a copy of the models set

--- a/pkg/kthena-router/datastore/store_test.go
+++ b/pkg/kthena-router/datastore/store_test.go
@@ -34,6 +34,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	inferencev1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	aiv1alpha1 "github.com/volcano-sh/kthena/pkg/apis/networking/v1alpha1"
@@ -412,6 +413,101 @@ func TestStoreAddOrUpdatePod(t *testing.T) {
 		ms2Info := value.(*modelServer)
 		assert.Equal(t, ms2Info.pods.Len(), 0, "model server 2 should not reference the pod")
 	}
+
+	err = s.AddOrUpdatePod(pod, []*aiv1alpha1.ModelServer{})
+	assert.NoError(t, err)
+	assert.Nil(t, s.GetPodInfo(podName))
+	if value, ok := s.modelServer.Load(utils.GetNamespaceName(ms1)); ok {
+		ms1Info := value.(*modelServer)
+		assert.Equal(t, ms1Info.pods.Len(), 0, "model server 1 should not reference the pod")
+	}
+
+	emptyPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "pod2",
+		},
+	}
+	emptyPodName := utils.GetNamespaceName(emptyPod)
+	err = s.AddOrUpdatePod(emptyPod, []*aiv1alpha1.ModelServer{})
+	assert.NoError(t, err)
+	assert.Nil(t, s.GetPodInfo(emptyPodName))
+}
+
+func TestStoreAddOrUpdatePodKeepsInferencePoolPod(t *testing.T) {
+	s := &store{
+		modelServer:    sync.Map{},
+		pods:           sync.Map{},
+		inferencePools: make(map[string]*inferencev1.InferencePool),
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "pod1",
+			Labels: map[string]string{
+				"model": "llama",
+				"pool":  "chat",
+			},
+		},
+	}
+	ms := &aiv1alpha1.ModelServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "model1",
+		},
+		Spec: aiv1alpha1.ModelServerSpec{
+			InferenceEngine: aiv1alpha1.VLLM,
+		},
+	}
+	inferencePool := &inferencev1.InferencePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "pool1",
+		},
+		Spec: inferencev1.InferencePoolSpec{
+			Selector: inferencev1.LabelSelector{
+				MatchLabels: map[inferencev1.LabelKey]inferencev1.LabelValue{
+					"pool": "chat",
+				},
+			},
+		},
+	}
+
+	s.AddOrUpdateModelServer(ms, nil)
+	assert.NoError(t, s.AddOrUpdateInferencePool(inferencePool))
+	assert.NoError(t, s.AddOrUpdatePod(pod, []*aiv1alpha1.ModelServer{ms}))
+
+	updatedPod := pod.DeepCopy()
+	updatedPod.Labels = map[string]string{
+		"model": "other",
+		"pool":  "chat",
+	}
+	podName := utils.GetNamespaceName(updatedPod)
+	assert.NoError(t, s.AddOrUpdatePod(updatedPod, []*aiv1alpha1.ModelServer{}))
+
+	podInfo := s.GetPodInfo(podName)
+	assert.NotNil(t, podInfo)
+	assert.Equal(t, 0, podInfo.GetModelServerCount())
+	assert.Equal(t, string(aiv1alpha1.VLLM), podInfo.GetEngine())
+	if value, ok := s.modelServer.Load(utils.GetNamespaceName(ms)); ok {
+		msInfo := value.(*modelServer)
+		assert.Equal(t, 0, msInfo.pods.Len())
+	}
+
+	pods, err := s.GetPodsByInferencePool(utils.GetNamespaceName(inferencePool))
+	assert.NoError(t, err)
+	assert.Len(t, pods, 1)
+	assert.Equal(t, podName, pods[0].GetPodNamespacedName())
+
+	assert.NoError(t, s.AppendModelServerToPod(updatedPod, []*aiv1alpha1.ModelServer{ms}))
+	poolUpdatedPod := updatedPod.DeepCopy()
+	poolUpdatedPod.Annotations = map[string]string{"updated": "true"}
+	assert.NoError(t, s.AddOrUpdateInferencePoolPod(poolUpdatedPod))
+
+	podInfo = s.GetPodInfo(podName)
+	assert.True(t, podInfo.HasModelServer(utils.GetNamespaceName(ms)))
+	assert.Equal(t, string(aiv1alpha1.VLLM), podInfo.GetEngine())
+	assert.Equal(t, "true", podInfo.GetPod().Annotations["updated"])
 }
 
 func TestStoreDeletePod(t *testing.T) {
@@ -514,6 +610,13 @@ func TestStoreAddOrUpdateModelServer(t *testing.T) {
 		msInfo := value.(*modelServer)
 		assert.True(t, msInfo.pods.Contains(types.NamespacedName{Namespace: "default", Name: "pod2"}))
 		assert.False(t, msInfo.pods.Contains(types.NamespacedName{Namespace: "default", Name: "pod1"}))
+	}
+
+	err = s.AddOrUpdateModelServer(ms, sets.New[types.NamespacedName]())
+	assert.NoError(t, err)
+	if value, ok := s.modelServer.Load(msName); ok {
+		msInfo := value.(*modelServer)
+		assert.Equal(t, 0, msInfo.pods.Len())
 	}
 }
 
@@ -2380,4 +2483,29 @@ func TestStoreRunBoundedConcurrency(t *testing.T) {
 	// Verify the bound was respected and parallelism actually occurred
 	assert.Greater(t, maxInFlight.Load(), int32(1), "expected at least some parallelism in scrapes")
 	assert.LessOrEqual(t, maxInFlight.Load(), int32(maxConcurrentPodScrapes), "in-flight requests should never exceed the semaphore cap")
+}
+
+func TestGetPodWorkloadPortUsesInferencePoolTargetPort(t *testing.T) {
+	s := newStore()
+	pod := createTestPod("default", "pod1")
+	pod.Labels = map[string]string{"pool": "chat"}
+	podInfo := NewPodInfo(pod, string(aiv1alpha1.VLLM))
+	podInfo.modelServer = sets.New[types.NamespacedName]()
+
+	inferencePool := &inferencev1.InferencePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "pool1",
+		},
+		Spec: inferencev1.InferencePoolSpec{
+			Selector: inferencev1.LabelSelector{
+				MatchLabels: map[inferencev1.LabelKey]inferencev1.LabelValue{
+					"pool": "chat",
+				},
+			},
+			TargetPorts: []inferencev1.Port{{Number: 9000}},
+		},
+	}
+	assert.NoError(t, s.AddOrUpdateInferencePool(inferencePool))
+	assert.Equal(t, uint32(9000), s.getPodWorkloadPort(podInfo))
 }

--- a/pkg/kthena-router/debug/handlers_test.go
+++ b/pkg/kthena-router/debug/handlers_test.go
@@ -82,6 +82,11 @@ func (m *MockStore) AddOrUpdatePod(pod *corev1.Pod, modelServer []*aiv1alpha1.Mo
 	return args.Error(0)
 }
 
+func (m *MockStore) AddOrUpdateInferencePoolPod(pod *corev1.Pod) error {
+	args := m.Called(pod)
+	return args.Error(0)
+}
+
 func (m *MockStore) AppendModelServerToPod(pod *corev1.Pod, modelServers []*aiv1alpha1.ModelServer) error {
 	args := m.Called(pod, modelServers)
 	return args.Error(0)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This fixes stale ModelServer pod bindings in the router store.

When a ModelServer selector changed to match no ready pods, the store kept the old pod set because empty pod sets were ignored. When a pod label changed so it no longer matched any ModelServer, the controller skipped updating the store because there were no matching ModelServers.

This PR makes those zero-match cases reconcile correctly.

**Which issue(s) this PR fixes**:
Fixes #1122

**Special notes for your reviewer**:

Added regression coverage for both stale paths:
- ModelServer selector no longer matches the old pod
- Pod labels no longer match the ModelServer selector

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```