### PR TITLE
fix(router): serialize error message in ParseModelRequest HTTP response

### DIFF
--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -513,12 +513,12 @@ func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest) error 
 func ParseModelRequest(c *gin.Context) (ModelRequest, error) {
 	bodyBytes, err := io.ReadAll(c.Request.Body)
 	if err != nil {
-		c.AbortWithStatusJSON(http.StatusInternalServerError, err)
+		c.AbortWithStatusJSON(http.StatusInternalServerError, err.Error())
 		return nil, err
 	}
 	var modelRequest ModelRequest
 	if err := json.Unmarshal(bodyBytes, &modelRequest); err != nil {
-		c.AbortWithStatusJSON(http.StatusBadRequest, err)
+		c.AbortWithStatusJSON(http.StatusBadRequest, err.Error())
 		return nil, err
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

ParseModelRequest() currently passes a Go error interface directly to AbortWithStatusJSON. Since Go errors don't have exported fields, json.Marshal produces an empty JSON object like {} or {"Offset":25} instead of the actual error message.

This means if someone sends a malformed request to the router, the response body is useless for debugging. Fix is straightforward — convert to string with err.Error(), same as the existing pattern at lines 271 and 527 in this file.

**Which issue(s) this PR fixes**:

Fixes #1308

**Special notes for your reviewer**:

Small change, 2 lines. Reproduced the issue locally with a curl command and verified the fix resolves it.

**Does this PR introduce a user-facing change?**:

```release-note
Fixed ParseModelRequest HTTP error response to include the actual error message instead of an empty JSON object
```