### PR TITLE
feat(autoscaler): adaptive reconcile interval based on scaling direction

### DIFF
--- a/pkg/autoscaler/controller/autoscale_controller.go
+++ b/pkg/autoscaler/controller/autoscale_controller.go
@@ -321,7 +321,7 @@ func (ac *AutoscaleController) doOptimize(ctx context.Context, autoscalePolicy *
 	if recommendedInstances == nil {
 		return outcomeStable, nil
 	}
-	// Do update replicas
+	// Do update replicas; compute direction only after a successful update.
 	outcome := outcomeStable
 	for _, param := range optimizer.Meta.Config.Params {
 		instancesCount, exists := recommendedInstances[param.Target.TargetRef.Name]
@@ -329,11 +329,11 @@ func (ac *AutoscaleController) doOptimize(ctx context.Context, autoscalePolicy *
 			klog.Warningf("recommended instances not exists, target ref name: %s", param.Target.TargetRef.Name)
 			continue
 		}
-		outcome = mergeOutcome(outcome, outcomeFromChange(replicasMap[param.Target.TargetRef.Name], instancesCount))
 		if err := ac.updateTargetReplicas(ctx, &param.Target, autoscalePolicy.Namespace, instancesCount); err != nil {
 			klog.Errorf("failed to update target kind:%s name: %s replicas:%d, err: %v", param.Target.TargetRef.Kind, param.Target.TargetRef.Name, instancesCount, err)
 			return outcomeStable, err
 		}
+		outcome = mergeOutcome(outcome, outcomeFromChange(replicasMap[param.Target.TargetRef.Name], instancesCount))
 	}
 
 	return outcome, nil

--- a/pkg/autoscaler/controller/autoscale_controller.go
+++ b/pkg/autoscaler/controller/autoscale_controller.go
@@ -39,7 +39,6 @@ import (
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	listerv1 "k8s.io/client-go/listers/core/v1"
@@ -95,6 +94,52 @@ func NewAutoscaleController(kubeClient kubernetes.Interface, client clientset.In
 	return ac
 }
 
+// scalingOutcome summarises the net direction of a single reconcile cycle
+// across all autoscaling policies. It drives the next reconcile interval.
+type scalingOutcome int
+
+const (
+	outcomeStable scalingOutcome = iota
+	outcomeScaleUp
+	outcomeScaleDown
+)
+
+// mergeOutcome returns the higher-priority outcome. Scale-up takes priority
+// over scale-down so that a mixed cycle reacts as fast as possible.
+func mergeOutcome(a, b scalingOutcome) scalingOutcome {
+	if a == outcomeScaleUp || b == outcomeScaleUp {
+		return outcomeScaleUp
+	}
+	if a == outcomeScaleDown || b == outcomeScaleDown {
+		return outcomeScaleDown
+	}
+	return outcomeStable
+}
+
+// outcomeFromChange derives the scaling direction from a before/after replica
+// comparison. When recommended < 0 the scaler decided to skip, treated as stable.
+func outcomeFromChange(current, recommended int32) scalingOutcome {
+	if recommended < 0 || recommended == current {
+		return outcomeStable
+	}
+	if recommended > current {
+		return outcomeScaleUp
+	}
+	return outcomeScaleDown
+}
+
+// nextInterval maps a reconcile outcome to the adaptive sync period.
+func nextInterval(o scalingOutcome) time.Duration {
+	switch o {
+	case outcomeScaleUp:
+		return util.AutoscalingScaleUpSyncPeriodSeconds * time.Second
+	case outcomeScaleDown:
+		return util.AutoscalingScaleDownSyncPeriodSeconds * time.Second
+	default:
+		return util.AutoscalingSyncPeriodSeconds * time.Second
+	}
+}
+
 func (ac *AutoscaleController) Run(ctx context.Context) {
 	defer utilruntime.HandleCrash()
 
@@ -109,24 +154,35 @@ func (ac *AutoscaleController) Run(ctx context.Context) {
 	)
 
 	klog.Info("start autoscale controller")
-	go wait.Until(func() {
-		ac.Reconcile(ctx)
-	}, util.AutoscalingSyncPeriodSeconds*time.Second, nil)
 
-	<-ctx.Done()
-	klog.Info("shut down autoscale controller")
+	// Use a zero-duration timer so the first reconcile fires immediately,
+	// matching the previous wait.Until behaviour.
+	timer := time.NewTimer(0)
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			klog.Info("shut down autoscale controller")
+			return
+		case <-timer.C:
+			next := ac.Reconcile(ctx)
+			timer.Reset(next)
+		}
+	}
 }
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
-func (ac *AutoscaleController) Reconcile(ctx context.Context) {
+// It returns the interval to wait before the next reconcile cycle.
+func (ac *AutoscaleController) Reconcile(ctx context.Context) time.Duration {
 	klog.V(4).Info("start to reconcile")
 	ctx, cancel := context.WithTimeout(ctx, util.AutoscaleCtxTimeoutSeconds*time.Second)
 	defer cancel()
 	policies, err := ac.autoscalingPoliciesLister.List(labels.Everything())
 	if err != nil {
 		klog.Errorf("failed to list autoscaling policies, err: %v", err)
-		return
+		return nextInterval(outcomeStable)
 	}
 
 	scalerSet := sets.New[string]()
@@ -163,13 +219,19 @@ func (ac *AutoscaleController) Reconcile(ctx context.Context) {
 		}
 	}
 
+	overall := outcomeStable
 	for _, policy := range policies {
-		err := ac.schedule(ctx, policy)
+		o, err := ac.schedule(ctx, policy)
 		if err != nil {
 			klog.Errorf("failed to process autoscale,err: %v", err)
 			continue
 		}
+		overall = mergeOutcome(overall, o)
 	}
+
+	interval := nextInterval(overall)
+	klog.V(4).Infof("reconcile complete, next interval: %s", interval)
+	return interval
 }
 
 func (ac *AutoscaleController) updateTargetReplicas(ctx context.Context, target *workload.Target, defaultNamespace string, replicas int32) error {
@@ -218,31 +280,35 @@ func (ac *AutoscaleController) getTargetReplicas(target *workload.Target, defaul
 	return 1, nil
 }
 
-func (ac *AutoscaleController) schedule(ctx context.Context, autoscalePolicy *workload.AutoscalingPolicy) error {
+func (ac *AutoscaleController) schedule(ctx context.Context, autoscalePolicy *workload.AutoscalingPolicy) (scalingOutcome, error) {
 	klog.V(2).Infof("start to process autoscaling policy %s", klog.KObj(autoscalePolicy))
 	if autoscalePolicy.Spec.HeterogeneousTarget != nil {
-		if err := ac.doOptimize(ctx, autoscalePolicy); err != nil {
+		o, err := ac.doOptimize(ctx, autoscalePolicy)
+		if err != nil {
 			klog.Errorf("failed to do optimize, err: %v", err)
-			return err
+			return outcomeStable, err
 		}
+		return o, nil
 	} else if autoscalePolicy.Spec.HomogeneousTarget != nil {
-		if err := ac.doScale(ctx, autoscalePolicy); err != nil {
+		o, err := ac.doScale(ctx, autoscalePolicy)
+		if err != nil {
 			klog.Errorf("failed to do scale, err: %v", err)
-			return err
+			return outcomeStable, err
 		}
+		return o, nil
 	} else if autoscalePolicy.Spec.DisaggregatedTarget != nil {
-		if err := ac.doDisaggregatedScale(ctx, autoscalePolicy); err != nil {
+		o, err := ac.doDisaggregatedScale(ctx, autoscalePolicy)
+		if err != nil {
 			klog.Errorf("failed to do disaggregated scale, err: %v", err)
-			return err
+			return outcomeStable, err
 		}
-	} else {
-		klog.Warningf("policy %s has no target configuration", autoscalePolicy.Name)
+		return o, nil
 	}
-
-	return nil
+	klog.Warningf("policy %s has no target configuration", autoscalePolicy.Name)
+	return outcomeStable, nil
 }
 
-func (ac *AutoscaleController) doOptimize(ctx context.Context, autoscalePolicy *workload.AutoscalingPolicy) error {
+func (ac *AutoscaleController) doOptimize(ctx context.Context, autoscalePolicy *workload.AutoscalingPolicy) (scalingOutcome, error) {
 	key := formatAutoscalerMapKey(autoscalePolicy.Namespace, autoscalePolicy.Name, nil)
 	optimizer, ok := ac.optimizerMap[key]
 	if !ok || optimizer.NeedUpdate(autoscalePolicy) {
@@ -256,7 +322,7 @@ func (ac *AutoscaleController) doOptimize(ctx context.Context, autoscalePolicy *
 		currentInstancesCount, err := ac.getTargetReplicas(&param.Target, autoscalePolicy.Namespace)
 		if err != nil {
 			klog.Errorf("failed to get current replicas, err: %v", err)
-			return err
+			return outcomeStable, err
 		}
 		replicasMap[param.Target.TargetRef.Name] = currentInstancesCount
 	}
@@ -265,25 +331,27 @@ func (ac *AutoscaleController) doOptimize(ctx context.Context, autoscalePolicy *
 	recommendedInstances, err := optimizer.Optimize(ctx, ac.podsLister, autoscalePolicy, replicasMap)
 	if err != nil {
 		klog.Errorf("failed to do optimize, err: %v", err)
-		return err
+		return outcomeStable, err
 	}
 	// Do update replicas
+	outcome := outcomeStable
 	for _, param := range optimizer.Meta.Config.Params {
 		instancesCount, exists := recommendedInstances[param.Target.TargetRef.Name]
 		if !exists {
 			klog.Warningf("recommended instances not exists, target ref name: %s", param.Target.TargetRef.Name)
 			continue
 		}
+		outcome = mergeOutcome(outcome, outcomeFromChange(replicasMap[param.Target.TargetRef.Name], instancesCount))
 		if err := ac.updateTargetReplicas(ctx, &param.Target, autoscalePolicy.Namespace, instancesCount); err != nil {
 			klog.Errorf("failed to update target kind:%s name: %s replicas:%d, err: %v", param.Target.TargetRef.Kind, param.Target.TargetRef.Name, instancesCount, err)
-			return err
+			return outcomeStable, err
 		}
 	}
 
-	return nil
+	return outcome, nil
 }
 
-func (ac *AutoscaleController) doScale(ctx context.Context, autoscalePolicy *workload.AutoscalingPolicy) error {
+func (ac *AutoscaleController) doScale(ctx context.Context, autoscalePolicy *workload.AutoscalingPolicy) (scalingOutcome, error) {
 	target := autoscalePolicy.Spec.HomogeneousTarget.Target
 	key := formatAutoscalerMapKey(autoscalePolicy.Namespace, autoscalePolicy.Name, &target.TargetRef)
 	scaler, ok := ac.scalerMap[key]
@@ -296,38 +364,38 @@ func (ac *AutoscaleController) doScale(ctx context.Context, autoscalePolicy *wor
 	currentInstancesCount, err := ac.getTargetReplicas(&target, autoscalePolicy.Namespace)
 	if err != nil {
 		klog.Errorf("failed to get current replicas, err: %v", err)
-		return err
+		return outcomeStable, err
 	}
 	// Get recommended replicas
 	klog.InfoS("do homogeneous scaling for target", "targetRef", target.TargetRef, "currentInstancesCount", currentInstancesCount)
 	recommendedInstances, err := scaler.Scale(ctx, ac.podsLister, autoscalePolicy, currentInstancesCount)
 	if err != nil {
 		klog.Errorf("failed to do homogeneous scaling for target %s, err: %v", target.TargetRef.Name, err)
-		return err
+		return outcomeStable, err
 	}
 	if recommendedInstances < 0 {
-		return nil
+		return outcomeStable, nil
 	}
 	// Do update replicas
 	if err := ac.updateTargetReplicas(ctx, &target, autoscalePolicy.Namespace, recommendedInstances); err != nil {
 		klog.Errorf("failed to update target replicas %s, err: %v", target.TargetRef.Name, err)
-		return err
+		return outcomeStable, err
 	}
 	klog.InfoS("successfully update target replicas", "targetRef", target.TargetRef, "recommendedInstances", recommendedInstances)
-	return nil
+	return outcomeFromChange(currentInstancesCount, recommendedInstances), nil
 }
 
 // doDisaggregatedScale runs one reconcile cycle for a DisaggregatedTarget: read
 // current role replicas, compute final role replicas, patch all changed roles in
 // one request, and publish AutoscalingPolicy status.
-func (ac *AutoscaleController) doDisaggregatedScale(ctx context.Context, autoscalePolicy *workload.AutoscalingPolicy) error {
+func (ac *AutoscaleController) doDisaggregatedScale(ctx context.Context, autoscalePolicy *workload.AutoscalingPolicy) (scalingOutcome, error) {
 	target := autoscalePolicy.Spec.DisaggregatedTarget
 	key := formatAutoscalerMapKey(autoscalePolicy.Namespace, autoscalePolicy.Name, &target.TargetRef)
 	disaggregatedScaler, ok := ac.disaggregatedScalerMap[key]
 	if !ok || disaggregatedScaler.NeedUpdate(autoscalePolicy) {
 		disaggregatedScaler = autoscaler.NewDisaggregatedAutoscaler(autoscalePolicy)
 		if disaggregatedScaler == nil {
-			return fmt.Errorf("failed to create disaggregated scaler: policy or target is nil")
+			return outcomeStable, fmt.Errorf("failed to create disaggregated scaler: policy or target is nil")
 		}
 		ac.disaggregatedScalerMap[key] = disaggregatedScaler
 		klog.Infof("asp: %s changed, create new disaggregated scaler", autoscalePolicy.Name)
@@ -338,14 +406,14 @@ func (ac *AutoscaleController) doDisaggregatedScale(ctx context.Context, autosca
 		if err := ac.updateDisaggregatedPolicyStatus(ctx, autoscalePolicy, nil, err, false); err != nil {
 			klog.Warningf("failed to update disaggregated autoscaling policy status %s/%s: %v", autoscalePolicy.Namespace, autoscalePolicy.Name, err)
 		}
-		return err
+		return outcomeStable, err
 	}
 	currentReplicas, err := getCurrentRoleReplicas(modelServing, target.Roles)
 	if err != nil {
 		if err := ac.updateDisaggregatedPolicyStatus(ctx, autoscalePolicy, nil, err, false); err != nil {
 			klog.Warningf("failed to update disaggregated autoscaling policy status %s/%s: %v", autoscalePolicy.Namespace, autoscalePolicy.Name, err)
 		}
-		return err
+		return outcomeStable, err
 	}
 
 	result, err := disaggregatedScaler.Scale(ctx, ac.podsLister, autoscalePolicy, currentReplicas)
@@ -353,22 +421,27 @@ func (ac *AutoscaleController) doDisaggregatedScale(ctx context.Context, autosca
 		if err := ac.updateDisaggregatedPolicyStatus(ctx, autoscalePolicy, nil, err, true); err != nil {
 			klog.Warningf("failed to update disaggregated autoscaling policy status %s/%s: %v", autoscalePolicy.Namespace, autoscalePolicy.Name, err)
 		}
-
-		return err
+		return outcomeStable, err
 	}
 	if result == nil {
-		return nil
+		return outcomeStable, nil
 	}
+
+	outcome := outcomeStable
+	for _, role := range result.Roles {
+		outcome = mergeOutcome(outcome, outcomeFromChange(role.CurrentReplicas, role.FinalReplicas))
+	}
+
 	if err := ac.updateTargetRoleReplicas(ctx, target, autoscalePolicy.Namespace, finalReplicasByRole(result.Roles)); err != nil {
 		if err := ac.updateDisaggregatedPolicyStatus(ctx, autoscalePolicy, result, err, true); err != nil {
 			klog.Warningf("failed to update disaggregated autoscaling policy status %s/%s: %v", autoscalePolicy.Namespace, autoscalePolicy.Name, err)
 		}
-		return err
+		return outcomeStable, err
 	}
 	if err := ac.updateDisaggregatedPolicyStatus(ctx, autoscalePolicy, result, nil, true); err != nil {
 		klog.Warningf("failed to update disaggregated autoscaling policy status %s/%s: %v", autoscalePolicy.Namespace, autoscalePolicy.Name, err)
 	}
-	return nil
+	return outcome, nil
 }
 
 // finalReplicasByRole derives the patch input from RoleScaleResult instead of

--- a/pkg/autoscaler/controller/autoscale_controller.go
+++ b/pkg/autoscaler/controller/autoscale_controller.go
@@ -283,26 +283,11 @@ func (ac *AutoscaleController) getTargetReplicas(target *workload.Target, defaul
 func (ac *AutoscaleController) schedule(ctx context.Context, autoscalePolicy *workload.AutoscalingPolicy) (scalingOutcome, error) {
 	klog.V(2).Infof("start to process autoscaling policy %s", klog.KObj(autoscalePolicy))
 	if autoscalePolicy.Spec.HeterogeneousTarget != nil {
-		o, err := ac.doOptimize(ctx, autoscalePolicy)
-		if err != nil {
-			klog.Errorf("failed to do optimize, err: %v", err)
-			return outcomeStable, err
-		}
-		return o, nil
+		return ac.doOptimize(ctx, autoscalePolicy)
 	} else if autoscalePolicy.Spec.HomogeneousTarget != nil {
-		o, err := ac.doScale(ctx, autoscalePolicy)
-		if err != nil {
-			klog.Errorf("failed to do scale, err: %v", err)
-			return outcomeStable, err
-		}
-		return o, nil
+		return ac.doScale(ctx, autoscalePolicy)
 	} else if autoscalePolicy.Spec.DisaggregatedTarget != nil {
-		o, err := ac.doDisaggregatedScale(ctx, autoscalePolicy)
-		if err != nil {
-			klog.Errorf("failed to do disaggregated scale, err: %v", err)
-			return outcomeStable, err
-		}
-		return o, nil
+		return ac.doDisaggregatedScale(ctx, autoscalePolicy)
 	}
 	klog.Warningf("policy %s has no target configuration", autoscalePolicy.Name)
 	return outcomeStable, nil
@@ -332,6 +317,9 @@ func (ac *AutoscaleController) doOptimize(ctx context.Context, autoscalePolicy *
 	if err != nil {
 		klog.Errorf("failed to do optimize, err: %v", err)
 		return outcomeStable, err
+	}
+	if recommendedInstances == nil {
+		return outcomeStable, nil
 	}
 	// Do update replicas
 	outcome := outcomeStable

--- a/pkg/autoscaler/controller/autoscale_controller_test.go
+++ b/pkg/autoscaler/controller/autoscale_controller_test.go
@@ -37,6 +37,7 @@ import (
 	resource "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
 	listerv1 "k8s.io/client-go/listers/core/v1"
 	k8stesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
@@ -125,7 +126,7 @@ func TestToleranceHigh_then_DoScale_expect_NoUpdateActions(t *testing.T) {
 	pods := []*corev1.Pod{readyPod(ns, "pod-a", host, lbs)}
 	ac := &AutoscaleController{client: client, modelServingLister: msLister, podsLister: fakePodLister{podsByNs: map[string][]*corev1.Pod{ns: pods}}, scalerMap: map[string]*autoscalerAutoscaler{}, optimizerMap: map[string]*autoscalerOptimizer{}}
 
-	if err := ac.doScale(context.Background(), policy); err != nil {
+	if _, err := ac.doScale(context.Background(), policy); err != nil {
 		t.Fatalf("doScale error: %v", err)
 	}
 	if len(client.Fake.Actions()) != 0 {
@@ -152,7 +153,7 @@ func TestHighLoad_then_DoScale_expect_Replicas10(t *testing.T) {
 	pods := []*corev1.Pod{readyPod(ns, "pod-up", host, lbs)}
 	ac := &AutoscaleController{client: client, modelServingLister: msLister, podsLister: fakePodLister{podsByNs: map[string][]*corev1.Pod{ns: pods}}, scalerMap: map[string]*autoscalerAutoscaler{}, optimizerMap: map[string]*autoscalerOptimizer{}}
 
-	if err := ac.doScale(context.Background(), policy); err != nil {
+	if _, err := ac.doScale(context.Background(), policy); err != nil {
 		t.Fatalf("doScale error: %v", err)
 	}
 	updated, err := client.WorkloadV1alpha1().ModelServings(ns).Get(context.Background(), "ms-up", metav1.GetOptions{})
@@ -187,7 +188,7 @@ func TestTwoBackends_then_DoOptimize_expect_PatchActions(t *testing.T) {
 	pods := []*corev1.Pod{readyPod(ns, "pod-a", host, lbsA), readyPod(ns, "pod-b", host, lbsB)}
 	ac := &AutoscaleController{client: client, modelServingLister: msLister, podsLister: fakePodLister{podsByNs: map[string][]*corev1.Pod{ns: pods}}, scalerMap: map[string]*autoscalerAutoscaler{}, optimizerMap: map[string]*autoscalerOptimizer{}}
 
-	if err := ac.doOptimize(context.Background(), policy); err != nil {
+	if _, err := ac.doOptimize(context.Background(), policy); err != nil {
 		t.Fatalf("doOptimize error: %v", err)
 	}
 	updates := 0
@@ -224,7 +225,7 @@ func TestTwoBackendsHighLoad_then_DoOptimize_expect_DistributionA5B4(t *testing.
 	pods := []*corev1.Pod{readyPod(ns, "pod-a2", host, lbsA), readyPod(ns, "pod-b2", host, lbsB)}
 	ac := &AutoscaleController{client: client, modelServingLister: msLister, podsLister: fakePodLister{podsByNs: map[string][]*corev1.Pod{ns: pods}}, scalerMap: map[string]*autoscalerAutoscaler{}, optimizerMap: map[string]*autoscalerOptimizer{}}
 
-	if err := ac.doOptimize(context.Background(), policy); err != nil {
+	if _, err := ac.doOptimize(context.Background(), policy); err != nil {
 		t.Fatalf("doOptimize error: %v", err)
 	}
 	updatedA, err := client.WorkloadV1alpha1().ModelServings(ns).Get(context.Background(), "ms-a2", metav1.GetOptions{})
@@ -325,7 +326,7 @@ func TestDoDisaggregatedScale_RatioRaisesDecode(t *testing.T) {
 		disaggregatedScalerMap: map[string]*autoscaler.DisaggregatedAutoscaler{},
 	}
 
-	if err := ac.doDisaggregatedScale(context.Background(), policy); err != nil {
+	if _, err := ac.doDisaggregatedScale(context.Background(), policy); err != nil {
 		t.Fatalf("doDisaggregatedScale error: %v", err)
 	}
 	updated, err := client.WorkloadV1alpha1().ModelServings(ns).Get(context.Background(), "ms-pd", metav1.GetOptions{})
@@ -946,5 +947,252 @@ func TestPatchDoesNotMutateResourcesInFakeClient(t *testing.T) {
 				gotPrefillCPU.String(), gotPrefillMem.String(),
 				gotDecodeCPU.String(), gotDecodeMem.String(), gotImage)
 		})
+	}
+}
+
+// TestOutcomeFromChange covers all three scaling directions.
+func TestOutcomeFromChange(t *testing.T) {
+	tests := []struct {
+		name        string
+		current     int32
+		recommended int32
+		want        scalingOutcome
+	}{
+		{"scale up", 2, 5, outcomeScaleUp},
+		{"scale down", 5, 2, outcomeScaleDown},
+		{"stable", 3, 3, outcomeStable},
+		{"skip (-1)", 3, -1, outcomeStable},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := outcomeFromChange(tt.current, tt.recommended)
+			if got != tt.want {
+				t.Fatalf("outcomeFromChange(%d, %d) = %d, want %d", tt.current, tt.recommended, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestMergeOutcome verifies that scale-up takes priority over scale-down,
+// and scale-down takes priority over stable.
+func TestMergeOutcome(t *testing.T) {
+	tests := []struct {
+		a, b scalingOutcome
+		want scalingOutcome
+	}{
+		{outcomeStable, outcomeStable, outcomeStable},
+		{outcomeStable, outcomeScaleDown, outcomeScaleDown},
+		{outcomeScaleDown, outcomeStable, outcomeScaleDown},
+		{outcomeStable, outcomeScaleUp, outcomeScaleUp},
+		{outcomeScaleUp, outcomeStable, outcomeScaleUp},
+		{outcomeScaleDown, outcomeScaleUp, outcomeScaleUp},
+		{outcomeScaleUp, outcomeScaleDown, outcomeScaleUp},
+	}
+	for _, tt := range tests {
+		got := mergeOutcome(tt.a, tt.b)
+		if got != tt.want {
+			t.Fatalf("mergeOutcome(%d, %d) = %d, want %d", tt.a, tt.b, got, tt.want)
+		}
+	}
+}
+
+// TestNextInterval maps each outcome to the expected adaptive period.
+func TestNextInterval(t *testing.T) {
+	tests := []struct {
+		outcome scalingOutcome
+		wantSec float64
+	}{
+		{outcomeScaleUp, 5},
+		{outcomeStable, 15},
+		{outcomeScaleDown, 30},
+	}
+	for _, tt := range tests {
+		got := nextInterval(tt.outcome)
+		if got.Seconds() != tt.wantSec {
+			t.Fatalf("nextInterval(%d) = %v, want %vs", tt.outcome, got, tt.wantSec)
+		}
+	}
+}
+
+// TestDoScale_AdaptiveOutcome verifies that doScale returns the correct
+// scaling outcome based on the direction of the replica change.
+func TestDoScale_AdaptiveOutcome(t *testing.T) {
+	ns := "ns"
+
+	tests := []struct {
+		name        string
+		current     int32
+		metricBody  string
+		wantOutcome scalingOutcome
+	}{
+		{
+			name:        "scale up when load exceeds target",
+			current:     1,
+			metricBody:  "# TYPE load gauge\nload 10\n",
+			wantOutcome: outcomeScaleUp,
+		},
+		{
+			name:        "stable when load equals target",
+			current:     1,
+			metricBody:  "# TYPE load gauge\nload 1\n",
+			wantOutcome: outcomeStable,
+		},
+		{
+			// 10 pods, metric=0.1 per pod, target=1 → recommended=ceil(10*0.1)=1 → scaleDown
+			name:        "scale down when replicas exceed demand",
+			current:     10,
+			metricBody:  "# TYPE load gauge\nload 0.1\n",
+			wantOutcome: outcomeScaleDown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ms := &workload.ModelServing{ObjectMeta: metav1.ObjectMeta{Name: "ms-adaptive", Namespace: ns}, Spec: workload.ModelServingSpec{Replicas: ptrInt32(tt.current)}}
+			client := clientfake.NewSimpleClientset(ms)
+			msLister := workloadLister.NewModelServingLister(newModelServingIndexer(ms))
+
+			srv := httptest.NewServer(httpHandlerWithBody(tt.metricBody))
+			defer srv.Close()
+			u, _ := url.Parse(srv.URL)
+			host, portStr, _ := net.SplitHostPort(u.Host)
+			port := toInt32(portStr)
+
+			target := workload.Target{TargetRef: corev1.ObjectReference{Kind: workload.ModelServingKind.Kind, Namespace: ns, Name: "ms-adaptive"}, MetricSources: map[string]workload.MetricSource{"load": {Pod: &workload.PodMetricSource{Uri: u.Path, Port: port}}}}
+			policy := &workload.AutoscalingPolicy{ObjectMeta: metav1.ObjectMeta{Name: "ap-adaptive", Namespace: ns}, Spec: workload.AutoscalingPolicySpec{TolerancePercent: 0, Metrics: []workload.AutoscalingPolicyMetric{{Name: "load", TargetValue: resource.MustParse("1")}}, HomogeneousTarget: &workload.HomogeneousTarget{Target: target, MinReplicas: 1, MaxReplicas: 10}}}
+
+			pods := []*corev1.Pod{readyPod(ns, "pod-adaptive", host, map[string]string{})}
+			ac := &AutoscaleController{client: client, modelServingLister: msLister, podsLister: fakePodLister{podsByNs: map[string][]*corev1.Pod{ns: pods}}, scalerMap: map[string]*autoscalerAutoscaler{}, optimizerMap: map[string]*autoscalerOptimizer{}}
+
+			got, err := ac.doScale(context.Background(), policy)
+			if err != nil {
+				t.Fatalf("doScale error: %v", err)
+			}
+			if got != tt.wantOutcome {
+				t.Fatalf("doScale outcome = %d, want %d", got, tt.wantOutcome)
+			}
+		})
+	}
+}
+
+// TestReconcile_ReturnsAdaptiveInterval verifies that Reconcile returns the
+// appropriate duration based on the scaling direction observed in the cycle.
+func TestReconcile_ReturnsAdaptiveInterval(t *testing.T) {
+	ns := "ns"
+
+	scaleUpMS := &workload.ModelServing{ObjectMeta: metav1.ObjectMeta{Name: "ms-up", Namespace: ns}, Spec: workload.ModelServingSpec{Replicas: ptrInt32(1)}}
+	client := clientfake.NewSimpleClientset(scaleUpMS)
+	msLister := workloadLister.NewModelServingLister(newModelServingIndexer(scaleUpMS))
+
+	policyIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+
+	srv := httptest.NewServer(httpHandlerWithBody("# TYPE load gauge\nload 10\n"))
+	defer srv.Close()
+	u, _ := url.Parse(srv.URL)
+	host, portStr, _ := net.SplitHostPort(u.Host)
+	port := toInt32(portStr)
+
+	target := workload.Target{TargetRef: corev1.ObjectReference{Kind: workload.ModelServingKind.Kind, Namespace: ns, Name: "ms-up"}, MetricSources: map[string]workload.MetricSource{"load": {Pod: &workload.PodMetricSource{Uri: u.Path, Port: port}}}}
+	policy := &workload.AutoscalingPolicy{ObjectMeta: metav1.ObjectMeta{Name: "ap-up", Namespace: ns}, Spec: workload.AutoscalingPolicySpec{TolerancePercent: 0, Metrics: []workload.AutoscalingPolicyMetric{{Name: "load", TargetValue: resource.MustParse("1")}}, HomogeneousTarget: &workload.HomogeneousTarget{Target: target, MinReplicas: 1, MaxReplicas: 10}}}
+	_ = policyIndexer.Add(policy)
+
+	pods := []*corev1.Pod{readyPod(ns, "pod-up", host, map[string]string{})}
+	ac := &AutoscaleController{
+		client:                    client,
+		autoscalingPoliciesLister: workloadLister.NewAutoscalingPolicyLister(policyIndexer),
+		modelServingLister:        msLister,
+		podsLister:                fakePodLister{podsByNs: map[string][]*corev1.Pod{ns: pods}},
+		scalerMap:                 map[string]*autoscalerAutoscaler{},
+		optimizerMap:              map[string]*autoscalerOptimizer{},
+		disaggregatedScalerMap:    map[string]*autoscaler.DisaggregatedAutoscaler{},
+	}
+
+	interval := ac.Reconcile(context.Background())
+	wantSec := float64(5)
+	if interval.Seconds() != wantSec {
+		t.Fatalf("Reconcile interval = %v, want %vs (scale-up period)", interval, wantSec)
+	}
+}
+
+// TestReconcile_StableInterval verifies that Reconcile returns the default
+// stable period when no scaling action is taken.
+func TestReconcile_StableInterval(t *testing.T) {
+	ns := "ns"
+
+	ms := &workload.ModelServing{ObjectMeta: metav1.ObjectMeta{Name: "ms-stable", Namespace: ns}, Spec: workload.ModelServingSpec{Replicas: ptrInt32(1)}}
+	client := clientfake.NewSimpleClientset(ms)
+	msLister := workloadLister.NewModelServingLister(newModelServingIndexer(ms))
+
+	policyIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+
+	srv := httptest.NewServer(httpHandlerWithBody("# TYPE load gauge\nload 1\n"))
+	defer srv.Close()
+	u, _ := url.Parse(srv.URL)
+	host, portStr, _ := net.SplitHostPort(u.Host)
+	port := toInt32(portStr)
+
+	target := workload.Target{TargetRef: corev1.ObjectReference{Kind: workload.ModelServingKind.Kind, Namespace: ns, Name: "ms-stable"}, MetricSources: map[string]workload.MetricSource{"load": {Pod: &workload.PodMetricSource{Uri: u.Path, Port: port}}}}
+	policy := &workload.AutoscalingPolicy{ObjectMeta: metav1.ObjectMeta{Name: "ap-stable", Namespace: ns}, Spec: workload.AutoscalingPolicySpec{TolerancePercent: 0, Metrics: []workload.AutoscalingPolicyMetric{{Name: "load", TargetValue: resource.MustParse("1")}}, HomogeneousTarget: &workload.HomogeneousTarget{Target: target, MinReplicas: 1, MaxReplicas: 10}}}
+	_ = policyIndexer.Add(policy)
+
+	pods := []*corev1.Pod{readyPod(ns, "pod-stable", host, map[string]string{})}
+	ac := &AutoscaleController{
+		client:                    client,
+		autoscalingPoliciesLister: workloadLister.NewAutoscalingPolicyLister(policyIndexer),
+		modelServingLister:        msLister,
+		podsLister:                fakePodLister{podsByNs: map[string][]*corev1.Pod{ns: pods}},
+		scalerMap:                 map[string]*autoscalerAutoscaler{},
+		optimizerMap:              map[string]*autoscalerOptimizer{},
+		disaggregatedScalerMap:    map[string]*autoscaler.DisaggregatedAutoscaler{},
+	}
+
+	interval := ac.Reconcile(context.Background())
+	wantSec := float64(15)
+	if interval.Seconds() != wantSec {
+		t.Fatalf("Reconcile interval = %v, want %vs (stable period)", interval, wantSec)
+	}
+}
+
+// TestReconcile_EmptyPolicies_DefaultInterval verifies that a cycle with no
+// policies returns the default stable interval.
+func TestReconcile_EmptyPolicies_DefaultInterval(t *testing.T) {
+	policyIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	ac := &AutoscaleController{
+		client:                    clientfake.NewSimpleClientset(),
+		autoscalingPoliciesLister: workloadLister.NewAutoscalingPolicyLister(policyIndexer),
+		scalerMap:                 map[string]*autoscalerAutoscaler{},
+		optimizerMap:              map[string]*autoscalerOptimizer{},
+		disaggregatedScalerMap:    map[string]*autoscaler.DisaggregatedAutoscaler{},
+	}
+
+	interval := ac.Reconcile(context.Background())
+	wantSec := float64(15)
+	if interval.Seconds() != wantSec {
+		t.Fatalf("Reconcile interval = %v, want %vs (default period)", interval, wantSec)
+	}
+}
+
+// TestRun_ShutdownOnContextCancel verifies that Run returns cleanly when the
+// context is cancelled and does not leak the timer goroutine.
+func TestRun_ShutdownOnContextCancel(t *testing.T) {
+	k8sClient := k8sfake.NewSimpleClientset()
+	crClient := clientfake.NewSimpleClientset()
+	ac := NewAutoscaleController(k8sClient, crClient)
+	if ac == nil {
+		t.Fatal("NewAutoscaleController returned nil")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		ac.Run(ctx)
+		close(done)
+	}()
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Run did not return after context cancellation")
 	}
 }

--- a/pkg/autoscaler/util/settings.go
+++ b/pkg/autoscaler/util/settings.go
@@ -17,9 +17,11 @@ limitations under the License.
 package util
 
 const (
-	AutoscalingSyncPeriodSeconds    = 15
-	SloQuantileSlidingWindowSeconds = 60
-	SloQuantileDataKeepSeconds      = 300
-	SloQuantilePercentile           = 95
-	AutoscaleCtxTimeoutSeconds      = 3
+	AutoscalingSyncPeriodSeconds          = 15
+	AutoscalingScaleUpSyncPeriodSeconds   = 5
+	AutoscalingScaleDownSyncPeriodSeconds = 30
+	SloQuantileSlidingWindowSeconds       = 60
+	SloQuantileDataKeepSeconds            = 300
+	SloQuantilePercentile                 = 95
+	AutoscaleCtxTimeoutSeconds            = 3
 )


### PR DESCRIPTION
## What type of PR is this?

/kind enhancement

## What this PR does / why we need it

The autoscaler currently reconciles at a fixed 15-second interval regardless of whether the previous reconciliation scaled the workload up, scaled it down, or made no changes. This results in slower reactions to traffic spikes, unnecessary reconciliation during scale-down, and wasted API server cycles when the system is stable.

This PR introduces adaptive reconcile intervals based on the scaling direction from the previous reconciliation:

- **Scale-up:** reconcile after **5 seconds**
- **Stable:** reconcile after **15 seconds**
- **Scale-down:** reconcile after **30 seconds**

The implementation derives the scaling direction directly from the reconciliation result without introducing additional controller state. Reconcile operations return the scaling outcome, which is aggregated across all autoscaling policies to determine the next reconcile interval.

Additionally, the controller's fixed `wait.Until` loop has been replaced with a `time.NewTimer`-based loop that:
- Preserves the existing immediate reconciliation on startup.
- Shuts down cleanly when the controller context is cancelled.
- Avoids the goroutine leak caused by using `wait.Until` with a nil stop channel.

To keep this change minimal, no CRD or API changes are introduced. The proposed `syncPolicy` configuration can be added in a follow-up once the adaptive scheduling behavior has been validated.

Comprehensive unit tests have been added covering:
- Scaling outcome detection
- Outcome merging
- Adaptive interval selection
- Scale-up, scale-down, and stable reconciliation
- Default behavior with no policies
- Controller shutdown on context cancellation

## Which issue(s) this PR fixes

Fixes #1204

## Special notes for your reviewer

- This implementation intentionally avoids introducing CRD or API changes to keep the review surface small.
- Adaptive intervals are implemented using sensible defaults (5s / 15s / 30s) proposed in the issue.
- The scheduling logic remains single-threaded and introduces no shared mutable state.
- Replacing `wait.Until` with a timer-based loop also fixes clean shutdown behavior by respecting context cancellation.

## Does this PR introduce a user-facing change?

```release-note
The autoscaler now adjusts its reconciliation interval based on the previous scaling outcome, allowing faster reactions to scale-up events, less frequent reconciliation after scale-down, and preserving the default interval when workloads are stable.
```