### PR TITLE
router: reject ambiguous ModelRoute string matches

### DIFF
--- a/charts/kthena/charts/networking/crds/networking.serving.volcano.sh_modelroutes.yaml
+++ b/charts/kthena/charts/networking/crds/networking.serving.volcano.sh_modelroutes.yaml
@@ -299,6 +299,11 @@ spec:
                               regex:
                                 type: string
                             type: object
+                            x-kubernetes-validations:
+                            - message: only one of exact, prefix, or regex may be
+                                set
+                              rule: '(has(self.exact) ? 1 : 0) + (has(self.prefix)
+                                ? 1 : 0) + (has(self.regex) ? 1 : 0) <= 1'
                           description: |-
                             Header to match: prefix, exact, regex
                             If unset, any header will be matched.
@@ -315,6 +320,10 @@ spec:
                             regex:
                               type: string
                           type: object
+                          x-kubernetes-validations:
+                          - message: only one of exact, prefix, or regex may be set
+                            rule: '(has(self.exact) ? 1 : 0) + (has(self.prefix) ?
+                              1 : 0) + (has(self.regex) ? 1 : 0) <= 1'
                       type: object
                     name:
                       description: Name is the name of the rule.

--- a/charts/kthena/charts/workload/crds/workload.serving.volcano.sh_modelboosters.yaml
+++ b/charts/kthena/charts/workload/crds/workload.serving.volcano.sh_modelboosters.yaml
@@ -1430,6 +1430,10 @@ spec:
                         regex:
                           type: string
                       type: object
+                      x-kubernetes-validations:
+                      - message: only one of exact, prefix, or regex may be set
+                        rule: '(has(self.exact) ? 1 : 0) + (has(self.prefix) ? 1 :
+                          0) + (has(self.regex) ? 1 : 0) <= 1'
                     description: |-
                       Header to match: prefix, exact, regex
                       If unset, any header will be matched.
@@ -1446,6 +1450,10 @@ spec:
                       regex:
                         type: string
                     type: object
+                    x-kubernetes-validations:
+                    - message: only one of exact, prefix, or regex may be set
+                      rule: '(has(self.exact) ? 1 : 0) + (has(self.prefix) ? 1 : 0)
+                        + (has(self.regex) ? 1 : 0) <= 1'
                 type: object
               name:
                 description: |-

--- a/pkg/apis/networking/v1alpha1/modelroute_types.go
+++ b/pkg/apis/networking/v1alpha1/modelroute_types.go
@@ -97,6 +97,7 @@ type BodyMatch struct {
 
 // StringMatch defines the matching conditions for string fields.
 // Only one of the fields may be set.
+// +kubebuilder:validation:XValidation:rule="(has(self.exact) ? 1 : 0) + (has(self.prefix) ? 1 : 0) + (has(self.regex) ? 1 : 0) <= 1",message="only one of exact, prefix, or regex may be set"
 type StringMatch struct {
 	Exact  *string `json:"exact,omitempty"`
 	Prefix *string `json:"prefix,omitempty"`

--- a/pkg/kthena-router/webhook/validator.go
+++ b/pkg/kthena-router/webhook/validator.go
@@ -199,17 +199,9 @@ func (v *KthenaRouterValidator) validateModelRoute(modelRoute *networkingv1alpha
 		}
 		if rule.ModelMatch != nil {
 			for key, sm := range rule.ModelMatch.Headers {
-				if sm != nil && sm.Regex != nil {
-					if _, err := regexp.Compile(*sm.Regex); err != nil {
-						allErrs = append(allErrs, field.Invalid(ruleField.Child("modelMatch").Child("headers").Key(key).Child("regex"), *sm.Regex, err.Error()))
-					}
-				}
+				allErrs = append(allErrs, validateStringMatch(sm, ruleField.Child("modelMatch").Child("headers").Key(key))...)
 			}
-			if rule.ModelMatch.Uri != nil && rule.ModelMatch.Uri.Regex != nil {
-				if _, err := regexp.Compile(*rule.ModelMatch.Uri.Regex); err != nil {
-					allErrs = append(allErrs, field.Invalid(ruleField.Child("modelMatch").Child("uri").Child("regex"), *rule.ModelMatch.Uri.Regex, err.Error()))
-				}
-			}
+			allErrs = append(allErrs, validateStringMatch(rule.ModelMatch.Uri, ruleField.Child("modelMatch").Child("uri"))...)
 		}
 	}
 
@@ -221,6 +213,34 @@ func (v *KthenaRouterValidator) validateModelRoute(modelRoute *networkingv1alpha
 		return false, fmt.Sprintf("validation failed:\n%s", strings.Join(messages, "\n"))
 	}
 	return true, ""
+}
+
+func validateStringMatch(sm *networkingv1alpha1.StringMatch, fldPath *field.Path) field.ErrorList {
+	var allErrs field.ErrorList
+	if sm == nil {
+		return allErrs
+	}
+
+	var matchTypes []string
+	if sm.Exact != nil {
+		matchTypes = append(matchTypes, "exact")
+	}
+	if sm.Prefix != nil {
+		matchTypes = append(matchTypes, "prefix")
+	}
+	if sm.Regex != nil {
+		matchTypes = append(matchTypes, "regex")
+	}
+	if len(matchTypes) > 1 {
+		allErrs = append(allErrs, field.Invalid(fldPath, strings.Join(matchTypes, ","), "only one of exact, prefix, or regex may be set"))
+	}
+
+	if sm.Regex != nil {
+		if _, err := regexp.Compile(*sm.Regex); err != nil {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("regex"), *sm.Regex, err.Error()))
+		}
+	}
+	return allErrs
 }
 
 // validateModelServer validates the ModelServer resource

--- a/pkg/kthena-router/webhook/validator_test.go
+++ b/pkg/kthena-router/webhook/validator_test.go
@@ -30,6 +30,10 @@ func TestValidateModelRoute(t *testing.T) {
 	weight0 := uint32(0)
 	invalidHeaderRegex := "["
 	invalidURIRegex := "["
+	exactMatch := "production"
+	prefixMatch := "/v1/"
+	regexMatch := "^/v1/.*"
+	uriExactMatch := "/v1/chat/completions"
 
 	tests := []struct {
 		name           string
@@ -453,6 +457,95 @@ func TestValidateModelRoute(t *testing.T) {
 			},
 			expectValid:    false,
 			expectedReason: "validation failed:\n  - spec.rules[0].modelMatch.uri.regex: Invalid value: \"[\": error parsing regexp: missing closing ]: `[`",
+		},
+		{
+			name: "invalid model route - header match has multiple types",
+			modelRoute: &networkingv1alpha1.ModelRoute{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "networking.serving.volcano.sh/v1alpha1",
+					Kind:       "ModelRoute",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "default",
+				},
+				Spec: networkingv1alpha1.ModelRouteSpec{
+					ModelName: "test-model",
+					Rules: []*networkingv1alpha1.Rule{
+						{
+							Name: "test-rule",
+							ModelMatch: &networkingv1alpha1.ModelMatch{
+								Headers: map[string]*networkingv1alpha1.StringMatch{
+									"x-env": {Exact: &exactMatch, Prefix: &prefixMatch},
+								},
+							},
+							TargetModels: []*networkingv1alpha1.TargetModel{
+								{ModelServerName: "test-server"},
+							},
+						},
+					},
+				},
+			},
+			expectValid:    false,
+			expectedReason: "validation failed:\n  - spec.rules[0].modelMatch.headers[x-env]: Invalid value: \"exact,prefix\": only one of exact, prefix, or regex may be set",
+		},
+		{
+			name: "invalid model route - uri match has multiple types",
+			modelRoute: &networkingv1alpha1.ModelRoute{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "networking.serving.volcano.sh/v1alpha1",
+					Kind:       "ModelRoute",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "default",
+				},
+				Spec: networkingv1alpha1.ModelRouteSpec{
+					ModelName: "test-model",
+					Rules: []*networkingv1alpha1.Rule{
+						{
+							Name: "test-rule",
+							ModelMatch: &networkingv1alpha1.ModelMatch{
+								Uri: &networkingv1alpha1.StringMatch{Prefix: &prefixMatch, Regex: &regexMatch},
+							},
+							TargetModels: []*networkingv1alpha1.TargetModel{
+								{ModelServerName: "test-server"},
+							},
+						},
+					},
+				},
+			},
+			expectValid:    false,
+			expectedReason: "validation failed:\n  - spec.rules[0].modelMatch.uri: Invalid value: \"prefix,regex\": only one of exact, prefix, or regex may be set",
+		},
+		{
+			name: "invalid model route - uri exact and regex match types",
+			modelRoute: &networkingv1alpha1.ModelRoute{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "networking.serving.volcano.sh/v1alpha1",
+					Kind:       "ModelRoute",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "default",
+				},
+				Spec: networkingv1alpha1.ModelRouteSpec{
+					ModelName: "test-model",
+					Rules: []*networkingv1alpha1.Rule{
+						{
+							Name: "test-rule",
+							ModelMatch: &networkingv1alpha1.ModelMatch{
+								Uri: &networkingv1alpha1.StringMatch{Exact: &uriExactMatch, Regex: &regexMatch},
+							},
+							TargetModels: []*networkingv1alpha1.TargetModel{
+								{ModelServerName: "test-server"},
+							},
+						},
+					},
+				},
+			},
+			expectValid:    false,
+			expectedReason: "validation failed:\n  - spec.rules[0].modelMatch.uri: Invalid value: \"exact,regex\": only one of exact, prefix, or regex may be set",
 		},
 		{
 			name: "invalid model route - nil rule",


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

StringMatch documents that only one of exact, prefix, or regex may be set, but ModelRoute validation did not enforce that.

This rejects ambiguous header/URI matches in both the CRD schema and router validating webhook.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
Added focused webhook tests for header and URI match conflicts.

**Does this PR introduce a user-facing change?**:

```release-note
ModelRoute validation now rejects StringMatch values that set more than one of exact, prefix, or regex.