### PR TITLE
fix(router): validate ModelServer workload selector

### DIFF
--- a/pkg/kthena-router/webhook/validator.go
+++ b/pkg/kthena-router/webhook/validator.go
@@ -224,7 +224,51 @@ func (v *KthenaRouterValidator) validateModelRoute(modelRoute *networkingv1alpha
 }
 
 // validateModelServer validates the ModelServer resource
-func (v *KthenaRouterValidator) validateModelServer(*networkingv1alpha1.ModelServer) (bool, string) {
+func (v *KthenaRouterValidator) validateModelServer(modelServer *networkingv1alpha1.ModelServer) (bool, string) {
+	var allErrs field.ErrorList
+	specField := field.NewPath("spec")
+	workloadSelectorField := specField.Child("workloadSelector")
+
+	if modelServer.Spec.WorkloadSelector == nil {
+		allErrs = append(allErrs, field.Required(workloadSelectorField, "workloadSelector must be specified"))
+	} else {
+		matchLabelsField := workloadSelectorField.Child("matchLabels")
+		if len(modelServer.Spec.WorkloadSelector.MatchLabels) == 0 {
+			allErrs = append(allErrs, field.Required(matchLabelsField, "labels must contain at least one label"))
+		} else if _, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{MatchLabels: modelServer.Spec.WorkloadSelector.MatchLabels}); err != nil {
+			allErrs = append(allErrs, field.Invalid(matchLabelsField, modelServer.Spec.WorkloadSelector.MatchLabels, fmt.Sprintf("invalid selector: %v", err)))
+		}
+
+		if modelServer.Spec.WorkloadSelector.PDGroup != nil {
+			pdGroup := modelServer.Spec.WorkloadSelector.PDGroup
+			pdGroupField := workloadSelectorField.Child("pdGroup")
+
+			if pdGroup.GroupKey == "" {
+				allErrs = append(allErrs, field.Required(pdGroupField.Child("groupKey"), "groupKey must be specified"))
+			}
+			prefillLabelsField := pdGroupField.Child("prefillLabels")
+			if len(pdGroup.PrefillLabels) == 0 {
+				allErrs = append(allErrs, field.Required(prefillLabelsField, "labels must contain at least one label"))
+			} else if _, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{MatchLabels: pdGroup.PrefillLabels}); err != nil {
+				allErrs = append(allErrs, field.Invalid(prefillLabelsField, pdGroup.PrefillLabels, fmt.Sprintf("invalid selector: %v", err)))
+			}
+
+			decodeLabelsField := pdGroupField.Child("decodeLabels")
+			if len(pdGroup.DecodeLabels) == 0 {
+				allErrs = append(allErrs, field.Required(decodeLabelsField, "labels must contain at least one label"))
+			} else if _, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{MatchLabels: pdGroup.DecodeLabels}); err != nil {
+				allErrs = append(allErrs, field.Invalid(decodeLabelsField, pdGroup.DecodeLabels, fmt.Sprintf("invalid selector: %v", err)))
+			}
+		}
+	}
+
+	if len(allErrs) > 0 {
+		var messages []string
+		for _, err := range allErrs {
+			messages = append(messages, fmt.Sprintf("  - %s", err.Error()))
+		}
+		return false, fmt.Sprintf("validation failed: %s", strings.Join(messages, ""))
+	}
 	return true, ""
 }
 

--- a/pkg/kthena-router/webhook/validator_test.go
+++ b/pkg/kthena-router/webhook/validator_test.go
@@ -518,3 +518,168 @@ func TestValidateModelRoute(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateModelServer(t *testing.T) {
+	tests := []struct {
+		name           string
+		modelServer    *networkingv1alpha1.ModelServer
+		expectValid    bool
+		expectedReason string
+	}{
+		{
+			name: "valid model server",
+			modelServer: &networkingv1alpha1.ModelServer{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "networking.serving.volcano.sh/v1alpha1",
+					Kind:       "ModelServer",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-server",
+					Namespace: "default",
+				},
+				Spec: networkingv1alpha1.ModelServerSpec{
+					InferenceEngine: networkingv1alpha1.VLLM,
+					WorkloadSelector: &networkingv1alpha1.WorkloadSelector{
+						MatchLabels: map[string]string{
+							"app": "test-server",
+						},
+					},
+					WorkloadPort: networkingv1alpha1.WorkloadPort{
+						Port: 8000,
+					},
+				},
+			},
+			expectValid: true,
+		},
+		{
+			name: "valid model server with pd group",
+			modelServer: &networkingv1alpha1.ModelServer{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "networking.serving.volcano.sh/v1alpha1",
+					Kind:       "ModelServer",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-server",
+					Namespace: "default",
+				},
+				Spec: networkingv1alpha1.ModelServerSpec{
+					InferenceEngine: networkingv1alpha1.VLLM,
+					WorkloadSelector: &networkingv1alpha1.WorkloadSelector{
+						MatchLabels: map[string]string{
+							"app": "test-server",
+						},
+						PDGroup: &networkingv1alpha1.PDGroup{
+							GroupKey: "pd-group",
+							PrefillLabels: map[string]string{
+								"role": "prefill",
+							},
+							DecodeLabels: map[string]string{
+								"role": "decode",
+							},
+						},
+					},
+					WorkloadPort: networkingv1alpha1.WorkloadPort{
+						Port: 8000,
+					},
+				},
+			},
+			expectValid: true,
+		},
+		{
+			name: "invalid model server - empty workload selector",
+			modelServer: &networkingv1alpha1.ModelServer{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "networking.serving.volcano.sh/v1alpha1",
+					Kind:       "ModelServer",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-server",
+					Namespace: "default",
+				},
+				Spec: networkingv1alpha1.ModelServerSpec{
+					InferenceEngine:  networkingv1alpha1.VLLM,
+					WorkloadSelector: &networkingv1alpha1.WorkloadSelector{},
+					WorkloadPort: networkingv1alpha1.WorkloadPort{
+						Port: 8000,
+					},
+				},
+			},
+			expectValid:    false,
+			expectedReason: "validation failed:   - spec.workloadSelector.matchLabels: Required value: labels must contain at least one label",
+		},
+		{
+			name: "invalid model server - invalid match labels",
+			modelServer: &networkingv1alpha1.ModelServer{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "networking.serving.volcano.sh/v1alpha1",
+					Kind:       "ModelServer",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-server",
+					Namespace: "default",
+				},
+				Spec: networkingv1alpha1.ModelServerSpec{
+					InferenceEngine: networkingv1alpha1.VLLM,
+					WorkloadSelector: &networkingv1alpha1.WorkloadSelector{
+						MatchLabels: map[string]string{
+							"app@name": "test-server",
+						},
+					},
+					WorkloadPort: networkingv1alpha1.WorkloadPort{
+						Port: 8000,
+					},
+				},
+			},
+			expectValid:    false,
+			expectedReason: "validation failed:   - spec.workloadSelector.matchLabels: Invalid value: {\"app@name\":\"test-server\"}: invalid selector: key: Invalid value: \"app@name\": name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')",
+		},
+		{
+			name: "invalid model server - empty pd group",
+			modelServer: &networkingv1alpha1.ModelServer{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "networking.serving.volcano.sh/v1alpha1",
+					Kind:       "ModelServer",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-server",
+					Namespace: "default",
+				},
+				Spec: networkingv1alpha1.ModelServerSpec{
+					InferenceEngine: networkingv1alpha1.VLLM,
+					WorkloadSelector: &networkingv1alpha1.WorkloadSelector{
+						MatchLabels: map[string]string{
+							"app": "test-server",
+						},
+						PDGroup: &networkingv1alpha1.PDGroup{
+							GroupKey:      "",
+							PrefillLabels: map[string]string{},
+							DecodeLabels:  map[string]string{},
+						},
+					},
+					WorkloadPort: networkingv1alpha1.WorkloadPort{
+						Port: 8000,
+					},
+				},
+			},
+			expectValid:    false,
+			expectedReason: "validation failed:   - spec.workloadSelector.pdGroup.groupKey: Required value: groupKey must be specified  - spec.workloadSelector.pdGroup.prefillLabels: Required value: labels must contain at least one label  - spec.workloadSelector.pdGroup.decodeLabels: Required value: labels must contain at least one label",
+		},
+	}
+
+	kubeClient := fake.NewSimpleClientset()
+	validator := NewKthenaRouterValidator(kubeClient, 8080)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			allowed, reason := validator.validateModelServer(tt.modelServer)
+
+			assert.Equal(t, tt.expectValid, allowed, "Expected validation result should match")
+
+			if !tt.expectValid {
+				assert.Equal(t, tt.expectedReason, reason, "Error message should match expected reason")
+			} else {
+				assert.Empty(t, reason, "Reason should be empty for valid model servers")
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Validate ModelServer workload selector config in the router webhook.

Before this, the ModelServer webhook accepted any ModelServer because `validateModelServer` always returned allowed. That lets unsafe configs like empty `matchLabels` or incomplete PDGroup labels get admitted and fail later during routing.

This rejects:
- missing workloadSelector
- empty workloadSelector.matchLabels
- empty PDGroup groupKey / prefillLabels / decodeLabels

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

Added unit coverage for valid ModelServer configs and the invalid selector cases.

**Does this PR introduce a user-facing change?**:

```release-note
ModelServer webhook now rejects empty workload selectors and incomplete PDGroup selector config.