### PR TITLE
model-booster: omit empty ModelServing schedulerName

### DIFF
--- a/pkg/apis/workload/v1alpha1/model_serving_types.go
+++ b/pkg/apis/workload/v1alpha1/model_serving_types.go
@@ -45,7 +45,7 @@ type ModelServingSpec struct {
 	//
 	// +optional
 	// +kubebuilder:default=volcano
-	SchedulerName string `json:"schedulerName"`
+	SchedulerName string `json:"schedulerName,omitempty"`
 
 	// Plugins defines optional plugin chain to customize serving pods.
 	// +optional

--- a/pkg/model-booster-controller/convert/model_serving_test.go
+++ b/pkg/model-booster-controller/convert/model_serving_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package convert
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -406,6 +407,30 @@ func TestBuildModelServingSkipEngineDependencyInstall(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBuildModelServingSchedulerNameSerialization(t *testing.T) {
+	t.Run("omits empty schedulerName", func(t *testing.T) {
+		model := loadYaml[workload.ModelBooster](t, "testdata/input/model.yaml")
+		serving, err := BuildModelServing(model)
+		require.NoError(t, err)
+
+		data, err := json.Marshal(serving)
+		require.NoError(t, err)
+		assert.NotContains(t, string(data), `"schedulerName"`)
+	})
+
+	t.Run("keeps explicit schedulerName", func(t *testing.T) {
+		model := loadYaml[workload.ModelBooster](t, "testdata/input/model.yaml")
+		model.Spec.Backend.SchedulerName = "volcano"
+
+		serving, err := BuildModelServing(model)
+		require.NoError(t, err)
+
+		data, err := json.Marshal(serving)
+		require.NoError(t, err)
+		assert.Contains(t, string(data), `"schedulerName":"volcano"`)
+	})
 }
 
 func TestBuildCacheVolume(t *testing.T) {

--- a/pkg/model-booster-controller/convert/testdata/expected/model-serving.yaml
+++ b/pkg/model-booster-controller/convert/testdata/expected/model-serving.yaml
@@ -18,7 +18,6 @@ metadata:
       uid: randomUID
 spec:
   replicas: 0
-  schedulerName: ""
   template:
     restartGracePeriodSeconds: 60
     gangPolicy:

--- a/test/e2e/controller-manager/testdata/ModelBooster-autoscaling.yaml
+++ b/test/e2e/controller-manager/testdata/ModelBooster-autoscaling.yaml
@@ -7,6 +7,7 @@ spec:
   backend:
     name: backend1
     type: vLLM
+    schedulerName: default-scheduler
     modelURI: hf://Qwen/Qwen2.5-0.5B-Instruct
     cacheURI: hostpath:///tmp/cache
     replicas: 1


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

When a ModelBooster backend does not set `schedulerName`, the generated ModelServing currently serializes an empty `spec.schedulerName` value. Because the field is present, the Kubernetes API server does not apply the ModelServing CRD default value of `volcano`.

This causes minimal ModelBooster deployments to use the default Kubernetes scheduler instead of the Volcano scheduler, so the expected Volcano scheduling path, including PodGroup creation, is skipped.

This PR adds `omitempty` to `ModelServingSpec.SchedulerName` so an unset scheduler name is omitted from the generated ModelServing request. The API server can then apply the existing CRD default. Explicit scheduler names are still preserved.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

This was found while validating the minimal ModelBooster deployment flow.

The self-healing e2e fixture now explicitly uses `default-scheduler` because that test focuses on child-resource reconciliation rather than Volcano scheduling behavior. Other ModelBooster e2e coverage still exercises the omitted schedulerName path.

AI assistance was used to help prepare and verify this change.

Tested with:

```console
go test ./pkg/model-booster-controller/...
git diff --check
```

**Does this PR introduce a user-facing change?**:

```release-note
ModelBooster-generated ModelServings now omit empty schedulerName values so the existing ModelServing CRD default scheduler can apply.
```
