### PR TITLE
model-booster: handle unavailable vllm metrics on prestop

### DIFF
--- a/pkg/model-booster-controller/convert/model_serving_test.go
+++ b/pkg/model-booster-controller/convert/model_serving_test.go
@@ -356,6 +356,31 @@ func TestCreateModelServingResources(t *testing.T) {
 	}
 }
 
+func TestBuildModelServingVLLMPreStopHandlesUnavailableMetrics(t *testing.T) {
+	model := loadYaml[workload.ModelBooster](t, "testdata/input/model.yaml")
+	serving, err := BuildModelServing(model)
+	require.NoError(t, err)
+	require.NotEmpty(t, serving.Spec.Template.Roles)
+
+	var engine *corev1.Container
+	for i := range serving.Spec.Template.Roles[0].EntryTemplate.Spec.Containers {
+		container := &serving.Spec.Template.Roles[0].EntryTemplate.Spec.Containers[i]
+		if container.Name == "engine" {
+			engine = container
+			break
+		}
+	}
+	require.NotNil(t, engine)
+	require.NotNil(t, engine.Lifecycle)
+	require.NotNil(t, engine.Lifecycle.PreStop)
+	require.NotNil(t, engine.Lifecycle.PreStop.Exec)
+	require.Len(t, engine.Lifecycle.PreStop.Exec.Command, 3)
+
+	script := engine.Lifecycle.PreStop.Exec.Command[2]
+	assert.Contains(t, script, "curl -fsS --max-time 2 http://localhost:8000/metrics")
+	assert.Contains(t, script, "Metrics endpoint unavailable, exiting preStop")
+}
+
 func TestBuildModelServingSkipEngineDependencyInstall(t *testing.T) {
 	tests := []struct {
 		name              string

--- a/pkg/model-booster-controller/convert/model_serving_test.go
+++ b/pkg/model-booster-controller/convert/model_serving_test.go
@@ -363,10 +363,15 @@ func TestBuildModelServingVLLMPreStopHandlesUnavailableMetrics(t *testing.T) {
 	require.NotEmpty(t, serving.Spec.Template.Roles)
 
 	var engine *corev1.Container
-	for i := range serving.Spec.Template.Roles[0].EntryTemplate.Spec.Containers {
-		container := &serving.Spec.Template.Roles[0].EntryTemplate.Spec.Containers[i]
-		if container.Name == "engine" {
-			engine = container
+	for roleIndex := range serving.Spec.Template.Roles {
+		for containerIndex := range serving.Spec.Template.Roles[roleIndex].EntryTemplate.Spec.Containers {
+			container := &serving.Spec.Template.Roles[roleIndex].EntryTemplate.Spec.Containers[containerIndex]
+			if container.Name == "engine" {
+				engine = container
+				break
+			}
+		}
+		if engine != nil {
 			break
 		}
 	}
@@ -377,8 +382,10 @@ func TestBuildModelServingVLLMPreStopHandlesUnavailableMetrics(t *testing.T) {
 	require.Len(t, engine.Lifecycle.PreStop.Exec.Command, 3)
 
 	script := engine.Lifecycle.PreStop.Exec.Command[2]
-	assert.Contains(t, script, "curl -fsS --max-time 2 http://localhost:8000/metrics")
+	assert.Contains(t, script, "curl -s --max-time 2 http://localhost:8000/metrics")
+	assert.Contains(t, script, `if [ -z "$RUNNING" ]; then`)
 	assert.Contains(t, script, "Metrics endpoint unavailable, exiting preStop")
+	assert.NotContains(t, script, "$ERR")
 }
 
 func TestBuildModelServingSkipEngineDependencyInstall(t *testing.T) {

--- a/pkg/model-booster-controller/convert/templates/vllm.yaml
+++ b/pkg/model-booster-controller/convert/templates/vllm.yaml
@@ -78,8 +78,12 @@ spec:
                         - -c
                         - |
                           while true; do
-                            RUNNING=$(curl -s http://localhost:8000/metrics | grep 'vllm:num_requests_running' | grep -v '#' | awk '{print $2}')
-                            WAITING=$(curl -s http://localhost:8000/metrics | grep 'vllm:num_requests_waiting' | grep -v '#' | awk '{print $2}')
+                            if ! METRICS=$(curl -fsS --max-time 2 http://localhost:8000/metrics 2>/dev/null); then
+                              echo "Terminating: Metrics endpoint unavailable, exiting preStop" >> /proc/1/fd/1
+                              exit 0
+                            fi
+                            RUNNING=$(echo "$METRICS" | grep 'vllm:num_requests_running' | grep -v '#' | awk '{print $2}' || true)
+                            WAITING=$(echo "$METRICS" | grep 'vllm:num_requests_waiting' | grep -v '#' | awk '{print $2}' || true)
                             if [ "$RUNNING" = "0.0" ] && [ "$WAITING" = "0.0" ]; then
                               echo "Terminating: No active or waiting requests, safe to terminate" >> /proc/1/fd/1
                               exit 0

--- a/pkg/model-booster-controller/convert/templates/vllm.yaml
+++ b/pkg/model-booster-controller/convert/templates/vllm.yaml
@@ -78,12 +78,13 @@ spec:
                         - -c
                         - |
                           while true; do
-                            if ! METRICS=$(curl -fsS --max-time 2 http://localhost:8000/metrics 2>/dev/null); then
+                            METRICS=$(curl -s --max-time 2 http://localhost:8000/metrics)
+                            RUNNING=$(echo "$METRICS" | grep 'vllm:num_requests_running' | grep -v '#' | awk '{print $2}' || true)
+                            WAITING=$(echo "$METRICS" | grep 'vllm:num_requests_waiting' | grep -v '#' | awk '{print $2}' || true)
+                            if [ -z "$RUNNING" ]; then
                               echo "Terminating: Metrics endpoint unavailable, exiting preStop" >> /proc/1/fd/1
                               exit 0
                             fi
-                            RUNNING=$(echo "$METRICS" | grep 'vllm:num_requests_running' | grep -v '#' | awk '{print $2}' || true)
-                            WAITING=$(echo "$METRICS" | grep 'vllm:num_requests_waiting' | grep -v '#' | awk '{print $2}' || true)
                             if [ "$RUNNING" = "0.0" ] && [ "$WAITING" = "0.0" ]; then
                               echo "Terminating: No active or waiting requests, safe to terminate" >> /proc/1/fd/1
                               exit 0

--- a/pkg/model-booster-controller/convert/testdata/expected/model-serving.yaml
+++ b/pkg/model-booster-controller/convert/testdata/expected/model-serving.yaml
@@ -115,8 +115,12 @@ spec:
                         - -c
                         - |
                           while true; do
-                            RUNNING=$(curl -s http://localhost:8000/metrics | grep 'vllm:num_requests_running' | grep -v '#' | awk '{print $2}')
-                            WAITING=$(curl -s http://localhost:8000/metrics | grep 'vllm:num_requests_waiting' | grep -v '#' | awk '{print $2}')
+                            if ! METRICS=$(curl -fsS --max-time 2 http://localhost:8000/metrics 2>/dev/null); then
+                              echo "Terminating: Metrics endpoint unavailable, exiting preStop" >> /proc/1/fd/1
+                              exit 0
+                            fi
+                            RUNNING=$(echo "$METRICS" | grep 'vllm:num_requests_running' | grep -v '#' | awk '{print $2}' || true)
+                            WAITING=$(echo "$METRICS" | grep 'vllm:num_requests_waiting' | grep -v '#' | awk '{print $2}' || true)
                             if [ "$RUNNING" = "0.0" ] && [ "$WAITING" = "0.0" ]; then
                               echo "Terminating: No active or waiting requests, safe to terminate" >> /proc/1/fd/1
                               exit 0

--- a/pkg/model-booster-controller/convert/testdata/expected/model-serving.yaml
+++ b/pkg/model-booster-controller/convert/testdata/expected/model-serving.yaml
@@ -115,12 +115,13 @@ spec:
                         - -c
                         - |
                           while true; do
-                            if ! METRICS=$(curl -fsS --max-time 2 http://localhost:8000/metrics 2>/dev/null); then
+                            METRICS=$(curl -s --max-time 2 http://localhost:8000/metrics)
+                            RUNNING=$(echo "$METRICS" | grep 'vllm:num_requests_running' | grep -v '#' | awk '{print $2}' || true)
+                            WAITING=$(echo "$METRICS" | grep 'vllm:num_requests_waiting' | grep -v '#' | awk '{print $2}' || true)
+                            if [ -z "$RUNNING" ]; then
                               echo "Terminating: Metrics endpoint unavailable, exiting preStop" >> /proc/1/fd/1
                               exit 0
                             fi
-                            RUNNING=$(echo "$METRICS" | grep 'vllm:num_requests_running' | grep -v '#' | awk '{print $2}' || true)
-                            WAITING=$(echo "$METRICS" | grep 'vllm:num_requests_waiting' | grep -v '#' | awk '{print $2}' || true)
                             if [ "$RUNNING" = "0.0" ] && [ "$WAITING" = "0.0" ]; then
                               echo "Terminating: No active or waiting requests, safe to terminate" >> /proc/1/fd/1
                               exit 0


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

ModelBooster's generated vLLM `preStop` hook waits for
`vllm:num_requests_running` and `vllm:num_requests_waiting` from
`http://localhost:8000/metrics` before allowing the engine container to exit.

When the vLLM process is running but has not opened port 8000, the old hook
keeps looping until Kubernetes reaches the pod termination grace period. This
can make pod or namespace cleanup wait for several minutes even though there is
no metrics endpoint to drain from.

This PR makes the generated vLLM `preStop` hook exit immediately when the
metrics endpoint is unavailable. When metrics are available, the existing drain
behavior is preserved: the hook still waits until both running and waiting
request counters are `0.0`.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

This is intentionally scoped to the observed failure mode where `/metrics` is
unreachable. It does not treat missing metric counters as zero, because a
reachable metrics endpoint with missing or renamed counters may indicate an
unexpected metrics format and should not silently bypass draining.

Local reproduction evidence from Docker Desktop, Kubernetes `v1.36.1`, arm64:

1. A tiny ModelBooster deployment generated the expected resources:

   ```text
   modelbooster.workload.serving.volcano.sh/smoke-tiny
   modelserving.workload.serving.volcano.sh/smoke-tiny-backend1
   modelserver.networking.serving.volcano.sh/smoke-tiny-backend1
   modelroute.networking.serving.volcano.sh/smoke-tiny
   podgroup.scheduling.volcano.sh/smoke-tiny-backend1-0   Running   1   1
   pod/smoke-tiny-backend1-0-leader-0-0                  1/2       Running
   ```

2. The downloader completed successfully:

   ```text
   Args:
     --source
     hf://sshleifer/tiny-gpt2
     --output-dir
     /tmp/kthena-smoke-tiny-20260708-a/67f7503e5881cc76a109e9c35f33735e

   State:
     Reason: Completed
     Exit Code: 0
     Started:  2026-07-08T07:16:16Z
     Finished: 2026-07-08T07:16:25Z
   ```

3. The runtime container became healthy, but the engine container did not:

   ```text
   runtime=true,{"running":{"startedAt":"2026-07-08T07:17:25Z"}}
   engine=false,{"running":{"startedAt":"2026-07-08T07:17:59Z"}}
   ```

4. The engine readiness probe failed because port 8000 was not listening:

   ```text
   Readiness probe failed:
   Get "http://10.244.1.15:8000/health":
   dial tcp 10.244.1.15:8000: connect: connection refused
   ```

5. A socket check from inside the pod showed the same thing:

   ```text
   port 8000: ConnectionRefusedError: [Errno 111] Connection refused
   port 8100: open
   port 5557: ConnectionRefusedError: [Errno 111] Connection refused
   ```

6. The vLLM engine logs stopped during initialization and never reached a
   serving/listening log line:

   ```text
   version 0.24.0
   non-default args: {'model': '/tmp/kthena-smoke-tiny-20260708-a/67f7503e5881cc76a109e9c35f33735e', 'dtype': 'float32', 'max_model_len': 128, 'served_model_name': ['tiny-gpt2'], 'block_size': 32, 'max_num_batched_tokens': 256}
   Resolved architecture: GPT2LMHeadModel
   Using max model len 128
   Chunked prefill is enabled with max_num_batched_tokens=256.
   Asynchronous scheduling is enabled.
   Final IR op priority after setting platform defaults: IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native'])
   ```

7. A direct vLLM control pod using the same image, same model path, and same
   vLLM args reproduced the same behavior without ModelBooster, the Kthena
   runtime sidecar, or `VLLM_USE_V1`:

   ```text
   port 8000: ConnectionRefusedError: [Errno 111] Connection refused
   port 5557: ConnectionRefusedError: [Errno 111] Connection refused
   ```

   This suggests the engine startup issue itself is specific to the selected
   local vLLM CPU image/model/arm64 environment. This PR does not try to fix
   that. It only prevents the generated `preStop` hook from waiting on a
   metrics endpoint that never came up.

8. Namespace deletion was delayed while the generated pods stayed terminating:

   ```text
   delete-start 2026-07-08T07:31:24Z
   delete-end   2026-07-08T07:37:51Z
   ```

   Total deletion time was about 6m27s. During deletion:

   ```text
   pod/smoke-tiny-backend1-0-leader-0-0         0/2   Terminating
   pod/smoke-tiny-reuse-backend1-0-leader-0-0   0/2   Terminating
   ```

Testing:

```bash
go test ./pkg/model-booster-controller/convert
```

Prepared with AI assistance and reviewed before submission.

**Does this PR introduce a user-facing change?**:

```release-note
Fix vLLM ModelBooster generated pods hanging during termination when the engine metrics endpoint is unavailable.
```
