### PR TITLE
fix(router): respect ModelRoute Gateway parent refs

### DIFF
--- a/pkg/kthena-router/datastore/store.go
+++ b/pkg/kthena-router/datastore/store.go
@@ -1357,6 +1357,10 @@ func (s *store) matchesSpecificGateway(mr *aiv1alpha1.ModelRoute, gatewayKey str
 	}
 
 	for _, parentRef := range mr.Spec.ParentRefs {
+		if !isGatewayParentRef(parentRef) {
+			continue
+		}
+
 		// Get namespace from parentRef, default to ModelRoute's namespace
 		namespace := mr.Namespace
 		if parentRef.Namespace != nil {

--- a/pkg/kthena-router/datastore/store_test.go
+++ b/pkg/kthena-router/datastore/store_test.go
@@ -2039,6 +2039,7 @@ func TestMatchModelServer_EmptyTargetModels_FallsThrough(t *testing.T) {
 
 func TestMatchModelServer_GatewayScoped(t *testing.T) {
 	kindGateway := gatewayv1.Kind("Gateway")
+	kindService := gatewayv1.Kind("Service")
 	sectionHTTPS := gatewayv1.SectionName("https")
 	sectionNonexistent := gatewayv1.SectionName("nonexistent-listener")
 
@@ -2078,6 +2079,31 @@ func TestMatchModelServer_GatewayScoped(t *testing.T) {
 			expectedServer: types.NamespacedName{Namespace: "default", Name: "llama3-server"},
 			expectedIsLora: false,
 			expectedError:  false,
+		},
+		{
+			name: "route skipped for non-gateway parentRef kind",
+			setupStore: func() *store {
+				s := newStore()
+				s.AddOrUpdateGateway(&gatewayv1.Gateway{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "my-gateway"},
+					Spec:       gatewayv1.GatewaySpec{Listeners: []gatewayv1.Listener{{Name: "http"}}},
+				})
+				s.AddOrUpdateModelRoute(&aiv1alpha1.ModelRoute{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "route-a"},
+					Spec: aiv1alpha1.ModelRouteSpec{
+						ModelName:  "llama3",
+						ParentRefs: []gatewayv1.ParentReference{{Name: "my-gateway", Kind: &kindService}},
+						Rules: []*aiv1alpha1.Rule{
+							{Name: "r", TargetModels: []*aiv1alpha1.TargetModel{{ModelServerName: "llama3-server", Weight: ptr(uint32(100))}}},
+						},
+					},
+				})
+				return s
+			},
+			modelName:     "llama3",
+			gatewayKey:    "default/my-gateway",
+			request:       &http.Request{URL: &url.URL{Path: "/v1/chat/completions"}},
+			expectedError: true,
 		},
 		{
 			name: "route skipped for different gateway",


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

ModelRoute gateway matching was only checking the parentRef namespace/name. That meant a parentRef with a non-Gateway kind could still match a Gateway if the name was the same.

This reuses the existing Gateway parentRef check before matching ModelRoute parentRefs.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Added a regression test for a ModelRoute parentRef with `kind: Service` not matching a Gateway with the same name.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
