### PR TITLE
Fix router TLS chart mount path

### DIFF
--- a/charts/kthena/charts/networking/templates/kthena-router/component/deployment.yaml
+++ b/charts/kthena/charts/networking/templates/kthena-router/component/deployment.yaml
@@ -147,7 +147,7 @@ spec:
             subPath: routerConfiguration
           {{- if and (eq .Values.global.certManagementMode "cert-manager") .Values.kthenaRouter.tls.enabled }}
           - name: router-tls-certs
-            mountPath: /etc/tls
+            mountPath: /etc/router-tls
             readOnly: true
           {{- end }}
           {{- if .Values.kthenaRouter.webhook.enabled }}


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

Fixes the kthena-router chart TLS mount path when router TLS and the webhook are both enabled with cert-manager.

The router already starts with `--tls-cert=/etc/router-tls/tls.crt` and `--tls-key=/etc/router-tls/tls.key`, but the chart was mounting the router TLS secret at `/etc/tls`, which is also used by the webhook certs. That makes the rendered Deployment invalid or leaves the router TLS files at the wrong path.

**Which issue(s) this PR fixes**:
Fixes #1350

**Special notes for your reviewer**:

The change is intentionally small: only the router TLS secret mount path is moved to match the existing router TLS args. Webhook certs still use `/etc/tls`.

**Does this PR introduce a user-facing change?**:

```release-note
Fix kthena-router Helm chart TLS mount path when cert-manager router TLS and webhook are enabled together.