### PR TITLE
feat: add debug containerPort for kthena-router when debugPort is set

### DIFF
--- a/charts/kthena/charts/networking/templates/kthena-router/component/deployment.yaml
+++ b/charts/kthena/charts/networking/templates/kthena-router/component/deployment.yaml
@@ -50,10 +50,15 @@ spec:
           ports:
             - containerPort: {{ .Values.kthenaRouter.port }}
               name: http
-          {{- if .Values.kthenaRouter.webhook.enabled }}
+            {{- if .Values.kthenaRouter.webhook.enabled }}
             - containerPort: {{ .Values.kthenaRouter.webhook.port }}
               name: webhook
-          {{- end }}
+            {{- end }}
+            {{- if .Values.kthenaRouter.debugPort }}
+            - containerPort: {{ int .Values.kthenaRouter.debugPort }}
+              name: debug
+              protocol: TCP
+            {{- end }}
           env:
             - name: POD_NAMESPACE
               valueFrom:


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement

---

**What this PR does / why we need it**:

Adds debug containerPort to kthena-router deployment when `kthenaRouter.debugPort` is set.

The router already listens on debug port for pprof endpoints (`/debug/pprof/*`), but the port was not declared in the Pod spec. This makes profiling workflows easier without manual patches.

---

**Which issue(s) this PR fixes**:
Fixes #1276

---

**Special notes for your reviewer**:

- The debug server is localhost-only (no external Service added for security)
- Uses `ne .debugPort 0.0` to handle Helm's float64 type comparison
- Backward compatible - no debug port when `debugPort` is 0 or not set

**Testing done**:
```bash
# Test with debug port
helm template kthena ./charts/kthena --set kthenaRouter.debugPort=15000
#  Shows containerPort: 15000

# Test without debug port  
helm template kthena ./charts/kthena
#  No debug port

# Helm lint
helm lint ./charts/kthena
#  0 charts failed
Does this PR introduce a user-facing change?:

Add debug containerPort to kthena-router deployment when `kthenaRouter.debugPort` is set, making pprof profiling endpoints accessible without manual patches.
text