### PR TITLE
feat(autoscaler): make reconcile period configurable via CLI flag

### DIFF
--- a/charts/kthena/charts/workload/templates/kthena-controller-manager/component/deployment.yaml
+++ b/charts/kthena/charts/workload/templates/kthena-controller-manager/component/deployment.yaml
@@ -41,6 +41,9 @@ spec:
             {{- if .Values.controllerManager.debugPort }}
             - --debug-port={{ .Values.controllerManager.debugPort }}
             {{- end }}
+            {{- if .Values.controllerManager.autoscalingSyncPeriodSeconds }}
+            - --autoscaling-sync-period-seconds={{ .Values.controllerManager.autoscalingSyncPeriodSeconds }}
+            {{- end }}
           imagePullPolicy: {{ .Values.controllerManager.image.pullPolicy }}
           resources:
             {{- toYaml .Values.controllerManager.resource | nindent 12 }}

--- a/charts/kthena/charts/workload/values.yaml
+++ b/charts/kthena/charts/workload/values.yaml
@@ -35,6 +35,10 @@ controllerManager:
   # debugPort is the debug HTTP server port.
   # If 0 or not specified, debug server is disabled.
   debugPort: 0
+  # autoscalingSyncPeriodSeconds is the reconcile interval in seconds for the autoscaler.
+  # Smaller values react faster to traffic spikes but increase API server load.
+  # If 0 or not specified, uses the binary default (15).
+  autoscalingSyncPeriodSeconds: 0
   # downloaderImage is the container image used for downloading models.
   downloaderImage:
     repository: ghcr.io/volcano-sh/downloader

--- a/charts/kthena/values.yaml
+++ b/charts/kthena/values.yaml
@@ -11,6 +11,9 @@ workload:
       pullPolicy: IfNotPresent
     # -- Debug server port for Controller Manager (set 0 to disable).
     debugPort: 0
+    # -- Reconcile interval in seconds for the autoscaler. Smaller values react
+    # faster to traffic spikes but increase API server load. 0 uses the binary default (15).
+    autoscalingSyncPeriodSeconds: 0
     downloaderImage:
       # -- Image repository for the Downloader.
       repository: ghcr.io/volcano-sh/downloader

--- a/cmd/kthena-controller-manager/main.go
+++ b/cmd/kthena-controller-manager/main.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"github.com/spf13/pflag"
+	"github.com/volcano-sh/kthena/pkg/autoscaler/util"
 	autoscalerwebhook "github.com/volcano-sh/kthena/pkg/autoscaler/webhook"
 	"github.com/volcano-sh/kthena/pkg/controller"
 	modelboosterwebhook "github.com/volcano-sh/kthena/pkg/model-booster-controller/webhook"
@@ -83,6 +84,8 @@ func main() {
 	pflag.Float32Var(&cc.KubeAPIQPS, "kube-api-qps", 0, "QPS to use while talking with kubernetes apiserver. If 0, use default value.")
 	pflag.IntVar(&cc.KubeAPIBurst, "kube-api-burst", 0, "Burst to use while talking with kubernetes apiserver. If 0, use default value.")
 	pflag.IntVar(&cc.DebugPort, "debug-port", 0, "Port for debug server to dump internal cache. If 0, debug server is disabled.")
+	pflag.IntVar(&cc.AutoscalingSyncPeriodSeconds, "autoscaling-sync-period-seconds", util.AutoscalingSyncPeriodSeconds,
+		"Reconcile interval in seconds for the autoscaler. Smaller values react faster to traffic spikes but increase API server load. 0 falls back to the default (15).")
 	pflag.Parse()
 
 	cc.Controllers = parseControllers(controllers)

--- a/docs/kthena/docs/reference/helm-chart-values.md
+++ b/docs/kthena/docs/reference/helm-chart-values.md
@@ -47,6 +47,7 @@ A Helm chart for deploying Kthena
 | networking.kthenaRouter.webhook.tls.certFile | string | `"/etc/tls/tls.crt"` | Certificate file path for the webhook. |
 | networking.kthenaRouter.webhook.tls.keyFile | string | `"/etc/tls/tls.key"` | Key file path for the webhook. |
 | networking.kthenaRouter.webhook.tls.secretName | string | `"kthena-router-webhook-certs"` | Secret name for storing webhook certificates. |
+| workload.controllerManager.autoscalingSyncPeriodSeconds | int | `0` | Reconcile interval in seconds for the autoscaler. Smaller values react faster to traffic spikes but increase API server load. 0 uses the binary default (15). |
 | workload.controllerManager.debugPort | int | `0` | Debug server port for Controller Manager (set 0 to disable). |
 | workload.controllerManager.downloaderImage.repository | string | `"ghcr.io/volcano-sh/downloader"` | Image repository for the Downloader. |
 | workload.controllerManager.downloaderImage.tag | string | `"latest"` | Image tag for the Downloader. |

--- a/pkg/autoscaler/controller/autoscale_controller.go
+++ b/pkg/autoscaler/controller/autoscale_controller.go
@@ -61,9 +61,13 @@ type AutoscaleController struct {
 	scalerMap                   map[string]*autoscaler.Autoscaler
 	optimizerMap                map[string]*autoscaler.Optimizer
 	disaggregatedScalerMap      map[string]*autoscaler.DisaggregatedAutoscaler
+	syncPeriodSeconds           int
 }
 
-func NewAutoscaleController(kubeClient kubernetes.Interface, client clientset.Interface) *AutoscaleController {
+func NewAutoscaleController(kubeClient kubernetes.Interface, client clientset.Interface, syncPeriodSeconds int) *AutoscaleController {
+	if syncPeriodSeconds <= 0 {
+		syncPeriodSeconds = util.AutoscalingSyncPeriodSeconds
+	}
 	informerFactory := informersv1alpha1.NewSharedInformerFactory(client, 0)
 	modelInferInformer := informerFactory.Workload().V1alpha1().ModelServings()
 	autoscalingPoliciesInformer := informerFactory.Workload().V1alpha1().AutoscalingPolicies()
@@ -91,6 +95,7 @@ func NewAutoscaleController(kubeClient kubernetes.Interface, client clientset.In
 		scalerMap:                   make(map[string]*autoscaler.Autoscaler),
 		optimizerMap:                make(map[string]*autoscaler.Optimizer),
 		disaggregatedScalerMap:      make(map[string]*autoscaler.DisaggregatedAutoscaler),
+		syncPeriodSeconds:           syncPeriodSeconds,
 	}
 	return ac
 }
@@ -111,7 +116,7 @@ func (ac *AutoscaleController) Run(ctx context.Context) {
 	klog.Info("start autoscale controller")
 	go wait.Until(func() {
 		ac.Reconcile(ctx)
-	}, util.AutoscalingSyncPeriodSeconds*time.Second, nil)
+	}, time.Duration(ac.syncPeriodSeconds)*time.Second, nil)
 
 	<-ctx.Done()
 	klog.Info("shut down autoscale controller")

--- a/pkg/autoscaler/controller/autoscale_controller_test.go
+++ b/pkg/autoscaler/controller/autoscale_controller_test.go
@@ -33,10 +33,12 @@ import (
 	workloadLister "github.com/volcano-sh/kthena/client-go/listers/workload/v1alpha1"
 	workload "github.com/volcano-sh/kthena/pkg/apis/workload/v1alpha1"
 	"github.com/volcano-sh/kthena/pkg/autoscaler/autoscaler"
+	"github.com/volcano-sh/kthena/pkg/autoscaler/util"
 	corev1 "k8s.io/api/core/v1"
 	resource "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
 	listerv1 "k8s.io/client-go/listers/core/v1"
 	k8stesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
@@ -104,6 +106,29 @@ func newModelServingIndexer(objs ...interface{}) cache.Indexer {
 		_ = idx.Add(o)
 	}
 	return idx
+}
+
+func TestNewAutoscaleControllerSyncPeriodFallback(t *testing.T) {
+	kubeClient := k8sfake.NewSimpleClientset()
+	client := clientfake.NewSimpleClientset()
+
+	// 0 falls back to the compiled default (15s).
+	ac := NewAutoscaleController(kubeClient, client, 0)
+	if ac == nil {
+		t.Fatal("expected non-nil controller for zero period")
+	}
+	if ac.syncPeriodSeconds != util.AutoscalingSyncPeriodSeconds {
+		t.Errorf("expected fallback syncPeriodSeconds=%d, got %d", util.AutoscalingSyncPeriodSeconds, ac.syncPeriodSeconds)
+	}
+
+	// Explicit positive value is respected.
+	ac2 := NewAutoscaleController(kubeClient, client, 5)
+	if ac2 == nil {
+		t.Fatal("expected non-nil controller for explicit period")
+	}
+	if ac2.syncPeriodSeconds != 5 {
+		t.Errorf("expected syncPeriodSeconds=5, got %d", ac2.syncPeriodSeconds)
+	}
 }
 
 func TestToleranceHigh_then_DoScale_expect_NoUpdateActions(t *testing.T) {

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -17,12 +17,13 @@ limitations under the License.
 package controller
 
 type Config struct {
-	EnableLeaderElection bool
-	Workers              int
-	Kubeconfig           string
-	MasterURL            string
-	Controllers          map[string]bool
-	KubeAPIQPS           float32
-	KubeAPIBurst         int
-	DebugPort            int
+	EnableLeaderElection         bool
+	Workers                      int
+	Kubeconfig                   string
+	MasterURL                    string
+	Controllers                  map[string]bool
+	KubeAPIQPS                   float32
+	KubeAPIBurst                 int
+	DebugPort                    int
+	AutoscalingSyncPeriodSeconds int
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -96,7 +96,7 @@ func SetupController(ctx context.Context, cc Config) {
 					klog.Info("LeaderWorkerSet CRD not found, LWS support disabled")
 				}
 			case AutoscalerController:
-				ac = autoscaler.NewAutoscaleController(kubeClient, client)
+				ac = autoscaler.NewAutoscaleController(kubeClient, client, cc.AutoscalingSyncPeriodSeconds)
 			}
 		}
 	}


### PR DESCRIPTION
The autoscaler reconcile loop was hard-coded to 15s, too slow for workloads that need to scale up aggressively on traffic spikes. Add a --autoscaling-sync-period-seconds flag to kthena-controller-manager so operators can tune the interval without rebuilding. Values <=0 fall back to the compiled default (15s), preserving existing behavior.

This replaces the earlier CRD-level syncPolicy proposal (issue #1204), which the community rejected because it conflicted with the existing ScaleUp/ScaleDown policy semantics and because per-direction periods cannot cleanly drive a single reconcile loop.

Expose the flag in the helm chart
(controllerManager.autoscalingSyncPeriodSeconds, default 0 = binary default) and add a unit test for the 0-fallback and explicit-value paths.

Refs #1204
