### PR TITLE
examples: make Qwen CPU ModelBooster work on arm64

### DIFF
--- a/docs/kthena/docs/assets/examples/model-booster/Qwen2.5-0.5B-Instruct.yaml
+++ b/docs/kthena/docs/assets/examples/model-booster/Qwen2.5-0.5B-Instruct.yaml
@@ -14,15 +14,19 @@ spec:
         value: "https://hf-mirror.com"
     workers:
       - type: "server"
-        image: "public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:latest" # This model will run on CPU, for more details visit https://docs.vllm.ai/en/stable/getting_started/installation/cpu.html#pre-built-images
+        image: "vllm/vllm-openai-cpu:latest" # This model will run on CPU, for more details visit https://docs.vllm.ai/en/stable/getting_started/installation/cpu.html#pre-built-images
         replicas: 1
         pods: 1
         config:
           served-model-name: "Qwen2.5-0.5B-Instruct"
-          max-model-len: 32768
-          max-num-batched-tokens: 65536
+          dtype: float16
+          max-model-len: 2048
+          max-num-batched-tokens: 512
+          max-num-seqs: 1
           block-size: 128
+          gpu-memory-utilization: 0.35
           enable-prefix-caching: ""
+          enforce-eager: ""
         resources:
           limits:
             cpu: "4"

--- a/examples/model-booster/Qwen2.5-0.5B-Instruct.yaml
+++ b/examples/model-booster/Qwen2.5-0.5B-Instruct.yaml
@@ -14,15 +14,19 @@ spec:
         value: "https://huggingface.co"
     workers:
       - type: "server"
-        image: "public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:latest" # This model will run on CPU, for more details visit https://docs.vllm.ai/en/stable/getting_started/installation/cpu.html#pre-built-images
+        image: "vllm/vllm-openai-cpu:latest" # This model will run on CPU, for more details visit https://docs.vllm.ai/en/stable/getting_started/installation/cpu.html#pre-built-images
         replicas: 1
         pods: 1
         config:
           served-model-name: "Qwen2.5-0.5B-Instruct"
-          max-model-len: 32768
-          max-num-batched-tokens: 65536
+          dtype: float16
+          max-model-len: 2048
+          max-num-batched-tokens: 512
+          max-num-seqs: 1
           block-size: 128
+          gpu-memory-utilization: 0.35
           enable-prefix-caching: ""
+          enforce-eager: ""
         resources:
           limits:
             cpu: "4"


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Updates the Qwen2.5-0.5B-Instruct ModelBooster example to use the official multi-architecture vLLM CPU image and a bounded CPU configuration that fits an 8Gi local arm64 worker. The current example uses an amd64-only image and oversized 32K context/batching settings, which prevent the documented local flow from completing on Apple Silicon Docker Desktop.

The documentation asset is updated with the same serving configuration so the rendered quick start matches the downloadable example.

**Which issue(s) this PR fixes**:
Fixes #612

**Special notes for your reviewer**:

Validated on Docker Desktop `linux/arm64` with an 8Gi worker and the real `Qwen/Qwen2.5-0.5B-Instruct` model.

Architecture and end-to-end result:

- Kubernetes selected the native arm64 image digest `sha256:6131639f0809b2d6f8ac6a60f2bf0b8ca89164c8a99dc272cb0af6f91332d818` for `vllm/vllm-openai-cpu:latest`.
- The engine reported vLLM `0.24.0`, resolved `Qwen2ForCausalLM`, and started without SIGILL.
- The final Pod reached `2/2 Ready` with zero restarts, and the ModelBooster reached `Active=True` with reason `ModelAvailable`.
- Router `GET /v1/models` returned HTTP 200 with model id `qwen`.
- Router `POST /v1/chat/completions` returned HTTP 200 from `Qwen2.5-0.5B-Instruct`; a four-token response generated `Hello! How can` with prompt/completion/total token counts `30/4/34`.

CPU dtype and memory observations from the same image:

- The image's Linux aarch64 CPU platform lists `torch.float16`, `torch.bfloat16`, and `torch.float32` as supported dtypes. The successful engine log reported `dtype=torch.float16`; it did not cast FP16 to FP32.
- On this arm64 Docker Desktop worker, BF16 used a BLAS fallback. Its warmup took about `54-56s` and non-KV usage was about `2.40 GiB`.
- The final FP16 run initialized the engine in `7.85s`, with about `1.94 GiB` non-KV usage and `0.77 GiB` KV cache.
- At the default CPU memory utilization (`0.92`), vLLM requested about `7.13 GiB` while only about `3.02 GiB` was available, so startup failed.
- In vLLM's CPU worker, `gpu-memory-utilization` controls the fraction of CPU memory reserved despite its name. At `0.35`, the successful run requested `2.71 GiB` total worker memory.
- The successful run also used `enforce-eager`; the engine log confirmed that it disabled `torch.compile`. A previous non-eager AOT warmup with the original 32K/65K settings triggered a node OOM.

The first model transfer was pre-seeded from the equivalent ModelScope artifact after a slow Hugging Face transfer. The `model.safetensors` SHA-256 (`fdf756fa7fcbe7404d5c60e26bff1a0c8b8aa1f72ced49e7dd0210fe288fb7fe`) matched the Hugging Face LFS object, and the Kthena downloader subsequently validated all 10 model files.

AI assistance was used to investigate and prepare this change. I reviewed the final diff and verified the reported results.

Tested with:
```console
kubectl apply --dry-run=server -f examples/model-booster/Qwen2.5-0.5B-Instruct.yaml
kubectl apply --dry-run=server -f docs/kthena/docs/assets/examples/model-booster/Qwen2.5-0.5B-Instruct.yaml
make test-docs
# Docker Desktop linux/arm64: real Qwen ModelBooster became Active; router GET /v1/models and POST /v1/chat/completions returned 200
```

**Does this PR introduce a user-facing change?**:
```release-note
The Qwen2.5-0.5B-Instruct ModelBooster example now uses the official multi-architecture vLLM CPU image and CPU settings validated on an 8Gi arm64 node.
```
