### PR TITLE
test(router): fix NewHTTPRouteController constructor signature in tests

### DIFF
--- a/pkg/kthena-router/controller/httproute_controller_test.go
+++ b/pkg/kthena-router/controller/httproute_controller_test.go
@@ -424,7 +424,8 @@ func TestHTTPRouteController_SyncHandler_MovesRouteWithGatewayOnlyInInformer(t *
 	_, err = gatewayClient.GatewayV1().HTTPRoutes(ns).Create(ctx, httpRoute, metav1.CreateOptions{})
 	assert.NoError(t, err)
 
-	ctrl := NewHTTPRouteController(gatewayInformerFactory, kubeInformerFactory, store)
+	ctrl, err := NewHTTPRouteController(gatewayInformerFactory, kubeInformerFactory, store)
+	require.NoError(t, err)
 	stop := make(chan struct{})
 	defer close(stop)
 	gatewayInformerFactory.Start(stop)
@@ -461,7 +462,8 @@ func TestHTTPRouteController_SyncHandler_WaitsForGatewayCreatedLater(t *testing.
 	_, err := gatewayClient.GatewayV1().HTTPRoutes(ns).Create(ctx, httpRoute, metav1.CreateOptions{})
 	assert.NoError(t, err)
 
-	ctrl := NewHTTPRouteController(gatewayInformerFactory, kubeInformerFactory, store)
+	ctrl, err := NewHTTPRouteController(gatewayInformerFactory, kubeInformerFactory, store)
+	require.NoError(t, err)
 	stop := make(chan struct{})
 	defer close(stop)
 	gatewayInformerFactory.Start(stop)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

PR #1134 updated the `NewHTTPRouteController` constructor to legitimately return an `error` if `AddEventHandler` fails. However, the unit tests in `httproute_controller_test.go` were not updated to expect the new return value. This resulted in a semantic merge conflict that is currently breaking `go test` and CI across the repository with the error:
`assignment mismatch: 1 variable but NewHTTPRouteController returns 2 values`

This PR simply updates the test file to assign the error and assert it using `require.NoError(t, err)` so that CI can go green again.

**Which issue(s) this PR fixes**:
Fixes the current CI compilation breakage on `main`.

**Special notes for your reviewer**:
None.

**Does this PR introduce a user-facing change?**:
```release-note
NONE