### PR TITLE
Consider KV cache storage tier in scoring

### DIFF
--- a/docs/kthena/docs/user-guide/config-router.md
+++ b/docs/kthena/docs/user-guide/config-router.md
@@ -19,7 +19,7 @@ Plugin Configuration (PluginConfig):
 | least-request | maxWaitingRequests                                          | Sets the maximum number of waiting requests                                                               |
 | least-latency | TTFTTPOTWeightFactor                                        | Sets the TTFT weight factor. Must be between `0.0` and `1.0`.                                             |
 | prefix-cache  | blockSizeToHash<br />maxBlocksToMatch<br />maxHashCacheSize | Configures prefix cache parameters                                                                        |
-| kvcache-aware | blockSizeToHash<br />maxBlocksToMatch                       | Configures KV cache aware token-block matching parameters. Requires Redis and the Kthena Runtime sidecar. |
+| kvcache-aware | blockSizeToHash<br />maxBlocksToMatch<br />tierWeights       | Configures KV cache aware token-block matching parameters. Requires Redis and the Kthena Runtime sidecar. |
 
 `TTFTTPOTWeightFactor` controls how the least-latency plugin balances Time To First Token (TTFT) and Time Per Output Token (TPOT):
 
@@ -87,6 +87,10 @@ data:
         args:
           blockSizeToHash: 16
           maxBlocksToMatch: 128
+          tierWeights:
+            gpu: 1.0
+            cpu: 0.8
+            cpu_pinned: 0.8
       plugins:
         Filter:
           enabled:
@@ -134,6 +138,10 @@ data:
           # Changes as needed.
           blockSizeToHash: 16
           maxBlocksToMatch: 128
+          tierWeights:
+            gpu: 1.0
+            cpu: 0.8
+            cpu_pinned: 0.8
       plugins:
         Filter:
           enabled:

--- a/docs/kthena/docs/user-guide/kvcache-aware.md
+++ b/docs/kthena/docs/user-guide/kvcache-aware.md
@@ -281,6 +281,10 @@ data:
         args:
           blockSizeToHash: 16
           maxBlocksToMatch: 128
+          tierWeights:
+            gpu: 1.0
+            cpu: 0.8
+            cpu_pinned: 0.8
       plugins:
         Filter:
           enabled:
@@ -295,12 +299,15 @@ data:
 
 **Plugin arguments:**
 
-| Parameter             | Default | Description                                                                      |
-| --------------------- | ------- | -------------------------------------------------------------------------------- |
-| `blockSizeToHash`     | 16      | Number of tokens per block. Must match the vLLM block size for optimal matching. |
-| `maxBlocksToMatch`    | 128     | Maximum number of blocks to process per request. Limits Redis queries.           |
-| `vllmTokenizerPort`   | 8000    | Port used to fetch the tokenizer from vLLM pods.                                 |
-| `sglangTokenizerPort` | 30000   | Port used to fetch the tokenizer from SGLang pods.                               |
+| Parameter             | Default                                      | Description                                                                      |
+| --------------------- | -------------------------------------------- | -------------------------------------------------------------------------------- |
+| `blockSizeToHash`     | 16                                           | Number of tokens per block. Must match the vLLM block size for optimal matching. |
+| `maxBlocksToMatch`    | 128                                          | Maximum number of blocks to process per request. Limits Redis queries.           |
+| `tierWeights`         | gpu: 1.0<br />cpu: 0.8<br />cpu_pinned: 0.8 | Optional weights for reported KV cache storage medium. Missing or unknown medium values use weight `1.0`. |
+| `vllmTokenizerPort`   | 8000                                         | Port used to fetch the tokenizer from vLLM pods.                                 |
+| `sglangTokenizerPort` | 30000                                        | Port used to fetch the tokenizer from SGLang pods.                               |
+
+The runtime sidecar records a block's storage medium when the inference engine reports it. vLLM reports `GPU`, `CPU`, `FS`, and `OBJ`. SGLang reports `GPU`, `CPU_PINNED`, `DISK`, and `EXTERNAL`. Use lower-case names in `tierWeights`, for example `cpu` for vLLM and `cpu_pinned` for SGLang. Timestamp-only Redis entries, missing media, and unconfigured media are scored with weight `1.0`; configure any reported tier that should be discounted. Configured weights must be between `0.0` and `1.0`.
 
 **Helm values:**
 

--- a/docs/proposal/kvcache-aware-plugin-design.md
+++ b/docs/proposal/kvcache-aware-plugin-design.md
@@ -6,6 +6,7 @@
 - **Distributed Cache Coordination**: Leverage Redis for cross-pod cache coordination in distributed inference environments
 - **Advanced Tokenization Support**: Integrate with model-specific tokenizers and chat template processing for accurate token sequence handling
 - **Semantic Cache Alignment**: Use token-based blocks instead of byte-based blocks for better semantic alignment with model inference patterns
+- **Storage-tier Aware Scoring**: Account for the storage medium of cached KV blocks when scoring cache hits
 
 ## 1. Introduction
 
@@ -35,6 +36,7 @@ The plugin addresses the challenge of efficiently routing inference requests to 
 
 **Redis-based Distributed Cache**
 - Uses Redis hash structures for block-to-pod mappings
+- Stores the cache block's storage medium alongside the last-updated timestamp when reported by the runtime
 - Efficient pipeline operations for batch queries
 - Timeout handling and error recovery
 
@@ -53,8 +55,9 @@ The plugin addresses the challenge of efficiently routing inference requests to 
 
 **Scoring Mechanism**
 - Scores pods based on consecutive token block matches from the beginning
-- Score calculation: `(matching consecutive blocks / total blocks) * 100`
+- Score calculation: `(weighted matching consecutive blocks / total blocks) * 100`
 - Range: 0-100, higher scores indicate better KV cache hit potential
+- Applies per-medium weights for reported storage tiers while keeping timestamp-only entries at weight 1.0
 - Early termination when no pods have consecutive matches
 
 ## 3. Technical Implementation
@@ -80,9 +83,14 @@ Input Prompt → Tokenization → Block Division → Hash Generation → Redis Q
 Key: "matrix:kv:block:deepseek-ai/DeepSeek-R1-Distill-Qwen-7B@12345678901234567890"
 Fields: {
   "pod-name-1.namespace.svc.cluster.local": "1703123456",
-  "pod-name-2.namespace.svc.cluster.local": "1703123789"
+  "pod-name-2.namespace.svc.cluster.local": "1703123789|GPU",
+  "pod-name-3.namespace.svc.cluster.local": "1703123900|CPU_PINNED"
 }
 ```
+
+Timestamp-only values remain valid and are treated as weight `1.0`. When a runtime reports a storage medium, the value is extended as `timestamp|medium`. New block updates overwrite the previous value for the same pod and block.
+
+If the medium is not reported or empty, the plugin falls back to weight `1.0`. A reported medium that is not present in `tierWeights` also uses `1.0`; operators should configure any reported tier they want discounted. This keeps existing runtime behavior unchanged and avoids penalizing engines that do not expose storage-tier information.
 
 ### 3.3. Configuration Parameters
 
@@ -90,6 +98,10 @@ Fields: {
 # KVCacheAware configuration
 blockSizeToHash: 16       # Tokens per block for hashing
 maxBlocksToMatch: 128     # Maximum blocks to process
+tierWeights:              # Optional per-medium score weights
+  gpu: 1.0
+  cpu: 0.8
+  cpu_pinned: 0.8
 ```
 
 ### 3.4. Scoring Algorithm
@@ -99,7 +111,9 @@ The plugin implements a consecutive block matching algorithm:
 1. **First Block Filtering**: Only consider pods that have the first token block
 2. **Consecutive Matching**: For each subsequent block, only keep pods that have both the current and all previous blocks
 3. **Early Termination**: Stop processing when no pods have consecutive matches
-4. **Score Calculation**: `(consecutive_matches / total_blocks) * 100`
+4. **Score Calculation**: `(weighted_consecutive_matches / total_blocks) * 100`
+
+Missing and unknown media default to weight `1.0`. Configured weights must be between `0.0` and `1.0`; values outside that range are ignored.
 
 ## 4. Integration with Kthena
 
@@ -130,6 +144,19 @@ Uses the existing Redis infrastructure:
 - **Singleton Pattern**: Leverages `utils.TryGetRedisClient()` for connection management
 - **Pipeline Operations**: Efficient batch queries for multiple blocks
 - **Error Handling**: Graceful degradation when Redis is unavailable
+
+### 4.4. Runtime Event Integration
+
+The runtime KV cache handlers write block ownership into the shared Redis key space. When vLLM or SGLang block events include a `medium` field, the handler stores that medium with the pod entry. The cache handler persists the value so the router can apply tier weights during scoring.
+
+The known medium values are the values reported by the upstream engine events when the corresponding cache tier is enabled:
+
+| Engine | Values |
+| ------ | ------ |
+| vLLM | `GPU`, `CPU`, `FS`, `OBJ` |
+| SGLang | `GPU`, `CPU_PINNED`, `DISK`, `EXTERNAL` |
+
+For vLLM, `FS` is the filesystem secondary tier and `OBJ` is the object-store secondary tier. For SGLang, `DISK` is the SSD/NVMe tier and `EXTERNAL` is the shared or remote pool tier, such as Mooncake.
 
 ## 5. Performance Considerations
 

--- a/pkg/kthena-router/scheduler/plugins/kvcache_aware.go
+++ b/pkg/kthena-router/scheduler/plugins/kvcache_aware.go
@@ -33,6 +33,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/redis/go-redis/v9"
@@ -71,16 +72,23 @@ const (
 	defaultSGLangTokenizerPort = 30000
 	maxTokenizerPort           = 65535
 
+	defaultGPUTierWeight       = 1.0
+	defaultCPUTierWeight       = 0.8
+	defaultCPUPinnedTierWeight = 0.8
+
 	// kvCacheFieldFreshDuration matches the runtime mapping key expiry
 	kvCacheFieldFreshDuration = 24 * time.Hour
 
 	kvCacheGCInterval = time.Hour
 	kvCacheGCScanSize = int64(100)
+
+	kvCacheFieldValueSeparator = "|"
 )
 
 type KVCacheAwareArgs struct {
-	BlockSizeToHash  int `yaml:"blockSizeToHash,omitempty"`
-	MaxBlocksToMatch int `yaml:"maxBlocksToMatch,omitempty"`
+	BlockSizeToHash  int                `yaml:"blockSizeToHash,omitempty"`
+	MaxBlocksToMatch int                `yaml:"maxBlocksToMatch,omitempty"`
+	TierWeights      map[string]float64 `yaml:"tierWeights,omitempty"`
 	// VLLMTokenizerPort overrides the default vLLM tokenizer port (8000).
 	VLLMTokenizerPort int `yaml:"vllmTokenizerPort,omitempty"`
 	// SGLangTokenizerPort overrides the default SGLang tokenizer port (30000).
@@ -94,6 +102,7 @@ type KVCacheAware struct {
 	redisClient      *redis.Client
 	processor        *TokenBlockProcessor
 	tokenizerManager *tokenization.TokenizerManager
+	tierWeights      map[string]float64
 	gcCursor         uint64
 }
 
@@ -120,6 +129,7 @@ type KVCacheAwareBlock struct {
 //	  "pod-name-1.namespace": "1703123456",
 //	  "pod-name-2.namespace": "1703123789"
 //	}
+
 func (b KVCacheAwareBlock) String(prefix string) string {
 	return fmt.Sprintf("%s%s@%d", prefix, b.ModelName, b.ChunkHash)
 }
@@ -145,6 +155,16 @@ func NewKVCacheAware(pluginArg runtime.RawExtension) *KVCacheAware {
 
 	vllmPort := normalizeTokenizerPort(tokenization.EngineVLLM, args.VLLMTokenizerPort, defaultVLLMTokenizerPort)
 	sglangPort := normalizeTokenizerPort(tokenization.EngineSGLang, args.SGLangTokenizerPort, defaultSGLangTokenizerPort)
+	tierWeights := map[string]float64{
+		"gpu":        defaultGPUTierWeight,
+		"cpu":        defaultCPUTierWeight,
+		"cpu_pinned": defaultCPUPinnedTierWeight,
+	}
+	for medium, weight := range args.TierWeights {
+		if weight >= 0 && weight <= 1 {
+			tierWeights[strings.ToLower(medium)] = weight
+		}
+	}
 
 	klog.Infof("KVCacheAware: config blockSizeToHash=%d, maxBlocksToMatch=%d, vllmTokenizerPort=%d, sglangTokenizerPort=%d",
 		blockSizeToHash, maxBlocksToMatch, vllmPort, sglangPort)
@@ -171,6 +191,7 @@ func NewKVCacheAware(pluginArg runtime.RawExtension) *KVCacheAware {
 		redisClient:      redisClient,
 		processor:        &TokenBlockProcessor{blockSize: blockSizeToHash},
 		tokenizerManager: manager,
+		tierWeights:      tierWeights,
 	}
 	plugin.startGC()
 	return plugin
@@ -268,17 +289,15 @@ func (t *KVCacheAware) Score(ctx *framework.Context, pods []*datastore.PodInfo) 
 	for _, p := range pods {
 		candidateNames[podCacheOwnerIdentifier(p)] = struct{}{}
 	}
-	for hash, podNames := range blockToPods {
-		kept := podNames[:0]
-		for _, name := range podNames {
+	for hash, podWeights := range blockToPods {
+		for name := range podWeights {
 			if _, ok := candidateNames[name]; ok {
-				kept = append(kept, name)
+				continue
 			}
+			delete(podWeights, name)
 		}
-		if len(kept) == 0 {
+		if len(podWeights) == 0 {
 			delete(blockToPods, hash)
-		} else {
-			blockToPods[hash] = kept
 		}
 	}
 
@@ -299,13 +318,13 @@ func (t *KVCacheAware) Score(ctx *framework.Context, pods []*datastore.PodInfo) 
 }
 
 // queryRedisForBlocks queries Redis to find which pods have cached the given token block hashes
-// Returns a map from block hash to the pod.namespace owner identifiers that have cached it.
+// Returns cached owner weights by block hash.
 // ownerStartedAt carries each candidate's container start time, used to drop stale ownership.
-func (t *KVCacheAware) queryRedisForBlocks(blockHashes []uint64, modelName string, ownerStartedAt map[string]int64) (map[uint64][]string, error) {
+func (t *KVCacheAware) queryRedisForBlocks(blockHashes []uint64, modelName string, ownerStartedAt map[string]int64) (map[uint64]map[string]float64, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	blockToPods := make(map[uint64][]string)
+	blockToPods := make(map[uint64]map[string]float64)
 
 	if t.redisClient == nil {
 		klog.Warningf("KVCacheAware.queryRedis: redis client is nil, cannot query")
@@ -348,9 +367,14 @@ func (t *KVCacheAware) queryRedisForBlocks(blockHashes []uint64, modelName strin
 			continue
 		}
 
-		klog.V(2).Infof("KVCacheAware.queryRedis: block[%d] hash=%d key=%s matched pods=%v", i, blockHashes[i], keys[i], pods)
+		podWeights := make(map[string]float64, len(pods))
+		for _, podName := range pods {
+			_, medium := parseKVCacheFieldValue(entries[podName])
+			podWeights[podName] = t.weightForMedium(medium)
+		}
 
-		blockToPods[blockHashes[i]] = pods
+		blockToPods[blockHashes[i]] = podWeights
+		klog.V(2).Infof("KVCacheAware.queryRedis: block[%d] hash=%d key=%s matched pods=%v", i, blockHashes[i], keys[i], podWeights)
 	}
 
 	klog.V(4).Infof("KVCacheAware.queryRedis: total blocks with hits: %d/%d", len(blockToPods), len(blockHashes))
@@ -402,7 +426,8 @@ func (t *KVCacheAware) gcStaleFields() {
 			continue
 		}
 		for pod, ts := range podTimes {
-			updatedAt, err := strconv.ParseInt(ts, 10, 64)
+			timestamp, _ := parseKVCacheFieldValue(ts)
+			updatedAt, err := strconv.ParseInt(timestamp, 10, 64)
 			if err == nil && now.Sub(time.Unix(updatedAt, 0)) > kvCacheFieldFreshDuration {
 				staleFields[key] = append(staleFields[key], pod)
 			}
@@ -463,7 +488,8 @@ func freshOwners(entries map[string]string, ownerStartedAt map[string]int64) []s
 	for owner, writtenAt := range entries {
 		startedAt, tracked := ownerStartedAt[owner]
 		if tracked {
-			written, err := strconv.ParseInt(writtenAt, 10, 64)
+			timestamp, _ := parseKVCacheFieldValue(writtenAt)
+			written, err := strconv.ParseInt(timestamp, 10, 64)
 			// An unparsable timestamp is kept: gcStaleFields skips it too, and a future
 			// higher-precision format would otherwise drop every owner at once.
 			// Both sides are second-truncated, so a same-second write is dropped: it may have
@@ -479,8 +505,31 @@ func freshOwners(entries map[string]string, ownerStartedAt map[string]int64) []s
 	return owners
 }
 
+func parseKVCacheFieldValue(value string) (string, string) {
+	parts := strings.SplitN(value, kvCacheFieldValueSeparator, 2)
+	if len(parts) == 1 {
+		return value, ""
+	}
+	return parts[0], parts[1]
+}
+
+func (t *KVCacheAware) weightForMedium(medium string) float64 {
+	medium = strings.ToLower(strings.TrimSpace(medium))
+	if medium == "" {
+		return 1.0
+	}
+	if t.tierWeights == nil {
+		return 1.0
+	}
+	weight, ok := t.tierWeights[medium]
+	if !ok {
+		return 1.0
+	}
+	return weight
+}
+
 // calculatePodScores returns per-pod scores and the longest block match length (used for the match_ratio metric).
-func (t *KVCacheAware) calculatePodScores(blockHashes []uint64, blockToPods map[uint64][]string) (map[string]int, int) {
+func (t *KVCacheAware) calculatePodScores(blockHashes []uint64, blockToPods map[uint64]map[string]float64) (map[string]int, int) {
 	if len(blockHashes) == 0 {
 		klog.V(4).Infof("KVCacheAware.calculateScores: no block hashes to process")
 		return map[string]int{}, 0
@@ -488,18 +537,20 @@ func (t *KVCacheAware) calculatePodScores(blockHashes []uint64, blockToPods map[
 
 	firstBlockPods, exists := blockToPods[blockHashes[0]]
 	if !exists || len(firstBlockPods) == 0 {
-		klog.V(4).Infof("KVCacheAware.calculateScores: first block hash=%d has no cached pods — all scores 0", blockHashes[0])
+		klog.V(4).Infof("KVCacheAware.calculateScores: first block hash=%d has no cached pods - all scores 0", blockHashes[0])
 		return map[string]int{}, 0
 	}
 
 	// only pods holding the first block can ever score, so this is the final size.
 	podScores := make(map[string]int, len(firstBlockPods))
+	weightedScores := make(map[string]float64, len(firstBlockPods))
 
 	klog.V(4).Infof("KVCacheAware.calculateScores: first block matched pods=%v, starting prefix matching across %d blocks",
 		firstBlockPods, len(blockHashes))
 
-	for _, podName := range firstBlockPods {
+	for podName, weight := range firstBlockPods {
 		podScores[podName] = 1
+		weightedScores[podName] = weight
 	}
 
 	// A pod is still matching at block i exactly when its score is i, so podScores
@@ -513,9 +564,10 @@ func (t *KVCacheAware) calculatePodScores(blockHashes []uint64, blockToPods map[
 		}
 
 		stillActive := 0
-		for _, podName := range blockPods {
+		for podName, weight := range blockPods {
 			if podScores[podName] == i {
 				podScores[podName]++
+				weightedScores[podName] += weight
 				stillActive++
 			}
 		}
@@ -534,7 +586,7 @@ func (t *KVCacheAware) calculatePodScores(blockHashes []uint64, blockToPods map[
 
 	longestMatch := lastMatchedBlock + 1
 	for podName, matchLen := range podScores {
-		score := int((float64(matchLen) / float64(totalBlocks)) * 100)
+		score := int((weightedScores[podName] / float64(totalBlocks)) * 100)
 		podScores[podName] = score
 		klog.V(4).Infof("KVCacheAware.calculateScores: pod=%s matched=%d/%d blocks, score=%d",
 			podName, matchLen, totalBlocks, score)

--- a/pkg/kthena-router/scheduler/plugins/kvcache_aware_test.go
+++ b/pkg/kthena-router/scheduler/plugins/kvcache_aware_test.go
@@ -46,6 +46,18 @@ import (
 
 // Test core functions that don't require external dependencies
 
+func testWeightedBlockOwners(blockToPods map[uint64][]string) map[uint64]map[string]float64 {
+	weightedOwners := make(map[uint64]map[string]float64, len(blockToPods))
+	for hash, pods := range blockToPods {
+		podWeights := make(map[string]float64, len(pods))
+		for _, pod := range pods {
+			podWeights[pod] = 1.0
+		}
+		weightedOwners[hash] = podWeights
+	}
+	return weightedOwners
+}
+
 func TestKVCacheAwareBlock_String_Core(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -356,12 +368,95 @@ func TestKVCacheAware_CalculatePodScores_Core(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, _ := plugin.calculatePodScores(tt.blockHashes, tt.blockToPods)
+			result, _ := plugin.calculatePodScores(tt.blockHashes, testWeightedBlockOwners(tt.blockToPods))
 
 			if !reflect.DeepEqual(result, tt.expected) {
 				t.Errorf("Expected %v, got %v", tt.expected, result)
 			}
 		})
+	}
+}
+
+func TestKVCacheAware_CalculatePodScoresWithWeights(t *testing.T) {
+	plugin := &KVCacheAware{}
+	blockHashes := []uint64{1, 2}
+	blockToPods := map[uint64]map[string]float64{
+		1: {
+			"gpu-pod":      1.0,
+			"cpu-pod":      0.8,
+			"disabled-pod": 0,
+		},
+		2: {
+			"gpu-pod":      1.0,
+			"cpu-pod":      0.8,
+			"disabled-pod": 0,
+		},
+	}
+
+	result, longest := plugin.calculatePodScores(blockHashes, blockToPods)
+
+	if result["gpu-pod"] != 100 {
+		t.Errorf("gpu-pod score = %d, want 100", result["gpu-pod"])
+	}
+	if result["cpu-pod"] != 80 {
+		t.Errorf("cpu-pod score = %d, want 80", result["cpu-pod"])
+	}
+	if result["disabled-pod"] != 0 {
+		t.Errorf("disabled-pod score = %d, want 0", result["disabled-pod"])
+	}
+	if longest != 2 {
+		t.Errorf("longest match = %d, want 2", longest)
+	}
+}
+
+func TestParseKVCacheFieldValue(t *testing.T) {
+	timestamp, medium := parseKVCacheFieldValue("1703123456|GPU")
+	if timestamp != "1703123456" || medium != "GPU" {
+		t.Errorf("parseKVCacheFieldValue returned %q, %q", timestamp, medium)
+	}
+
+	timestamp, medium = parseKVCacheFieldValue("1703123456")
+	if timestamp != "1703123456" || medium != "" {
+		t.Errorf("parseKVCacheFieldValue returned %q, %q", timestamp, medium)
+	}
+}
+
+func TestKVCacheAware_WeightForMedium(t *testing.T) {
+	plugin := &KVCacheAware{
+		tierWeights: map[string]float64{
+			"gpu":        1.0,
+			"cpu":        0.8,
+			"cpu_pinned": 0,
+		},
+	}
+
+	if weight := plugin.weightForMedium("CPU"); weight != 0.8 {
+		t.Errorf("CPU weight = %v, want 0.8", weight)
+	}
+	if weight := plugin.weightForMedium("CPU_PINNED"); weight != 0 {
+		t.Errorf("CPU_PINNED weight = %v, want 0", weight)
+	}
+	if weight := plugin.weightForMedium("DISK"); weight != 1.0 {
+		t.Errorf("DISK weight = %v, want 1.0", weight)
+	}
+}
+
+func TestNewKVCacheAware_TierWeights(t *testing.T) {
+	plugin := NewKVCacheAware(runtime.RawExtension{
+		Raw: []byte(`{"tierWeights":{"gpu":0.9,"cpu_pinned":0,"disk":-1,"fs":1.5}}`),
+	})
+
+	if plugin.tierWeights["gpu"] != 0.9 {
+		t.Errorf("gpu weight = %v, want 0.9", plugin.tierWeights["gpu"])
+	}
+	if plugin.tierWeights["cpu_pinned"] != 0 {
+		t.Errorf("cpu_pinned weight = %v, want 0", plugin.tierWeights["cpu_pinned"])
+	}
+	if _, ok := plugin.tierWeights["disk"]; ok {
+		t.Errorf("disk weight should be ignored")
+	}
+	if _, ok := plugin.tierWeights["fs"]; ok {
+		t.Errorf("fs weight should be ignored")
 	}
 }
 
@@ -397,13 +492,58 @@ func TestKVCacheAware_QueryRedisForBlocks_ReturnsRedisOwners(t *testing.T) {
 		t.Fatalf("queryRedisForBlocks returned error: %v", err)
 	}
 	gotPods := make(map[string]bool, len(result[hash]))
-	for _, pod := range result[hash] {
+	for pod := range result[hash] {
 		gotPods[pod] = true
 	}
 	for _, pod := range []string{"pod-1", "pod-1.default", "pod-2.default"} {
 		if !gotPods[pod] {
 			t.Errorf("expected %s in result, got %v", pod, result[hash])
 		}
+	}
+}
+
+func TestKVCacheAware_QueryRedisForBlocks_ReturnsTierWeights(t *testing.T) {
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("failed to start miniredis: %v", err)
+	}
+	defer mr.Close()
+
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer client.Close()
+
+	plugin := &KVCacheAware{
+		keyPrefix:   kvCacheKeyPrefix,
+		redisClient: client,
+		tierWeights: map[string]float64{
+			"gpu":        1.0,
+			"cpu":        0.8,
+			"cpu_pinned": 0.8,
+		},
+	}
+
+	ctx := context.Background()
+	hash := uint64(222)
+	key := KVCacheAwareBlock{ModelName: "qwen", ChunkHash: hash}.String(kvCacheKeyPrefix)
+	now := fmt.Sprintf("%d", time.Now().Unix())
+	if err := client.HSet(ctx, key,
+		"gpu-pod", now+"|GPU",
+		"cpu-pod", now+"|CPU_PINNED",
+	).Err(); err != nil {
+		t.Fatalf("failed to seed redis: %v", err)
+	}
+
+	blockToPods, err := plugin.queryRedisForBlocks([]uint64{hash}, "qwen", nil)
+	if err != nil {
+		t.Fatalf("queryRedisForBlocks returned error: %v", err)
+	}
+	result, _ := plugin.calculatePodScores([]uint64{hash}, blockToPods)
+
+	if result["gpu-pod"] != 100 {
+		t.Errorf("gpu-pod score = %d, want 100", result["gpu-pod"])
+	}
+	if result["cpu-pod"] != 80 {
+		t.Errorf("cpu-pod score = %d, want 80", result["cpu-pod"])
 	}
 }
 
@@ -439,7 +579,7 @@ func TestKVCacheAware_QueryRedisForBlocks_KeepsNamespacedOwners(t *testing.T) {
 	}
 
 	gotPods := make(map[string]bool, len(result[hash]))
-	for _, pod := range result[hash] {
+	for pod := range result[hash] {
 		gotPods[pod] = true
 	}
 	for _, pod := range []string{"pod-1.default", "pod-1.other"} {
@@ -478,7 +618,7 @@ func TestKVCacheAware_GCStaleFields(t *testing.T) {
 		"pod-1", now,
 		"pod-1.default", now,
 		"pod-2.default", now,
-		"pod-3.default", stale,
+		"pod-3.default", stale+"|CPU_PINNED",
 	).Err(); err != nil {
 		t.Fatalf("failed to seed redis: %v", err)
 	}
@@ -1022,7 +1162,7 @@ func TestKVCacheAware_CalculatePodScores_AdvancedCases_Core(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, _ := plugin.calculatePodScores(tt.blockHashes, tt.blockToPods)
+			result, _ := plugin.calculatePodScores(tt.blockHashes, testWeightedBlockOwners(tt.blockToPods))
 
 			if !reflect.DeepEqual(result, tt.expected) {
 				t.Errorf("Expected %v, got %v", tt.expected, result)
@@ -1256,7 +1396,7 @@ func TestKVCacheAware_Integration_Core(t *testing.T) {
 					blockHashes[1]: {"pod1"},
 				}
 
-				scores, _ := plugin.calculatePodScores(blockHashes, blockToPods)
+				scores, _ := plugin.calculatePodScores(blockHashes, testWeightedBlockOwners(blockToPods))
 
 				expectedScores := map[string]int{
 					"pod1": 100, // 2/2 * 100
@@ -1312,7 +1452,7 @@ func TestKVCacheAware_Integration_Core(t *testing.T) {
 					// pod1 missing block 3
 				}
 
-				scores, _ := plugin.calculatePodScores(blockHashes, blockToPods)
+				scores, _ := plugin.calculatePodScores(blockHashes, testWeightedBlockOwners(blockToPods))
 				expected := map[string]int{
 					"pod1": 66, // 2/3 * 100 = 66.666... -> 66
 				}
@@ -1781,7 +1921,7 @@ func TestKVCacheAware_CalculatePodScores_Complex_Core(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, _ := plugin.calculatePodScores(tt.blockHashes, tt.blockToPods)
+			result, _ := plugin.calculatePodScores(tt.blockHashes, testWeightedBlockOwners(tt.blockToPods))
 
 			if !reflect.DeepEqual(result, tt.expected) {
 				t.Errorf("Expected %v, got %v", tt.expected, result)
@@ -2173,7 +2313,7 @@ func TestKVCacheAware_Integration_Comprehensive_Core(t *testing.T) {
 					blockHashes[1]: {"pod1"},
 				}
 
-				scores, _ := plugin.calculatePodScores(blockHashes, blockToPods)
+				scores, _ := plugin.calculatePodScores(blockHashes, testWeightedBlockOwners(blockToPods))
 				expectedScores := map[string]int{
 					"pod1": 100, // 2/2 * 100
 					"pod2": 50,  // 1/2 * 100
@@ -2264,7 +2404,7 @@ func TestKVCacheAware_CalculatePodScoresAndMatch_LongestMatch(t *testing.T) {
 		3: {"pod1"},
 		4: {"pod1"},
 	}
-	scores, longest := plugin.calculatePodScores(blockHashes, blockToPods)
+	scores, longest := plugin.calculatePodScores(blockHashes, testWeightedBlockOwners(blockToPods))
 	if scores["pod1"] != 100 {
 		t.Errorf("pod1 score = %d, want 100", scores["pod1"])
 	}
@@ -2272,6 +2412,7 @@ func TestKVCacheAware_CalculatePodScoresAndMatch_LongestMatch(t *testing.T) {
 		t.Errorf("longest match = %d, want 4", longest)
 	}
 }
+
 func TestKVCacheAware_CandidateFilteringRestrictsLongestMatch(t *testing.T) {
 	plugin := &KVCacheAware{}
 	blockHashes := []uint64{10, 20, 30, 40}
@@ -2283,7 +2424,7 @@ func TestKVCacheAware_CandidateFilteringRestrictsLongestMatch(t *testing.T) {
 		40: {"pod3"},
 	}
 
-	if _, clusterLongest := plugin.calculatePodScores(blockHashes, blockToPods); clusterLongest != 4 {
+	if _, clusterLongest := plugin.calculatePodScores(blockHashes, testWeightedBlockOwners(blockToPods)); clusterLongest != 4 {
 		t.Fatalf("unfiltered longestMatch = %d, want 4 (inflated by non-candidate pod3)", clusterLongest)
 	}
 
@@ -2292,7 +2433,7 @@ func TestKVCacheAware_CandidateFilteringRestrictsLongestMatch(t *testing.T) {
 		10: {"pod1"},
 		20: {"pod1"},
 	}
-	if _, candidateLongest := plugin.calculatePodScores(blockHashes, candidateScoped); candidateLongest != 2 {
+	if _, candidateLongest := plugin.calculatePodScores(blockHashes, testWeightedBlockOwners(candidateScoped)); candidateLongest != 2 {
 		t.Errorf("candidate-restricted longestMatch = %d, want 2 (pod1 holds only the first 2 blocks)", candidateLongest)
 	}
 }
@@ -2482,8 +2623,8 @@ func TestKVCacheAware_QueryRedisForBlocks_DropsOwnershipFromBeforeRestart(t *tes
 	longRunning := now.Add(-24 * time.Hour)
 
 	if err := client.HSet(ctx, key,
-		"restarted.default", fmt.Sprintf("%d", writtenAt.Unix()),
-		"stable.default", fmt.Sprintf("%d", writtenAt.Unix()),
+		"restarted.default", fmt.Sprintf("%d|GPU", writtenAt.Unix()),
+		"stable.default", fmt.Sprintf("%d|CPU", writtenAt.Unix()),
 	).Err(); err != nil {
 		t.Fatalf("failed to seed redis: %v", err)
 	}
@@ -2498,7 +2639,7 @@ func TestKVCacheAware_QueryRedisForBlocks_DropsOwnershipFromBeforeRestart(t *tes
 		t.Fatalf("queryRedisForBlocks returned error: %v", err)
 	}
 
-	if want := []string{"stable.default"}; !reflect.DeepEqual(result[hash], want) {
+	if want := map[string]float64{"stable.default": 1.0}; !reflect.DeepEqual(result[hash], want) {
 		t.Errorf("queryRedisForBlocks() = %v, want %v", result[hash], want)
 	}
 }
@@ -2580,7 +2721,8 @@ func BenchmarkCalculatePodScores(b *testing.B) {
 	for _, c := range cases {
 		name := fmt.Sprintf("blocks=%d/pods=%d/match=%.0f%%", defaultMaxBlocksToMatch, c.pods, c.matchFrac*100)
 		b.Run(name, func(b *testing.B) {
-			blockHashes, blockToPods := benchPodScoreInput(defaultMaxBlocksToMatch, c.pods, c.matchFrac)
+			blockHashes, owners := benchPodScoreInput(defaultMaxBlocksToMatch, c.pods, c.matchFrac)
+			blockToPods := testWeightedBlockOwners(owners)
 			plugin := &KVCacheAware{}
 			b.ReportAllocs()
 			b.ResetTimer()

--- a/python/kthena/runtime/events.py
+++ b/python/kthena/runtime/events.py
@@ -46,11 +46,13 @@ class VLLMBlockStoredEvent:
     token_ids: Optional[List[int]] = None
     block_size: Optional[int] = None
     lora_id: Optional[int] = None
+    medium: Optional[str] = None
 
 
 @dataclass
 class VLLMBlockRemovedEvent:
     block_hashes: List[int]
+    medium: Optional[str] = None
 
 
 @dataclass

--- a/python/kthena/runtime/kv_cache_manager.py
+++ b/python/kthena/runtime/kv_cache_manager.py
@@ -72,7 +72,8 @@ class VLLMKVCacheRedisManager:
         return f"{cls.MAPPING_KEY_PREFIX}:{pod_identifier}@{engine_hash}"
 
     async def add_blocks(self, model_name: str, block_hashes: List[int],
-                         pod_identifier: str, token_ids: Optional[List[int]] = None) -> bool:
+                         pod_identifier: str, token_ids: Optional[List[int]] = None,
+                         medium: Optional[str] = None) -> bool:
         if not block_hashes or not model_name or not pod_identifier:
             return not block_hashes
 
@@ -85,7 +86,7 @@ class VLLMKVCacheRedisManager:
             timestamp = str(int(time.time()))
 
             success = await self._process_token_blocks_with_mapping(
-                model_name, block_hashes, token_ids, pod_identifier, timestamp, pipe)
+                model_name, block_hashes, token_ids, pod_identifier, timestamp, pipe, medium)
 
             if not success:
                 return False
@@ -103,7 +104,7 @@ class VLLMKVCacheRedisManager:
 
     async def _process_token_blocks_with_mapping(self, model_name: str, engine_hashes: List[int],
                                                  token_ids: List[int], pod_identifier: str,
-                                                 timestamp: str, pipe) -> bool:
+                                                 timestamp: str, pipe, medium: Optional[str] = None) -> bool:
         if not engine_hashes:
             return False
 
@@ -125,7 +126,8 @@ class VLLMKVCacheRedisManager:
             mapping_key = self._get_hash_mapping_key(engine_hash, pod_identifier)
             pipe.set(mapping_key, str(std_hash))
             pipe.expire(mapping_key, MAPPING_KEY_TTL_SECONDS)
-            pipe.hset(matrix_block_key, pod_identifier, timestamp)
+            value = f"{timestamp}|{medium}" if medium else timestamp
+            pipe.hset(matrix_block_key, pod_identifier, value)
         return True
 
     async def remove_blocks(self, model_name: str, block_hashes: List[int],
@@ -296,7 +298,8 @@ class VLLMKVCacheEventHandler(EventHandler):
             model_name=event_data.model_name,
             block_hashes=block_event.block_hashes,
             pod_identifier=event_data.pod_identifier,
-            token_ids=block_event.token_ids
+            token_ids=block_event.token_ids,
+            medium=block_event.medium,
         )
 
     async def _handle_block_removed(self, event_data: VLLMEventData) -> None:
@@ -307,7 +310,7 @@ class VLLMKVCacheEventHandler(EventHandler):
         await self.redis_manager.remove_blocks(
             model_name=event_data.model_name,
             block_hashes=block_event.block_hashes,
-            pod_identifier=event_data.pod_identifier
+            pod_identifier=event_data.pod_identifier,
         )
 
     async def _handle_all_blocks_cleared(self, event_data: VLLMEventData) -> None:
@@ -367,6 +370,7 @@ class SGLangKVCacheEventHandler(EventHandler):
             block_hashes=block_event.block_hashes,
             pod_identifier=event_data.pod_identifier,
             token_ids=block_event.token_ids,
+            medium=block_event.medium,
         )
 
     async def _handle_block_removed(self, event_data: SGLangEventData) -> None:

--- a/python/kthena/runtime/zmq_subscriber.py
+++ b/python/kthena/runtime/zmq_subscriber.py
@@ -49,10 +49,12 @@ class BlockStored(KVCacheEvent):
     token_ids: list[int]
     block_size: int
     lora_id: Optional[int]
+    medium: Optional[str] = None
 
 
 class BlockRemoved(KVCacheEvent):
     block_hashes: list[int]
+    medium: Optional[str] = None
 
 
 class AllBlocksCleared(KVCacheEvent):
@@ -239,13 +241,15 @@ class VLLMZMQSubscriber:
                     parent_block_hash=event.parent_block_hash,
                     token_ids=event.token_ids,
                     block_size=event.block_size,
-                    lora_id=event.lora_id
+                    lora_id=event.lora_id,
+                    medium=event.medium,
                 )
                 event_type = EventType.VLLM_BLOCK_STORED
 
             elif isinstance(event, BlockRemoved):
                 vllm_event = VLLMBlockRemovedEvent(
-                    block_hashes=event.block_hashes
+                    block_hashes=event.block_hashes,
+                    medium=event.medium,
                 )
                 event_type = EventType.VLLM_BLOCK_REMOVED
 

--- a/python/kthena/tests/test_sglang_kv_cache_handler.py
+++ b/python/kthena/tests/test_sglang_kv_cache_handler.py
@@ -124,9 +124,10 @@ async def test_block_stored_writes_matrix_and_mapping_keys():
     # Pod registered against each matrix block (engine-agnostic namespace).
     hset_calls = [c for c in pipeline.calls if c[0] == "hset"]
     assert len(hset_calls) == 2
-    for (_, key, field, _), std_hash in zip(hset_calls, expected_std_hashes):
+    for (_, key, field, value), std_hash in zip(hset_calls, expected_std_hashes):
         assert key == f"matrix:kv:block:qwen@{std_hash}"
         assert field == "pod-1"
+        assert value.endswith("|GPU")
 
 
 @pytest.mark.asyncio

--- a/python/kthena/tests/test_zmq_subscriber.py
+++ b/python/kthena/tests/test_zmq_subscriber.py
@@ -12,11 +12,59 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from dataclasses import replace
+from unittest.mock import AsyncMock
 
+import msgspec
 import pytest
 
 from kthena.runtime import zmq_subscriber
-from kthena.runtime.zmq_subscriber import VLLMZMQSubscriber
+from kthena.runtime.events import VLLMBlockStoredEvent
+from kthena.runtime.zmq_subscriber import BlockStored, KVEventBatch, VLLMZMQSubscriber
+
+
+def test_vllm_block_stored_decodes_without_medium():
+    batch = KVEventBatch(
+        ts=1.0,
+        events=[
+            BlockStored(
+                block_hashes=[1],
+                parent_block_hash=None,
+                token_ids=[1],
+                block_size=16,
+                lora_id=None,
+            )
+        ],
+    )
+
+    payload = msgspec.msgpack.encode(batch)
+    decoded = msgspec.msgpack.Decoder(type=KVEventBatch).decode(payload)
+
+    assert decoded.events[0].medium is None
+
+
+@pytest.mark.asyncio
+async def test_vllm_block_stored_preserves_medium():
+    sub = VLLMZMQSubscriber(pod_identifier="pod-a", model_name="m")
+    sub.event_publisher = AsyncMock()
+    batch = KVEventBatch(
+        ts=1.0,
+        events=[
+            BlockStored(
+                block_hashes=[1],
+                parent_block_hash=None,
+                token_ids=[1],
+                block_size=16,
+                lora_id=None,
+                medium="CPU",
+            )
+        ],
+    )
+
+    await sub._process_message(msgspec.msgpack.encode(batch), "pod-a", "m")
+
+    published = sub.event_publisher.publish.await_args.args[0]
+    assert isinstance(published.vllm_event, VLLMBlockStoredEvent)
+    assert published.vllm_event.medium == "CPU"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement

**What this PR does / why we need it**:

Makes the `kvcache-aware` scheduler plugin consider the storage medium of cached KV blocks when scoring pods. Cached blocks keep the existing timestamp behavior, while runtimes that report a medium can now let the router apply tier weights during longest-prefix scoring.

**Which issue(s) this PR fixes**:
Fixes #1283

**Special notes for your reviewer**:

The Redis value format remains backward-compatible: existing timestamp-only entries continue to score with weight `1.0`.

**Does this PR introduce a user-facing change?**:

```release-note
kvcache-aware scoring can now weight KV cache hits by reported storage medium.