### PR TITLE
router: refresh ModelRoute indexes on update

### DIFF
--- a/pkg/kthena-router/datastore/store.go
+++ b/pkg/kthena-router/datastore/store.go
@@ -1172,6 +1172,8 @@ func (s *store) DeletePod(podName types.NamespacedName) error {
 func (s *store) AddOrUpdateModelRoute(mr *aiv1alpha1.ModelRoute) error {
 	s.routeMutex.Lock()
 	key := mr.Namespace + "/" + mr.Name
+	_, _, queueCleanupCandidates := s.removeModelRouteFromIndexesLocked(key)
+
 	s.routeInfo[key] = &modelRouteInfo{
 		model: mr.Spec.ModelName,
 		loras: mr.Spec.LoraAdapters,
@@ -1234,7 +1236,15 @@ func (s *store) AddOrUpdateModelRoute(mr *aiv1alpha1.ModelRoute) error {
 		}
 	}
 
+	var queuesToClean []string
+	for _, name := range queueCleanupCandidates {
+		if len(s.routes[name]) == 0 && len(s.loraRoutes[name]) == 0 {
+			queuesToClean = append(queuesToClean, name)
+		}
+	}
 	s.routeMutex.Unlock()
+
+	s.cleanRequestWaitingQueues(queuesToClean)
 
 	s.triggerCallbacks("ModelRoute", EventData{
 		EventType:  EventUpdate,
@@ -1244,27 +1254,12 @@ func (s *store) AddOrUpdateModelRoute(mr *aiv1alpha1.ModelRoute) error {
 	return nil
 }
 
-func sortModelRoutesInPlace(routes []*aiv1alpha1.ModelRoute) {
-	sort.Slice(routes, func(i, j int) bool {
-		ti, tj := routes[i].CreationTimestamp.Time, routes[j].CreationTimestamp.Time
-		if !ti.Equal(tj) {
-			return ti.Before(tj)
-		}
-		ri, rj := routes[i].ResourceVersion, routes[j].ResourceVersion
-		if ri != rj {
-			return ri < rj
-		}
-		return routes[i].Namespace+"/"+routes[i].Name < routes[j].Namespace+"/"+routes[j].Name
-	})
-}
-
-func (s *store) DeleteModelRoute(namespacedName string) error {
-	s.routeMutex.Lock()
+func (s *store) removeModelRouteFromIndexesLocked(namespacedName string) (string, *aiv1alpha1.ModelRoute, []string) {
 	info := s.routeInfo[namespacedName]
 	var modelName string
 	var deletedRoute *aiv1alpha1.ModelRoute
 	// Collect all model/lora names that may have associated queues (for cleanup after unlock)
-	var namesToCleanQueue []string
+	var queueCleanupCandidates []string
 	if info != nil {
 		modelName = info.model
 		// Remove from routes map
@@ -1281,7 +1276,7 @@ func (s *store) DeleteModelRoute(namespacedName string) error {
 			}
 			if len(newRoutes) == 0 {
 				delete(s.routes, modelName)
-				namesToCleanQueue = append(namesToCleanQueue, modelName)
+				queueCleanupCandidates = append(queueCleanupCandidates, modelName)
 			} else {
 				s.routes[modelName] = newRoutes
 			}
@@ -1300,7 +1295,7 @@ func (s *store) DeleteModelRoute(namespacedName string) error {
 			}
 			if len(newLoraRoutes) == 0 {
 				delete(s.loraRoutes, lora)
-				namesToCleanQueue = append(namesToCleanQueue, lora)
+				queueCleanupCandidates = append(queueCleanupCandidates, lora)
 			} else {
 				s.loraRoutes[lora] = newLoraRoutes
 			}
@@ -1328,11 +1323,11 @@ func (s *store) DeleteModelRoute(namespacedName string) error {
 		}
 	}
 
-	delete(s.routeInfo, namespacedName)
-	s.routeMutex.Unlock()
+	return modelName, deletedRoute, queueCleanupCandidates
+}
 
-	// Clean up associated waiting queues for both base model and all lora adapters
-	for _, name := range namesToCleanQueue {
+func (s *store) cleanRequestWaitingQueues(names []string) {
+	for _, name := range names {
 		val, _ := s.requestWaitingQueue.LoadAndDelete(name)
 		if val != nil {
 			queue, _ := val.(*RequestPriorityQueue)
@@ -1340,6 +1335,30 @@ func (s *store) DeleteModelRoute(namespacedName string) error {
 			klog.Infof("deleted waiting queue for model %s", name)
 		}
 	}
+}
+
+func sortModelRoutesInPlace(routes []*aiv1alpha1.ModelRoute) {
+	sort.Slice(routes, func(i, j int) bool {
+		ti, tj := routes[i].CreationTimestamp.Time, routes[j].CreationTimestamp.Time
+		if !ti.Equal(tj) {
+			return ti.Before(tj)
+		}
+		ri, rj := routes[i].ResourceVersion, routes[j].ResourceVersion
+		if ri != rj {
+			return ri < rj
+		}
+		return routes[i].Namespace+"/"+routes[i].Name < routes[j].Namespace+"/"+routes[j].Name
+	})
+}
+
+func (s *store) DeleteModelRoute(namespacedName string) error {
+	s.routeMutex.Lock()
+	modelName, deletedRoute, queueCleanupCandidates := s.removeModelRouteFromIndexesLocked(namespacedName)
+	delete(s.routeInfo, namespacedName)
+	s.routeMutex.Unlock()
+
+	// Clean up associated waiting queues for both base model and all lora adapters
+	s.cleanRequestWaitingQueues(queueCleanupCandidates)
 
 	// Trigger callbacks outside the lock to avoid potential deadlocks
 	s.triggerCallbacks("ModelRoute", EventData{

--- a/pkg/kthena-router/datastore/store_test.go
+++ b/pkg/kthena-router/datastore/store_test.go
@@ -1703,6 +1703,71 @@ func newStore(inspector ...PodRuntimeInspector) *store {
 	return New(WithPodRuntimeInspector(inspector[0])).(*store)
 }
 
+func TestAddOrUpdateModelRoute_UpdatesLoraRoutes(t *testing.T) {
+	s := newStore()
+
+	mr := &aiv1alpha1.ModelRoute{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "route"},
+		Spec: aiv1alpha1.ModelRouteSpec{
+			ModelName:    "llama",
+			LoraAdapters: []string{"math-lora"},
+			Rules: []*aiv1alpha1.Rule{
+				{Name: "r", TargetModels: []*aiv1alpha1.TargetModel{{ModelServerName: "math-server", Weight: ptr(uint32(100))}}},
+			},
+		},
+	}
+	assert.NoError(t, s.AddOrUpdateModelRoute(mr))
+	s.requestWaitingQueue.Store("llama", NewRequestPriorityQueue(nil))
+	s.requestWaitingQueue.Store("math-lora", NewRequestPriorityQueue(nil))
+
+	mr = mr.DeepCopy()
+	mr.Spec.LoraAdapters = []string{"code-lora"}
+	mr.Spec.Rules[0].TargetModels[0].ModelServerName = "code-server"
+	assert.NoError(t, s.AddOrUpdateModelRoute(mr))
+
+	req := &http.Request{URL: &url.URL{Path: "/v1/chat/completions"}}
+	_, _, _, err := s.MatchModelTarget("math-lora", req, "")
+	assert.Error(t, err)
+
+	target, isLora, _, err := s.MatchModelTarget("code-lora", req, "")
+	assert.NoError(t, err)
+	assert.True(t, isLora)
+	assert.Equal(t, ModelTargetKindModelServer, target.Kind)
+	assert.Equal(t, types.NamespacedName{Namespace: "default", Name: "code-server"}, target.Name)
+
+	_, exists := s.requestWaitingQueue.Load("llama")
+	assert.True(t, exists)
+	_, exists = s.requestWaitingQueue.Load("math-lora")
+	assert.False(t, exists)
+}
+
+func TestAddOrUpdateModelRoute_UpdatesGatewayRoutes(t *testing.T) {
+	s := newStore()
+	kindGateway := gatewayv1.Kind("Gateway")
+
+	mr := &aiv1alpha1.ModelRoute{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "route"},
+		Spec: aiv1alpha1.ModelRouteSpec{
+			ModelName:  "llama",
+			ParentRefs: []gatewayv1.ParentReference{{Name: "gateway-a", Kind: &kindGateway}},
+			Rules: []*aiv1alpha1.Rule{
+				{Name: "r", TargetModels: []*aiv1alpha1.TargetModel{{ModelServerName: "server-a", Weight: ptr(uint32(100))}}},
+			},
+		},
+	}
+	assert.NoError(t, s.AddOrUpdateModelRoute(mr))
+
+	mr = mr.DeepCopy()
+	mr.Spec.ParentRefs = []gatewayv1.ParentReference{{Name: "gateway-b", Kind: &kindGateway}}
+	assert.NoError(t, s.AddOrUpdateModelRoute(mr))
+
+	s.routeMutex.RLock()
+	_, exists := s.gatewayModelRoutes["default/gateway-a"]
+	assert.False(t, exists)
+	assert.True(t, s.gatewayModelRoutes["default/gateway-b"].Contains("default/route"))
+	s.routeMutex.RUnlock()
+}
+
 func TestAddOrUpdateHTTPRoute_UpdatesGatewayRoutes(t *testing.T) {
 	s := newStore()
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Refreshes ModelRoute indexes before storing an updated route.

Without this, updating a ModelRoute can leave stale entries in the old model, LoRA, or gateway indexes. A removed LoRA adapter or old parentRef may still match after the route has been updated.

**Which issue(s) this PR fixes**:
Fixes #N/A

**Special notes for your reviewer**:

Adds regression coverage for updating LoRA adapters and gateway parentRefs on the same ModelRoute.

**Does this PR introduce a user-facing change?**:

```release-note
NONE