### PR TITLE
feat(router): add pod circuit breaker for serving-level health, beyond K8s Ready

### DIFF
--- a/pkg/kthena-router/connectors/transport.go
+++ b/pkg/kthena-router/connectors/transport.go
@@ -31,6 +31,22 @@ import (
 	"k8s.io/klog/v2"
 )
 
+// httpStatusError wraps an upstream non-2xx HTTP response with its status code
+type httpStatusError struct {
+	code  int
+	phase string // "prefill" or "decode"
+}
+
+// Error returns the diagnostic message, identical to the previous fmt.Errorf text
+func (e *httpStatusError) Error() string {
+	return fmt.Sprintf("%s request failed with status %d", e.phase, e.code)
+}
+
+// Code returns the upstream HTTP status code
+func (e *httpStatusError) Code() int {
+	return e.code
+}
+
 func prefillerProxy(_ *gin.Context, req *http.Request) error {
 	resp, err := http.DefaultTransport.RoundTrip(req)
 	if err != nil {
@@ -39,7 +55,7 @@ func prefillerProxy(_ *gin.Context, req *http.Request) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("prefill request failed with status %d", resp.StatusCode)
+		return &httpStatusError{code: resp.StatusCode, phase: "prefill"}
 	}
 
 	klog.V(4).Infof("Prefill request completed successfully")
@@ -54,7 +70,7 @@ func decoderProxy(c *gin.Context, req *http.Request) (int, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return 0, fmt.Errorf("decode request failed with status %d", resp.StatusCode)
+		return 0, &httpStatusError{code: resp.StatusCode, phase: "decode"}
 	}
 
 	// Copy response headers

--- a/pkg/kthena-router/datastore/store.go
+++ b/pkg/kthena-router/datastore/store.go
@@ -230,6 +230,9 @@ type Store interface {
 	// the given pod. Must be called once the response is received (or the request fails).
 	DecrPodOnFlightRequests(podName types.NamespacedName)
 
+	// RecordPodProxyResult records a proxy outcome: 5xx increments the counter, success resets it
+	RecordPodProxyResult(podName types.NamespacedName, is5xxFailure bool)
+
 	// GetTokenCount returns the token count for a user and model
 	GetTokenCount(userId, modelName string) (float64, error)
 	// UpdateTokenCount updates token usage for a user and model
@@ -307,6 +310,9 @@ type PodInfo struct {
 	// When a Redis-backed OnFlightCounter is configured on the store this field is also
 	// kept in sync with the global Redis counter so it reflects cross-router traffic.
 	onFlightRequestNum atomic.Int64
+
+	// consecutive5xxFailures counts consecutive 5xx proxy outcomes for this pod
+	consecutive5xxFailures atomic.Int64
 
 	mutex sync.RWMutex // Protects concurrent access to Pod, engine, metrics, models and modelServer fields
 	// Protected fields - use accessor methods for thread-safe access
@@ -836,6 +842,21 @@ func (s *store) DecrPodOnFlightRequests(podName types.NamespacedName) {
 		}
 	}
 	podInfo.DecrOnFlightRequests()
+}
+
+// RecordPodProxyResult records a proxy outcome; no-op if the pod is not tracked
+func (s *store) RecordPodProxyResult(podName types.NamespacedName, is5xxFailure bool) {
+	value, ok := s.pods.Load(podName)
+	if !ok {
+		klog.V(4).Infof("RecordPodProxyResult: pod %s not found in store", podName)
+		return
+	}
+	podInfo := value.(*PodInfo)
+	if is5xxFailure {
+		podInfo.IncrConsecutive5xxFailures()
+	} else {
+		podInfo.ResetConsecutive5xxFailures()
+	}
 }
 
 func (s *store) AddOrUpdateModelServer(ms *aiv1alpha1.ModelServer, pods sets.Set[types.NamespacedName]) error {
@@ -1874,6 +1895,21 @@ func (p *PodInfo) SetOnFlightRequestNum(v int64) {
 // by this router instance (or globally, if a Redis counter is configured).
 func (p *PodInfo) GetOnFlightRequestNum() int64 {
 	return p.onFlightRequestNum.Load()
+}
+
+// IncrConsecutive5xxFailures atomically increments the consecutive-5xx failure counter.
+func (p *PodInfo) IncrConsecutive5xxFailures() int64 {
+	return p.consecutive5xxFailures.Add(1)
+}
+
+// ResetConsecutive5xxFailures atomically resets the consecutive-5xx failure counter.
+func (p *PodInfo) ResetConsecutive5xxFailures() {
+	p.consecutive5xxFailures.Store(0)
+}
+
+// GetConsecutive5xxFailures returns the current consecutive-5xx failure count.
+func (p *PodInfo) GetConsecutive5xxFailures() int64 {
+	return p.consecutive5xxFailures.Load()
 }
 
 // GetTPOT returns the time per output token

--- a/pkg/kthena-router/debug/handlers_test.go
+++ b/pkg/kthena-router/debug/handlers_test.go
@@ -339,6 +339,8 @@ func (m *MockStore) IncrPodOnFlightRequests(podName types.NamespacedName) {}
 
 func (m *MockStore) DecrPodOnFlightRequests(podName types.NamespacedName) {}
 
+func (m *MockStore) RecordPodProxyResult(podName types.NamespacedName, is5xxFailure bool) {}
+
 func newTestContext(params gin.Params) (*gin.Context, *httptest.ResponseRecorder) {
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)

--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -718,11 +718,18 @@ func (r *Router) proxy(
 
 		if err != nil {
 			klog.Errorf(" pod request error: %v", err)
+			// Only a 5xx increments the counter; 4xx/transport errors leave it unchanged
+			var httpErr interface{ Code() int }
+			if errors.As(err, &httpErr) && httpErr.Code() >= 500 {
+				r.store.RecordPodProxyResult(podName, true)
+			}
 			if c.Writer.Written() {
 				return err
 			}
 			continue
 		}
+		// Success resets the pod's consecutive-5xx counter.
+		r.store.RecordPodProxyResult(podName, false)
 		// record in prefix cache
 		r.scheduler.RunPostHooks(ctx, i)
 		return nil
@@ -936,6 +943,19 @@ func proxyRequest(
 	return nil
 }
 
+// http5xxError wraps an upstream 5xx response for circuit-breaking
+type http5xxError struct{ code int }
+
+// Error returns the diagnostic message
+func (e *http5xxError) Error() string {
+	return fmt.Sprintf("upstream returned HTTP %d", e.code)
+}
+
+// Code returns the wrapped upstream HTTP status code (500-599)
+func (e *http5xxError) Code() int {
+	return e.code
+}
+
 func doRequest(
 	req *http.Request,
 	podIP string,
@@ -952,6 +972,10 @@ func doRequest(
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		resp.Body.Close()
+		// Wrap 5xx for circuit-breaking; 4xx/other non-2xx stay a plain error
+		if resp.StatusCode >= 500 {
+			return nil, &http5xxError{code: resp.StatusCode}
+		}
 		return nil, fmt.Errorf("http resp error, http code is %d", resp.StatusCode)
 	}
 	return resp, nil
@@ -1059,6 +1083,12 @@ func (r *Router) proxyToPDDisaggregated(
 		if err != nil {
 			klog.Errorf("proxy failed for prefill pod %s, decode pod %s: %v",
 				prefillPod.Name, decodePod.Name, err)
+			// Attribute a 5xx to both pods (cannot tell which side failed); success resets both
+			var httpErr interface{ Code() int }
+			if errors.As(err, &httpErr) && httpErr.Code() >= 500 {
+				r.store.RecordPodProxyResult(prefillPodName, true)
+				r.store.RecordPodProxyResult(decodePodName, true)
+			}
 			continue
 		}
 
@@ -1071,6 +1101,10 @@ func (r *Router) proxyToPDDisaggregated(
 		if metricsRecorder != nil {
 			metricsRecorder.RecordOutputTokens(outputTokens)
 		}
+
+		// Success resets both pods' consecutive-5xx counters.
+		r.store.RecordPodProxyResult(prefillPodName, false)
+		r.store.RecordPodProxyResult(decodePodName, false)
 
 		// Record successful operation in cache
 		r.scheduler.RunPostHooks(ctx, i)

--- a/pkg/kthena-router/scheduler/scheduler_impl.go
+++ b/pkg/kthena-router/scheduler/scheduler_impl.go
@@ -34,6 +34,10 @@ import (
 const (
 	// Get the top five scoring podinfo
 	topN = 5
+
+	// circuit5xxThreshold is the consecutive-5xx count at which a pod's total
+	// score is halved (circuit breaker). A success resets the counter.
+	circuit5xxThreshold = 5
 )
 
 type SchedulerImpl struct {
@@ -245,6 +249,13 @@ func (s *SchedulerImpl) RunScorePlugins(pods []*datastore.PodInfo, ctx *framewor
 			} else {
 				res[k] += v * scorePlugin.weight
 			}
+		}
+	}
+
+	// Circuit breaker: halve the score of a pod with circuit5xxThreshold consecutive 5xx
+	for pod, score := range res {
+		if pod.GetConsecutive5xxFailures() >= circuit5xxThreshold {
+			res[pod] = score / 2
 		}
 	}
 

--- a/pkg/kthena-router/scheduler/scheduler_impl_test.go
+++ b/pkg/kthena-router/scheduler/scheduler_impl_test.go
@@ -371,3 +371,46 @@ func TestPDSchedulerFiltersOverloadedDecodePod(t *testing.T) {
 	err = NewScheduler(store, nil).Schedule(ctx, pods)
 	require.Error(t, err)
 }
+
+// TestRunScorePluginsCircuitBreakerPenalty verifies a suspect pod's score is halved.
+func TestRunScorePluginsCircuitBreakerPenalty(t *testing.T) {
+	healthyPod := createTestPodInfo("healthy")
+	suspectPod := createTestPodInfo("suspect")
+	// Trip the circuit breaker on the suspect pod.
+	for i := 0; i < circuit5xxThreshold; i++ {
+		suspectPod.IncrConsecutive5xxFailures()
+	}
+	require.Equal(t, int64(circuit5xxThreshold), suspectPod.GetConsecutive5xxFailures())
+	require.Zero(t, healthyPod.GetConsecutive5xxFailures())
+
+	store := datastore.New()
+	// Add pods to the store so least-request can read their on-flight counts.
+	require.NoError(t, store.AddOrUpdatePod(healthyPod.GetPod(), nil))
+	require.NoError(t, store.AddOrUpdatePod(suspectPod.GetPod(), nil))
+
+	scheduler := NewScheduler(store, nil).(*SchedulerImpl)
+	ctx := &framework.Context{
+		Prompt:          &common.ChatMessage{},
+		ModelServerName: types.NamespacedName{Namespace: "default", Name: "test"},
+	}
+
+	result := scheduler.RunScorePlugins([]*datastore.PodInfo{healthyPod, suspectPod}, ctx)
+
+	// The suspect pod must have been penalised (halved); the healthy pod must not.
+	healthyScore, okH := result[healthyPod]
+	suspectScore, okS := result[suspectPod]
+	require.True(t, okH)
+	require.True(t, okS)
+
+	// With identical plugin inputs the pre-penalty scores are equal, so the only
+	// divergence is the 50% circuit-breaker cut on the suspect pod.
+	if healthyScore == suspectScore {
+		t.Fatalf("expected suspect pod score to be halved, but both are %d", healthyScore)
+	}
+	assert.Equal(t, healthyScore/2, suspectScore, "suspect pod total score should be half of healthy pod")
+
+	// Self-healing: reset the suspect pod's counter and its score must recover.
+	suspectPod.ResetConsecutive5xxFailures()
+	result = scheduler.RunScorePlugins([]*datastore.PodInfo{healthyPod, suspectPod}, ctx)
+	assert.Equal(t, result[healthyPod], result[suspectPod], "suspect pod score should recover after reset")
+}


### PR DESCRIPTION
## Problem: the router has no serving-level pod health check, only K8s Ready

The router's candidate set is gated **only** by the K8s `isPodReady` condition (Running + Ready + no DeletionTimestamp). There is no serving-level health signal: a pod can be `Ready` yet degraded at the inference layer — repeated 5xx, engine stall, GPU throttling — and K8s does not reflect any of these, so the router keeps the pod in the candidate set and keeps sending traffic to it.

The only mitigation today is the **in-request** proxy retry walking the TopN list, which is per-request, not cross-request: the next request re-scores from scratch with **no memory of the prior failure**, so the degraded pod is picked first again — every request fails once before falling back, P99 tail latency rises, and an in-flight slot + upstream connection is wasted each time. See the linked issue for the full analysis.

## Solution: a lightweight serving-level circuit breaker

A purely-local circuit breaker — no new scheduler plugin, no new scheduling dimension, no connector changes:

- **Per-pod consecutive-5xx counter** (`PodInfo.consecutive5xxFailures`, atomic). `+1` on a 5xx proxy outcome, reset to `0` on success (self-healing).
- **Score penalty**: in `RunScorePlugins`, after summing all score plugins, a pod whose counter reaches `circuit5xxThreshold` (5) has its **total score halved**, pushing it to the back of the candidate list.
- **5xx attribution**: `doRequest` wraps a 5xx in a typed `http5xxError` (concrete status code preserved) so the proxy layer can `errors.As` it. Only a 5xx is blamed on the pod; **4xx and transport errors are not**.

This gives the router a serving-level health signal it lacked — the breaker opens on consecutive 5xx and self-heals on the next success.

## Why these choices

- **Penalty on total score, not a new plugin.** A new score plugin would only affect one dimension and could be outweighed by other plugins; halving the total score is plugin/weight-agnostic and keeps the change minimal (no
 factory/ConfigMap/registration changes). Matches the design note in the linked issue (halve the score of a pod with consecutive 5xx).
- **Circuit breaker, not hard eviction.** Hard-filtering can leave zero candidates and fail the whole schedule. Halving the score degrades gracefully and self-heals.
- **Only 5xx.** 4xx is a client error (e.g. invalid prompt) and is not the pod's fault; attributing it would mis-circuit a pod serving bad-request traffic. Existing 4xx behaviour is left unchanged.
- **Local, no Redis.** Each router tracks its own proxy outcomes. Cross-router sharing was considered out of scope; local is the simpler correct default.
- **PD-disaggregated path.** The aggregated connector error cannot tell which side failed, and KV-cache transfer failures are not a pod-health signal, so
a 5xx is attributed to both pods (mis-attribution self-heals on the next
success). No connector / `OnFlightHooks` changes.

## What it does not change

- 4xx handling (still retried as today, not blamed on the pod)
- Transport/timeout errors (not blamed on the pod)
- Any connector, `OnFlightHooks`, or KV-cache transfer path
- Any existing score plugin internals — penalty applied at the total-score layer
- Default scheduler config / plugin registration
 
## Test

- New `TestRunScorePluginsCircuitBreakerPenalty`: a pod tripped to the threshold has its total score halved vs an identical healthy pod, and recovers after reset (self-healing).
- `go build ./...`, `go vet ./...`, `go test ./pkg/kthena-router/...` all green. `MockStore` and embedded wrapper stores updated for the new `Store.RecordPodProxyResult`.

Fixes #1366