### PR TITLE
fix(backend): propagate error from GetMetricsProvider in GetPodModels

### DIFF
--- a/pkg/kthena-router/backend/backend.go
+++ b/pkg/kthena-router/backend/backend.go
@@ -75,7 +75,7 @@ func GetPodModels(engine string, pod *corev1.Pod, port uint32) ([]string, error)
 	provider, err := GetMetricsProvider(engine)
 	if err != nil {
 		klog.Errorf("Failed to get inference engine: %v", err)
-		return nil, nil
+		return nil, err
 	}
 
 	return provider.GetPodModels(pod, port)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`GetPodModels()` at `pkg/kthena-router/backend/backend.go:78` returns `(nil, nil)` when `GetMetricsProvider` fails for an unsupported inference engine. The caller at `pkg/kthena-router/datastore/store.go:1557` checks `err != nil` — since `err` is nil, the error handling branch is silently bypassed and `podInfo.UpdateModels(nil)` executes instead. The pod is treated as having no models with no error propagated.

**Which issue(s) this PR fixes**:

Fixes #1320

**Special notes for your reviewer**:

One-line change. The `klog.Errorf` on line 77 is intentionally kept — logging the error before returning follows defensive Go practice.

**Does this PR introduce a user-facing change?**:

```release-note
Fixed GetPodModels to propagate engine lookup errors to the caller instead of silently falling through to UpdateModels(nil)
```
