### PR TITLE
add PD-disaggregated multi-node example and e2e

### DIFF
--- a/docs/kthena/docs/assets/examples/model-serving/vllm-pd-multinode.yaml
+++ b/docs/kthena/docs/assets/examples/model-serving/vllm-pd-multinode.yaml
@@ -1,0 +1,300 @@
+apiVersion: workload.serving.volcano.sh/v1alpha1
+kind: ModelServing
+metadata:
+  name: vllm-pd-multinode
+  namespace: default
+spec:
+  schedulerName: volcano
+  replicas: 1
+  recoveryPolicy: ServingGroupRecreate
+  template:
+    restartGracePeriodSeconds: 60
+    gangPolicy:
+      minRoleReplicas:
+        prefill: 1
+        decode: 1
+    roles:
+      - name: prefill
+        replicas: 1
+        entryTemplate:
+          spec:
+            initContainers:
+              - name: downloader
+                imagePullPolicy: IfNotPresent
+                image: ghcr.io/volcano-sh/downloader:latest
+                args:
+                  - --source
+                  - Qwen/Qwen3-8B
+                  - --output-dir
+                  - /models/Qwen3-8B/
+                volumeMounts:
+                  - name: models
+                    mountPath: /models
+            containers:
+              - name: leader
+                image: ghcr.io/volcano-sh/vllm-openai:v0.10.0-cu128-nixl-v0.4.1-lmcache-0.3.2
+                command: ["sh", "-c"]
+                args:
+                  - |
+                    set -e
+                    bash /vllm-workspace/examples/online_serving/multi-node-serving.sh leader --ray_cluster_size="${GROUP_SIZE}"
+                    python3 -m vllm.entrypoints.openai.api_server \
+                    --host "0.0.0.0" \
+                    --port "8000" \
+                    --uvicorn-log-level warning \
+                    --model /models/Qwen3-8B \
+                    --served-model-name Qwen/Qwen3-8B \
+                    --tensor-parallel-size 1 \
+                    --pipeline_parallel_size 2 \
+                    --distributed_executor_backend ray \
+                    --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_producer"}'
+                env:
+                  - name: PYTHONHASHSEED
+                    value: "1047"
+                  - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+                    value: "0.0.0.0"
+                  - name: VLLM_NIXL_SIDE_CHANNEL_PORT
+                    value: "5558"
+                  - name: VLLM_WORKER_MULTIPROC_METHOD
+                    value: spawn
+                  - name: VLLM_ENABLE_V1_MULTIPROCESSING
+                    value: "0"
+                  - name: GLOO_SOCKET_IFNAME
+                    value: eth0
+                  - name: NCCL_SOCKET_IFNAME
+                    value: eth0
+                  - name: NCCL_IB_DISABLE
+                    value: "0"
+                  - name: NCCL_IB_GID_INDEX
+                    value: "7"
+                  - name: UCX_TLS
+                    value: ^gga
+                ports:
+                  - containerPort: 8000
+                volumeMounts:
+                  - name: models
+                    mountPath: /models
+                    readOnly: true
+                  - name: shared-mem
+                    mountPath: /dev/shm
+                resources:
+                  limits:
+                    nvidia.com/gpu: 1
+                securityContext:
+                  capabilities:
+                    add:
+                      - IPC_LOCK
+                readinessProbe:
+                  initialDelaySeconds: 5
+                  periodSeconds: 5
+                  failureThreshold: 3
+                  httpGet:
+                    path: /health
+                    port: 8000
+                livenessProbe:
+                  initialDelaySeconds: 900
+                  periodSeconds: 5
+                  failureThreshold: 3
+                  httpGet:
+                    path: /health
+                    port: 8000
+            volumes:
+              - name: models
+                emptyDir: {}
+              - name: shared-mem
+                emptyDir:
+                  sizeLimit: 256Mi
+                  medium: Memory
+        workerReplicas: 1
+        workerTemplate:
+          spec:
+            initContainers:
+              - name: downloader
+                imagePullPolicy: IfNotPresent
+                image: ghcr.io/volcano-sh/downloader:latest
+                args:
+                  - --source
+                  - Qwen/Qwen3-8B
+                  - --output-dir
+                  - /models/Qwen3-8B/
+                volumeMounts:
+                  - name: models
+                    mountPath: /models
+            containers:
+              - name: worker
+                image: ghcr.io/volcano-sh/vllm-openai:v0.10.0-cu128-nixl-v0.4.1-lmcache-0.3.2
+                command: ["sh", "-c"]
+                args:
+                  - |
+                    bash /vllm-workspace/examples/online_serving/multi-node-serving.sh worker --ray_address="${ENTRY_ADDRESS}"
+                env:
+                  - name: PYTHONHASHSEED
+                    value: "1047"
+                  - name: GLOO_SOCKET_IFNAME
+                    value: eth0
+                  - name: NCCL_SOCKET_IFNAME
+                    value: eth0
+                  - name: NCCL_IB_DISABLE
+                    value: "0"
+                  - name: NCCL_IB_GID_INDEX
+                    value: "7"
+                  - name: UCX_TLS
+                    value: ^gga
+                resources:
+                  limits:
+                    nvidia.com/gpu: 1
+                volumeMounts:
+                  - name: models
+                    mountPath: /models
+                    readOnly: true
+                  - name: shared-mem
+                    mountPath: /dev/shm
+            volumes:
+              - name: models
+                emptyDir: {}
+              - name: shared-mem
+                emptyDir:
+                  sizeLimit: 256Mi
+                  medium: Memory
+      - name: decode
+        replicas: 1
+        entryTemplate:
+          spec:
+            initContainers:
+              - name: downloader
+                imagePullPolicy: IfNotPresent
+                image: ghcr.io/volcano-sh/downloader:latest
+                args:
+                  - --source
+                  - Qwen/Qwen3-8B
+                  - --output-dir
+                  - /models/Qwen3-8B/
+                volumeMounts:
+                  - name: models
+                    mountPath: /models
+            containers:
+              - name: leader
+                image: ghcr.io/volcano-sh/vllm-openai:v0.10.0-cu128-nixl-v0.4.1-lmcache-0.3.2
+                command: ["sh", "-c"]
+                args:
+                  - |
+                    set -e
+                    bash /vllm-workspace/examples/online_serving/multi-node-serving.sh leader --ray_cluster_size="${GROUP_SIZE}"
+                    python3 -m vllm.entrypoints.openai.api_server \
+                    --host "0.0.0.0" \
+                    --port "8000" \
+                    --uvicorn-log-level warning \
+                    --model /models/Qwen3-8B \
+                    --served-model-name Qwen/Qwen3-8B \
+                    --tensor-parallel-size 1 \
+                    --pipeline_parallel_size 2 \
+                    --distributed_executor_backend ray \
+                    --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_consumer"}'
+                env:
+                  - name: PYTHONHASHSEED
+                    value: "1047"
+                  - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+                    value: "0.0.0.0"
+                  - name: VLLM_NIXL_SIDE_CHANNEL_PORT
+                    value: "5558"
+                  - name: VLLM_WORKER_MULTIPROC_METHOD
+                    value: spawn
+                  - name: VLLM_ENABLE_V1_MULTIPROCESSING
+                    value: "0"
+                  - name: GLOO_SOCKET_IFNAME
+                    value: eth0
+                  - name: NCCL_SOCKET_IFNAME
+                    value: eth0
+                  - name: NCCL_IB_DISABLE
+                    value: "0"
+                  - name: NCCL_IB_GID_INDEX
+                    value: "7"
+                  - name: UCX_TLS
+                    value: ^gga
+                ports:
+                  - containerPort: 8000
+                volumeMounts:
+                  - name: models
+                    mountPath: /models
+                    readOnly: true
+                  - name: shared-mem
+                    mountPath: /dev/shm
+                resources:
+                  limits:
+                    nvidia.com/gpu: 1
+                securityContext:
+                  capabilities:
+                    add:
+                      - IPC_LOCK
+                readinessProbe:
+                  initialDelaySeconds: 5
+                  periodSeconds: 5
+                  failureThreshold: 3
+                  httpGet:
+                    path: /health
+                    port: 8000
+                livenessProbe:
+                  initialDelaySeconds: 900
+                  periodSeconds: 5
+                  failureThreshold: 3
+                  httpGet:
+                    path: /health
+                    port: 8000
+            volumes:
+              - name: models
+                emptyDir: {}
+              - name: shared-mem
+                emptyDir:
+                  sizeLimit: 256Mi
+                  medium: Memory
+        workerReplicas: 1
+        workerTemplate:
+          spec:
+            initContainers:
+              - name: downloader
+                imagePullPolicy: IfNotPresent
+                image: ghcr.io/volcano-sh/downloader:latest
+                args:
+                  - --source
+                  - Qwen/Qwen3-8B
+                  - --output-dir
+                  - /models/Qwen3-8B/
+                volumeMounts:
+                  - name: models
+                    mountPath: /models
+            containers:
+              - name: worker
+                image: ghcr.io/volcano-sh/vllm-openai:v0.10.0-cu128-nixl-v0.4.1-lmcache-0.3.2
+                command: ["sh", "-c"]
+                args:
+                  - |
+                    bash /vllm-workspace/examples/online_serving/multi-node-serving.sh worker --ray_address="${ENTRY_ADDRESS}"
+                env:
+                  - name: PYTHONHASHSEED
+                    value: "1047"
+                  - name: GLOO_SOCKET_IFNAME
+                    value: eth0
+                  - name: NCCL_SOCKET_IFNAME
+                    value: eth0
+                  - name: NCCL_IB_DISABLE
+                    value: "0"
+                  - name: NCCL_IB_GID_INDEX
+                    value: "7"
+                  - name: UCX_TLS
+                    value: ^gga
+                resources:
+                  limits:
+                    nvidia.com/gpu: 1
+                volumeMounts:
+                  - name: models
+                    mountPath: /models
+                    readOnly: true
+                  - name: shared-mem
+                    mountPath: /dev/shm
+            volumes:
+              - name: models
+                emptyDir: {}
+              - name: shared-mem
+                emptyDir:
+                  sizeLimit: 256Mi
+                  medium: Memory

--- a/docs/kthena/docs/user-guide/multi-node-inference.md
+++ b/docs/kthena/docs/user-guide/multi-node-inference.md
@@ -180,6 +180,66 @@ spec:
 `ENTRY_ADDRESS` is an environment variable that Kthena automatically injects into every worker pod. Its value is set to the headless service address of the corresponding entry pod (e.g., `llama-multinode-0-405b-0-0.default`). You do not need to define it yourself. When multiple Role replicas exist, each worker pod receives the correct entry address for its own replica, so Ray workers always connect to the right head node. See the [Labels and Environment Variables](../architecture/model-serving-controller.mdx#environment-variables) section for the full list of injected variables.
 :::
 
+### Combined PD-Disaggregation and Multi-Node Layout
+
+If your deployment needs both prefill/decode disaggregation and multi-node execution, you can combine the two patterns by defining separate `prefill` and `decode` roles and using leader/worker pods inside each role. A full example is available at [vllm-pd-multinode.yaml](../assets/examples/model-serving/vllm-pd-multinode.yaml).
+
+The example creates one ServingGroup with four pods: a prefill leader and worker, plus a decode leader and worker. Each leader starts the vLLM multi-node Ray head before the OpenAI API server, and each worker joins the corresponding leader through the `ENTRY_ADDRESS` injected by Kthena.
+
+Before applying this layout, make sure your cluster has:
+
+- enough GPU capacity for every leader and worker pod in the ServingGroup
+- pod-to-pod connectivity for Ray, NCCL/Gloo, and the configured KV-transfer connector
+- the correct `NCCL_SOCKET_IFNAME`, `GLOO_SOCKET_IFNAME`, and RDMA-related environment values for your nodes
+- access to the model source from both leader and worker pods; the example uses per-pod downloader init containers and `emptyDir` volumes, but production deployments usually replace that with shared storage or an image-local model cache
+
+Pair the `ModelServing` with a `ModelServer` that selects the same workload and defines the PD group. Because the `ModelServing` example configures vLLM with `NixlConnector`, set `kvConnector.type: nixl` on the `ModelServer` as well. This layout has worker pods, so the PD selectors include `modelserving.volcano.sh/entry: "true"` and router traffic only targets the leader pods that expose the OpenAI API:
+
+```yaml
+apiVersion: networking.serving.volcano.sh/v1alpha1
+kind: ModelServer
+metadata:
+  name: vllm-pd-multinode
+  namespace: default
+spec:
+  kvConnector:
+    type: nixl
+  workloadSelector:
+    matchLabels:
+      modelserving.volcano.sh/name: vllm-pd-multinode
+      modelserving.volcano.sh/entry: "true"
+    pdGroup:
+      groupKey: "modelserving.volcano.sh/group-name"
+      prefillLabels:
+        modelserving.volcano.sh/role: prefill
+        modelserving.volcano.sh/entry: "true"
+      decodeLabels:
+        modelserving.volcano.sh/role: decode
+        modelserving.volcano.sh/entry: "true"
+  workloadPort:
+    port: 8000
+  model: "Qwen/Qwen3-8B"
+  inferenceEngine: "vLLM"
+  trafficPolicy:
+    timeout: 10s
+```
+
+Then route requests for the served model to that `ModelServer`:
+
+```yaml
+apiVersion: networking.serving.volcano.sh/v1alpha1
+kind: ModelRoute
+metadata:
+  name: vllm-pd-multinode
+  namespace: default
+spec:
+  modelName: "Qwen/Qwen3-8B"
+  rules:
+    - name: "default"
+      targetModels:
+        - modelServerName: "vllm-pd-multinode"
+```
+
 ### Tensor and Pipeline Parallelism Configuration
 
 The multi‑node example configures tensor parallelism and pipeline parallelism through the command‑line arguments of the inference engine. In the `multi-node.yaml` manifest, the entry‑point container includes:

--- a/examples/model-serving/vllm-pd-multinode.yaml
+++ b/examples/model-serving/vllm-pd-multinode.yaml
@@ -1,0 +1,300 @@
+apiVersion: workload.serving.volcano.sh/v1alpha1
+kind: ModelServing
+metadata:
+  name: vllm-pd-multinode
+  namespace: default
+spec:
+  schedulerName: volcano
+  replicas: 1
+  recoveryPolicy: ServingGroupRecreate
+  template:
+    restartGracePeriodSeconds: 60
+    gangPolicy:
+      minRoleReplicas:
+        prefill: 1
+        decode: 1
+    roles:
+      - name: prefill
+        replicas: 1
+        entryTemplate:
+          spec:
+            initContainers:
+              - name: downloader
+                imagePullPolicy: IfNotPresent
+                image: ghcr.io/volcano-sh/downloader:latest
+                args:
+                  - --source
+                  - Qwen/Qwen3-8B
+                  - --output-dir
+                  - /models/Qwen3-8B/
+                volumeMounts:
+                  - name: models
+                    mountPath: /models
+            containers:
+              - name: leader
+                image: ghcr.io/volcano-sh/vllm-openai:v0.10.0-cu128-nixl-v0.4.1-lmcache-0.3.2
+                command: ["sh", "-c"]
+                args:
+                  - |
+                    set -e
+                    bash /vllm-workspace/examples/online_serving/multi-node-serving.sh leader --ray_cluster_size="${GROUP_SIZE}"
+                    python3 -m vllm.entrypoints.openai.api_server \
+                    --host "0.0.0.0" \
+                    --port "8000" \
+                    --uvicorn-log-level warning \
+                    --model /models/Qwen3-8B \
+                    --served-model-name Qwen/Qwen3-8B \
+                    --tensor-parallel-size 1 \
+                    --pipeline_parallel_size 2 \
+                    --distributed_executor_backend ray \
+                    --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_producer"}'
+                env:
+                  - name: PYTHONHASHSEED
+                    value: "1047"
+                  - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+                    value: "0.0.0.0"
+                  - name: VLLM_NIXL_SIDE_CHANNEL_PORT
+                    value: "5558"
+                  - name: VLLM_WORKER_MULTIPROC_METHOD
+                    value: spawn
+                  - name: VLLM_ENABLE_V1_MULTIPROCESSING
+                    value: "0"
+                  - name: GLOO_SOCKET_IFNAME
+                    value: eth0
+                  - name: NCCL_SOCKET_IFNAME
+                    value: eth0
+                  - name: NCCL_IB_DISABLE
+                    value: "0"
+                  - name: NCCL_IB_GID_INDEX
+                    value: "7"
+                  - name: UCX_TLS
+                    value: ^gga
+                ports:
+                  - containerPort: 8000
+                volumeMounts:
+                  - name: models
+                    mountPath: /models
+                    readOnly: true
+                  - name: shared-mem
+                    mountPath: /dev/shm
+                resources:
+                  limits:
+                    nvidia.com/gpu: 1
+                securityContext:
+                  capabilities:
+                    add:
+                      - IPC_LOCK
+                readinessProbe:
+                  initialDelaySeconds: 5
+                  periodSeconds: 5
+                  failureThreshold: 3
+                  httpGet:
+                    path: /health
+                    port: 8000
+                livenessProbe:
+                  initialDelaySeconds: 900
+                  periodSeconds: 5
+                  failureThreshold: 3
+                  httpGet:
+                    path: /health
+                    port: 8000
+            volumes:
+              - name: models
+                emptyDir: {}
+              - name: shared-mem
+                emptyDir:
+                  sizeLimit: 256Mi
+                  medium: Memory
+        workerReplicas: 1
+        workerTemplate:
+          spec:
+            initContainers:
+              - name: downloader
+                imagePullPolicy: IfNotPresent
+                image: ghcr.io/volcano-sh/downloader:latest
+                args:
+                  - --source
+                  - Qwen/Qwen3-8B
+                  - --output-dir
+                  - /models/Qwen3-8B/
+                volumeMounts:
+                  - name: models
+                    mountPath: /models
+            containers:
+              - name: worker
+                image: ghcr.io/volcano-sh/vllm-openai:v0.10.0-cu128-nixl-v0.4.1-lmcache-0.3.2
+                command: ["sh", "-c"]
+                args:
+                  - |
+                    bash /vllm-workspace/examples/online_serving/multi-node-serving.sh worker --ray_address="${ENTRY_ADDRESS}"
+                env:
+                  - name: PYTHONHASHSEED
+                    value: "1047"
+                  - name: GLOO_SOCKET_IFNAME
+                    value: eth0
+                  - name: NCCL_SOCKET_IFNAME
+                    value: eth0
+                  - name: NCCL_IB_DISABLE
+                    value: "0"
+                  - name: NCCL_IB_GID_INDEX
+                    value: "7"
+                  - name: UCX_TLS
+                    value: ^gga
+                resources:
+                  limits:
+                    nvidia.com/gpu: 1
+                volumeMounts:
+                  - name: models
+                    mountPath: /models
+                    readOnly: true
+                  - name: shared-mem
+                    mountPath: /dev/shm
+            volumes:
+              - name: models
+                emptyDir: {}
+              - name: shared-mem
+                emptyDir:
+                  sizeLimit: 256Mi
+                  medium: Memory
+      - name: decode
+        replicas: 1
+        entryTemplate:
+          spec:
+            initContainers:
+              - name: downloader
+                imagePullPolicy: IfNotPresent
+                image: ghcr.io/volcano-sh/downloader:latest
+                args:
+                  - --source
+                  - Qwen/Qwen3-8B
+                  - --output-dir
+                  - /models/Qwen3-8B/
+                volumeMounts:
+                  - name: models
+                    mountPath: /models
+            containers:
+              - name: leader
+                image: ghcr.io/volcano-sh/vllm-openai:v0.10.0-cu128-nixl-v0.4.1-lmcache-0.3.2
+                command: ["sh", "-c"]
+                args:
+                  - |
+                    set -e
+                    bash /vllm-workspace/examples/online_serving/multi-node-serving.sh leader --ray_cluster_size="${GROUP_SIZE}"
+                    python3 -m vllm.entrypoints.openai.api_server \
+                    --host "0.0.0.0" \
+                    --port "8000" \
+                    --uvicorn-log-level warning \
+                    --model /models/Qwen3-8B \
+                    --served-model-name Qwen/Qwen3-8B \
+                    --tensor-parallel-size 1 \
+                    --pipeline_parallel_size 2 \
+                    --distributed_executor_backend ray \
+                    --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_consumer"}'
+                env:
+                  - name: PYTHONHASHSEED
+                    value: "1047"
+                  - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+                    value: "0.0.0.0"
+                  - name: VLLM_NIXL_SIDE_CHANNEL_PORT
+                    value: "5558"
+                  - name: VLLM_WORKER_MULTIPROC_METHOD
+                    value: spawn
+                  - name: VLLM_ENABLE_V1_MULTIPROCESSING
+                    value: "0"
+                  - name: GLOO_SOCKET_IFNAME
+                    value: eth0
+                  - name: NCCL_SOCKET_IFNAME
+                    value: eth0
+                  - name: NCCL_IB_DISABLE
+                    value: "0"
+                  - name: NCCL_IB_GID_INDEX
+                    value: "7"
+                  - name: UCX_TLS
+                    value: ^gga
+                ports:
+                  - containerPort: 8000
+                volumeMounts:
+                  - name: models
+                    mountPath: /models
+                    readOnly: true
+                  - name: shared-mem
+                    mountPath: /dev/shm
+                resources:
+                  limits:
+                    nvidia.com/gpu: 1
+                securityContext:
+                  capabilities:
+                    add:
+                      - IPC_LOCK
+                readinessProbe:
+                  initialDelaySeconds: 5
+                  periodSeconds: 5
+                  failureThreshold: 3
+                  httpGet:
+                    path: /health
+                    port: 8000
+                livenessProbe:
+                  initialDelaySeconds: 900
+                  periodSeconds: 5
+                  failureThreshold: 3
+                  httpGet:
+                    path: /health
+                    port: 8000
+            volumes:
+              - name: models
+                emptyDir: {}
+              - name: shared-mem
+                emptyDir:
+                  sizeLimit: 256Mi
+                  medium: Memory
+        workerReplicas: 1
+        workerTemplate:
+          spec:
+            initContainers:
+              - name: downloader
+                imagePullPolicy: IfNotPresent
+                image: ghcr.io/volcano-sh/downloader:latest
+                args:
+                  - --source
+                  - Qwen/Qwen3-8B
+                  - --output-dir
+                  - /models/Qwen3-8B/
+                volumeMounts:
+                  - name: models
+                    mountPath: /models
+            containers:
+              - name: worker
+                image: ghcr.io/volcano-sh/vllm-openai:v0.10.0-cu128-nixl-v0.4.1-lmcache-0.3.2
+                command: ["sh", "-c"]
+                args:
+                  - |
+                    bash /vllm-workspace/examples/online_serving/multi-node-serving.sh worker --ray_address="${ENTRY_ADDRESS}"
+                env:
+                  - name: PYTHONHASHSEED
+                    value: "1047"
+                  - name: GLOO_SOCKET_IFNAME
+                    value: eth0
+                  - name: NCCL_SOCKET_IFNAME
+                    value: eth0
+                  - name: NCCL_IB_DISABLE
+                    value: "0"
+                  - name: NCCL_IB_GID_INDEX
+                    value: "7"
+                  - name: UCX_TLS
+                    value: ^gga
+                resources:
+                  limits:
+                    nvidia.com/gpu: 1
+                volumeMounts:
+                  - name: models
+                    mountPath: /models
+                    readOnly: true
+                  - name: shared-mem
+                    mountPath: /dev/shm
+            volumes:
+              - name: models
+                emptyDir: {}
+              - name: shared-mem
+                emptyDir:
+                  sizeLimit: 256Mi
+                  medium: Memory

--- a/test/e2e/router/e2e_test.go
+++ b/test/e2e/router/e2e_test.go
@@ -125,6 +125,12 @@ func TestModelRoutePrefillDecodeDisaggregation(t *testing.T) {
 	TestModelRoutePrefillDecodeDisaggregationShared(t, testCtx, testNamespace, false, "")
 }
 
+// TestModelRoutePrefillDecodeMultinode tests PD disaggregation with a multi-node ModelServing.
+// This test runs the shared test function without Gateway API (no ParentRefs).
+func TestModelRoutePrefillDecodeMultinode(t *testing.T) {
+	TestModelRoutePrefillDecodeMultinodeShared(t, testCtx, testNamespace, false, "")
+}
+
 // TestModelRouteSglangPrefillDecodeDisaggregation tests SGLang PD disaggregation with ModelServing, ModelServer, and ModelRoute.
 // This test runs the shared test function without Gateway API (no ParentRefs).
 func TestModelRouteSglangPrefillDecodeDisaggregation(t *testing.T) {

--- a/test/e2e/router/gateway-api/e2e_test.go
+++ b/test/e2e/router/gateway-api/e2e_test.go
@@ -118,6 +118,12 @@ func TestModelRoutePrefillDecodeDisaggregation(t *testing.T) {
 	router.TestModelRoutePrefillDecodeDisaggregationShared(t, testCtx, testNamespace, true, kthenaNamespace)
 }
 
+// TestModelRoutePrefillDecodeMultinode tests PD disaggregation with a multi-node ModelServing.
+// This test runs the shared test function with Gateway API enabled (with ParentRefs).
+func TestModelRoutePrefillDecodeMultinode(t *testing.T) {
+	router.TestModelRoutePrefillDecodeMultinodeShared(t, testCtx, testNamespace, true, kthenaNamespace)
+}
+
 // TestModelRouteSglangPrefillDecodeDisaggregation tests SGLang PD disaggregation with ModelServing, ModelServer, and ModelRoute.
 // This test runs the shared test function with Gateway API enabled (with ParentRefs).
 func TestModelRouteSglangPrefillDecodeDisaggregation(t *testing.T) {

--- a/test/e2e/router/shared.go
+++ b/test/e2e/router/shared.go
@@ -58,6 +58,9 @@ const (
 	modelServingVLLMPDDisaggregationFixture   = "ModelServing-ds1.5b-pd-disaggregation.yaml"
 	modelServerVLLMPDDisaggregationFixture    = "ModelServer-ds1.5b-pd-disaggregation.yaml"
 	modelRouteVLLMPDDisaggregationFixture     = "ModelRoute-ds1.5b-pd-disaggregation.yaml"
+	modelServingVLLMPDMultinodeFixture        = "ModelServing-ds1.5b-pd-multinode.yaml"
+	modelServerVLLMPDMultinodeFixture         = "ModelServer-ds1.5b-pd-multinode.yaml"
+	modelRouteVLLMPDMultinodeFixture          = "ModelRoute-ds1.5b-pd-multinode.yaml"
 	modelServingSGLangPDDisaggregationFixture = "ModelServing-sglang-pd-disaggregation.yaml"
 	modelServerSGLangPDDisaggregationFixture  = "ModelServer-sglang-pd-disaggregation.yaml"
 	modelRouteSGLangPDDisaggregationFixture   = "ModelRoute-sglang-pd-disaggregation.yaml"
@@ -341,6 +344,18 @@ func TestModelRoutePrefillDecodeDisaggregationShared(t *testing.T, testCtx *rout
 			modelServing: modelServingVLLMPDDisaggregationFixture,
 			modelServer:  modelServerVLLMPDDisaggregationFixture,
 			modelRoute:   modelRouteVLLMPDDisaggregationFixture,
+		},
+	)
+}
+
+// TestModelRoutePrefillDecodeMultinodeShared verifies PD disaggregation on a multi-node ModelServing.
+func TestModelRoutePrefillDecodeMultinodeShared(t *testing.T, testCtx *routercontext.RouterTestContext, testNamespace string, useGatewayAPI bool, kthenaNamespace string) {
+	testModelRoutePrefillDecodeDisaggregationSharedWithFixtures(
+		t, testCtx, testNamespace, useGatewayAPI, kthenaNamespace,
+		pdDisaggregationFixtures{
+			modelServing: modelServingVLLMPDMultinodeFixture,
+			modelServer:  modelServerVLLMPDMultinodeFixture,
+			modelRoute:   modelRouteVLLMPDMultinodeFixture,
 		},
 	)
 }

--- a/test/e2e/router/testdata/ModelRoute-ds1.5b-pd-multinode.yaml
+++ b/test/e2e/router/testdata/ModelRoute-ds1.5b-pd-multinode.yaml
@@ -1,0 +1,11 @@
+apiVersion: networking.serving.volcano.sh/v1alpha1
+kind: ModelRoute
+metadata:
+  name: deepseek-r1-1-5b-pd-multinode
+  namespace: default
+spec:
+  modelName: "deepseek-r1-1-5b-pd-multinode"
+  rules:
+    - name: "default"
+      targetModels:
+        - modelServerName: "deepseek-r1-1-5b-pd-multinode"

--- a/test/e2e/router/testdata/ModelServer-ds1.5b-pd-multinode.yaml
+++ b/test/e2e/router/testdata/ModelServer-ds1.5b-pd-multinode.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.serving.volcano.sh/v1alpha1
+kind: ModelServer
+metadata:
+  name: deepseek-r1-1-5b-pd-multinode
+  namespace: default
+spec:
+  workloadSelector:
+    matchLabels:
+      modelserving.volcano.sh/name: deepseek-r1-1-5b-pd-multinode
+      modelserving.volcano.sh/entry: "true"
+    pdGroup:
+      groupKey: "modelserving.volcano.sh/group-name"
+      prefillLabels:
+        modelserving.volcano.sh/role: "prefill"
+        modelserving.volcano.sh/entry: "true"
+      decodeLabels:
+        modelserving.volcano.sh/role: "decode"
+        modelserving.volcano.sh/entry: "true"
+  workloadPort:
+    port: 8000
+  model: "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
+  inferenceEngine: "vLLM"
+  trafficPolicy:
+    timeout: 10s

--- a/test/e2e/router/testdata/ModelServing-ds1.5b-pd-multinode.yaml
+++ b/test/e2e/router/testdata/ModelServing-ds1.5b-pd-multinode.yaml
@@ -1,0 +1,77 @@
+apiVersion: workload.serving.volcano.sh/v1alpha1
+kind: ModelServing
+metadata:
+  name: deepseek-r1-1-5b-pd-multinode
+  namespace: default
+spec:
+  schedulerName: volcano
+  replicas: 1
+  recoveryPolicy: ServingGroupRecreate
+  template:
+    gangPolicy:
+      minRoleReplicas:
+        prefill: 1
+        decode: 1
+    roles:
+      - name: prefill
+        replicas: 1
+        entryTemplate:
+          spec:
+            containers:
+              - name: leader
+                image: ghcr.io/llm-d/llm-d-inference-sim:latest
+                imagePullPolicy: IfNotPresent
+                args:
+                  - --model=kthena-mock-1.5b-prefill-multinode
+                  - --served-model-name=deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B
+                  - --port=8000
+                  - --mode=echo
+                  - --time-to-first-token=0
+                  - --inter-token-latency=0
+                  - --prefill-time-per-token=1ms
+                ports:
+                  - containerPort: 8000
+                readinessProbe:
+                  httpGet:
+                    path: /health
+                    port: 8000
+                  initialDelaySeconds: 2
+                  periodSeconds: 2
+        workerReplicas: 1
+        workerTemplate:
+          spec:
+            containers:
+              - name: worker
+                image: nginx:1.28.2
+                imagePullPolicy: IfNotPresent
+      - name: decode
+        replicas: 1
+        entryTemplate:
+          spec:
+            containers:
+              - name: leader
+                image: ghcr.io/llm-d/llm-d-inference-sim:latest
+                imagePullPolicy: IfNotPresent
+                args:
+                  - --model=kthena-mock-1.5b-decode-multinode
+                  - --served-model-name=deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B
+                  - --port=8000
+                  - --mode=echo
+                  - --time-to-first-token=0
+                  - --inter-token-latency=0
+                  - --kv-cache-transfer-latency=1ms
+                ports:
+                  - containerPort: 8000
+                readinessProbe:
+                  httpGet:
+                    path: /health
+                    port: 8000
+                  initialDelaySeconds: 2
+                  periodSeconds: 2
+        workerReplicas: 1
+        workerTemplate:
+          spec:
+            containers:
+              - name: worker
+                image: nginx:1.28.2
+                imagePullPolicy: IfNotPresent


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

This PR adds a ModelServing example that combines prefill/decode (PD) disaggregation
with multi-node vLLM execution, documents it, and adds router e2e coverage that
exercises the example end-to-end.

The new example defines separate `prefill` and `decode` roles. Each role has a leader
pod that starts the vLLM Ray head before the OpenAI API server, plus a worker pod that
joins through the `ENTRY_ADDRESS` injected by Kthena. Worker pods also download and
mount the model so the local model path is available on both leader and worker pods.

It also updates the multi-node inference guide with the expected pod layout, cluster
prerequisites, and matching `ModelServer` / `ModelRoute` configuration for PD-aware
routing.

To make sure the example actually works (not just renders as docs), it also adds
router e2e tests and fixtures that deploy this PD + multi-node topology and validate
PD-aware routing, both without and with Gateway API.

**Which issue(s) this PR fixes**:
Fixes #474

**Special notes for your reviewer**:

This is primarily a docs/example change, but it also ships e2e tests so the example is
validated in CI rather than only described:

- Docs / example:
  - `examples/model-serving/vllm-pd-multinode.yaml` and the matching docs asset copy.
  - `docs/kthena/docs/user-guide/multi-node-inference.md`.
  - The `ModelServer` guide example selects only entry pods with
    `modelserving.volcano.sh/entry: "true"`, so router traffic targets the leader/API
    pods rather than worker pods.
- Router e2e coverage (validates the example):
  - `test/e2e/router/e2e_test.go` and `test/e2e/router/gateway-api/e2e_test.go`:
    new `TestModelRoutePrefillDecodeMultinode` (without / with Gateway API).
  - `test/e2e/router/shared.go`: shared `TestModelRoutePrefillDecodeMultinodeShared`
    helper reusing the existing PD test flow.
  - `test/e2e/router/testdata/ModelServing|ModelServer|ModelRoute-ds1.5b-pd-multinode.yaml`
    fixtures (mock inference sim, consistent with the existing PD-disaggregation fixtures).
- Validated with:
  - `make test-docs` (typecheck + Docusaurus build, Node.js v20).
  - `go vet` / `golangci-lint` on `test/e2e/router/...` (the e2e run itself is covered by CI).
  - YAML parse for both example copies.
- I used AI assistance to draft and review this change, and reviewed the final diff and
  validation results before opening this PR.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
