### PR TITLE
fix: reserve RoleDeleting ordinals during scale-up and relax role partition e2e checks

### DIFF
--- a/pkg/model-serving-controller/controller/model_serving_controller.go
+++ b/pkg/model-serving-controller/controller/model_serving_controller.go
@@ -974,15 +974,15 @@ func (c *ModelServingController) scaleUpRoles(ctx context.Context, ms *workloadv
 
 	// Find the maximum ordinal in existing roles.
 	// Since roleList is already sorted in ascending order by ordinal,
-	// we can track maxOrdinal while building existingOrdinals.
+	// we can directly get the maxOrdinal from the last element.
 	maxOrdinal := -1
 	existingOrdinals := make(map[int]bool)
 	for _, role := range roleList {
 		_, ordinal := utils.GetParentNameAndOrdinal(role.Name)
 		existingOrdinals[ordinal] = true
-		if ordinal > maxOrdinal {
-			maxOrdinal = ordinal
-		}
+	}
+	if len(roleList) > 0 {
+		_, maxOrdinal = utils.GetParentNameAndOrdinal(roleList[len(roleList)-1].Name)
 	}
 
 	// Role needs to scale up, and the ServingGroup status needs to be set to Scaling

--- a/pkg/model-serving-controller/controller/model_serving_controller.go
+++ b/pkg/model-serving-controller/controller/model_serving_controller.go
@@ -978,9 +978,6 @@ func (c *ModelServingController) scaleUpRoles(ctx context.Context, ms *workloadv
 	maxOrdinal := -1
 	existingOrdinals := make(map[int]bool)
 	for _, role := range roleList {
-		if role.Status == datastore.RoleDeleting {
-			continue
-		}
 		_, ordinal := utils.GetParentNameAndOrdinal(role.Name)
 		existingOrdinals[ordinal] = true
 		if ordinal > maxOrdinal {

--- a/pkg/model-serving-controller/controller/model_serving_controller_test.go
+++ b/pkg/model-serving-controller/controller/model_serving_controller_test.go
@@ -2295,6 +2295,7 @@ func TestScaleUpRoles(t *testing.T) {
 		name string
 
 		existingIndices    []int // Indices of existing Roles
+		deletingIndices    []int // Subset of existingIndices that are RoleDeleting
 		expectedCount      int   // Target count for scale up
 		expectedNewIndices []int // Expected indices for newly created roles
 
@@ -2349,6 +2350,15 @@ func TestScaleUpRoles(t *testing.T) {
 			expectedNewIndices: []int{1, 2, 3, 4},
 			expectNoCreation:   false,
 		},
+		{
+			// RoleDeleting ordinals must reserve their index so scale-up does not recreate them.
+			name:               "scale up reserves RoleDeleting ordinals",
+			existingIndices:    []int{0, 1},
+			deletingIndices:    []int{1},
+			expectedCount:      3,
+			expectedNewIndices: []int{2},
+			expectNoCreation:   false,
+		},
 	}
 
 	for idx, tt := range tests {
@@ -2397,17 +2407,32 @@ func TestScaleUpRoles(t *testing.T) {
 				},
 			}
 
+			deletingSet := make(map[int]bool, len(tt.deletingIndices))
+			for _, ordinal := range tt.deletingIndices {
+				deletingSet[ordinal] = true
+			}
+
 			// Pre-populate the store with ServingGroup and Roles
-			controller.store.AddServingGroup(utils.GetNamespaceName(ms), 0, "test-revision")
+			nsn := utils.GetNamespaceName(ms)
+			controller.store.AddServingGroup(nsn, 0, "test-revision")
 			for _, ordinal := range tt.existingIndices {
-				controller.store.AddRole(utils.GetNamespaceName(ms), groupName, "prefill", utils.GenerateRoleID("prefill", ordinal), "test-revision", "test-roleTemplateHash")
+				roleID := utils.GenerateRoleID("prefill", ordinal)
+				controller.store.AddRole(nsn, groupName, "prefill", roleID, "test-revision", "test-roleTemplateHash")
+				if deletingSet[ordinal] {
+					assert.NoError(t, controller.store.UpdateRoleStatus(nsn, groupName, "prefill", roleID, datastore.RoleDeleting))
+				}
 			}
 
 			// Build the roleList to pass to scaleUpRoles
 			existingRoles := make([]datastore.Role, len(tt.existingIndices))
 			for i, ordinal := range tt.existingIndices {
+				status := datastore.RoleCreating
+				if deletingSet[ordinal] {
+					status = datastore.RoleDeleting
+				}
 				existingRoles[i] = datastore.Role{
-					Name: utils.GenerateRoleID("prefill", ordinal),
+					Name:   utils.GenerateRoleID("prefill", ordinal),
+					Status: status,
 				}
 			}
 
@@ -2417,7 +2442,7 @@ func TestScaleUpRoles(t *testing.T) {
 			controller.scaleUpRoles(context.Background(), ms, groupName, targetRole, existingRoles, tt.expectedCount, 0, "new-revision")
 
 			// Verify the results
-			roles, err := controller.store.GetRoleList(utils.GetNamespaceName(ms), groupName, "prefill")
+			roles, err := controller.store.GetRoleList(nsn, groupName, "prefill")
 			assert.NoError(t, err)
 
 			if tt.expectNoCreation {
@@ -2435,6 +2460,13 @@ func TestScaleUpRoles(t *testing.T) {
 						}
 					}
 					assert.True(t, found, "Expected role %s to be created", expectedName)
+				}
+
+				// RoleDeleting ordinals must stay reserved and not be recreated.
+				for _, ordinal := range tt.deletingIndices {
+					roleID := utils.GenerateRoleID("prefill", ordinal)
+					assert.Equal(t, datastore.RoleDeleting, controller.store.GetRoleStatus(nsn, groupName, "prefill", roleID),
+						"RoleDeleting ordinal %d should remain reserved", ordinal)
 				}
 
 				// Verify total roles count

--- a/test/e2e/controller-manager/model_serving_test.go
+++ b/test/e2e/controller-manager/model_serving_test.go
@@ -2220,7 +2220,6 @@ func TestModelServingRoleRollingUpdatePartition(t *testing.T) {
 	replicas := int32(1)
 	initialRoleReplicas := int32(4)
 	partition := int32(2)
-	protectedOrdinals := []int32{0, 1}
 
 	modelServing := &workload.ModelServing{
 		ObjectMeta: metav1.ObjectMeta{
@@ -2270,7 +2269,7 @@ func TestModelServingRoleRollingUpdatePartition(t *testing.T) {
 	updatedMS.Spec.Template.Roles[0].EntryTemplate.Spec.Containers[0].Image = nginxAlpineImage
 	updatedMS.Spec.Template.Roles[0].Partition = ptr.To(intstr.FromInt32(partition))
 
-	t.Logf("Updating prefill role image to %s; partition=%d should keep prefill-0/1 on old image", nginxAlpineImage, partition)
+	t.Logf("Updating prefill role image to %s; partition=%d should keep ordinals [0, %d) on old image", nginxAlpineImage, partition, partition)
 	_, err = kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Update(ctx, updatedMS, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
@@ -2299,7 +2298,7 @@ func TestModelServingRoleRollingUpdatePartition(t *testing.T) {
 			return false
 		}
 
-		for _, ord := range protectedOrdinals {
+		for ord := int32(0); ord < partition; ord++ {
 			if imageByOrdinal[ord] != nginxImage {
 				t.Logf("Protected prefill-%d image=%s, expecting old image=%s", ord, imageByOrdinal[ord], nginxImage)
 				return false
@@ -2307,14 +2306,7 @@ func TestModelServingRoleRollingUpdatePartition(t *testing.T) {
 		}
 		updatedCorrect := 0
 		for ord, img := range imageByOrdinal {
-			isProtected := false
-			for _, protected := range protectedOrdinals {
-				if ord == protected {
-					isProtected = true
-					break
-				}
-			}
-			if isProtected {
+			if ord < partition {
 				continue
 			}
 			if img != nginxAlpineImage {
@@ -2415,23 +2407,25 @@ func TestModelServingRolePartitionScaleUp(t *testing.T) {
 		if len(imageByOrdinal) != int(roleReplicas) {
 			return false
 		}
-		if imageByOrdinal[0] != nginxImage {
-			t.Logf("Partition state not ready: protected prefill-0 image=%s", imageByOrdinal[0])
-			return false
+		for ord := int32(0); ord < partition; ord++ {
+			if imageByOrdinal[ord] != nginxImage {
+				t.Logf("Partition state not ready: protected prefill-%d image=%s", ord, imageByOrdinal[ord])
+				return false
+			}
 		}
-		updatedCount := 0
+		updatedCorrect := 0
 		for ord, img := range imageByOrdinal {
-			if ord == 0 {
+			if ord < partition {
 				continue
 			}
 			if img != nginxAlpineImage {
 				t.Logf("Partition state not ready: non-protected prefill-%d image=%s", ord, img)
 				return false
 			}
-			updatedCount++
+			updatedCorrect++
 		}
-		if updatedCount != int(roleReplicas)-int(partition) {
-			t.Logf("Partition state not ready: updated replicas=%d, expecting %d, images=%v", updatedCount, roleReplicas-partition, imageByOrdinal)
+		if updatedCorrect != int(roleReplicas-partition) {
+			t.Logf("Partition state not ready: updated replicas=%d, expecting %d, images=%v", updatedCorrect, roleReplicas-partition, imageByOrdinal)
 			return false
 		}
 		ms, err := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Get(ctx, modelServing.Name, metav1.GetOptions{})
@@ -2616,10 +2610,20 @@ func TestModelServingRolePartitionScaleDown(t *testing.T) {
 				return false
 			}
 		}
-		for ord := partition; ord < initialRoleReplicas; ord++ {
-			if imageByOrdinal[ord] != nginxAlpineImage {
+		updatedCorrect := 0
+		for ord, img := range imageByOrdinal {
+			if ord < partition {
+				continue
+			}
+			if img != nginxAlpineImage {
 				return false
 			}
+			updatedCorrect++
+		}
+		if updatedCorrect != int(initialRoleReplicas-partition) {
+			t.Logf("Partition state not ready: updated replicas=%d, expecting %d, images=%v",
+				updatedCorrect, initialRoleReplicas-partition, imageByOrdinal)
+			return false
 		}
 		return true
 	}, 3*time.Minute, 2*time.Second, "Role partition state did not converge before scale down")
@@ -2690,8 +2694,14 @@ func TestModelServingRolePartitionScaleDown(t *testing.T) {
 				return false
 			}
 		}
-		if _, ok := imageByOrdinal[partition]; ok {
-			t.Logf("Updated replica prefill-%d should have been removed", partition)
+		updatedCorrect := 0
+		for ord := range imageByOrdinal {
+			if ord >= partition {
+				updatedCorrect++
+			}
+		}
+		if updatedCorrect != 0 {
+			t.Logf("Updated replicas remaining=%d, expecting 0; images=%v", updatedCorrect, imageByOrdinal)
 			return false
 		}
 		return true


### PR DESCRIPTION


**What type of PR is this?**

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes https://github.com/volcano-sh/kthena/issues/1354

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
