### PR TITLE
[Router] Prevent head-of-line blocking in SessionBoost grace period

### DIFF
--- a/pkg/kthena-router/datastore/session_boost_queue.go
+++ b/pkg/kthena-router/datastore/session_boost_queue.go
@@ -251,24 +251,53 @@ func (pq *RequestPriorityQueue) drainPendingRelease() bool {
 	}
 }
 
-// waitGraceAndDequeue holds a just-freed slot for up to SessionBoostGracePeriod
+// waitGraceAndDequeue holds a just-freed slot for the duration of SessionBoostGracePeriod
 // before dispatching, giving a same-session follow-up time to arrive. It does not
 // need to watch for the follow-up itself: boosted requests outrank others in the
 // heap and, among boosted requests, the one whose session completed most recently
-// wins, so once the timer fires tryBackpressureDequeue admits the warmest boosted
-// follow-up first if one showed up. The wait always runs for the full window even
-// when the head is already boosted, because a follow-up from an even-more-recently
-// completed session may yet arrive and should be the one to ride the warm prefix
-// cache. The wait stays responsive to shutdown via ctx/stopCh.
+// wins. The wait always runs for the full window even when a boosted follow-up is
+// already waiting, because a follow-up from an even-more-recently completed session
+// may yet arrive and should be the one to ride the warm prefix cache.
+// It actively listens to notifyCh and releaseCh while waiting so that additional
+// capacity can be drained without stealing the slot reserved for this grace period.
+// The wait stays responsive to shutdown via ctx/stopCh.
 func (pq *RequestPriorityQueue) waitGraceAndDequeue(ctx context.Context) {
 	klog.V(4).Infof("[SessionBoost] grace: holding freed slot for %v", pq.config.SessionBoostGracePeriod)
+
+	// Reserve one inflight permit so calls to tryBackpressureDequeue made while waiting
+	// do not consume the slot we are holding for the grace period.
+	pq.inflightCount.Add(1)
+
+	var released bool
+	defer func() {
+		if !released {
+			pq.inflightCount.Add(-1)
+		}
+	}()
+
 	timer := time.NewTimer(pq.config.SessionBoostGracePeriod)
 	defer timer.Stop()
-	select {
-	case <-ctx.Done():
-	case <-pq.stopCh:
-	case <-timer.C:
-		pq.tryBackpressureDequeue(ctx)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-pq.stopCh:
+			return
+		case <-pq.notifyCh:
+			// Drain other permits if additional capacity exists. We do not dispatch
+			// the boosted request for this slot until the grace timer fully expires,
+			// allowing even warmer follow-ups time to arrive.
+			pq.tryBackpressureDequeue(ctx)
+		case <-pq.releaseCh:
+			// Another slot freed up. Dispatch any waiting requests into it.
+			pq.tryBackpressureDequeue(ctx)
+		case <-timer.C:
+			// Grace period expired. Release the reservation and dispatch whatever is next.
+			released = true
+			pq.inflightCount.Add(-1)
+			pq.tryBackpressureDequeue(ctx)
+			return
+		}
 	}
 }
 

--- a/pkg/kthena-router/datastore/session_boost_queue_test.go
+++ b/pkg/kthena-router/datastore/session_boost_queue_test.go
@@ -19,6 +19,7 @@ package datastore
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -728,5 +729,198 @@ func TestSessionBoost_ConcurrentAdmitAbandonNoLeak(t *testing.T) {
 		if got := q.GetInflightCount(); got != 0 {
 			t.Fatalf("iteration %d: inflight leaked, count=%d", i, got)
 		}
+	}
+}
+
+func TestSessionBoostQueue_GracePeriod_WaitsFullDuration(t *testing.T) {
+	checker := func() bool { return true }
+
+	cfg := sessionBoostConfig()
+	// Use a short grace period for the test so it doesn't artificially inflate CI time.
+	cfg.SessionBoostGracePeriod = 100 * time.Millisecond
+	cfg.InflightPerPod = 1
+	q := newSessionBoostQueue(cfg, checker)
+	defer q.Close()
+
+	now := time.Now()
+	req1 := &Request{
+		UserID:      "user-A",
+		ModelName:   "model-1",
+		SessionID:   "session-1",
+		RequestTime: now,
+		NotifyChan:  make(chan struct{}),
+	}
+	if err := q.PushRequest(req1); err != nil {
+		t.Fatalf("PushRequest failed: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	go q.Run(ctx, 0)
+
+	// Wait for req1 to be admitted
+	<-req1.NotifyChan
+
+	// Mark session completed and trigger the grace period
+	q.MarkSessionRequestCompleted("session-1")
+	req1.Release()
+
+	// Wait deterministically for the grace period reservation
+	timeout := time.Now().Add(1 * time.Second)
+	for q.GetInflightCount() != 1 {
+		if time.Now().After(timeout) {
+			t.Fatal("Timeout waiting for grace period inflight reservation")
+		}
+		time.Sleep(1 * time.Millisecond)
+	}
+	gracePeriodStart := time.Now()
+
+	// Push a boosted follow-up during the grace period
+	boostedFollowUp := &Request{
+		UserID:      "user-A",
+		ModelName:   "model-1",
+		SessionID:   "session-1",
+		RequestTime: time.Now(),
+		NotifyChan:  make(chan struct{}),
+	}
+
+	if err := q.PushRequest(boostedFollowUp); err != nil {
+		t.Fatalf("PushRequest failed: %v", err)
+	}
+
+	// The boosted request MUST NOT be dequeued instantly; it must wait the full timer.
+	select {
+	case <-boostedFollowUp.NotifyChan:
+		elapsed := time.Since(gracePeriodStart)
+		if elapsed < 80*time.Millisecond {
+			t.Fatalf("Boosted request was dispatched too early (%v). Expected to wait the full 100ms grace period.", elapsed)
+		}
+	case <-time.After(300 * time.Millisecond):
+		t.Fatal("Timeout: boosted request was not admitted at all")
+	}
+}
+
+func TestSessionBoostQueue_GracePeriod_SecondaryCapacityDrained(t *testing.T) {
+	var backendCapacity atomic.Int32
+	backendCapacity.Store(2)
+	checker := func() bool { return backendCapacity.Load() > 0 }
+
+	cfg := sessionBoostConfig()
+	cfg.SessionBoostGracePeriod = 100 * time.Millisecond
+	cfg.InflightPerPod = 2
+	q := newSessionBoostQueue(cfg, checker)
+	defer q.Close()
+
+	now := time.Now()
+
+	// Fill both slots
+	req1 := &Request{UserID: "user-A", ModelName: "m", SessionID: "session-1", RequestTime: now, NotifyChan: make(chan struct{})}
+	req2 := &Request{UserID: "user-B", ModelName: "m", SessionID: "session-2", RequestTime: now, NotifyChan: make(chan struct{})}
+	if err := q.PushRequest(req1); err != nil {
+		t.Fatal(err)
+	}
+	if err := q.PushRequest(req2); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	go q.Run(ctx, 0)
+
+	<-req1.NotifyChan
+	<-req2.NotifyChan
+	backendCapacity.Store(0)
+
+	q.MarkSessionRequestCompleted("session-1")
+
+	// Release slot 1 to trigger the grace period
+	backendCapacity.Store(1)
+	req1.Release()
+
+	// Wait deterministically for the grace period reservation (req2 is still inflight)
+	timeout := time.Now().Add(1 * time.Second)
+	for q.GetInflightCount() != 2 {
+		if time.Now().After(timeout) {
+			t.Fatal("Timeout waiting for grace period inflight reservation")
+		}
+		time.Sleep(1 * time.Millisecond)
+	}
+
+	// Push a normal request, which should be blocked by the reserved slot
+	normalReq := &Request{UserID: "normal", ModelName: "m", SessionID: "normal-sess", RequestTime: time.Now(), NotifyChan: make(chan struct{})}
+	if err := q.PushRequest(normalReq); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-normalReq.NotifyChan:
+		t.Fatal("Normal request incorrectly stole the reserved grace period slot")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// Release slot 2. The normal request should be admitted here safely.
+	backendCapacity.Store(2)
+	req2.Release()
+
+	select {
+	case <-normalReq.NotifyChan:
+	case <-time.After(1 * time.Second):
+		t.Fatal("Normal request was starved; secondary capacity was not drained")
+	}
+
+	// Finally, push the boosted follow-up. It should get the reserved slot 1 once the 100ms timer fires.
+	boostedReq := &Request{UserID: "user-A", ModelName: "m", SessionID: "session-1", RequestTime: time.Now(), NotifyChan: make(chan struct{})}
+	if err := q.PushRequest(boostedReq); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-boostedReq.NotifyChan:
+	case <-time.After(1 * time.Second):
+		t.Fatal("Boosted request was not admitted into its reserved slot")
+	}
+}
+
+func TestSessionBoostQueue_GracePeriod_ContextCancelledNoLeak(t *testing.T) {
+	checker := func() bool { return true }
+
+	cfg := sessionBoostConfig()
+	cfg.SessionBoostGracePeriod = 2 * time.Second
+	cfg.InflightPerPod = 1
+	q := newSessionBoostQueue(cfg, checker)
+	defer q.Close()
+
+	req1 := &Request{UserID: "user-A", ModelName: "m", SessionID: "session-1", RequestTime: time.Now(), NotifyChan: make(chan struct{})}
+	if err := q.PushRequest(req1); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go q.Run(ctx, 0)
+
+	// Trigger grace period
+	<-req1.NotifyChan
+	q.MarkSessionRequestCompleted("session-1")
+	req1.Release()
+
+	// Wait deterministically for the grace period reservation
+	timeout := time.Now().Add(1 * time.Second)
+	for q.GetInflightCount() != 1 {
+		if time.Now().After(timeout) {
+			t.Fatal("Timeout waiting for grace period inflight reservation")
+		}
+		time.Sleep(1 * time.Millisecond)
+	}
+
+	// Cancel the context while the dispatcher is waiting in the grace period
+	cancel()
+
+	// Verify the inflight reservation was released cleanly
+	timeout = time.Now().Add(1 * time.Second)
+	for q.GetInflightCount() != 0 {
+		if time.Now().After(timeout) {
+			t.Fatal("Inflight permit leaked on context cancellation!")
+		}
+		time.Sleep(1 * time.Millisecond)
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement
/area router

**What this PR does / why we need it**:

The session-boost grace period holds more than the slot it reserved. `waitGraceAndDequeue` parks the dispatcher on `timer.C` for the whole window and does not read `releaseCh` or `notifyCh` while parked, so any *other* slot freeing during that window is stuck too, even though nothing is holding it. A queued request ends up waiting behind capacity that is already free.

This replaces the blocking sleep with an inner `for`/`select` that keeps reading `releaseCh` and `notifyCh` during the window, and reserves the held slot with `inflightCount.Add(1)` so a concurrent `tryBackpressureDequeue` cannot take the one we are keeping for the follow-up.

Holding the reserved slot for the full window is unchanged. #1334 made that deliberate so the warmest follow-up wins, and this does not touch it.

**Which issue(s) this PR fixes**:
Fixes #1348

**Bug evidence (required for bug-related PRs)**:

Two slots in flight, one request queued, `SessionBoostGracePeriod` 1.5s. Release the first slot, which correctly starts the window and holds that slot. 50ms later release the second slot, which nothing is holding:

```
before   queued request admitted after 1.4507s
after    queued request admitted after 52us
```

5 runs each on linux/amd64, go1.26. Before: 1.4507s to 1.4509s. After: 38us to 134us.

**Special notes for your reviewer**:

Tests on the branch:
* `GracePeriod_WaitsFullDuration` - the reserved slot is held for the full window, so #1334's ordering is unchanged
* `GracePeriod_SecondaryCapacityDrained` - a second freed slot is usable immediately without giving away the reserved one
* `GracePeriod_ContextCancelledNoLeak` - the reservation unwinds on cancellation and shutdown

The existing grace period tests still pass, and the whole datastore package is clean under `-race`.

**Does this PR introduce a user-facing change?**:
```release-note
kthena-router: the session-boost grace period no longer holds backend slots it has not reserved, so queued requests can use capacity that frees during the window.
```