### PR TITLE
 test: stabilize controller-manager E2E by preloading vLLM image and avoiding unnecessary image pulls

### DIFF
--- a/test/e2e/controller-manager/model_booster_test.go
+++ b/test/e2e/controller-manager/model_booster_test.go
@@ -36,6 +36,14 @@ import (
 const (
 	testDataDir                   = "test/e2e/controller-manager/testdata"
 	modelBoosterTestSchedulerName = "volcano"
+
+	// modelActiveWaitTimeout bounds the wait for a real vLLM backend to become Active.
+	// It covers the model-downloader init container fetching the model plus the engine's
+	// own cold start, so it is intentionally larger than the other Eventually calls in this
+	// file that only wait on controller reconciliation. Preloading the engine image (see
+	// test/e2e/setup.sh) removes the image-pull portion of that wait; this margin covers
+	// the remaining Hugging Face model download and vLLM engine startup.
+	modelActiveWaitTimeout = 7 * time.Minute
 )
 
 // TestModelCR creates a ModelBooster CR from YAML, waits for it to become active,
@@ -67,7 +75,7 @@ func TestModelCR(t *testing.T) {
 		}
 		return meta.IsStatusConditionPresentAndEqual(m.Status.Conditions,
 			string(workload.ModelStatusConditionTypeActive), metav1.ConditionTrue)
-	}, 5*time.Minute, 5*time.Second, "Model did not become Active")
+	}, modelActiveWaitTimeout, 5*time.Second, "Model did not become Active")
 
 	// Test chat via port-forward
 	messages := []utils.ChatMessage{
@@ -263,7 +271,7 @@ func TestModelBoosterSelfHealing(t *testing.T) {
 		}
 		return meta.IsStatusConditionPresentAndEqual(m.Status.Conditions,
 			string(workload.ModelStatusConditionTypeActive), metav1.ConditionTrue)
-	}, 5*time.Minute, 5*time.Second, "Model did not become Active")
+	}, modelActiveWaitTimeout, 5*time.Second, "Model did not become Active")
 
 	t.Log("Model is active. Testing self-healing of ModelServing...")
 

--- a/test/e2e/controller-manager/testdata/ModelBooster-autoscaling.yaml
+++ b/test/e2e/controller-manager/testdata/ModelBooster-autoscaling.yaml
@@ -13,7 +13,9 @@ spec:
     replicas: 1
     workers:
     - type: server
-      image: ghcr.io/huntersman/vllm-cpu-env:latest
+      # Pinned to a non-"latest" tag so Kubernetes defaults imagePullPolicy to
+      # IfNotPresent, matching what test/e2e/setup.sh preloads into Kind.
+      image: ghcr.io/huntersman/vllm-cpu-env:main
       replicas: 1
       pods: 1
       config:

--- a/test/e2e/controller-manager/testdata/ModelBooster-vllm.yaml
+++ b/test/e2e/controller-manager/testdata/ModelBooster-vllm.yaml
@@ -12,7 +12,9 @@ spec:
     replicas: 1
     workers:
     - type: server
-      image: ghcr.io/huntersman/vllm-cpu-env:latest
+      # Pinned to a non-"latest" tag so Kubernetes defaults imagePullPolicy to
+      # IfNotPresent, matching what test/e2e/setup.sh preloads into Kind.
+      image: ghcr.io/huntersman/vllm-cpu-env:main
       replicas: 1
       pods: 1
       config:

--- a/test/e2e/setup.sh
+++ b/test/e2e/setup.sh
@@ -21,6 +21,17 @@ TAG=${TAG:-latest}
 CLUSTER_NAME=${CLUSTER_NAME:-kthena-e2e}
 TEST_CATEGORY=${TEST_CATEGORY:-all}
 
+# External runtime image referenced by the controller-manager ModelBooster E2E fixtures.
+# It is not built by this repo, so it must be pulled once and preloaded into Kind here
+# rather than left for kubelet to pull live while a test's Eventually is ticking.
+VLLM_CPU_ENV_IMAGE=${VLLM_CPU_ENV_IMAGE:-ghcr.io/huntersman/vllm-cpu-env:main}
+
+preload_vllm_cpu_env_image() {
+  echo "Preloading external vLLM CPU image (${VLLM_CPU_ENV_IMAGE}) used by ModelBooster E2E fixtures"
+  docker pull "${VLLM_CPU_ENV_IMAGE}"
+  kind load docker-image "${VLLM_CPU_ENV_IMAGE}" --name "${CLUSTER_NAME}"
+}
+
 # Create Kind cluster
 echo "Creating Kind cluster: ${CLUSTER_NAME}"
 kind create cluster --name "${CLUSTER_NAME}"
@@ -65,6 +76,7 @@ case "${TEST_CATEGORY}" in
   controller-manager)
     echo "Start to install LeaderWorkerSet CRDs"
     kubectl create -f https://raw.githubusercontent.com/kubernetes-sigs/lws/refs/tags/v0.8.0/charts/lws/crds/leaderworkerset.x-k8s.io_leaderworkersets.yaml
+    preload_vllm_cpu_env_image
     ;;
   router)
     echo "Router tests: no additional CRDs needed"
@@ -76,6 +88,7 @@ case "${TEST_CATEGORY}" in
     kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/v1.2.0/manifests.yaml
     echo "Start to install LeaderWorkerSet CRDs"
     kubectl create -f https://raw.githubusercontent.com/kubernetes-sigs/lws/refs/tags/v0.8.0/charts/lws/crds/leaderworkerset.x-k8s.io_leaderworkersets.yaml
+    preload_vllm_cpu_env_image
     ;;
 esac
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The controller-manager E2E suite has been intermittently timing out in `TestModelCR` and `TestModelBoosterSelfHealing` while waiting for the `Model` to become `Active`.

This PR reduces external runtime dependencies on the critical startup path instead of simply increasing CI timeouts.

The changes include:

- Preload `ghcr.io/huntersman/vllm-cpu-env:latest` into the Kind cluster during E2E setup, matching how the repository's own images are already loaded.
- Set `imagePullPolicy: IfNotPresent` for the engine server containers in the vLLM template so the preloaded image is actually reused instead of being pulled from GHCR on every run.
- Increase only the `Eventually` timeout in `TestModelCR` and `TestModelBoosterSelfHealing` from 5 minutes to 7 minutes to account for the remaining Hugging Face model download latency without affecting other tests or workflow timeouts.

This removes an unnecessary live image pull from the test startup path while keeping the existing end-to-end coverage intact.

**Which issue(s) this PR fixes**:

Fixes #1342

**Special notes for your reviewer**:

- This PR does **not** modify controller logic.
- It focuses only on improving the stability of the controller-manager E2E suite.
- The Hugging Face model download remains part of the test because it is required to exercise the real downloader/runtime workflow.
- Alternatives such as increasing the GitHub Actions job timeout or replacing the model with a mocked fixture were intentionally avoided to preserve test coverage while addressing the unnecessary image-pull overhead.

**Does this PR introduce a user-facing change?**

```release-note
NONE