### PR TITLE
Fix HTTPRoute reconcile after Gateway creation

### DIFF
--- a/pkg/kthena-router/controller/httproute_controller.go
+++ b/pkg/kthena-router/controller/httproute_controller.go
@@ -100,6 +100,15 @@ func NewHTTPRouteController(
 	if _, err = gatewayInformer.Informer().AddEventHandler(gatewayFilter); err != nil {
 		return nil, fmt.Errorf("failed to add gateway event handler for httproute controller: %w", err)
 	}
+	store.RegisterCallback("Gateway", func(data datastore.EventData) {
+		if data.EventType != datastore.EventAdd {
+			return
+		}
+		key := fmt.Sprintf("%s/%s", data.Gateway.Namespace, data.Gateway.Name)
+		if gw := store.GetGateway(key); gw != nil {
+			controller.enqueueHTTPRoutesForGateway(gw)
+		}
+	})
 
 	if _, err = namespaceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    controller.enqueueHTTPRoutesForNamespace,
@@ -187,7 +196,7 @@ func (c *HTTPRouteController) syncHandler(key string) error {
 	}
 
 	// Only process HTTPRoutes that reference kthena-router GatewayClass
-	// Check all parentRefs - process immediately if any matches, retry only if no match and a Gateway is pending
+	// Check all parentRefs - process immediately if any matches, wait for Gateway events if a Gateway is pending
 	var gatewayPending bool
 	for _, parentRef := range httpRoute.Spec.ParentRefs {
 		if !isGatewayParentRef(parentRef) {
@@ -201,9 +210,12 @@ func (c *HTTPRouteController) syncHandler(key string) error {
 		gw := c.store.GetGateway(gatewayKey)
 		if gw == nil {
 			informerGateway, err := c.gatewayLister.Gateways(gatewayNamespace).Get(string(parentRef.Name))
-			if err != nil {
+			if apierrors.IsNotFound(err) {
 				gatewayPending = true
 				continue
+			}
+			if err != nil {
+				return err
 			}
 			gw = informerGateway
 		}
@@ -218,7 +230,7 @@ func (c *HTTPRouteController) syncHandler(key string) error {
 		}
 	}
 	if gatewayPending {
-		return fmt.Errorf("gateway not synced yet")
+		return nil
 	}
 	klog.V(4).Infof("Skipping HTTPRoute %s/%s: does not reference kthena-router Gateway", namespace, name)
 	_ = c.store.DeleteHTTPRoute(key)

--- a/pkg/kthena-router/controller/httproute_controller_test.go
+++ b/pkg/kthena-router/controller/httproute_controller_test.go
@@ -472,8 +472,13 @@ func TestHTTPRouteController_SyncHandler_WaitsForGatewayCreatedLater(t *testing.
 		t.Fatal("cache sync timeout")
 	}
 
+	for ctrl.workqueue.Len() > 0 {
+		obj, _ := ctrl.workqueue.Get()
+		ctrl.workqueue.Done(obj)
+	}
+
 	err = ctrl.syncHandler(ns + "/route")
-	assert.Error(t, err)
+	assert.NoError(t, err)
 	assert.Nil(t, store.GetHTTPRoute(ns+"/route"))
 
 	gw := &gatewayv1.Gateway{
@@ -489,16 +494,14 @@ func TestHTTPRouteController_SyncHandler_WaitsForGatewayCreatedLater(t *testing.
 			},
 		},
 	}
-	_, err = gatewayClient.GatewayV1().Gateways(ns).Create(ctx, gw, metav1.CreateOptions{})
+	err = store.AddOrUpdateGateway(gw)
 	assert.NoError(t, err)
 
 	found := waitForObjectInCache(t, 5*time.Second, func() bool {
-		_, err := ctrl.gatewayLister.Gateways(ns).Get("gateway")
-		return err == nil
+		return ctrl.workqueue.Len() == 1
 	})
-	require.True(t, found, "Gateway should be in cache")
+	require.True(t, found, "Gateway add should enqueue waiting HTTPRoute")
 
-	err = ctrl.syncHandler(ns + "/route")
-	assert.NoError(t, err)
+	assert.True(t, ctrl.processNextWorkItem())
 	assert.Len(t, store.GetHTTPRoutesByGateway(ns+"/gateway"), 1)
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

When an HTTPRoute is created before its referenced Gateway, the route should be reconciled again once that Gateway is added.

This updates the HTTPRoute controller to requeue matching HTTPRoutes from the Gateway add path, and keeps the missing-Gateway case pending instead of treating it as a sync failure.

**Which issue(s) this PR fixes**:
Fixes #1296

**Special notes for your reviewer**:

NONE

**Does this PR introduce a user-facing change?**:
```release-note
NONE