### PR TITLE
fix(router): correct misleading existing-pod lookup in ModelServer sync

### DIFF
--- a/pkg/kthena-router/controller/httproute_controller_test.go
+++ b/pkg/kthena-router/controller/httproute_controller_test.go
@@ -424,7 +424,8 @@ func TestHTTPRouteController_SyncHandler_MovesRouteWithGatewayOnlyInInformer(t *
 	_, err = gatewayClient.GatewayV1().HTTPRoutes(ns).Create(ctx, httpRoute, metav1.CreateOptions{})
 	assert.NoError(t, err)
 
-	ctrl := NewHTTPRouteController(gatewayInformerFactory, kubeInformerFactory, store)
+	ctrl, err := NewHTTPRouteController(gatewayInformerFactory, kubeInformerFactory, store)
+	require.NoError(t, err)
 	stop := make(chan struct{})
 	defer close(stop)
 	gatewayInformerFactory.Start(stop)
@@ -461,7 +462,8 @@ func TestHTTPRouteController_SyncHandler_WaitsForGatewayCreatedLater(t *testing.
 	_, err := gatewayClient.GatewayV1().HTTPRoutes(ns).Create(ctx, httpRoute, metav1.CreateOptions{})
 	assert.NoError(t, err)
 
-	ctrl := NewHTTPRouteController(gatewayInformerFactory, kubeInformerFactory, store)
+	ctrl, err := NewHTTPRouteController(gatewayInformerFactory, kubeInformerFactory, store)
+	require.NoError(t, err)
 	stop := make(chan struct{})
 	defer close(stop)
 	gatewayInformerFactory.Start(stop)

--- a/pkg/kthena-router/controller/modelserver_controller.go
+++ b/pkg/kthena-router/controller/modelserver_controller.go
@@ -216,43 +216,29 @@ func (c *ModelServerController) syncModelServerHandler(key string) error {
 
 	_ = c.store.AddOrUpdateModelServer(ms, pods)
 
-	// Get already bound pods to avoid unnecessary updates
-	existingPods, err := c.store.GetPodsByModelServer(utils.GetNamespaceName(ms))
-	if err != nil {
-		klog.V(4).Infof("failed to get existing pods for ModelServer %s/%s: %v", ms.Namespace, ms.Name, err)
-	}
-
-	// Build a set of existing pod names that are already bound to the model server
-	existingPodNames := sets.New[types.NamespacedName]()
-	for _, podInfo := range existingPods {
-		pod := podInfo.GetPod()
-		if pod == nil {
-			continue
-		}
-		if !podInfo.HasModelServer(utils.GetNamespaceName(ms)) {
-			// If the pod is not bound to the model server, establish the binding
-			if err := c.store.AppendModelServerToPod(pod, []*aiv1alpha1.ModelServer{ms}); err != nil {
-				klog.Warningf("failed to append modelserver %s/%s to pod %s/%s: %v", ms.Namespace, ms.Name, pod.Namespace, pod.Name, err)
-				continue
-			}
-		}
-		existingPodNames.Insert(utils.GetNamespaceName(pod))
-	}
-
-	// Add new pods that are not yet bound to the store
+	// Bind every ready pod selected by this ModelServer. Pods that already have
+	// an entry in the store get the binding appended so their runtime metrics and
+	// bindings to other ModelServers are preserved; brand-new pods are created
+	// with the binding. We check each pod against the store directly instead of
+	// re-reading GetPodsByModelServer, which would only echo back the pod set that
+	// AddOrUpdateModelServer just wrote and cannot distinguish existing pods from
+	// new ones.
+	msName := utils.GetNamespaceName(ms)
 	for _, pod := range podList {
 		if !isPodReady(pod) {
 			continue
 		}
 
 		podName := utils.GetNamespaceName(pod)
-		// Skip pods that are already properly bound
-		if existingPodNames.Contains(podName) {
+		if c.store.GetPodInfo(podName) != nil {
+			if err := c.store.AppendModelServerToPod(pod, []*aiv1alpha1.ModelServer{ms}); err != nil {
+				klog.Warningf("failed to append modelserver %s to pod %s: %v", msName, podName, err)
+			}
 			continue
 		}
 
 		if err := c.store.AddOrUpdatePod(pod, []*aiv1alpha1.ModelServer{ms}); err != nil {
-			klog.Warningf("failed to add new pod %s/%s to data store: %v", pod.Namespace, pod.Name, err)
+			klog.Warningf("failed to add new pod %s to data store: %v", podName, err)
 		}
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

In `ModelServerController.syncModelServerHandler`, the store update and the
"existing pods" lookup run in the wrong order, which makes the lookup and its
comment meaningless:

```go
_ = c.store.AddOrUpdateModelServer(ms, pods)

// Get already bound pods to avoid unnecessary updates
existingPods, err := c.store.GetPodsByModelServer(...)
```

`AddOrUpdateModelServer` has *already* overwritten the ModelServer's pod set
with the freshly computed desired set, so `GetPodsByModelServer` merely echoes
that same set back. The comment claims it returns "already bound pods to avoid
unnecessary updates", but it cannot distinguish pods that already exist in the
store from newly selected ones — the de-duplication it describes does nothing
useful.

This PR removes the misleading `GetPodsByModelServer` round-trip and replaces it
with a direct per-pod store lookup: for each ready, selected pod, append the
binding when a `PodInfo` already exists (preserving runtime metrics and bindings
to other ModelServers) or create it otherwise. **Behavior is unchanged** — the
code and comment now actually match.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

- Scope is intentionally limited to the misleading `existingPods` lookup.
  Reconciling *stale* bindings when a ModelServer selector (or a pod's labels)
  stop matching is a separate concern already addressed by #1280, and is **not**
  touched here to avoid overlap/conflict.
- No interface or datastore changes; this is a controller-local cleanup.
- Verified locally: `go test ./pkg/kthena-router/...` and `gofmt`.
- AI assistance: drafted with an AI coding assistant and reviewed/tested by me
  before submission.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
