### PR TITLE
feat(router): add external provider observability and accounting

### DIFF
--- a/docs/kthena/docs/user-guide/router-observability.md
+++ b/docs/kthena/docs/user-guide/router-observability.md
@@ -96,6 +96,30 @@ Raw user identifiers are deliberately not exported. The `user_id` label is
 fixed to `_all`, keeping cardinality bounded and avoiding exposure of user
 identity through the metrics endpoint.
 
+### Metric schema migration
+
+This release adds `model_route`, `backend_type`, `backend_name`, and
+`upstream_model` to the existing request, request-duration, and token metrics.
+It also adds destination labels to
+`kthena_router_active_upstream_requests`. The metric names are unchanged, but
+the label sets are not. Prometheus therefore starts new time series after the
+Router upgrade; old counter series do not continue under the new labels.
+
+Update dashboards, alerts, recording rules, and tests that match an exact label
+set. To reproduce the previous aggregate view, sum over the destination labels:
+
+```promql
+sum by (model, path, status_code, error_type) (
+  rate(kthena_router_requests_total[5m])
+)
+```
+
+The label values come from Kubernetes objects and fixed enums, not request IDs,
+URLs, Secret names, or error text. Cardinality still grows with the product of
+ModelRoutes, backends, upstream models, paths, status codes, and error types.
+Estimate those combinations before upgrading, especially for clusters with many
+routes or long Prometheus retention.
+
 ### Tokenizer and cache-aware scheduling
 
 | Metric | Type | Labels | Description |

--- a/docs/kthena/docs/user-guide/router-observability.md
+++ b/docs/kthena/docs/user-guide/router-observability.md
@@ -52,15 +52,32 @@ been exercised.
 
 | Metric | Type | Labels | Description |
 | --- | --- | --- | --- |
-| `kthena_router_requests_total` | Counter | `model`, `path`, `status_code`, `error_type` | Completed HTTP requests |
-| `kthena_router_request_duration_seconds` | Histogram | `model`, `path`, `status_code` | End-to-end request latency |
+| `kthena_router_requests_total` | Counter | `model`, `path`, `status_code`, `error_type`, `model_route`, `backend_type`, `backend_name`, `upstream_model` | Completed HTTP requests |
+| `kthena_router_request_duration_seconds` | Histogram | `model`, `path`, `status_code`, `model_route`, `backend_type`, `backend_name`, `upstream_model` | End-to-end request latency |
 | `kthena_router_request_prefill_duration_seconds` | Histogram | `model`, `path`, `status_code` | Prefill latency for prefill/decode-disaggregated requests |
 | `kthena_router_request_decode_duration_seconds` | Histogram | `model`, `path`, `status_code` | Decode latency for prefill/decode-disaggregated requests |
-| `kthena_router_tokens_total` | Counter | `model`, `path`, `token_type` | Input or output tokens; `token_type` is `input` or `output` |
+| `kthena_router_tokens_total` | Counter | `model`, `path`, `token_type`, `model_route`, `backend_type`, `backend_name`, `upstream_model` | Input or output tokens; `token_type` is `input` or `output` |
 | `kthena_router_rate_limit_exceeded_total` | Counter | `model`, `limit_type`, `path` | Requests rejected by input-token, output-token, or request rate limits |
 | `kthena_router_active_requests` | Gauge | none | All requests currently handled by this router process |
 | `kthena_router_active_downstream_requests` | Gauge | `model` | Active client-to-router requests |
-| `kthena_router_active_upstream_requests` | Gauge | `model_server`, `model_route` | Active router-to-backend requests |
+| `kthena_router_active_upstream_requests` | Gauge | `model_server`, `model_route`, `backend_type`, `backend_name`, `upstream_model` | Active router-to-backend requests |
+
+Input token values come from the Router's pre-dispatch tokenizer and are also
+used for input rate limiting. Output token values use upstream-reported usage
+when it is available. For external providers, the input value may differ from
+billing usage because tokenizers, system prompts, and cache accounting vary by
+provider.
+
+Destination labels use values from resolved routing configuration:
+
+- `backend_type` is `model_server`, `external_provider`, `inference_pool`,
+  `unresolved`, or `none`.
+- `model_route` and `backend_name` use `namespace/name`; `none` means the label
+  does not apply.
+- `upstream_model` is the model sent to the backend. Without a backend override,
+  it is the requested model. LoRA requests use the matched adapter name.
+- `model_server` remains on `kthena_router_active_upstream_requests` for
+  compatibility and is `none` for other backend types.
 
 ### Scheduler and user-fairness queue
 
@@ -156,6 +173,11 @@ The JSON field names below match the emitted contract:
   "model_route": "prod/llama3-70b-route",
   "model_server": "prod/llama3-70b-server",
   "selected_pod": "llama3-70b-deployment-7b9f4c2d-kjx9p",
+  "backend_type": "model_server",
+  "backend_name": "prod/llama3-70b-server",
+  "upstream_model": "llama3-70b-instruct",
+  "upstream_status_code": 200,
+  "upstream_attempts": 1,
   "request_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
   "input_tokens": 412,
   "output_tokens": 189,

--- a/docs/proposal/router-observability.md
+++ b/docs/proposal/router-observability.md
@@ -51,6 +51,9 @@ The router exposes the following metrics to monitor request processing:
 - Standard HTTP status codes
 - Controlled model catalog
 - Predefined error types
+- Destination labels come from ModelRoute, ModelServer, ExternalModelProvider, and InferencePool objects or fixed sentinel values. They must not contain request IDs, URLs, Secret names, or raw errors.
+
+Adding `model_route`, `backend_type`, `backend_name`, and `upstream_model` to existing metrics is an intentional schema migration. It increases the possible series count by the configured route-backend-model combinations, but makes mixed internal and external destinations distinguishable without introducing a second set of metric names. Operators must update exact-label queries, alerts, recording rules, dashboards, and tests when adopting this schema.
 
 #### Request Processing Metrics
 

--- a/docs/proposal/router-observability.md
+++ b/docs/proposal/router-observability.md
@@ -41,6 +41,10 @@ The router exposes the following metrics to monitor request processing:
 - `status_code`: HTTP response status code (200, 400, 500) - monitor success/failure patterns
 - `model`: AI model name - essential for AI workload monitoring
 - `error_type`: Specific error categories for detailed troubleshooting
+- `model_route`: Namespaced ModelRoute name, or `none`
+- `backend_type`: Bounded destination kind (`model_server`, `external_provider`, `inference_pool`, `unresolved`, or `none`)
+- `backend_name`: Namespaced backend resource name, or `none`
+- `upstream_model`: Configured upstream model, or `none`
 
 **Label Cardinality Management**: Keep label values bounded to avoid high cardinality issues:
 - Limited set of endpoints and methods
@@ -51,20 +55,22 @@ The router exposes the following metrics to monitor request processing:
 #### Request Processing Metrics
 
 **HTTP Request Metrics**
-- `kthena_router_requests_total{model="<model_name>",path="<path>",status_code="<code>",error_type="<error_type>"}` (Counter)
+- `kthena_router_requests_total{model="<model_name>",path="<path>",status_code="<code>",error_type="<error_type>",model_route="<route_name>",backend_type="<type>",backend_name="<backend_name>",upstream_model="<upstream_model>"}` (Counter)
   - Total number of HTTP requests processed by the router
   - Labels: 
     - `model`: AI model name
     - `path`: Request path (/v1/chat/completions, /v1/completions, etc.)
     - `status_code`: HTTP response status code (200, 400, 500, etc.)
     - `error_type`: Type of error (validation, timeout, internal, rate_limit, etc.)
+    - `model_route`, `backend_type`, `backend_name`, `upstream_model`: Bounded destination identity
 
-- `kthena_router_request_duration_seconds{model="<model_name>",path="<path>",status_code="<code>"}` (Histogram)
+- `kthena_router_request_duration_seconds{model="<model_name>",path="<path>",status_code="<code>",model_route="<route_name>",backend_type="<type>",backend_name="<backend_name>",upstream_model="<upstream_model>"}` (Histogram)
   - End-to-end request processing latency distribution for all requests
   - Labels:
     - `model`: AI model name
     - `path`: Request path (/v1/chat/completions, /v1/completions, etc.)
     - `status_code`: HTTP response status code (200, 400, 500, etc.)
+    - `model_route`, `backend_type`, `backend_name`, `upstream_model`: Bounded destination identity
   - Buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60]
 
 - `kthena_router_request_prefill_duration_seconds{model="<model_name>",path="<path>",status_code="<code>"}` (Histogram)
@@ -88,19 +94,21 @@ The router exposes the following metrics to monitor request processing:
   - Labels:
     - `model`: AI model name
 
-- `kthena_router_active_upstream_requests{model_route="<route_name>",model_server="<server_name>"}` (Gauge)
+- `kthena_router_active_upstream_requests{model_server="<server_name>",model_route="<route_name>",backend_type="<type>",backend_name="<backend_name>",upstream_model="<upstream_model>"}` (Gauge)
   - Current number of active upstream requests (from router to backend pods)
   - Labels:
     - `model_route`: ModelRoute name handling the requests
     - `model_server`: ModelServer name processing the requests
+    - `backend_type`, `backend_name`, `upstream_model`: Destination-neutral backend identity; `model_server` is retained for query compatibility
 
 **AI-Specific Token Metrics**
-- `kthena_router_tokens_total{model="<model_name>",path="<path>",token_type="input|output"}` (Counter)
+- `kthena_router_tokens_total{model="<model_name>",path="<path>",token_type="input|output",model_route="<route_name>",backend_type="<type>",backend_name="<backend_name>",upstream_model="<upstream_model>"}` (Counter)
   - Total tokens processed/generated
   - Labels:
     - `model`: AI model name
     - `path`: Request path (/v1/chat/completions, /v1/completions, etc.)
     - `token_type`: Token type ("input" for processed tokens, "output" for generated tokens)
+    - `model_route`, `backend_type`, `backend_name`, `upstream_model`: Bounded destination identity
 
 **Scheduler Plugin Metrics**
 - `kthena_router_scheduler_plugin_duration_seconds{model="<model_name>",plugin="<plugin_name>",type="filter|score"}` (Histogram)
@@ -162,6 +170,11 @@ The router generates structured access logs for each request, following Envoy's 
   "model_route": "default/llama2-route-v1",
   "model_server": "default/llama2-server",
   "selected_pod": "llama2-deployment-5f7b8c9d-xk2p4",
+  "backend_type": "model_server",
+  "backend_name": "default/llama2-server",
+  "upstream_model": "llama2-7b",
+  "upstream_status_code": 200,
+  "upstream_attempts": 1,
   "request_id": "550e8400-e29b-41d4-a716-446655440000",
   
   // Token information
@@ -185,7 +198,7 @@ The router generates structured access logs for each request, following Envoy's 
 #### Text Format (Alternative)
 For environments preferring text logs, a structured text format is also supported:
 ```
-[2024-01-15T10:30:45.123Z] "POST /v1/chat/completions HTTP/1.1" 200 model_name=llama2-7b model_route=default/llama2-route-v1 model_server=default/llama2-server selected_pod=llama2-deployment-5f7b8c9d-xk2p4 request_id=550e8400-e29b-41d4-a716-446655440000 tokens=150/75 timings=2350ms(45+2180+5)
+[2024-01-15T10:30:45.123Z] "POST /v1/chat/completions HTTP/1.1" 200 model_name=llama2-7b model_route=default/llama2-route-v1 model_server=default/llama2-server selected_pod=llama2-deployment-5f7b8c9d-xk2p4 backend_type=model_server backend_name=default/llama2-server upstream_model=llama2-7b upstream_status_code=200 upstream_attempts=1 request_id=550e8400-e29b-41d4-a716-446655440000 tokens=150/75 timings=2350ms(45+2180+5)
 ```
 
 **Text Format Features:**
@@ -206,6 +219,12 @@ For environments preferring text logs, a structured text format is also supporte
 - `model_route`: Which ModelRoute CR was matched for this request (namespace/name format)
 - `model_server`: Which ModelServer CR was selected for routing (namespace/name format)
 - `selected_pod`: The specific pod that processed the inference request
+- `backend_type`: Destination kind shared by ModelServer, ExternalModelProvider, and InferencePool paths
+- `backend_name`: Namespaced backend resource name
+- `upstream_model`: Model identifier sent to the selected backend
+- `upstream_status_code`: HTTP status returned by the accepted upstream attempt
+- `upstream_attempts`: Number of upstream attempts made for the request
+- `error_origin`: Bounded failure origin (`router` or `upstream`), omitted for successful requests
 - `request_id`: Unique request identifier (generated if not provided in x-request-id header)
 
 **Token Tracking**:

--- a/pkg/kthena-router/accesslog/logger.go
+++ b/pkg/kthena-router/accesslog/logger.go
@@ -180,6 +180,24 @@ func (l *accessLoggerImpl) formatText(entry *AccessLogEntry) (string, error) {
 	if entry.RequestID != "" {
 		fmt.Fprintf(&line, " request_id=%s", entry.RequestID)
 	}
+	if entry.BackendType != "" {
+		fmt.Fprintf(&line, " backend_type=%s", entry.BackendType)
+	}
+	if entry.BackendName != "" {
+		fmt.Fprintf(&line, " backend_name=%s", entry.BackendName)
+	}
+	if entry.UpstreamModel != "" {
+		fmt.Fprintf(&line, " upstream_model=%s", entry.UpstreamModel)
+	}
+	if entry.UpstreamStatusCode > 0 {
+		fmt.Fprintf(&line, " upstream_status_code=%d", entry.UpstreamStatusCode)
+	}
+	if entry.UpstreamAttempts > 0 {
+		fmt.Fprintf(&line, " upstream_attempts=%d", entry.UpstreamAttempts)
+	}
+	if entry.ErrorOrigin != "" {
+		fmt.Fprintf(&line, " error_origin=%s", entry.ErrorOrigin)
+	}
 
 	// Add Gateway API / Inference Extension fields (if present)
 	if entry.Gateway != "" {

--- a/pkg/kthena-router/accesslog/logger_test.go
+++ b/pkg/kthena-router/accesslog/logger_test.go
@@ -37,6 +37,11 @@ func TestAccessLogEntry_ToJSON(t *testing.T) {
 		ModelServer:                "default/llama2-server",
 		SelectedPod:                "llama2-deployment-5f7b8c9d-xk2p4",
 		RequestID:                  "test-request-id",
+		BackendType:                "model_server",
+		BackendName:                "default/llama2-server",
+		UpstreamModel:              "llama2-7b",
+		UpstreamStatusCode:         200,
+		UpstreamAttempts:           1,
 		InputTokens:                150,
 		OutputTokens:               75,
 		DurationTotal:              2350,
@@ -68,6 +73,11 @@ func TestAccessLogEntry_ToJSON(t *testing.T) {
 	assert.Equal(t, "default/llama2-route-v1", parsed["model_route"])
 	assert.Equal(t, "default/llama2-server", parsed["model_server"])
 	assert.Equal(t, "llama2-deployment-5f7b8c9d-xk2p4", parsed["selected_pod"])
+	assert.Equal(t, "model_server", parsed["backend_type"])
+	assert.Equal(t, "default/llama2-server", parsed["backend_name"])
+	assert.Equal(t, "llama2-7b", parsed["upstream_model"])
+	assert.Equal(t, float64(200), parsed["upstream_status_code"])
+	assert.Equal(t, float64(1), parsed["upstream_attempts"])
 	assert.Equal(t, float64(150), parsed["input_tokens"])
 	assert.Equal(t, float64(75), parsed["output_tokens"])
 
@@ -90,6 +100,11 @@ func TestAccessLogEntry_ToText(t *testing.T) {
 		ModelServer:                "default/llama2-server",
 		SelectedPod:                "llama2-deployment-5f7b8c9d-xk2p4",
 		RequestID:                  "test-request-id",
+		BackendType:                "model_server",
+		BackendName:                "default/llama2-server",
+		UpstreamModel:              "llama2-7b",
+		UpstreamStatusCode:         200,
+		UpstreamAttempts:           1,
 		InputTokens:                150,
 		OutputTokens:               75,
 		DurationTotal:              2350,
@@ -118,6 +133,11 @@ func TestAccessLogEntry_ToText(t *testing.T) {
 		`model_server=default/llama2-server`,
 		`selected_pod=llama2-deployment-5f7b8c9d-xk2p4`,
 		`request_id=test-request-id`,
+		`backend_type=model_server`,
+		`backend_name=default/llama2-server`,
+		`upstream_model=llama2-7b`,
+		`upstream_status_code=200`,
+		`upstream_attempts=1`,
 		`tokens=150/75`,
 		`timings=2350ms(45+2180+5)`,
 	}
@@ -191,6 +211,15 @@ func TestAccessLogContext_Lifecycle(t *testing.T) {
 	assert.Equal(t, "default/test-route", ctx.ModelRoute)
 	assert.Equal(t, "default/test-server", ctx.ModelServer)
 	assert.Equal(t, "test-pod-123", ctx.SelectedPod)
+	ctx.SetBackendInfo("model_server", "default/test-server", "test-model-base")
+	ctx.SetUpstreamInfo(429, 2)
+	ctx.SetErrorOrigin("upstream")
+	assert.Equal(t, "model_server", ctx.BackendType)
+	assert.Equal(t, "default/test-server", ctx.BackendName)
+	assert.Equal(t, "test-model-base", ctx.UpstreamModel)
+	assert.Equal(t, 429, ctx.UpstreamStatusCode)
+	assert.Equal(t, 2, ctx.UpstreamAttempts)
+	assert.Equal(t, "upstream", ctx.ErrorOrigin)
 
 	// Set token counts
 	ctx.SetTokenCounts(100, 50)
@@ -225,6 +254,12 @@ func TestAccessLogContext_Lifecycle(t *testing.T) {
 	assert.Equal(t, "default/test-route", entry.ModelRoute)
 	assert.Equal(t, "default/test-server", entry.ModelServer)
 	assert.Equal(t, "test-pod-123", entry.SelectedPod)
+	assert.Equal(t, "model_server", entry.BackendType)
+	assert.Equal(t, "default/test-server", entry.BackendName)
+	assert.Equal(t, "test-model-base", entry.UpstreamModel)
+	assert.Equal(t, 429, entry.UpstreamStatusCode)
+	assert.Equal(t, 2, entry.UpstreamAttempts)
+	assert.Equal(t, "upstream", entry.ErrorOrigin)
 	assert.Equal(t, 100, entry.InputTokens)
 	assert.Equal(t, 50, entry.OutputTokens)
 	assert.Greater(t, entry.DurationTotal, int64(0))

--- a/pkg/kthena-router/accesslog/middleware.go
+++ b/pkg/kthena-router/accesslog/middleware.go
@@ -87,6 +87,27 @@ func SetRequestRouting(c *gin.Context, modelRoute, modelServer, selectedPod stri
 	}
 }
 
+// SetBackendInfo sets destination-neutral backend information in the access log context.
+func SetBackendInfo(c *gin.Context, backendType, backendName, upstreamModel string) {
+	if ctx := GetAccessLogContext(c); ctx != nil {
+		ctx.SetBackendInfo(backendType, backendName, upstreamModel)
+	}
+}
+
+// SetUpstreamInfo sets upstream attempt outcome information in the access log context.
+func SetUpstreamInfo(c *gin.Context, statusCode, attempts int) {
+	if ctx := GetAccessLogContext(c); ctx != nil {
+		ctx.SetUpstreamInfo(statusCode, attempts)
+	}
+}
+
+// SetErrorOrigin sets the bounded error origin in the access log context.
+func SetErrorOrigin(c *gin.Context, origin string) {
+	if ctx := GetAccessLogContext(c); ctx != nil {
+		ctx.SetErrorOrigin(origin)
+	}
+}
+
 // SetGatewayAPIInfo sets Gateway API / inference extension routing information in the access log context.
 func SetGatewayAPIInfo(c *gin.Context, gateway, httpRoute, inferencePool string) {
 	if ctx := GetAccessLogContext(c); ctx != nil {

--- a/pkg/kthena-router/accesslog/types.go
+++ b/pkg/kthena-router/accesslog/types.go
@@ -39,6 +39,14 @@ type AccessLogEntry struct {
 	SelectedPod string `json:"selected_pod,omitempty"`
 	RequestID   string `json:"request_id,omitempty"`
 
+	// Destination-neutral upstream information.
+	BackendType        string `json:"backend_type,omitempty"`
+	BackendName        string `json:"backend_name,omitempty"`
+	UpstreamModel      string `json:"upstream_model,omitempty"`
+	UpstreamStatusCode int    `json:"upstream_status_code,omitempty"`
+	UpstreamAttempts   int    `json:"upstream_attempts,omitempty"`
+	ErrorOrigin        string `json:"error_origin,omitempty"`
+
 	// Gateway API / Gateway API Inference Extension information
 	Gateway       string `json:"gateway,omitempty"`
 	HTTPRoute     string `json:"http_route,omitempty"`
@@ -76,6 +84,13 @@ type AccessLogContext struct {
 	Gateway       string
 	HTTPRoute     string
 	InferencePool string
+
+	BackendType        string
+	BackendName        string
+	UpstreamModel      string
+	UpstreamStatusCode int
+	UpstreamAttempts   int
+	ErrorOrigin        string
 
 	// Token counts
 	InputTokens  int
@@ -115,6 +130,28 @@ func (ctx *AccessLogContext) SetModelRouting(modelRoute string, modelServer stri
 	ctx.ModelRoute = modelRoute
 	ctx.ModelServer = modelServer
 	ctx.SelectedPod = selectedPod
+}
+
+// SetBackendInfo sets destination-neutral backend information.
+func (ctx *AccessLogContext) SetBackendInfo(backendType, backendName, upstreamModel string) {
+	ctx.BackendType = backendType
+	ctx.BackendName = backendName
+	ctx.UpstreamModel = upstreamModel
+}
+
+// SetUpstreamInfo sets upstream attempt outcome information.
+func (ctx *AccessLogContext) SetUpstreamInfo(statusCode, attempts int) {
+	if statusCode > 0 {
+		ctx.UpstreamStatusCode = statusCode
+	}
+	if attempts > 0 {
+		ctx.UpstreamAttempts = attempts
+	}
+}
+
+// SetErrorOrigin sets the bounded error origin.
+func (ctx *AccessLogContext) SetErrorOrigin(origin string) {
+	ctx.ErrorOrigin = origin
 }
 
 // SetGatewayAPIInfo sets Gateway API related information (if available).
@@ -208,6 +245,12 @@ func (ctx *AccessLogContext) ToAccessLogEntry(statusCode int) *AccessLogEntry {
 		ModelServer:                modelServerName,
 		SelectedPod:                ctx.SelectedPod,
 		RequestID:                  ctx.RequestID,
+		BackendType:                ctx.BackendType,
+		BackendName:                ctx.BackendName,
+		UpstreamModel:              ctx.UpstreamModel,
+		UpstreamStatusCode:         ctx.UpstreamStatusCode,
+		UpstreamAttempts:           ctx.UpstreamAttempts,
+		ErrorOrigin:                ctx.ErrorOrigin,
 		Gateway:                    ctx.Gateway,
 		HTTPRoute:                  ctx.HTTPRoute,
 		InferencePool:              ctx.InferencePool,

--- a/pkg/kthena-router/metrics/metrics.go
+++ b/pkg/kthena-router/metrics/metrics.go
@@ -26,19 +26,22 @@ import (
 
 const (
 	// Label names
-	LabelModel       = "model"
-	LabelPath        = "path"
-	LabelStatusCode  = "status_code"
-	LabelErrorType   = "error_type"
-	LabelTokenType   = "token_type"
-	LabelPlugin      = "plugin"
-	LabelType        = "type"
-	LabelLimitType   = "limit_type"
-	LabelModelRoute  = "model_route"
-	LabelModelServer = "model_server"
-	LabelEngine      = "engine"
-	LabelUserID      = "user_id"
-	LabelStage       = "stage"
+	LabelModel         = "model"
+	LabelPath          = "path"
+	LabelStatusCode    = "status_code"
+	LabelErrorType     = "error_type"
+	LabelTokenType     = "token_type"
+	LabelPlugin        = "plugin"
+	LabelType          = "type"
+	LabelLimitType     = "limit_type"
+	LabelModelRoute    = "model_route"
+	LabelModelServer   = "model_server"
+	LabelBackendType   = "backend_type"
+	LabelBackendName   = "backend_name"
+	LabelUpstreamModel = "upstream_model"
+	LabelEngine        = "engine"
+	LabelUserID        = "user_id"
+	LabelStage         = "stage"
 
 	UnknownModel            = "unknown"
 	FairnessAggregateUserID = "_all"
@@ -59,6 +62,14 @@ const (
 	LimitTypeInputTokens  = "input_tokens"
 	LimitTypeOutputTokens = "output_tokens"
 	LimitTypeRequests     = "requests"
+
+	// Backend type values
+	BackendTypeNone             = "none"
+	BackendTypeModelServer      = "model_server"
+	BackendTypeExternalProvider = "external_provider"
+	BackendTypeInferencePool    = "inference_pool"
+	BackendTypeUnresolved       = "unresolved"
+	DestinationLabelValueNone   = "none"
 )
 
 // Metrics holds all Prometheus metrics for the kthena-router
@@ -128,7 +139,7 @@ func NewMetrics() *Metrics {
 				Name: "kthena_router_requests_total",
 				Help: "Total number of HTTP requests processed by the router",
 			},
-			[]string{LabelModel, LabelPath, LabelStatusCode, LabelErrorType},
+			[]string{LabelModel, LabelPath, LabelStatusCode, LabelErrorType, LabelModelRoute, LabelBackendType, LabelBackendName, LabelUpstreamModel},
 		),
 
 		RequestDuration: *promauto.NewHistogramVec(
@@ -137,7 +148,7 @@ func NewMetrics() *Metrics {
 				Help:    "End-to-end request processing latency distribution for all requests",
 				Buckets: []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60},
 			},
-			[]string{LabelModel, LabelPath, LabelStatusCode},
+			[]string{LabelModel, LabelPath, LabelStatusCode, LabelModelRoute, LabelBackendType, LabelBackendName, LabelUpstreamModel},
 		),
 
 		RequestPrefillDuration: *promauto.NewHistogramVec(
@@ -163,7 +174,7 @@ func NewMetrics() *Metrics {
 				Name: "kthena_router_tokens_total",
 				Help: "Total tokens processed/generated",
 			},
-			[]string{LabelModel, LabelPath, LabelTokenType},
+			[]string{LabelModel, LabelPath, LabelTokenType, LabelModelRoute, LabelBackendType, LabelBackendName, LabelUpstreamModel},
 		),
 
 		SchedulerPluginDuration: *promauto.NewHistogramVec(
@@ -196,7 +207,7 @@ func NewMetrics() *Metrics {
 				Name: "kthena_router_active_upstream_requests",
 				Help: "Current number of active upstream requests (from router to backend pods)",
 			},
-			[]string{LabelModelServer, LabelModelRoute},
+			[]string{LabelModelServer, LabelModelRoute, LabelBackendType, LabelBackendName, LabelUpstreamModel},
 		),
 
 		FairnessQueueSize: *promauto.NewGaugeVec(
@@ -415,8 +426,14 @@ func (m *Metrics) RecordKVCacheError(model, stage string) {
 
 // RecordRequest records a completed request with all relevant metrics
 func (m *Metrics) RecordRequest(model, path, statusCode, errorType string, duration time.Duration) {
-	m.RequestsTotal.WithLabelValues(model, path, statusCode, errorType).Inc()
-	m.RequestDuration.WithLabelValues(model, path, statusCode).Observe(duration.Seconds())
+	m.RecordRequestForDestination(model, path, statusCode, errorType, "", "", "", "", duration)
+}
+
+// RecordRequestForDestination records a completed request with backend destination labels.
+func (m *Metrics) RecordRequestForDestination(model, path, statusCode, errorType, modelRoute, backendType, backendName, upstreamModel string, duration time.Duration) {
+	modelRoute, backendType, backendName, upstreamModel = normalizeDestinationLabels(modelRoute, backendType, backendName, upstreamModel)
+	m.RequestsTotal.WithLabelValues(model, path, statusCode, errorType, modelRoute, backendType, backendName, upstreamModel).Inc()
+	m.RequestDuration.WithLabelValues(model, path, statusCode, modelRoute, backendType, backendName, upstreamModel).Observe(duration.Seconds())
 }
 
 // RecordPrefillDuration records prefill phase duration for PD-disaggregated requests
@@ -431,11 +448,17 @@ func (m *Metrics) RecordDecodeDuration(model, path, statusCode string, duration 
 
 // RecordTokens records input and output token counts
 func (m *Metrics) RecordTokens(model, path string, inputTokens, outputTokens int) {
+	m.RecordTokensForDestination(model, path, "", "", "", "", inputTokens, outputTokens)
+}
+
+// RecordTokensForDestination records input and output token counts with backend destination labels.
+func (m *Metrics) RecordTokensForDestination(model, path, modelRoute, backendType, backendName, upstreamModel string, inputTokens, outputTokens int) {
+	modelRoute, backendType, backendName, upstreamModel = normalizeDestinationLabels(modelRoute, backendType, backendName, upstreamModel)
 	if inputTokens > 0 {
-		m.TokensTotal.WithLabelValues(model, path, TokenTypeInput).Add(float64(inputTokens))
+		m.TokensTotal.WithLabelValues(model, path, TokenTypeInput, modelRoute, backendType, backendName, upstreamModel).Add(float64(inputTokens))
 	}
 	if outputTokens > 0 {
-		m.TokensTotal.WithLabelValues(model, path, TokenTypeOutput).Add(float64(outputTokens))
+		m.TokensTotal.WithLabelValues(model, path, TokenTypeOutput, modelRoute, backendType, backendName, upstreamModel).Add(float64(outputTokens))
 	}
 }
 
@@ -476,7 +499,14 @@ func (m *Metrics) SetActiveDownstreamRequests(model string, count float64) {
 
 // SetActiveUpstreamRequests sets the current number of active upstream requests
 func (m *Metrics) SetActiveUpstreamRequests(modelServer, modelRoute string, count float64) {
-	m.ActiveUpstreamRequests.WithLabelValues(modelServer, modelRoute).Set(count)
+	m.SetActiveUpstreamRequestsForDestination(modelRoute, BackendTypeModelServer, modelServer, "", count)
+}
+
+// SetActiveUpstreamRequestsForDestination sets active upstream requests with backend destination labels.
+func (m *Metrics) SetActiveUpstreamRequestsForDestination(modelRoute, backendType, backendName, upstreamModel string, count float64) {
+	modelRoute, backendType, backendName, upstreamModel = normalizeDestinationLabels(modelRoute, backendType, backendName, upstreamModel)
+	modelServer := activeUpstreamModelServerLabel(backendType, backendName)
+	m.ActiveUpstreamRequests.WithLabelValues(modelServer, modelRoute, backendType, backendName, upstreamModel).Set(count)
 }
 
 // IncActiveDownstreamRequests increments the active downstream requests counter
@@ -491,12 +521,26 @@ func (m *Metrics) DecActiveDownstreamRequests(model string) {
 
 // IncActiveUpstreamRequests increments the active upstream requests counter
 func (m *Metrics) IncActiveUpstreamRequests(modelServer, modelRoute string) {
-	m.ActiveUpstreamRequests.WithLabelValues(modelServer, modelRoute).Inc()
+	m.IncActiveUpstreamRequestsForDestination(modelRoute, BackendTypeModelServer, modelServer, "")
+}
+
+// IncActiveUpstreamRequestsForDestination increments active upstream requests with backend destination labels.
+func (m *Metrics) IncActiveUpstreamRequestsForDestination(modelRoute, backendType, backendName, upstreamModel string) {
+	modelRoute, backendType, backendName, upstreamModel = normalizeDestinationLabels(modelRoute, backendType, backendName, upstreamModel)
+	modelServer := activeUpstreamModelServerLabel(backendType, backendName)
+	m.ActiveUpstreamRequests.WithLabelValues(modelServer, modelRoute, backendType, backendName, upstreamModel).Inc()
 }
 
 // DecActiveUpstreamRequests decrements the active upstream requests counter
 func (m *Metrics) DecActiveUpstreamRequests(modelServer, modelRoute string) {
-	m.ActiveUpstreamRequests.WithLabelValues(modelServer, modelRoute).Dec()
+	m.DecActiveUpstreamRequestsForDestination(modelRoute, BackendTypeModelServer, modelServer, "")
+}
+
+// DecActiveUpstreamRequestsForDestination decrements active upstream requests with backend destination labels.
+func (m *Metrics) DecActiveUpstreamRequestsForDestination(modelRoute, backendType, backendName, upstreamModel string) {
+	modelRoute, backendType, backendName, upstreamModel = normalizeDestinationLabels(modelRoute, backendType, backendName, upstreamModel)
+	modelServer := activeUpstreamModelServerLabel(backendType, backendName)
+	m.ActiveUpstreamRequests.WithLabelValues(modelServer, modelRoute, backendType, backendName, upstreamModel).Dec()
 }
 
 // IncFairnessQueueSize increments the fairness queue size. Raw user identifiers
@@ -592,14 +636,19 @@ func (m *Metrics) DecSessionBoostQueueInflight(model string) {
 
 // RequestMetricsRecorder is a helper struct to record detailed metrics for individual requests
 type RequestMetricsRecorder struct {
-	metrics          *Metrics
-	model            string
-	path             string
-	modelServer      string
-	modelRoute       string
-	startTime        time.Time
-	prefillStartTime *time.Time
-	decodeStartTime  *time.Time
+	metrics            *Metrics
+	model              string
+	path               string
+	modelServer        string
+	modelRoute         string
+	backendType        string
+	backendName        string
+	upstreamModel      string
+	destinationBound   bool
+	pendingInputTokens int
+	startTime          time.Time
+	prefillStartTime   *time.Time
+	decodeStartTime    *time.Time
 }
 
 // NewRequestMetricsRecorder creates a new recorder for a specific request
@@ -616,20 +665,39 @@ func NewRequestMetricsRecorder(metrics *Metrics, model, path string) *RequestMet
 func (r *RequestMetricsRecorder) SetUpstreamConnectionInfo(modelServer, modelRoute string) {
 	r.modelServer = modelServer
 	r.modelRoute = modelRoute
+	r.BindDestination(modelRoute, BackendTypeModelServer, modelServer, "")
+}
+
+// BindDestination sets backend labels for request-scoped metrics and flushes
+// input tokens that were measured before routing selected a backend.
+func (r *RequestMetricsRecorder) BindDestination(modelRoute, backendType, backendName, upstreamModel string) {
+	r.modelRoute, r.backendType, r.backendName, r.upstreamModel = normalizeDestinationLabels(modelRoute, backendType, backendName, upstreamModel)
+	r.modelServer = r.backendName
+	r.destinationBound = true
+	if r.pendingInputTokens > 0 {
+		r.metrics.RecordTokensForDestination(r.model, r.path, r.modelRoute, r.backendType, r.backendName, r.upstreamModel, r.pendingInputTokens, 0)
+		r.pendingInputTokens = 0
+	}
 }
 
 // RecordInputTokens records input token usage for this request
 func (r *RequestMetricsRecorder) RecordInputTokens(tokens int) {
-	if tokens > 0 {
-		r.metrics.TokensTotal.WithLabelValues(r.model, r.path, TokenTypeInput).Add(float64(tokens))
+	if tokens <= 0 {
+		return
 	}
+	if !r.destinationBound {
+		r.pendingInputTokens += tokens
+		return
+	}
+	r.metrics.RecordTokensForDestination(r.model, r.path, r.modelRoute, r.backendType, r.backendName, r.upstreamModel, tokens, 0)
 }
 
 // RecordOutputTokens records output token usage for this request
 func (r *RequestMetricsRecorder) RecordOutputTokens(tokens int) {
-	if tokens > 0 {
-		r.metrics.TokensTotal.WithLabelValues(r.model, r.path, TokenTypeOutput).Add(float64(tokens))
+	if tokens <= 0 {
+		return
 	}
+	r.metrics.RecordTokensForDestination(r.model, r.path, r.modelRoute, r.backendType, r.backendName, r.upstreamModel, 0, tokens)
 }
 
 // RecordRateLimitExceeded records when rate limiting is applied
@@ -667,8 +735,12 @@ func (r *RequestMetricsRecorder) FinishDecodePhase(statusCode string) {
 
 // Finish completes the request recording with final status
 func (r *RequestMetricsRecorder) Finish(statusCode, errorType string) {
+	if !r.destinationBound && r.pendingInputTokens > 0 {
+		r.metrics.RecordTokensForDestination(r.model, r.path, DestinationLabelValueNone, BackendTypeUnresolved, DestinationLabelValueNone, DestinationLabelValueNone, r.pendingInputTokens, 0)
+		r.pendingInputTokens = 0
+	}
 	duration := time.Since(r.startTime)
-	r.metrics.RecordRequest(r.model, r.path, statusCode, errorType, duration)
+	r.metrics.RecordRequestForDestination(r.model, r.path, statusCode, errorType, r.modelRoute, r.backendType, r.backendName, r.upstreamModel, duration)
 }
 
 // RecordSchedulerPluginDuration records the execution time for a scheduler plugin
@@ -703,17 +775,40 @@ func (r *RequestMetricsRecorder) RecordKVCacheError(stage string) {
 
 // IncActiveUpstreamRequests increments the active upstream requests counter for this request
 func (r *RequestMetricsRecorder) IncActiveUpstreamRequests() {
-	if r.modelServer != "" && r.modelRoute != "" {
-		r.metrics.IncActiveUpstreamRequests(r.modelServer, r.modelRoute)
+	if r.destinationBound {
+		r.metrics.IncActiveUpstreamRequestsForDestination(r.modelRoute, r.backendType, r.backendName, r.upstreamModel)
 	}
 }
 
 // DecActiveUpstreamRequests decrements the active upstream requests counter for this request
 func (r *RequestMetricsRecorder) DecActiveUpstreamRequests() {
-	if r.modelServer != "" && r.modelRoute != "" {
-		r.metrics.DecActiveUpstreamRequests(r.modelServer, r.modelRoute)
+	if r.destinationBound {
+		r.metrics.DecActiveUpstreamRequestsForDestination(r.modelRoute, r.backendType, r.backendName, r.upstreamModel)
 	}
 }
 
 // Global metrics instance
 var DefaultMetrics = NewMetrics()
+
+func normalizeDestinationLabels(modelRoute, backendType, backendName, upstreamModel string) (string, string, string, string) {
+	if modelRoute == "" {
+		modelRoute = DestinationLabelValueNone
+	}
+	if backendType == "" {
+		backendType = BackendTypeUnresolved
+	}
+	if backendName == "" {
+		backendName = DestinationLabelValueNone
+	}
+	if upstreamModel == "" {
+		upstreamModel = DestinationLabelValueNone
+	}
+	return modelRoute, backendType, backendName, upstreamModel
+}
+
+func activeUpstreamModelServerLabel(backendType, backendName string) string {
+	if backendType == BackendTypeModelServer {
+		return backendName
+	}
+	return DestinationLabelValueNone
+}

--- a/pkg/kthena-router/metrics/metrics.go
+++ b/pkg/kthena-router/metrics/metrics.go
@@ -205,7 +205,7 @@ func NewMetrics() *Metrics {
 		ActiveUpstreamRequests: *promauto.NewGaugeVec(
 			prometheus.GaugeOpts{
 				Name: "kthena_router_active_upstream_requests",
-				Help: "Current number of active upstream requests (from router to backend pods)",
+				Help: "Current number of active upstream requests (from router to upstream backends)",
 			},
 			[]string{LabelModelServer, LabelModelRoute, LabelBackendType, LabelBackendName, LabelUpstreamModel},
 		),

--- a/pkg/kthena-router/metrics/metrics.go
+++ b/pkg/kthena-router/metrics/metrics.go
@@ -72,6 +72,16 @@ const (
 	DestinationLabelValueNone   = "none"
 )
 
+// DestinationLabels identifies the backend selected for a routed request.
+// Keeping the four labels together prevents callers from accidentally mixing
+// values when recording different metric families for the same destination.
+type DestinationLabels struct {
+	ModelRoute    string
+	BackendType   string
+	BackendName   string
+	UpstreamModel string
+}
+
 // Metrics holds all Prometheus metrics for the kthena-router
 type Metrics struct {
 	// Request counters
@@ -426,14 +436,35 @@ func (m *Metrics) RecordKVCacheError(model, stage string) {
 
 // RecordRequest records a completed request with all relevant metrics
 func (m *Metrics) RecordRequest(model, path, statusCode, errorType string, duration time.Duration) {
-	m.RecordRequestForDestination(model, path, statusCode, errorType, "", "", "", "", duration)
+	m.RecordRequestForDestination(model, path, statusCode, errorType, DestinationLabels{}, duration)
 }
 
 // RecordRequestForDestination records a completed request with backend destination labels.
-func (m *Metrics) RecordRequestForDestination(model, path, statusCode, errorType, modelRoute, backendType, backendName, upstreamModel string, duration time.Duration) {
-	modelRoute, backendType, backendName, upstreamModel = normalizeDestinationLabels(modelRoute, backendType, backendName, upstreamModel)
-	m.RequestsTotal.WithLabelValues(model, path, statusCode, errorType, modelRoute, backendType, backendName, upstreamModel).Inc()
-	m.RequestDuration.WithLabelValues(model, path, statusCode, modelRoute, backendType, backendName, upstreamModel).Observe(duration.Seconds())
+func (m *Metrics) RecordRequestForDestination(
+	model, path, statusCode, errorType string,
+	destination DestinationLabels,
+	duration time.Duration,
+) {
+	destination = destination.normalized()
+	m.RequestsTotal.WithLabelValues(
+		model,
+		path,
+		statusCode,
+		errorType,
+		destination.ModelRoute,
+		destination.BackendType,
+		destination.BackendName,
+		destination.UpstreamModel,
+	).Inc()
+	m.RequestDuration.WithLabelValues(
+		model,
+		path,
+		statusCode,
+		destination.ModelRoute,
+		destination.BackendType,
+		destination.BackendName,
+		destination.UpstreamModel,
+	).Observe(duration.Seconds())
 }
 
 // RecordPrefillDuration records prefill phase duration for PD-disaggregated requests
@@ -448,17 +479,37 @@ func (m *Metrics) RecordDecodeDuration(model, path, statusCode string, duration 
 
 // RecordTokens records input and output token counts
 func (m *Metrics) RecordTokens(model, path string, inputTokens, outputTokens int) {
-	m.RecordTokensForDestination(model, path, "", "", "", "", inputTokens, outputTokens)
+	m.RecordTokensForDestination(model, path, DestinationLabels{}, inputTokens, outputTokens)
 }
 
 // RecordTokensForDestination records input and output token counts with backend destination labels.
-func (m *Metrics) RecordTokensForDestination(model, path, modelRoute, backendType, backendName, upstreamModel string, inputTokens, outputTokens int) {
-	modelRoute, backendType, backendName, upstreamModel = normalizeDestinationLabels(modelRoute, backendType, backendName, upstreamModel)
+func (m *Metrics) RecordTokensForDestination(
+	model, path string,
+	destination DestinationLabels,
+	inputTokens, outputTokens int,
+) {
+	destination = destination.normalized()
 	if inputTokens > 0 {
-		m.TokensTotal.WithLabelValues(model, path, TokenTypeInput, modelRoute, backendType, backendName, upstreamModel).Add(float64(inputTokens))
+		m.TokensTotal.WithLabelValues(
+			model,
+			path,
+			TokenTypeInput,
+			destination.ModelRoute,
+			destination.BackendType,
+			destination.BackendName,
+			destination.UpstreamModel,
+		).Add(float64(inputTokens))
 	}
 	if outputTokens > 0 {
-		m.TokensTotal.WithLabelValues(model, path, TokenTypeOutput, modelRoute, backendType, backendName, upstreamModel).Add(float64(outputTokens))
+		m.TokensTotal.WithLabelValues(
+			model,
+			path,
+			TokenTypeOutput,
+			destination.ModelRoute,
+			destination.BackendType,
+			destination.BackendName,
+			destination.UpstreamModel,
+		).Add(float64(outputTokens))
 	}
 }
 
@@ -499,14 +550,24 @@ func (m *Metrics) SetActiveDownstreamRequests(model string, count float64) {
 
 // SetActiveUpstreamRequests sets the current number of active upstream requests
 func (m *Metrics) SetActiveUpstreamRequests(modelServer, modelRoute string, count float64) {
-	m.SetActiveUpstreamRequestsForDestination(modelRoute, BackendTypeModelServer, modelServer, "", count)
+	m.SetActiveUpstreamRequestsForDestination(DestinationLabels{
+		ModelRoute:  modelRoute,
+		BackendType: BackendTypeModelServer,
+		BackendName: modelServer,
+	}, count)
 }
 
 // SetActiveUpstreamRequestsForDestination sets active upstream requests with backend destination labels.
-func (m *Metrics) SetActiveUpstreamRequestsForDestination(modelRoute, backendType, backendName, upstreamModel string, count float64) {
-	modelRoute, backendType, backendName, upstreamModel = normalizeDestinationLabels(modelRoute, backendType, backendName, upstreamModel)
-	modelServer := activeUpstreamModelServerLabel(backendType, backendName)
-	m.ActiveUpstreamRequests.WithLabelValues(modelServer, modelRoute, backendType, backendName, upstreamModel).Set(count)
+func (m *Metrics) SetActiveUpstreamRequestsForDestination(destination DestinationLabels, count float64) {
+	destination = destination.normalized()
+	modelServer := activeUpstreamModelServerLabel(destination)
+	m.ActiveUpstreamRequests.WithLabelValues(
+		modelServer,
+		destination.ModelRoute,
+		destination.BackendType,
+		destination.BackendName,
+		destination.UpstreamModel,
+	).Set(count)
 }
 
 // IncActiveDownstreamRequests increments the active downstream requests counter
@@ -521,26 +582,46 @@ func (m *Metrics) DecActiveDownstreamRequests(model string) {
 
 // IncActiveUpstreamRequests increments the active upstream requests counter
 func (m *Metrics) IncActiveUpstreamRequests(modelServer, modelRoute string) {
-	m.IncActiveUpstreamRequestsForDestination(modelRoute, BackendTypeModelServer, modelServer, "")
+	m.IncActiveUpstreamRequestsForDestination(DestinationLabels{
+		ModelRoute:  modelRoute,
+		BackendType: BackendTypeModelServer,
+		BackendName: modelServer,
+	})
 }
 
 // IncActiveUpstreamRequestsForDestination increments active upstream requests with backend destination labels.
-func (m *Metrics) IncActiveUpstreamRequestsForDestination(modelRoute, backendType, backendName, upstreamModel string) {
-	modelRoute, backendType, backendName, upstreamModel = normalizeDestinationLabels(modelRoute, backendType, backendName, upstreamModel)
-	modelServer := activeUpstreamModelServerLabel(backendType, backendName)
-	m.ActiveUpstreamRequests.WithLabelValues(modelServer, modelRoute, backendType, backendName, upstreamModel).Inc()
+func (m *Metrics) IncActiveUpstreamRequestsForDestination(destination DestinationLabels) {
+	destination = destination.normalized()
+	modelServer := activeUpstreamModelServerLabel(destination)
+	m.ActiveUpstreamRequests.WithLabelValues(
+		modelServer,
+		destination.ModelRoute,
+		destination.BackendType,
+		destination.BackendName,
+		destination.UpstreamModel,
+	).Inc()
 }
 
 // DecActiveUpstreamRequests decrements the active upstream requests counter
 func (m *Metrics) DecActiveUpstreamRequests(modelServer, modelRoute string) {
-	m.DecActiveUpstreamRequestsForDestination(modelRoute, BackendTypeModelServer, modelServer, "")
+	m.DecActiveUpstreamRequestsForDestination(DestinationLabels{
+		ModelRoute:  modelRoute,
+		BackendType: BackendTypeModelServer,
+		BackendName: modelServer,
+	})
 }
 
 // DecActiveUpstreamRequestsForDestination decrements active upstream requests with backend destination labels.
-func (m *Metrics) DecActiveUpstreamRequestsForDestination(modelRoute, backendType, backendName, upstreamModel string) {
-	modelRoute, backendType, backendName, upstreamModel = normalizeDestinationLabels(modelRoute, backendType, backendName, upstreamModel)
-	modelServer := activeUpstreamModelServerLabel(backendType, backendName)
-	m.ActiveUpstreamRequests.WithLabelValues(modelServer, modelRoute, backendType, backendName, upstreamModel).Dec()
+func (m *Metrics) DecActiveUpstreamRequestsForDestination(destination DestinationLabels) {
+	destination = destination.normalized()
+	modelServer := activeUpstreamModelServerLabel(destination)
+	m.ActiveUpstreamRequests.WithLabelValues(
+		modelServer,
+		destination.ModelRoute,
+		destination.BackendType,
+		destination.BackendName,
+		destination.UpstreamModel,
+	).Dec()
 }
 
 // IncFairnessQueueSize increments the fairness queue size. Raw user identifiers
@@ -639,11 +720,7 @@ type RequestMetricsRecorder struct {
 	metrics            *Metrics
 	model              string
 	path               string
-	modelServer        string
-	modelRoute         string
-	backendType        string
-	backendName        string
-	upstreamModel      string
+	destination        DestinationLabels
 	destinationBound   bool
 	pendingInputTokens int
 	startTime          time.Time
@@ -661,21 +738,13 @@ func NewRequestMetricsRecorder(metrics *Metrics, model, path string) *RequestMet
 	}
 }
 
-// SetUpstreamConnectionInfo sets the upstream connection information for this request
-func (r *RequestMetricsRecorder) SetUpstreamConnectionInfo(modelServer, modelRoute string) {
-	r.modelServer = modelServer
-	r.modelRoute = modelRoute
-	r.BindDestination(modelRoute, BackendTypeModelServer, modelServer, "")
-}
-
 // BindDestination sets backend labels for request-scoped metrics and flushes
 // input tokens that were measured before routing selected a backend.
-func (r *RequestMetricsRecorder) BindDestination(modelRoute, backendType, backendName, upstreamModel string) {
-	r.modelRoute, r.backendType, r.backendName, r.upstreamModel = normalizeDestinationLabels(modelRoute, backendType, backendName, upstreamModel)
-	r.modelServer = r.backendName
+func (r *RequestMetricsRecorder) BindDestination(destination DestinationLabels) {
+	r.destination = destination.normalized()
 	r.destinationBound = true
 	if r.pendingInputTokens > 0 {
-		r.metrics.RecordTokensForDestination(r.model, r.path, r.modelRoute, r.backendType, r.backendName, r.upstreamModel, r.pendingInputTokens, 0)
+		r.metrics.RecordTokensForDestination(r.model, r.path, r.destination, r.pendingInputTokens, 0)
 		r.pendingInputTokens = 0
 	}
 }
@@ -689,7 +758,7 @@ func (r *RequestMetricsRecorder) RecordInputTokens(tokens int) {
 		r.pendingInputTokens += tokens
 		return
 	}
-	r.metrics.RecordTokensForDestination(r.model, r.path, r.modelRoute, r.backendType, r.backendName, r.upstreamModel, tokens, 0)
+	r.metrics.RecordTokensForDestination(r.model, r.path, r.destination, tokens, 0)
 }
 
 // RecordOutputTokens records output token usage for this request
@@ -697,7 +766,7 @@ func (r *RequestMetricsRecorder) RecordOutputTokens(tokens int) {
 	if tokens <= 0 {
 		return
 	}
-	r.metrics.RecordTokensForDestination(r.model, r.path, r.modelRoute, r.backendType, r.backendName, r.upstreamModel, 0, tokens)
+	r.metrics.RecordTokensForDestination(r.model, r.path, r.destination, 0, tokens)
 }
 
 // RecordRateLimitExceeded records when rate limiting is applied
@@ -736,11 +805,11 @@ func (r *RequestMetricsRecorder) FinishDecodePhase(statusCode string) {
 // Finish completes the request recording with final status
 func (r *RequestMetricsRecorder) Finish(statusCode, errorType string) {
 	if !r.destinationBound && r.pendingInputTokens > 0 {
-		r.metrics.RecordTokensForDestination(r.model, r.path, DestinationLabelValueNone, BackendTypeUnresolved, DestinationLabelValueNone, DestinationLabelValueNone, r.pendingInputTokens, 0)
+		r.metrics.RecordTokensForDestination(r.model, r.path, DestinationLabels{}, r.pendingInputTokens, 0)
 		r.pendingInputTokens = 0
 	}
 	duration := time.Since(r.startTime)
-	r.metrics.RecordRequestForDestination(r.model, r.path, statusCode, errorType, r.modelRoute, r.backendType, r.backendName, r.upstreamModel, duration)
+	r.metrics.RecordRequestForDestination(r.model, r.path, statusCode, errorType, r.destination, duration)
 }
 
 // RecordSchedulerPluginDuration records the execution time for a scheduler plugin
@@ -776,39 +845,39 @@ func (r *RequestMetricsRecorder) RecordKVCacheError(stage string) {
 // IncActiveUpstreamRequests increments the active upstream requests counter for this request
 func (r *RequestMetricsRecorder) IncActiveUpstreamRequests() {
 	if r.destinationBound {
-		r.metrics.IncActiveUpstreamRequestsForDestination(r.modelRoute, r.backendType, r.backendName, r.upstreamModel)
+		r.metrics.IncActiveUpstreamRequestsForDestination(r.destination)
 	}
 }
 
 // DecActiveUpstreamRequests decrements the active upstream requests counter for this request
 func (r *RequestMetricsRecorder) DecActiveUpstreamRequests() {
 	if r.destinationBound {
-		r.metrics.DecActiveUpstreamRequestsForDestination(r.modelRoute, r.backendType, r.backendName, r.upstreamModel)
+		r.metrics.DecActiveUpstreamRequestsForDestination(r.destination)
 	}
 }
 
 // Global metrics instance
 var DefaultMetrics = NewMetrics()
 
-func normalizeDestinationLabels(modelRoute, backendType, backendName, upstreamModel string) (string, string, string, string) {
-	if modelRoute == "" {
-		modelRoute = DestinationLabelValueNone
+func (destination DestinationLabels) normalized() DestinationLabels {
+	if destination.ModelRoute == "" {
+		destination.ModelRoute = DestinationLabelValueNone
 	}
-	if backendType == "" {
-		backendType = BackendTypeUnresolved
+	if destination.BackendType == "" {
+		destination.BackendType = BackendTypeUnresolved
 	}
-	if backendName == "" {
-		backendName = DestinationLabelValueNone
+	if destination.BackendName == "" {
+		destination.BackendName = DestinationLabelValueNone
 	}
-	if upstreamModel == "" {
-		upstreamModel = DestinationLabelValueNone
+	if destination.UpstreamModel == "" {
+		destination.UpstreamModel = DestinationLabelValueNone
 	}
-	return modelRoute, backendType, backendName, upstreamModel
+	return destination
 }
 
-func activeUpstreamModelServerLabel(backendType, backendName string) string {
-	if backendType == BackendTypeModelServer {
-		return backendName
+func activeUpstreamModelServerLabel(destination DestinationLabels) string {
+	if destination.BackendType == BackendTypeModelServer {
+		return destination.BackendName
 	}
 	return DestinationLabelValueNone
 }

--- a/pkg/kthena-router/metrics/metrics_test.go
+++ b/pkg/kthena-router/metrics/metrics_test.go
@@ -83,6 +83,19 @@ func counterVal(t *testing.T, vec *prometheus.CounterVec, lvs ...string) float64
 	return m.GetCounter().GetValue()
 }
 
+func gaugeVal(t *testing.T, vec *prometheus.GaugeVec, lvs ...string) float64 {
+	t.Helper()
+	g, err := vec.GetMetricWithLabelValues(lvs...)
+	if err != nil {
+		t.Fatalf("GetMetricWithLabelValues: %v", err)
+	}
+	m := &dto.Metric{}
+	if err := g.Write(m); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	return m.GetGauge().GetValue()
+}
+
 func TestFairnessMetricsAggregateUserIdentity(t *testing.T) {
 	m := DefaultMetrics
 	const model = "metricstest-fairness-aggregate-user"
@@ -235,5 +248,74 @@ func TestRequestRecorderDelegation(t *testing.T) {
 	}
 	if got := histCount(t, &m.KVCacheMatchRatio, model) - kvBefore; got != 1 {
 		t.Errorf("recorder kvcache match_ratio delta = %d, want 1", got)
+	}
+}
+
+func TestRequestRecorderBindsDestinationLabels(t *testing.T) {
+	m := DefaultMetrics
+	const model = "metricstest-recorder-destination"
+	const path = "/v1/chat/completions"
+	const modelRoute = "default/mr-external"
+	const backendName = "default/openai-provider"
+	const upstreamModel = "gpt-4o-mini"
+	r := NewRequestMetricsRecorder(m, model, path)
+
+	inputBefore := counterVal(t, &m.TokensTotal, model, path, TokenTypeInput, modelRoute, BackendTypeExternalProvider, backendName, upstreamModel)
+	outputBefore := counterVal(t, &m.TokensTotal, model, path, TokenTypeOutput, modelRoute, BackendTypeExternalProvider, backendName, upstreamModel)
+	requestBefore := counterVal(t, &m.RequestsTotal, model, path, "200", "successful_request", modelRoute, BackendTypeExternalProvider, backendName, upstreamModel)
+	durationBefore := histCount(t, &m.RequestDuration, model, path, "200", modelRoute, BackendTypeExternalProvider, backendName, upstreamModel)
+
+	r.RecordInputTokens(5)
+	if got := counterVal(t, &m.TokensTotal, model, path, TokenTypeInput, modelRoute, BackendTypeExternalProvider, backendName, upstreamModel) - inputBefore; got != 0 {
+		t.Errorf("input token delta before destination bind = %v, want 0", got)
+	}
+
+	r.BindDestination(modelRoute, BackendTypeExternalProvider, backendName, upstreamModel)
+	r.RecordOutputTokens(3)
+	r.Finish("200", "successful_request")
+
+	if got := counterVal(t, &m.TokensTotal, model, path, TokenTypeInput, modelRoute, BackendTypeExternalProvider, backendName, upstreamModel) - inputBefore; got != 5 {
+		t.Errorf("input token delta after destination bind = %v, want 5", got)
+	}
+	if got := counterVal(t, &m.TokensTotal, model, path, TokenTypeOutput, modelRoute, BackendTypeExternalProvider, backendName, upstreamModel) - outputBefore; got != 3 {
+		t.Errorf("output token delta = %v, want 3", got)
+	}
+	if got := counterVal(t, &m.RequestsTotal, model, path, "200", "successful_request", modelRoute, BackendTypeExternalProvider, backendName, upstreamModel) - requestBefore; got != 1 {
+		t.Errorf("request delta = %v, want 1", got)
+	}
+	if got := histCount(t, &m.RequestDuration, model, path, "200", modelRoute, BackendTypeExternalProvider, backendName, upstreamModel) - durationBefore; got != 1 {
+		t.Errorf("request duration sample count delta = %d, want 1", got)
+	}
+}
+
+func TestRequestRecorderFlushesInputTokensAsUnresolved(t *testing.T) {
+	m := DefaultMetrics
+	const model = "metricstest-recorder-unresolved"
+	const path = "/v1/chat/completions"
+	r := NewRequestMetricsRecorder(m, model, path)
+
+	before := counterVal(t, &m.TokensTotal, model, path, TokenTypeInput, DestinationLabelValueNone, BackendTypeUnresolved, DestinationLabelValueNone, DestinationLabelValueNone)
+	r.RecordInputTokens(7)
+	r.Finish("404", "model_server_matching")
+
+	if got := counterVal(t, &m.TokensTotal, model, path, TokenTypeInput, DestinationLabelValueNone, BackendTypeUnresolved, DestinationLabelValueNone, DestinationLabelValueNone) - before; got != 7 {
+		t.Errorf("unresolved input token delta = %v, want 7", got)
+	}
+}
+
+func TestActiveUpstreamRequestsKeepModelServerCompatibilityLabel(t *testing.T) {
+	m := DefaultMetrics
+	const modelRoute = "default/mr-external"
+	const backendName = "default/openai-provider"
+	const upstreamModel = "gpt-4o-mini"
+
+	before := gaugeVal(t, &m.ActiveUpstreamRequests, DestinationLabelValueNone, modelRoute, BackendTypeExternalProvider, backendName, upstreamModel)
+	m.IncActiveUpstreamRequestsForDestination(modelRoute, BackendTypeExternalProvider, backendName, upstreamModel)
+	if got := gaugeVal(t, &m.ActiveUpstreamRequests, DestinationLabelValueNone, modelRoute, BackendTypeExternalProvider, backendName, upstreamModel) - before; got != 1 {
+		t.Errorf("external active upstream delta = %v, want 1", got)
+	}
+	m.DecActiveUpstreamRequestsForDestination(modelRoute, BackendTypeExternalProvider, backendName, upstreamModel)
+	if got := gaugeVal(t, &m.ActiveUpstreamRequests, DestinationLabelValueNone, modelRoute, BackendTypeExternalProvider, backendName, upstreamModel) - before; got != 0 {
+		t.Errorf("external active upstream delta after decrement = %v, want 0", got)
 	}
 }

--- a/pkg/kthena-router/metrics/metrics_test.go
+++ b/pkg/kthena-router/metrics/metrics_test.go
@@ -258,6 +258,12 @@ func TestRequestRecorderBindsDestinationLabels(t *testing.T) {
 	const modelRoute = "default/mr-external"
 	const backendName = "default/openai-provider"
 	const upstreamModel = "gpt-4o-mini"
+	destination := DestinationLabels{
+		ModelRoute:    modelRoute,
+		BackendType:   BackendTypeExternalProvider,
+		BackendName:   backendName,
+		UpstreamModel: upstreamModel,
+	}
 	r := NewRequestMetricsRecorder(m, model, path)
 
 	inputBefore := counterVal(t, &m.TokensTotal, model, path, TokenTypeInput, modelRoute, BackendTypeExternalProvider, backendName, upstreamModel)
@@ -270,7 +276,7 @@ func TestRequestRecorderBindsDestinationLabels(t *testing.T) {
 		t.Errorf("input token delta before destination bind = %v, want 0", got)
 	}
 
-	r.BindDestination(modelRoute, BackendTypeExternalProvider, backendName, upstreamModel)
+	r.BindDestination(destination)
 	r.RecordOutputTokens(3)
 	r.Finish("200", "successful_request")
 
@@ -308,13 +314,19 @@ func TestActiveUpstreamRequestsKeepModelServerCompatibilityLabel(t *testing.T) {
 	const modelRoute = "default/mr-external"
 	const backendName = "default/openai-provider"
 	const upstreamModel = "gpt-4o-mini"
+	destination := DestinationLabels{
+		ModelRoute:    modelRoute,
+		BackendType:   BackendTypeExternalProvider,
+		BackendName:   backendName,
+		UpstreamModel: upstreamModel,
+	}
 
 	before := gaugeVal(t, &m.ActiveUpstreamRequests, DestinationLabelValueNone, modelRoute, BackendTypeExternalProvider, backendName, upstreamModel)
-	m.IncActiveUpstreamRequestsForDestination(modelRoute, BackendTypeExternalProvider, backendName, upstreamModel)
+	m.IncActiveUpstreamRequestsForDestination(destination)
 	if got := gaugeVal(t, &m.ActiveUpstreamRequests, DestinationLabelValueNone, modelRoute, BackendTypeExternalProvider, backendName, upstreamModel) - before; got != 1 {
 		t.Errorf("external active upstream delta = %v, want 1", got)
 	}
-	m.DecActiveUpstreamRequestsForDestination(modelRoute, BackendTypeExternalProvider, backendName, upstreamModel)
+	m.DecActiveUpstreamRequestsForDestination(destination)
 	if got := gaugeVal(t, &m.ActiveUpstreamRequests, DestinationLabelValueNone, modelRoute, BackendTypeExternalProvider, backendName, upstreamModel) - before; got != 0 {
 		t.Errorf("external active upstream delta after decrement = %v, want 0", got)
 	}

--- a/pkg/kthena-router/providers/adapter.go
+++ b/pkg/kthena-router/providers/adapter.go
@@ -141,6 +141,16 @@ func modelOverride(provider *networkingv1alpha1.ExternalModelProvider) (string, 
 	return *provider.Spec.Model, true
 }
 
+// UpstreamModelName returns the model name the provider serves for a request:
+// the configured spec.model override when set, otherwise the route model from
+// the client request. It mirrors the rewrite applied by BuildRequest.
+func UpstreamModelName(provider *networkingv1alpha1.ExternalModelProvider, requestModel string) string {
+	if model, ok := modelOverride(provider); ok {
+		return model
+	}
+	return requestModel
+}
+
 // ValidateConfiguration validates provider settings that are required by every
 // request. It is used both by reconciliation and as defense in depth in the
 // request-building path.

--- a/pkg/kthena-router/router/external_provider_observability_test.go
+++ b/pkg/kthena-router/router/external_provider_observability_test.go
@@ -472,7 +472,7 @@ func TestExternalProviderObservabilityStreamReadFailure(t *testing.T) {
 	fixture := newExternalObservabilityFixture(t, "stream-read-failure", aiv1alpha1.OpenAI, upstream.URL)
 	path := "/v1/responses"
 	requestBody := addModelToRequestBody(`{"input":"hello","stream":true}`, fixture.clientModel)
-	before := observeExternalMetrics(t, fixture, path, http.StatusOK, "proxy")
+	before := observeExternalMetrics(t, fixture, path, http.StatusOK, "response_forwarding")
 
 	w, accessCtx := executeExternalObservabilityStreamRequest(t, fixture, path, requestBody)
 
@@ -480,9 +480,9 @@ func TestExternalProviderObservabilityStreamReadFailure(t *testing.T) {
 	assert.Contains(t, w.Body.String(), `"type":"response.created"`)
 	assertExternalAccessLog(t, accessCtx, fixture, http.StatusOK, 1, http.StatusOK, "router", 0)
 	require.NotNil(t, accessCtx.Error)
-	assert.Equal(t, "proxy", accessCtx.Error.Type)
-	assertExternalMetricDeltas(t, fixture, path, http.StatusOK, "proxy", before, accessCtx.InputTokens, 0)
-	assertExternalMetricsExposed(t, fixture, path, http.StatusOK, "proxy", accessCtx.InputTokens, 0)
+	assert.Equal(t, "response_forwarding", accessCtx.Error.Type)
+	assertExternalMetricDeltas(t, fixture, path, http.StatusOK, "response_forwarding", before, accessCtx.InputTokens, 0)
+	assertExternalMetricsExposed(t, fixture, path, http.StatusOK, "response_forwarding", accessCtx.InputTokens, 0)
 }
 
 func TestExternalProviderObservabilityConfigurationFailure(t *testing.T) {

--- a/pkg/kthena-router/router/external_provider_observability_test.go
+++ b/pkg/kthena-router/router/external_provider_observability_test.go
@@ -1,0 +1,837 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package router
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	aiv1alpha1 "github.com/volcano-sh/kthena/pkg/apis/networking/v1alpha1"
+	"github.com/volcano-sh/kthena/pkg/kthena-router/accesslog"
+	"github.com/volcano-sh/kthena/pkg/kthena-router/datastore"
+	"github.com/volcano-sh/kthena/pkg/kthena-router/metrics"
+)
+
+func TestExternalProviderObservabilitySuccess(t *testing.T) {
+	tests := []struct {
+		name             string
+		providerType     aiv1alpha1.ExternalProviderType
+		path             string
+		requestBody      string
+		responseBody     string
+		wantOutputTokens int
+	}{
+		{
+			name:             "openai chat completions",
+			providerType:     aiv1alpha1.OpenAI,
+			path:             "/v1/chat/completions",
+			requestBody:      `{"messages":[{"role":"user","content":"hello"}]}`,
+			responseBody:     `{"id":"chat-observability","usage":{"prompt_tokens":3,"completion_tokens":5,"total_tokens":8}}`,
+			wantOutputTokens: 5,
+		},
+		{
+			name:             "openai responses",
+			providerType:     aiv1alpha1.OpenAI,
+			path:             "/v1/responses",
+			requestBody:      `{"input":"hello","stream":false}`,
+			responseBody:     `{"id":"resp-observability","object":"response","usage":{"input_tokens":12,"output_tokens":3,"total_tokens":15}}`,
+			wantOutputTokens: 3,
+		},
+		{
+			name:             "anthropic messages",
+			providerType:     aiv1alpha1.Anthropic,
+			path:             "/v1/messages",
+			requestBody:      `{"messages":[{"role":"user","content":"hello"}],"max_tokens":8}`,
+			responseBody:     `{"id":"msg-observability","type":"message","usage":{"input_tokens":7,"output_tokens":9}}`,
+			wantOutputTokens: 9,
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			suffix := fmt.Sprintf("success-%d", i)
+			upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprint(w, tt.responseBody)
+			}))
+			defer upstream.Close()
+
+			fixture := newExternalObservabilityFixture(t, suffix, tt.providerType, upstream.URL)
+			requestBody := addModelToRequestBody(tt.requestBody, fixture.clientModel)
+			before := observeExternalMetrics(t, fixture, tt.path, http.StatusOK, "successful_request")
+
+			w, accessCtx := executeExternalObservabilityRequest(t, fixture, tt.path, requestBody)
+
+			assert.Equal(t, http.StatusOK, w.Code)
+			assertExternalAccessLog(t, accessCtx, fixture, http.StatusOK, 1, http.StatusOK, "", tt.wantOutputTokens)
+			assertExternalMetricDeltas(t, fixture, tt.path, http.StatusOK, "successful_request", before, accessCtx.InputTokens, tt.wantOutputTokens)
+			assertExternalMetricsExposed(t, fixture, tt.path, http.StatusOK, "successful_request", accessCtx.InputTokens, tt.wantOutputTokens)
+		})
+	}
+}
+
+func TestExternalProviderObservabilityNonTextInputUsesLocalTextAccounting(t *testing.T) {
+	tests := []struct {
+		name             string
+		providerType     aiv1alpha1.ExternalProviderType
+		path             string
+		requestBody      string
+		responseBody     string
+		wantOutputTokens int
+	}{
+		{
+			name:             "openai chat image only",
+			providerType:     aiv1alpha1.OpenAI,
+			path:             "/v1/chat/completions",
+			requestBody:      `{"messages":[{"role":"user","content":[{"type":"image_url","image_url":{"url":"https://example.com/cat.png"}}]}]}`,
+			responseBody:     `{"id":"chat-non-text","usage":{"prompt_tokens":101,"completion_tokens":2,"total_tokens":103}}`,
+			wantOutputTokens: 2,
+		},
+		{
+			name:             "openai responses codex tool items only",
+			providerType:     aiv1alpha1.OpenAI,
+			path:             "/v1/responses",
+			requestBody:      `{"input":[{"type":"additional_tools","tools":[{"type":"custom","name":"shell"}]},{"type":"custom_tool_call_output","call_id":"call-1","output":"ok"}]}`,
+			responseBody:     `{"id":"resp-non-text","object":"response","usage":{"input_tokens":202,"output_tokens":3,"total_tokens":205}}`,
+			wantOutputTokens: 3,
+		},
+		{
+			name:             "anthropic image only",
+			providerType:     aiv1alpha1.Anthropic,
+			path:             "/v1/messages",
+			requestBody:      `{"messages":[{"role":"user","content":[{"type":"image","source":{"type":"base64","media_type":"image/png","data":"AA=="}}]}],"max_tokens":8}`,
+			responseBody:     `{"id":"msg-non-text","type":"message","usage":{"input_tokens":303,"output_tokens":4}}`,
+			wantOutputTokens: 4,
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			upstreamCalls := 0
+			upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				upstreamCalls++
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprint(w, tt.responseBody)
+			}))
+			defer upstream.Close()
+
+			fixture := newExternalObservabilityFixture(t, fmt.Sprintf("non-text-%d", i), tt.providerType, upstream.URL)
+			requestBody := addModelToRequestBody(tt.requestBody, fixture.clientModel)
+			before := observeExternalMetrics(t, fixture, tt.path, http.StatusOK, "successful_request")
+
+			w, accessCtx := executeExternalObservabilityRequest(t, fixture, tt.path, requestBody)
+
+			assert.Equal(t, http.StatusOK, w.Code)
+			assert.Equal(t, 1, upstreamCalls)
+			assert.Zero(t, accessCtx.InputTokens)
+			assertExternalAccessLog(t, accessCtx, fixture, http.StatusOK, 1, http.StatusOK, "", tt.wantOutputTokens)
+			assertExternalMetricDeltas(t, fixture, tt.path, http.StatusOK, "successful_request", before, 0, tt.wantOutputTokens)
+			assertExternalMetricsExposed(t, fixture, tt.path, http.StatusOK, "successful_request", 0, tt.wantOutputTokens)
+		})
+	}
+}
+
+func TestExternalProviderObservabilityStreamingResponses(t *testing.T) {
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "event: response.created\n")
+		fmt.Fprint(w, "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-observability-stream\"}}\n\n")
+		fmt.Fprint(w, "event: response.completed\n")
+		fmt.Fprint(w, "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-observability-stream\",\"usage\":{\"input_tokens\":12,\"output_tokens\":4,\"total_tokens\":16}}}\n\n")
+	}))
+	defer upstream.Close()
+
+	fixture := newExternalObservabilityFixture(t, "responses-stream", aiv1alpha1.OpenAI, upstream.URL)
+	requestBody := addModelToRequestBody(`{"input":"hello","stream":true}`, fixture.clientModel)
+	before := observeExternalMetrics(t, fixture, "/v1/responses", http.StatusOK, "successful_request")
+
+	w, accessCtx := executeExternalObservabilityStreamRequest(t, fixture, "/v1/responses", requestBody)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "response.completed")
+	assertExternalAccessLog(t, accessCtx, fixture, http.StatusOK, 1, http.StatusOK, "", 4)
+	assertExternalMetricDeltas(t, fixture, "/v1/responses", http.StatusOK, "successful_request", before, accessCtx.InputTokens, 4)
+}
+
+func TestExternalProviderObservabilityStreamingUsageProtocols(t *testing.T) {
+	tests := []struct {
+		name             string
+		providerType     aiv1alpha1.ExternalProviderType
+		path             string
+		requestBody      string
+		responseBody     string
+		responseMarker   string
+		wantOutputTokens int
+	}{
+		{
+			name:             "openai chat completions",
+			providerType:     aiv1alpha1.OpenAI,
+			path:             "/v1/chat/completions",
+			requestBody:      `{"messages":[{"role":"user","content":"hello"}],"stream":true}`,
+			responseBody:     "data: {\"id\":\"chat-stream\",\"choices\":[],\"usage\":{\"prompt_tokens\":12,\"completion_tokens\":5,\"total_tokens\":17}}\n\ndata: [DONE]\n\n",
+			responseMarker:   "data: [DONE]",
+			wantOutputTokens: 5,
+		},
+		{
+			name:         "anthropic messages",
+			providerType: aiv1alpha1.Anthropic,
+			path:         "/v1/messages",
+			requestBody:  `{"messages":[{"role":"user","content":"hello"}],"max_tokens":8,"stream":true}`,
+			responseBody: "data: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":13,\"output_tokens\":1}}}\n\n" +
+				"data: {\"type\":\"message_delta\",\"usage\":{\"output_tokens\":6}}\n\n" +
+				"data: {\"type\":\"message_stop\"}\n\n",
+			responseMarker:   `"type":"message_stop"`,
+			wantOutputTokens: 6,
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "text/event-stream")
+				fmt.Fprint(w, tt.responseBody)
+			}))
+			defer upstream.Close()
+
+			fixture := newExternalObservabilityFixture(t, fmt.Sprintf("stream-protocol-%d", i), tt.providerType, upstream.URL)
+			requestBody := addModelToRequestBody(tt.requestBody, fixture.clientModel)
+			before := observeExternalMetrics(t, fixture, tt.path, http.StatusOK, "successful_request")
+
+			w, accessCtx := executeExternalObservabilityStreamRequest(t, fixture, tt.path, requestBody)
+
+			assert.Equal(t, http.StatusOK, w.Code)
+			assert.Contains(t, w.Body.String(), tt.responseMarker)
+			assertExternalAccessLog(t, accessCtx, fixture, http.StatusOK, 1, http.StatusOK, "", tt.wantOutputTokens)
+			assertExternalMetricDeltas(t, fixture, tt.path, http.StatusOK, "successful_request", before, accessCtx.InputTokens, tt.wantOutputTokens)
+			assertExternalMetricsExposed(t, fixture, tt.path, http.StatusOK, "successful_request", accessCtx.InputTokens, tt.wantOutputTokens)
+		})
+	}
+}
+
+func TestForwardResponsesStreamTreatsCancellationAfterTerminalEventAsComplete(t *testing.T) {
+	w := &closeNotifyRecorder{ResponseRecorder: httptest.NewRecorder(), closeCh: make(chan bool)}
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body: &payloadThenErrorReadCloser{
+			payload: []byte("event: response.completed\n" +
+				"data: {\"type\":\"response.completed\",\"response\":{\"usage\":{\"input_tokens\":12,\"output_tokens\":4,\"total_tokens\":16}}}\n\n"),
+			err: context.Canceled,
+		},
+	}
+
+	var usage TokenUsage
+	err := forwardResponseWithUsageParser(c, resp, true, &openAIResponsesUsageParser{}, func(got TokenUsage) {
+		usage = got
+	})
+
+	require.NoError(t, err)
+	assert.Contains(t, w.Body.String(), `"type":"response.completed"`)
+	assert.Equal(t, TokenUsage{PromptTokens: 12, CompletionTokens: 4, TotalTokens: 16}, usage)
+}
+
+func TestForwardResponsesStreamReportsCancellationBeforeTerminalEvent(t *testing.T) {
+	w := &closeNotifyRecorder{ResponseRecorder: httptest.NewRecorder(), closeCh: make(chan bool)}
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body: &payloadThenErrorReadCloser{
+			payload: []byte("event: response.created\n" +
+				"data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-cancelled\"}}\n\n"),
+			err: context.Canceled,
+		},
+	}
+
+	err := forwardResponseWithUsageParser(c, resp, true, &openAIResponsesUsageParser{}, nil)
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Contains(t, w.Body.String(), `"type":"response.created"`)
+}
+
+func TestForwardResponsesStreamReportsCloseNotifyBeforeTerminalEvent(t *testing.T) {
+	w := &closeNotifyRecorder{ResponseRecorder: httptest.NewRecorder(), closeCh: make(chan bool)}
+	close(w.closeCh)
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body:       http.NoBody,
+	}
+
+	err := forwardResponseWithUsageParser(c, resp, true, &openAIResponsesUsageParser{}, nil)
+
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestForwardResponsesStreamReportsTerminalWriteFailure(t *testing.T) {
+	writeErr := errors.New("terminal write failed")
+	base := &closeNotifyRecorder{ResponseRecorder: httptest.NewRecorder(), closeCh: make(chan bool)}
+	w := &terminalWriteErrorRecorder{closeNotifyRecorder: base, err: writeErr}
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body: &payloadThenErrorReadCloser{
+			payload: []byte("event: response.completed\n" +
+				"data: {\"type\":\"response.completed\",\"response\":{\"usage\":{\"input_tokens\":12,\"output_tokens\":4,\"total_tokens\":16}}}\n\n"),
+			err: context.Canceled,
+		},
+	}
+
+	err := forwardResponseWithUsageParser(c, resp, true, &openAIResponsesUsageParser{}, nil)
+
+	require.ErrorIs(t, err, writeErr)
+}
+
+func TestForwardProviderStreamsTreatCloseNotifyAfterTerminalEventAsComplete(t *testing.T) {
+	tests := []struct {
+		name   string
+		body   string
+		marker string
+		parser responseUsageParser
+	}{
+		{
+			name:   "openai chat done",
+			body:   "data: [DONE]\n\n",
+			marker: "data: [DONE]",
+			parser: &openAIUsageParser{},
+		},
+		{
+			name:   "openai responses completed",
+			body:   "data: {\"type\":\"response.completed\",\"response\":{}}\n\n",
+			marker: `"type":"response.completed"`,
+			parser: &openAIResponsesUsageParser{},
+		},
+		{
+			name:   "anthropic message stop",
+			body:   "data: {\"type\":\"message_stop\"}\n\n",
+			marker: `"type":"message_stop"`,
+			parser: &anthropicUsageParser{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			base := &closeNotifyRecorder{ResponseRecorder: httptest.NewRecorder(), closeCh: make(chan bool)}
+			w := &closeAfterMarkerRecorder{closeNotifyRecorder: base, marker: []byte(tt.marker)}
+			c, _ := gin.CreateTestContext(w)
+			c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+			resp := &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+				Body:       io.NopCloser(bytes.NewBufferString(tt.body)),
+			}
+
+			err := forwardResponseWithUsageParser(c, resp, true, tt.parser, nil)
+
+			require.NoError(t, err)
+		})
+	}
+}
+
+type terminalWriteErrorRecorder struct {
+	*closeNotifyRecorder
+	err error
+}
+
+type closeAfterMarkerRecorder struct {
+	*closeNotifyRecorder
+	marker []byte
+	closed bool
+}
+
+func (r *closeAfterMarkerRecorder) Write(p []byte) (int, error) {
+	n, err := r.closeNotifyRecorder.Write(p)
+	if err == nil && n == len(p) && !r.closed && bytes.Contains(p, r.marker) {
+		close(r.closeCh)
+		r.closed = true
+	}
+	return n, err
+}
+
+func (r *terminalWriteErrorRecorder) Write(p []byte) (int, error) {
+	if bytes.Contains(p, []byte(`"type":"response.completed"`)) {
+		return 0, r.err
+	}
+	return r.closeNotifyRecorder.Write(p)
+}
+
+type payloadThenErrorReadCloser struct {
+	payload []byte
+	err     error
+}
+
+func (r *payloadThenErrorReadCloser) Read(p []byte) (int, error) {
+	if len(r.payload) == 0 {
+		return 0, r.err
+	}
+	n := copy(p, r.payload)
+	r.payload = r.payload[n:]
+	return n, nil
+}
+
+func (*payloadThenErrorReadCloser) Close() error {
+	return nil
+}
+
+var _ io.ReadCloser = (*payloadThenErrorReadCloser)(nil)
+
+func TestExternalProviderObservabilityUpstreamResponse(t *testing.T) {
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		fmt.Fprint(w, `{"error":"rate limited"}`)
+	}))
+	defer upstream.Close()
+
+	fixture := newExternalObservabilityFixture(t, "upstream-429", aiv1alpha1.OpenAI, upstream.URL)
+	path := "/v1/chat/completions"
+	requestBody := addModelToRequestBody(`{"messages":[{"role":"user","content":"hello"}]}`, fixture.clientModel)
+	before := observeExternalMetrics(t, fixture, path, http.StatusTooManyRequests, "upstream_response")
+
+	w, accessCtx := executeExternalObservabilityRequest(t, fixture, path, requestBody)
+
+	assert.Equal(t, http.StatusTooManyRequests, w.Code)
+	assert.JSONEq(t, `{"error":"rate limited"}`, w.Body.String())
+	assertExternalAccessLog(t, accessCtx, fixture, http.StatusTooManyRequests, 1, http.StatusTooManyRequests, "upstream", 0)
+	assertExternalMetricDeltas(t, fixture, path, http.StatusTooManyRequests, "upstream_response", before, accessCtx.InputTokens, 0)
+	assertExternalMetricsExposed(t, fixture, path, http.StatusTooManyRequests, "upstream_response", accessCtx.InputTokens, 0)
+}
+
+func TestExternalProviderObservabilityTransportFailure(t *testing.T) {
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	baseURL := upstream.URL
+	upstream.Close()
+
+	fixture := newExternalObservabilityFixture(t, "transport-failure", aiv1alpha1.OpenAI, baseURL)
+	path := "/v1/chat/completions"
+	requestBody := addModelToRequestBody(`{"messages":[{"role":"user","content":"hello"}]}`, fixture.clientModel)
+	before := observeExternalMetrics(t, fixture, path, http.StatusBadGateway, "upstream_transport")
+
+	w, accessCtx := executeExternalObservabilityRequest(t, fixture, path, requestBody)
+
+	assert.Equal(t, http.StatusBadGateway, w.Code)
+	assert.NotContains(t, w.Body.String(), baseURL)
+	assert.NotContains(t, w.Body.String(), "provider-key")
+	assertExternalAccessLog(t, accessCtx, fixture, http.StatusBadGateway, 1, 0, "router", 0)
+	require.NotNil(t, accessCtx.Error)
+	assert.NotContains(t, accessCtx.Error.Message, baseURL)
+	assert.NotContains(t, accessCtx.Error.Message, "provider-key")
+	assertExternalMetricDeltas(t, fixture, path, http.StatusBadGateway, "upstream_transport", before, accessCtx.InputTokens, 0)
+	assertExternalMetricsExposed(t, fixture, path, http.StatusBadGateway, "upstream_transport", accessCtx.InputTokens, 0)
+}
+
+func TestExternalProviderObservabilityStreamReadFailure(t *testing.T) {
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Content-Length", "1024")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "event: response.created\n")
+		fmt.Fprint(w, "data: {\"type\":\"response.created\",\"response\":{\"id\":\"truncated\"}}\n\n")
+	}))
+	defer upstream.Close()
+
+	fixture := newExternalObservabilityFixture(t, "stream-read-failure", aiv1alpha1.OpenAI, upstream.URL)
+	path := "/v1/responses"
+	requestBody := addModelToRequestBody(`{"input":"hello","stream":true}`, fixture.clientModel)
+	before := observeExternalMetrics(t, fixture, path, http.StatusOK, "proxy")
+
+	w, accessCtx := executeExternalObservabilityStreamRequest(t, fixture, path, requestBody)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"type":"response.created"`)
+	assertExternalAccessLog(t, accessCtx, fixture, http.StatusOK, 1, http.StatusOK, "router", 0)
+	require.NotNil(t, accessCtx.Error)
+	assert.Equal(t, "proxy", accessCtx.Error.Type)
+	assertExternalMetricDeltas(t, fixture, path, http.StatusOK, "proxy", before, accessCtx.InputTokens, 0)
+	assertExternalMetricsExposed(t, fixture, path, http.StatusOK, "proxy", accessCtx.InputTokens, 0)
+}
+
+func TestExternalProviderObservabilityConfigurationFailure(t *testing.T) {
+	fixture := newExternalObservabilityFixture(t, "missing-secret", aiv1alpha1.OpenAI, "https://provider.invalid/v1")
+	require.NoError(t, fixture.store.DeleteSecret(types.NamespacedName{Namespace: "default", Name: fixture.secretName}))
+	path := "/v1/chat/completions"
+	requestBody := addModelToRequestBody(`{"messages":[{"role":"user","content":"hello"}]}`, fixture.clientModel)
+	before := observeExternalMetrics(t, fixture, path, http.StatusServiceUnavailable, "provider_config")
+
+	w, accessCtx := executeExternalObservabilityRequest(t, fixture, path, requestBody)
+
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+	assert.NotContains(t, w.Body.String(), fixture.secretName)
+	assert.NotContains(t, w.Body.String(), "api-key")
+	assertExternalAccessLog(t, accessCtx, fixture, http.StatusServiceUnavailable, 0, 0, "router", 0)
+	require.NotNil(t, accessCtx.Error)
+	assert.Equal(t, "provider_config", accessCtx.Error.Type)
+	assert.NotContains(t, accessCtx.Error.Message, fixture.secretName)
+	assert.NotContains(t, accessCtx.Error.Message, "api-key")
+	assertExternalMetricDeltas(t, fixture, path, http.StatusServiceUnavailable, "provider_config", before, accessCtx.InputTokens, 0)
+	assertExternalMetricsExposed(t, fixture, path, http.StatusServiceUnavailable, "provider_config", accessCtx.InputTokens, 0)
+}
+
+func TestExternalProviderObservabilityDiscoveryFailure(t *testing.T) {
+	const suffix = "discovery-failure"
+	fixture := newExternalObservabilityFixture(t, suffix, aiv1alpha1.OpenAI, "https://provider.invalid/v1")
+	require.NoError(t, fixture.store.DeleteExternalModelProvider(types.NamespacedName{
+		Namespace: "default",
+		Name:      "observability-provider-" + suffix,
+	}))
+	path := "/v1/chat/completions"
+	requestBody := addModelToRequestBody(`{"messages":[{"role":"user","content":"hello"}]}`, fixture.clientModel)
+	destination := []string{metrics.DestinationLabelValueNone, metrics.BackendTypeUnresolved, metrics.DestinationLabelValueNone, metrics.DestinationLabelValueNone}
+	requestBefore := externalCounterValue(t, &fixture.router.metrics.RequestsTotal,
+		append([]string{fixture.clientModel, path, "404", "provider_discovery"}, destination...)...)
+	durationBefore := externalHistogramCount(t, &fixture.router.metrics.RequestDuration,
+		append([]string{fixture.clientModel, path, "404"}, destination...)...)
+	inputBefore := externalCounterValue(t, &fixture.router.metrics.TokensTotal,
+		append([]string{fixture.clientModel, path, metrics.TokenTypeInput}, destination...)...)
+
+	w, accessCtx := executeExternalObservabilityRequest(t, fixture, path, requestBody)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	require.NotNil(t, accessCtx.Error)
+	assert.Equal(t, "provider_discovery", accessCtx.Error.Type)
+	assert.Equal(t, "router", accessCtx.ErrorOrigin)
+	assert.Equal(t, requestBefore+1, externalCounterValue(t, &fixture.router.metrics.RequestsTotal,
+		append([]string{fixture.clientModel, path, "404", "provider_discovery"}, destination...)...))
+	assert.Equal(t, durationBefore+1, externalHistogramCount(t, &fixture.router.metrics.RequestDuration,
+		append([]string{fixture.clientModel, path, "404"}, destination...)...))
+	assert.Equal(t, inputBefore+float64(accessCtx.InputTokens), externalCounterValue(t, &fixture.router.metrics.TokensTotal,
+		append([]string{fixture.clientModel, path, metrics.TokenTypeInput}, destination...)...))
+}
+
+func TestExternalProviderObservabilityProtocolFailure(t *testing.T) {
+	fixture := newExternalObservabilityFixture(t, "protocol-mismatch", aiv1alpha1.Anthropic, "https://provider.invalid")
+	path := "/v1/chat/completions"
+	requestBody := addModelToRequestBody(`{"messages":[{"role":"user","content":"hello"}]}`, fixture.clientModel)
+	before := observeExternalMetrics(t, fixture, path, http.StatusBadRequest, "request_protocol")
+
+	w, accessCtx := executeExternalObservabilityRequest(t, fixture, path, requestBody)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.NotContains(t, w.Body.String(), "provider-key")
+	assertExternalAccessLog(t, accessCtx, fixture, http.StatusBadRequest, 0, 0, "router", 0)
+	require.NotNil(t, accessCtx.Error)
+	assert.Equal(t, "request_protocol", accessCtx.Error.Type)
+	assert.NotContains(t, accessCtx.Error.Message, "provider-key")
+	assertExternalMetricDeltas(t, fixture, path, http.StatusBadRequest, "request_protocol", before, accessCtx.InputTokens, 0)
+	assertExternalMetricsExposed(t, fixture, path, http.StatusBadRequest, "request_protocol", accessCtx.InputTokens, 0)
+}
+
+func TestExternalProviderActiveMetricsTrackInFlightRequest(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(started)
+		<-release
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"id":"active-observability","usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`)
+	}))
+	defer upstream.Close()
+
+	fixture := newExternalObservabilityFixture(t, "active", aiv1alpha1.OpenAI, upstream.URL)
+	path := "/v1/chat/completions"
+	requestBody := addModelToRequestBody(`{"messages":[{"role":"user","content":"hello"}]}`, fixture.clientModel)
+	activeUpstreamBefore := externalGaugeValue(t, &fixture.router.metrics.ActiveUpstreamRequests, fixture.activeLabels()...)
+	activeDownstreamBefore := externalGaugeValue(t, &fixture.router.metrics.ActiveDownstreamRequests, fixture.clientModel)
+	activeRequestsBefore := fixture.router.metrics.ActiveRequestsCount()
+
+	done := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		w, _ := executeExternalObservabilityRequest(t, fixture, path, requestBody)
+		done <- w
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for external upstream request")
+	}
+	assert.Equal(t, activeUpstreamBefore+1, externalGaugeValue(t, &fixture.router.metrics.ActiveUpstreamRequests, fixture.activeLabels()...))
+	assert.Equal(t, activeDownstreamBefore+1, externalGaugeValue(t, &fixture.router.metrics.ActiveDownstreamRequests, fixture.clientModel))
+	assert.Equal(t, activeRequestsBefore+1, fixture.router.metrics.ActiveRequestsCount())
+
+	close(release)
+	select {
+	case w := <-done:
+		assert.Equal(t, http.StatusOK, w.Code)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for external request completion")
+	}
+	assert.Equal(t, activeUpstreamBefore, externalGaugeValue(t, &fixture.router.metrics.ActiveUpstreamRequests, fixture.activeLabels()...))
+	assert.Equal(t, activeDownstreamBefore, externalGaugeValue(t, &fixture.router.metrics.ActiveDownstreamRequests, fixture.clientModel))
+	assert.Equal(t, activeRequestsBefore, fixture.router.metrics.ActiveRequestsCount())
+}
+
+type externalObservabilityFixture struct {
+	router        *Router
+	store         datastore.Store
+	clientModel   string
+	providerModel string
+	modelRoute    string
+	backendName   string
+	secretName    string
+}
+
+func newExternalObservabilityFixture(t *testing.T, suffix string, providerType aiv1alpha1.ExternalProviderType, baseURL string) externalObservabilityFixture {
+	t.Helper()
+	store := datastore.New()
+	router := NewRouter(store, "../scheduler/testdata/configmap.yaml")
+	clientModel := "observability-client-" + suffix
+	providerModel := "observability-upstream-" + suffix
+	providerName := "observability-provider-" + suffix
+	secretName := "observability-secret-" + suffix
+	routeName := "observability-route-" + suffix
+	headers := map[string]string{}
+	if providerType == aiv1alpha1.Anthropic {
+		headers["anthropic-version"] = "2023-06-01"
+	}
+
+	require.NoError(t, store.AddOrUpdateExternalModelProvider(&aiv1alpha1.ExternalModelProvider{
+		ObjectMeta: metav1.ObjectMeta{Name: providerName, Namespace: "default"},
+		Spec: aiv1alpha1.ExternalModelProviderSpec{
+			ProviderType:       providerType,
+			BaseURL:            baseURL,
+			Model:              &providerModel,
+			InsecureSkipVerify: true,
+			Auth: &aiv1alpha1.ProviderAuth{SecretRef: corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: secretName},
+				Key:                  "api-key",
+			}},
+			Headers: headers,
+		},
+	}))
+	require.NoError(t, store.AddOrUpdateSecret(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: "default"},
+		Data:       map[string][]byte{"api-key": []byte("provider-key")},
+	}))
+	require.NoError(t, store.AddOrUpdateModelRoute(&aiv1alpha1.ModelRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: routeName, Namespace: "default"},
+		Spec: aiv1alpha1.ModelRouteSpec{
+			ModelName: clientModel,
+			Rules: []*aiv1alpha1.Rule{{TargetModels: []*aiv1alpha1.TargetModel{{
+				ExternalModelProviderName: providerName,
+			}}}},
+		},
+	}))
+
+	return externalObservabilityFixture{
+		router:        router,
+		store:         store,
+		clientModel:   clientModel,
+		providerModel: providerModel,
+		modelRoute:    "default/" + routeName,
+		backendName:   "default/" + providerName,
+		secretName:    secretName,
+	}
+}
+
+func (f externalObservabilityFixture) destinationLabels() []string {
+	return []string{f.modelRoute, metrics.BackendTypeExternalProvider, f.backendName, f.providerModel}
+}
+
+func (f externalObservabilityFixture) activeLabels() []string {
+	return []string{metrics.DestinationLabelValueNone, f.modelRoute, metrics.BackendTypeExternalProvider, f.backendName, f.providerModel}
+}
+
+func addModelToRequestBody(body, model string) string {
+	return fmt.Sprintf(`{"model":%q,%s`, model, body[1:])
+}
+
+func executeExternalObservabilityRequest(t *testing.T, fixture externalObservabilityFixture, path, body string) (*httptest.ResponseRecorder, *accesslog.AccessLogContext) {
+	t.Helper()
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, path, bytes.NewBufferString(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	accessCtx := accesslog.NewAccessLogContext("external-observability", http.MethodPost, path, c.Request.Proto, fixture.clientModel)
+	c.Set(accesslog.AccessLogContextKey, accessCtx)
+	fixture.router.HandlerFunc()(c)
+	return w, accessCtx
+}
+
+func executeExternalObservabilityStreamRequest(t *testing.T, fixture externalObservabilityFixture, path, body string) (*closeNotifyRecorder, *accesslog.AccessLogContext) {
+	t.Helper()
+	w := &closeNotifyRecorder{ResponseRecorder: httptest.NewRecorder(), closeCh: make(chan bool)}
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, path, bytes.NewBufferString(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	accessCtx := accesslog.NewAccessLogContext("external-observability-stream", http.MethodPost, path, c.Request.Proto, fixture.clientModel)
+	c.Set(accesslog.AccessLogContextKey, accessCtx)
+	fixture.router.HandlerFunc()(c)
+	return w, accessCtx
+}
+
+type externalMetricSnapshot struct {
+	requests       float64
+	durationCount  uint64
+	inputTokens    float64
+	outputTokens   float64
+	activeUpstream float64
+	activeDown     float64
+	activeRequests int64
+}
+
+func observeExternalMetrics(t *testing.T, fixture externalObservabilityFixture, path string, statusCode int, errorType string) externalMetricSnapshot {
+	t.Helper()
+	status := fmt.Sprint(statusCode)
+	destination := fixture.destinationLabels()
+	return externalMetricSnapshot{
+		requests: externalCounterValue(t, &fixture.router.metrics.RequestsTotal,
+			append([]string{fixture.clientModel, path, status, errorType}, destination...)...),
+		durationCount: externalHistogramCount(t, &fixture.router.metrics.RequestDuration,
+			append([]string{fixture.clientModel, path, status}, destination...)...),
+		inputTokens: externalCounterValue(t, &fixture.router.metrics.TokensTotal,
+			append([]string{fixture.clientModel, path, metrics.TokenTypeInput}, destination...)...),
+		outputTokens: externalCounterValue(t, &fixture.router.metrics.TokensTotal,
+			append([]string{fixture.clientModel, path, metrics.TokenTypeOutput}, destination...)...),
+		activeUpstream: externalGaugeValue(t, &fixture.router.metrics.ActiveUpstreamRequests, fixture.activeLabels()...),
+		activeDown:     externalGaugeValue(t, &fixture.router.metrics.ActiveDownstreamRequests, fixture.clientModel),
+		activeRequests: fixture.router.metrics.ActiveRequestsCount(),
+	}
+}
+
+func assertExternalMetricDeltas(t *testing.T, fixture externalObservabilityFixture, path string, statusCode int, errorType string, before externalMetricSnapshot, inputTokens, outputTokens int) {
+	t.Helper()
+	after := observeExternalMetrics(t, fixture, path, statusCode, errorType)
+	assert.Equal(t, float64(1), after.requests-before.requests)
+	assert.Equal(t, uint64(1), after.durationCount-before.durationCount)
+	assert.Equal(t, float64(inputTokens), after.inputTokens-before.inputTokens)
+	assert.Equal(t, float64(outputTokens), after.outputTokens-before.outputTokens)
+	assert.Equal(t, before.activeUpstream, after.activeUpstream)
+	assert.Equal(t, before.activeDown, after.activeDown)
+	assert.Equal(t, before.activeRequests, after.activeRequests)
+}
+
+func assertExternalMetricsExposed(t *testing.T, fixture externalObservabilityFixture, path string, statusCode int, errorType string, inputTokens, outputTokens int) {
+	t.Helper()
+	requestLabels := map[string]string{
+		"model": fixture.clientModel, "path": path, "status_code": fmt.Sprint(statusCode), "error_type": errorType,
+		"model_route": fixture.modelRoute, "backend_type": metrics.BackendTypeExternalProvider,
+		"backend_name": fixture.backendName, "upstream_model": fixture.providerModel,
+	}
+	assert.Equal(t, float64(1), gatheredExternalCounter(t, "kthena_router_requests_total", requestLabels))
+	tokenLabels := map[string]string{
+		"model": fixture.clientModel, "path": path, "model_route": fixture.modelRoute,
+		"backend_type": metrics.BackendTypeExternalProvider, "backend_name": fixture.backendName,
+		"upstream_model": fixture.providerModel,
+	}
+	tokenLabels["token_type"] = metrics.TokenTypeInput
+	assert.Equal(t, float64(inputTokens), gatheredExternalCounter(t, "kthena_router_tokens_total", tokenLabels))
+	tokenLabels["token_type"] = metrics.TokenTypeOutput
+	assert.Equal(t, float64(outputTokens), gatheredExternalCounter(t, "kthena_router_tokens_total", tokenLabels))
+}
+
+func assertExternalAccessLog(t *testing.T, accessCtx *accesslog.AccessLogContext, fixture externalObservabilityFixture, statusCode, attempts, upstreamStatus int, errorOrigin string, outputTokens int) {
+	t.Helper()
+	entry := accessCtx.ToAccessLogEntry(statusCode)
+	assert.Equal(t, fixture.clientModel, entry.ModelName)
+	assert.Equal(t, fixture.modelRoute, entry.ModelRoute)
+	assert.Equal(t, metrics.BackendTypeExternalProvider, entry.BackendType)
+	assert.Equal(t, fixture.backendName, entry.BackendName)
+	assert.Equal(t, fixture.providerModel, entry.UpstreamModel)
+	assert.Equal(t, upstreamStatus, entry.UpstreamStatusCode)
+	assert.Equal(t, attempts, entry.UpstreamAttempts)
+	assert.Equal(t, errorOrigin, entry.ErrorOrigin)
+	assert.Equal(t, accessCtx.InputTokens, entry.InputTokens)
+	assert.Equal(t, outputTokens, entry.OutputTokens)
+	assert.GreaterOrEqual(t, entry.DurationTotal, int64(0))
+	assert.GreaterOrEqual(t, entry.DurationRequestProcessing, int64(0))
+	assert.GreaterOrEqual(t, entry.DurationUpstreamProcessing, int64(0))
+	assert.GreaterOrEqual(t, entry.DurationResponseProcessing, int64(0))
+}
+
+func externalCounterValue(t *testing.T, counter *prometheus.CounterVec, labels ...string) float64 {
+	t.Helper()
+	metric, err := counter.GetMetricWithLabelValues(labels...)
+	require.NoError(t, err)
+	var value dto.Metric
+	require.NoError(t, metric.Write(&value))
+	return value.GetCounter().GetValue()
+}
+
+func externalGaugeValue(t *testing.T, gauge *prometheus.GaugeVec, labels ...string) float64 {
+	t.Helper()
+	metric, err := gauge.GetMetricWithLabelValues(labels...)
+	require.NoError(t, err)
+	var value dto.Metric
+	require.NoError(t, metric.Write(&value))
+	return value.GetGauge().GetValue()
+}
+
+func externalHistogramCount(t *testing.T, histogram *prometheus.HistogramVec, labels ...string) uint64 {
+	t.Helper()
+	observer, err := histogram.GetMetricWithLabelValues(labels...)
+	require.NoError(t, err)
+	metric, ok := observer.(prometheus.Metric)
+	require.True(t, ok)
+	var value dto.Metric
+	require.NoError(t, metric.Write(&value))
+	return value.GetHistogram().GetSampleCount()
+}
+
+func gatheredExternalCounter(t *testing.T, metricName string, wantLabels map[string]string) float64 {
+	t.Helper()
+	families, err := prometheus.DefaultGatherer.Gather()
+	require.NoError(t, err)
+	for _, family := range families {
+		if family.GetName() != metricName {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			labels := make(map[string]string, len(metric.GetLabel()))
+			for _, pair := range metric.GetLabel() {
+				labels[pair.GetName()] = pair.GetValue()
+			}
+			matches := true
+			for name, value := range wantLabels {
+				if labels[name] != value {
+					matches = false
+					break
+				}
+			}
+			if matches {
+				return metric.GetCounter().GetValue()
+			}
+		}
+	}
+	t.Fatalf("metric %s with labels %v was not gathered", metricName, wantLabels)
+	return 0
+}

--- a/pkg/kthena-router/router/external_provider_observability_test.go
+++ b/pkg/kthena-router/router/external_provider_observability_test.go
@@ -380,7 +380,7 @@ func responseParserFor(
 	t.Helper()
 	adapter, err := providers.NewAdapter(providerType)
 	require.NoError(t, err)
-	return adapter.ResponseParser(path)
+	return adapter.ResponseParser(nil, path)
 }
 
 type terminalWriteErrorRecorder struct {

--- a/pkg/kthena-router/router/external_provider_observability_test.go
+++ b/pkg/kthena-router/router/external_provider_observability_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/volcano-sh/kthena/pkg/kthena-router/accesslog"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/datastore"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/metrics"
+	"github.com/volcano-sh/kthena/pkg/kthena-router/providers"
 )
 
 func TestExternalProviderObservabilitySuccess(t *testing.T) {
@@ -254,14 +255,14 @@ func TestForwardResponsesStreamTreatsCancellationAfterTerminalEventAsComplete(t 
 		},
 	}
 
-	var usage TokenUsage
-	err := forwardResponseWithUsageParser(c, resp, true, &openAIResponsesUsageParser{}, func(got TokenUsage) {
+	var usage providers.TokenUsage
+	err := forwardResponseWithUsageParser(c, resp, true, responseParserFor(t, aiv1alpha1.OpenAI, "/v1/responses"), func(got providers.TokenUsage) {
 		usage = got
 	})
 
 	require.NoError(t, err)
 	assert.Contains(t, w.Body.String(), `"type":"response.completed"`)
-	assert.Equal(t, TokenUsage{PromptTokens: 12, CompletionTokens: 4, TotalTokens: 16}, usage)
+	assert.Equal(t, providers.TokenUsage{PromptTokens: 12, CompletionTokens: 4, TotalTokens: 16}, usage)
 }
 
 func TestForwardResponsesStreamReportsCancellationBeforeTerminalEvent(t *testing.T) {
@@ -278,7 +279,7 @@ func TestForwardResponsesStreamReportsCancellationBeforeTerminalEvent(t *testing
 		},
 	}
 
-	err := forwardResponseWithUsageParser(c, resp, true, &openAIResponsesUsageParser{}, nil)
+	err := forwardResponseWithUsageParser(c, resp, true, responseParserFor(t, aiv1alpha1.OpenAI, "/v1/responses"), nil)
 
 	require.ErrorIs(t, err, context.Canceled)
 	assert.Contains(t, w.Body.String(), `"type":"response.created"`)
@@ -295,7 +296,7 @@ func TestForwardResponsesStreamReportsCloseNotifyBeforeTerminalEvent(t *testing.
 		Body:       http.NoBody,
 	}
 
-	err := forwardResponseWithUsageParser(c, resp, true, &openAIResponsesUsageParser{}, nil)
+	err := forwardResponseWithUsageParser(c, resp, true, responseParserFor(t, aiv1alpha1.OpenAI, "/v1/responses"), nil)
 
 	require.ErrorIs(t, err, context.Canceled)
 }
@@ -316,35 +317,39 @@ func TestForwardResponsesStreamReportsTerminalWriteFailure(t *testing.T) {
 		},
 	}
 
-	err := forwardResponseWithUsageParser(c, resp, true, &openAIResponsesUsageParser{}, nil)
+	err := forwardResponseWithUsageParser(c, resp, true, responseParserFor(t, aiv1alpha1.OpenAI, "/v1/responses"), nil)
 
 	require.ErrorIs(t, err, writeErr)
 }
 
 func TestForwardProviderStreamsTreatCloseNotifyAfterTerminalEventAsComplete(t *testing.T) {
 	tests := []struct {
-		name   string
-		body   string
-		marker string
-		parser responseUsageParser
+		name         string
+		body         string
+		marker       string
+		providerType aiv1alpha1.ExternalProviderType
+		path         string
 	}{
 		{
-			name:   "openai chat done",
-			body:   "data: [DONE]\n\n",
-			marker: "data: [DONE]",
-			parser: &openAIUsageParser{},
+			name:         "openai chat done",
+			body:         "data: [DONE]\n\n",
+			marker:       "data: [DONE]",
+			providerType: aiv1alpha1.OpenAI,
+			path:         "/v1/chat/completions",
 		},
 		{
-			name:   "openai responses completed",
-			body:   "data: {\"type\":\"response.completed\",\"response\":{}}\n\n",
-			marker: `"type":"response.completed"`,
-			parser: &openAIResponsesUsageParser{},
+			name:         "openai responses completed",
+			body:         "data: {\"type\":\"response.completed\",\"response\":{}}\n\n",
+			marker:       `"type":"response.completed"`,
+			providerType: aiv1alpha1.OpenAI,
+			path:         "/v1/responses",
 		},
 		{
-			name:   "anthropic message stop",
-			body:   "data: {\"type\":\"message_stop\"}\n\n",
-			marker: `"type":"message_stop"`,
-			parser: &anthropicUsageParser{},
+			name:         "anthropic message stop",
+			body:         "data: {\"type\":\"message_stop\"}\n\n",
+			marker:       `"type":"message_stop"`,
+			providerType: aiv1alpha1.Anthropic,
+			path:         "/v1/messages",
 		},
 	}
 
@@ -353,18 +358,29 @@ func TestForwardProviderStreamsTreatCloseNotifyAfterTerminalEventAsComplete(t *t
 			base := &closeNotifyRecorder{ResponseRecorder: httptest.NewRecorder(), closeCh: make(chan bool)}
 			w := &closeAfterMarkerRecorder{closeNotifyRecorder: base, marker: []byte(tt.marker)}
 			c, _ := gin.CreateTestContext(w)
-			c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+			c.Request = httptest.NewRequest(http.MethodPost, tt.path, nil)
 			resp := &http.Response{
 				StatusCode: http.StatusOK,
 				Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
 				Body:       io.NopCloser(bytes.NewBufferString(tt.body)),
 			}
 
-			err := forwardResponseWithUsageParser(c, resp, true, tt.parser, nil)
+			err := forwardResponseWithUsageParser(c, resp, true, responseParserFor(t, tt.providerType, tt.path), nil)
 
 			require.NoError(t, err)
 		})
 	}
+}
+
+func responseParserFor(
+	t *testing.T,
+	providerType aiv1alpha1.ExternalProviderType,
+	path string,
+) providers.ResponseUsageParser {
+	t.Helper()
+	adapter, err := providers.NewAdapter(providerType)
+	require.NoError(t, err)
+	return adapter.ResponseParser(path)
 }
 
 type terminalWriteErrorRecorder struct {

--- a/pkg/kthena-router/router/external_provider_passthrough_test.go
+++ b/pkg/kthena-router/router/external_provider_passthrough_test.go
@@ -17,22 +17,16 @@ limitations under the License.
 package router
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
-	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	aiv1alpha1 "github.com/volcano-sh/kthena/pkg/apis/networking/v1alpha1"
-	"github.com/volcano-sh/kthena/pkg/kthena-router/accesslog"
-	"github.com/volcano-sh/kthena/pkg/kthena-router/datastore"
 )
 
 func TestExternalProviderForwardsOpaqueRequestContent(t *testing.T) {
@@ -82,12 +76,12 @@ func TestExternalProviderForwardsOpaqueRequestContent(t *testing.T) {
 			}))
 			defer upstream.Close()
 
-			fixture := newExternalPassthroughFixture(t, fmt.Sprintf("passthrough-%d", i), tt.providerType, upstream.URL)
-			body := addPassthroughModel(tt.requestBody, fixture.clientModel)
+			fixture := newExternalObservabilityFixture(t, fmt.Sprintf("passthrough-%d", i), tt.providerType, upstream.URL)
+			body := addModelToRequestBody(tt.requestBody, fixture.clientModel)
 			var original map[string]interface{}
 			require.NoError(t, json.Unmarshal([]byte(body), &original))
 
-			w, accessCtx := executeExternalPassthroughRequest(t, fixture, tt.path, body)
+			w, accessCtx := executeExternalObservabilityRequest(t, fixture, tt.path, body)
 
 			require.Equal(t, http.StatusOK, w.Code, w.Body.String())
 			assert.Equal(t, 1, upstreamCalls)
@@ -98,71 +92,4 @@ func TestExternalProviderForwardsOpaqueRequestContent(t *testing.T) {
 			assert.Nil(t, accessCtx.Error)
 		})
 	}
-}
-
-type externalPassthroughFixture struct {
-	router        *Router
-	clientModel   string
-	providerModel string
-}
-
-func newExternalPassthroughFixture(t *testing.T, suffix string, providerType aiv1alpha1.ExternalProviderType, baseURL string) externalPassthroughFixture {
-	t.Helper()
-	store := datastore.New()
-	router := NewRouter(store, "../scheduler/testdata/configmap.yaml")
-	clientModel := "passthrough-client-" + suffix
-	providerModel := "passthrough-upstream-" + suffix
-	providerName := "passthrough-provider-" + suffix
-	secretName := "passthrough-secret-" + suffix
-	routeName := "passthrough-route-" + suffix
-	headers := map[string]string{}
-	if providerType == aiv1alpha1.Anthropic {
-		headers["anthropic-version"] = "2023-06-01"
-	}
-
-	require.NoError(t, store.AddOrUpdateExternalModelProvider(&aiv1alpha1.ExternalModelProvider{
-		ObjectMeta: metav1.ObjectMeta{Name: providerName, Namespace: "default"},
-		Spec: aiv1alpha1.ExternalModelProviderSpec{
-			ProviderType:       providerType,
-			BaseURL:            baseURL,
-			Model:              &providerModel,
-			InsecureSkipVerify: true,
-			Auth: &aiv1alpha1.ProviderAuth{SecretRef: corev1.SecretKeySelector{
-				LocalObjectReference: corev1.LocalObjectReference{Name: secretName},
-				Key:                  "api-key",
-			}},
-			Headers: headers,
-		},
-	}))
-	require.NoError(t, store.AddOrUpdateSecret(&corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: "default"},
-		Data:       map[string][]byte{"api-key": []byte("provider-key")},
-	}))
-	require.NoError(t, store.AddOrUpdateModelRoute(&aiv1alpha1.ModelRoute{
-		ObjectMeta: metav1.ObjectMeta{Name: routeName, Namespace: "default"},
-		Spec: aiv1alpha1.ModelRouteSpec{
-			ModelName: clientModel,
-			Rules: []*aiv1alpha1.Rule{{TargetModels: []*aiv1alpha1.TargetModel{{
-				ExternalModelProviderName: providerName,
-			}}}},
-		},
-	}))
-
-	return externalPassthroughFixture{router: router, clientModel: clientModel, providerModel: providerModel}
-}
-
-func addPassthroughModel(body, model string) string {
-	return fmt.Sprintf(`{"model":%q,%s`, model, body[1:])
-}
-
-func executeExternalPassthroughRequest(t *testing.T, fixture externalPassthroughFixture, path, body string) (*httptest.ResponseRecorder, *accesslog.AccessLogContext) {
-	t.Helper()
-	w := httptest.NewRecorder()
-	c, _ := gin.CreateTestContext(w)
-	c.Request = httptest.NewRequest(http.MethodPost, path, bytes.NewBufferString(body))
-	c.Request.Header.Set("Content-Type", "application/json")
-	accessCtx := accesslog.NewAccessLogContext("external-passthrough", http.MethodPost, path, c.Request.Proto, fixture.clientModel)
-	c.Set(accesslog.AccessLogContextKey, accessCtx)
-	fixture.router.HandlerFunc()(c)
-	return w, accessCtx
 }

--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -595,9 +595,7 @@ func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest) error 
 	}
 
 	upstreamModelForMetrics := modelName
-	if modelServer == nil {
-		upstreamModelForMetrics = metrics.DestinationLabelValueNone
-	} else if modelServer.Spec.Model != nil && !isLora {
+	if modelServer != nil && modelServer.Spec.Model != nil && !isLora {
 		upstreamModelForMetrics = *modelServer.Spec.Model
 	}
 

--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -451,7 +451,6 @@ func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest) error 
 					if proxyErr.origin != "" {
 						accesslog.SetErrorOrigin(c, proxyErr.origin)
 					}
-					accesslog.SetErrorOrigin(c, "router")
 					c.Set("finishReason", proxyErr.reason)
 					if !c.Writer.Written() {
 						c.AbortWithStatusJSON(proxyErr.statusCode, proxyErr.message)

--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -942,7 +942,7 @@ func (r *Router) proxyExternalProvider(
 	if provider.Spec.Model != nil && *provider.Spec.Model != "" {
 		upstreamModel = *provider.Spec.Model
 	}
-	accesslog.SetBackendInfo(c, "external_provider", providerName, upstreamModel)
+	accesslog.SetBackendInfo(c, metrics.BackendTypeExternalProvider, providerName, upstreamModel)
 
 	modelRouteName := ""
 	if routeName, exists := c.Get("modelRouteName"); exists {

--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -645,9 +645,15 @@ func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest) error 
 		backendName = inferencePoolFullName
 	}
 	accesslog.SetBackendInfo(c, backendType, backendName, upstreamModel)
+	destination := metrics.DestinationLabels{
+		ModelRoute:    modelRouteName,
+		BackendType:   backendType,
+		BackendName:   backendName,
+		UpstreamModel: upstreamModel,
+	}
 	if recorder, exists := c.Get("metricsRecorder"); exists {
 		if rec, ok := recorder.(*metrics.RequestMetricsRecorder); ok {
-			rec.BindDestination(modelRouteName, backendType, backendName, upstreamModel)
+			rec.BindDestination(destination)
 		}
 	}
 
@@ -803,16 +809,6 @@ func (r *Router) proxy(
 	port int32,
 	onUsage func(u providers.TokenUsage),
 ) error {
-	modelServerName := fmt.Sprintf("%s/%s", ctx.ModelServerName.Namespace, ctx.ModelServerName.Name)
-
-	// Get model route name from context
-	var modelRouteName string
-	if routeName, exists := c.Get("modelRouteName"); exists {
-		if name, ok := routeName.(string); ok {
-			modelRouteName = name
-		}
-	}
-
 	// Capture body bytes once so each retry attempt gets a fresh reader.
 	// transport.RoundTrip drains req.Body on every call, so reusing the same
 	// request across loop iterations sends an empty body to subsequent pods.
@@ -836,14 +832,16 @@ func (r *Router) proxy(
 		// Track this request as in-flight to the chosen pod.
 		r.store.IncrPodOnFlightRequests(podName)
 
-		// Increment upstream request count with backend destination labels.
-		r.metrics.IncActiveUpstreamRequestsForDestination(modelRouteName, metrics.BackendTypeModelServer, modelServerName, ctx.UpstreamModel)
+		if ctx.MetricsRecorder != nil {
+			ctx.MetricsRecorder.IncActiveUpstreamRequests()
+		}
 
 		// Request dispatched to the pod.
 		err := proxyRequest(c, req, podObj.Status.PodIP, port, stream, onUsage)
 
-		// Decrement upstream request count when request completes
-		r.metrics.DecActiveUpstreamRequestsForDestination(modelRouteName, metrics.BackendTypeModelServer, modelServerName, ctx.UpstreamModel)
+		if ctx.MetricsRecorder != nil {
+			ctx.MetricsRecorder.DecActiveUpstreamRequests()
+		}
 
 		// Request is complete (success or failure) — decrement on-flight counter.
 		r.store.DecrPodOnFlightRequests(podName)
@@ -956,7 +954,12 @@ func (r *Router) proxyExternalProvider(
 	if recorder, exists := c.Get("metricsRecorder"); exists {
 		if rec, ok := recorder.(*metrics.RequestMetricsRecorder); ok {
 			metricsRecorder = rec
-			rec.BindDestination(modelRouteName, metrics.BackendTypeExternalProvider, providerName, upstreamModel)
+			rec.BindDestination(metrics.DestinationLabels{
+				ModelRoute:    modelRouteName,
+				BackendType:   metrics.BackendTypeExternalProvider,
+				BackendName:   providerName,
+				UpstreamModel: upstreamModel,
+			})
 		}
 	}
 
@@ -993,8 +996,10 @@ func (r *Router) proxyExternalProvider(
 	responseParser := adapter.ResponseParser(c, req.URL.Path)
 
 	accesslog.SetUpstreamInfo(c, 0, 1)
-	r.metrics.IncActiveUpstreamRequestsForDestination(modelRouteName, metrics.BackendTypeExternalProvider, providerName, upstreamModel)
-	defer r.metrics.DecActiveUpstreamRequestsForDestination(modelRouteName, metrics.BackendTypeExternalProvider, providerName, upstreamModel)
+	if metricsRecorder != nil {
+		metricsRecorder.IncActiveUpstreamRequests()
+		defer metricsRecorder.DecActiveUpstreamRequests()
+	}
 
 	return proxyExternalRequest(c, upstreamRequest, responseParser, provider.Spec.InsecureSkipVerify, isStreaming(modelRequest), providerName, func(usage providers.TokenUsage) {
 		if usage.TotalTokens <= 0 {
@@ -1344,22 +1349,6 @@ func (r *Router) proxyToPDDisaggregated(
 		if rec, ok := recorder.(*metrics.RequestMetricsRecorder); ok {
 			metricsRecorder = rec
 		}
-	}
-
-	modelServerName := fmt.Sprintf("%s/%s", ctx.ModelServerName.Namespace, ctx.ModelServerName.Name)
-	accesslog.SetBackendInfo(c, metrics.BackendTypeModelServer, modelServerName, ctx.UpstreamModel)
-
-	// Get model route name from context
-	var modelRouteName string
-	if routeName, exists := c.Get("modelRouteName"); exists {
-		if name, ok := routeName.(string); ok {
-			modelRouteName = name
-		}
-	}
-
-	// Set upstream connection info in metrics recorder
-	if metricsRecorder != nil {
-		metricsRecorder.BindDestination(modelRouteName, metrics.BackendTypeModelServer, modelServerName, ctx.UpstreamModel)
 	}
 
 	// Try multiple prefill/decode pairs

--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -404,6 +404,7 @@ func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest) error 
 	var modelTarget datastore.ModelTarget
 	var modelRoute *v1alpha1.ModelRoute
 	var modelServer *v1alpha1.ModelServer
+	var inferencePoolFullName string
 
 	// Get gateway key from context if available (set by Gateway listener)
 	var gatewayKey string
@@ -430,6 +431,7 @@ func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest) error 
 			if provider == nil {
 				klog.Errorf("failed to get external model provider: %v", modelTarget.Name)
 				accesslog.SetError(c, "provider_discovery", fmt.Sprintf("can't find external model provider: %v", modelTarget.Name))
+				accesslog.SetErrorOrigin(c, "router")
 				c.Set("finishReason", "provider_discovery")
 				c.AbortWithStatusJSON(http.StatusNotFound, fmt.Sprintf("can't find external model provider: %v", modelTarget.Name))
 				return nil
@@ -446,6 +448,7 @@ func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest) error 
 				var proxyErr *externalProxyError
 				if errors.As(err, &proxyErr) {
 					accesslog.SetError(c, proxyErr.reason, proxyErr.message)
+					accesslog.SetErrorOrigin(c, "router")
 					c.Set("finishReason", proxyErr.reason)
 					if !c.Writer.Written() {
 						c.AbortWithStatusJSON(proxyErr.statusCode, proxyErr.message)
@@ -454,6 +457,7 @@ func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest) error 
 				}
 
 				accesslog.SetError(c, "external_provider_proxy", "external provider request processing failed")
+				accesslog.SetErrorOrigin(c, "router")
 				c.Set("finishReason", "external_provider_proxy")
 				if !c.Writer.Written() {
 					c.AbortWithStatusJSON(http.StatusInternalServerError, "request processing failed")
@@ -501,6 +505,7 @@ func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest) error 
 
 		// Get InferencePool from store
 		inferencePoolKey := fmt.Sprintf("%s/%s", inferencePoolName.Namespace, inferencePoolName.Name)
+		inferencePoolFullName = inferencePoolKey
 		inferencePool := r.store.GetInferencePool(inferencePoolKey)
 		if inferencePool == nil {
 			klog.Errorf("failed to get inference pool: %v", inferencePoolName)
@@ -587,11 +592,19 @@ func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest) error 
 		sessionID = c.Request.Header.Get(sessionHeader)
 	}
 
+	upstreamModelForMetrics := modelName
+	if modelServer == nil {
+		upstreamModelForMetrics = metrics.DestinationLabelValueNone
+	} else if modelServer.Spec.Model != nil && !isLora {
+		upstreamModelForMetrics = *modelServer.Spec.Model
+	}
+
 	ctx := &framework.Context{
 		Model:           modelName,
 		Prompt:          prompt,
 		SessionID:       sessionID,
 		ModelServerName: modelServerName,
+		UpstreamModel:   upstreamModelForMetrics,
 		PDGroup:         pdGroup,
 		MetricsRecorder: metricsRecorder,
 	}
@@ -604,7 +617,10 @@ func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest) error 
 	}
 
 	// Set complete request routing information in access log
-	modelServerFullName := fmt.Sprintf("%s/%s", modelServerName.Namespace, modelServerName.Name)
+	modelServerFullName := ""
+	if modelServer != nil {
+		modelServerFullName = fmt.Sprintf("%s/%s", modelServerName.Namespace, modelServerName.Name)
+	}
 	modelRouteName := ""
 	if modelRoute != nil {
 		modelRouteName = fmt.Sprintf("%s/%s", modelRoute.Namespace, modelRoute.Name)
@@ -619,6 +635,20 @@ func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest) error 
 		// Set routing info even if no pod is selected (for error cases)
 		accesslog.SetRequestRouting(c, modelRouteName, modelServerFullName, "")
 	}
+	backendType := metrics.BackendTypeModelServer
+	backendName := modelServerFullName
+	upstreamModel := ctx.UpstreamModel
+	if modelServer == nil {
+		backendType = metrics.BackendTypeInferencePool
+		backendName = inferencePoolFullName
+	}
+	accesslog.SetBackendInfo(c, backendType, backendName, upstreamModel)
+	if recorder, exists := c.Get("metricsRecorder"); exists {
+		if rec, ok := recorder.(*metrics.RequestMetricsRecorder); ok {
+			rec.BindDestination(modelRouteName, backendType, backendName, upstreamModel)
+		}
+	}
+
 	req := c.Request
 	if err := r.proxyModelEndpoint(c, req, ctx, modelRequest, port); err != nil {
 		klog.Errorf("request failed reqID: %s: %v", c.Request.Header.Get("x-request-id"), err)
@@ -796,6 +826,7 @@ func (r *Router) proxy(
 
 	for i := 0; i < len(ctx.BestPods); i++ {
 		req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+		accesslog.SetUpstreamInfo(c, 0, i+1)
 		pod := ctx.BestPods[i]
 		podObj := pod.GetPod()
 		podName := types.NamespacedName{Namespace: podObj.Namespace, Name: podObj.Name}
@@ -803,14 +834,14 @@ func (r *Router) proxy(
 		// Track this request as in-flight to the chosen pod.
 		r.store.IncrPodOnFlightRequests(podName)
 
-		// Increment upstream request count with both modelServer and modelRoute.
-		r.metrics.IncActiveUpstreamRequests(modelServerName, modelRouteName)
+		// Increment upstream request count with backend destination labels.
+		r.metrics.IncActiveUpstreamRequestsForDestination(modelRouteName, metrics.BackendTypeModelServer, modelServerName, ctx.UpstreamModel)
 
 		// Request dispatched to the pod.
 		err := proxyRequest(c, req, podObj.Status.PodIP, port, stream, onUsage)
 
 		// Decrement upstream request count when request completes
-		r.metrics.DecActiveUpstreamRequests(modelServerName, modelRouteName)
+		r.metrics.DecActiveUpstreamRequestsForDestination(modelRouteName, metrics.BackendTypeModelServer, modelServerName, ctx.UpstreamModel)
 
 		// Request is complete (success or failure) — decrement on-flight counter.
 		r.store.DecrPodOnFlightRequests(podName)
@@ -907,10 +938,23 @@ func (r *Router) proxyExternalProvider(
 	defer accesslog.MarkUpstreamEnd(c)
 
 	providerName := fmt.Sprintf("%s/%s", provider.Namespace, provider.Name)
+	upstreamModel := modelName
+	if provider.Spec.Model != nil && *provider.Spec.Model != "" {
+		upstreamModel = *provider.Spec.Model
+	}
+	accesslog.SetBackendInfo(c, "external_provider", providerName, upstreamModel)
+
+	modelRouteName := ""
+	if routeName, exists := c.Get("modelRouteName"); exists {
+		if name, ok := routeName.(string); ok {
+			modelRouteName = name
+		}
+	}
 	var metricsRecorder *metrics.RequestMetricsRecorder
 	if recorder, exists := c.Get("metricsRecorder"); exists {
 		if rec, ok := recorder.(*metrics.RequestMetricsRecorder); ok {
 			metricsRecorder = rec
+			rec.BindDestination(modelRouteName, metrics.BackendTypeExternalProvider, providerName, upstreamModel)
 		}
 	}
 
@@ -945,6 +989,10 @@ func (r *Router) proxyExternalProvider(
 
 	userID := c.GetString(common.UserIdKey)
 	responseParser := adapter.ResponseParser(c, req.URL.Path)
+
+	accesslog.SetUpstreamInfo(c, 0, 1)
+	r.metrics.IncActiveUpstreamRequestsForDestination(modelRouteName, metrics.BackendTypeExternalProvider, providerName, upstreamModel)
+	defer r.metrics.DecActiveUpstreamRequestsForDestination(modelRouteName, metrics.BackendTypeExternalProvider, providerName, upstreamModel)
 
 	return proxyExternalRequest(c, upstreamRequest, responseParser, provider.Spec.InsecureSkipVerify, isStreaming(modelRequest), providerName, func(usage providers.TokenUsage) {
 		if usage.TotalTokens <= 0 {
@@ -1045,6 +1093,7 @@ func proxyRequest(
 	resp, err := doRequest(req, podIP, port)
 	if resp != nil {
 		defer resp.Body.Close()
+		accesslog.SetUpstreamInfo(c, resp.StatusCode, 0)
 	}
 	if err != nil {
 		return fmt.Errorf("decode request error: %w", err)
@@ -1073,8 +1122,10 @@ func proxyExternalRequest(
 	}
 	defer resp.Body.Close()
 
+	accesslog.SetUpstreamInfo(c, resp.StatusCode, 1)
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
 		accesslog.SetError(c, "upstream_response", fmt.Sprintf("provider %s returned HTTP %d", providerName, resp.StatusCode))
+		accesslog.SetErrorOrigin(c, "upstream")
 		c.Set("finishReason", "upstream_response")
 	}
 
@@ -1289,6 +1340,7 @@ func (r *Router) proxyToPDDisaggregated(
 	}
 
 	modelServerName := fmt.Sprintf("%s/%s", ctx.ModelServerName.Namespace, ctx.ModelServerName.Name)
+	accesslog.SetBackendInfo(c, metrics.BackendTypeModelServer, modelServerName, ctx.UpstreamModel)
 
 	// Get model route name from context
 	var modelRouteName string
@@ -1300,7 +1352,7 @@ func (r *Router) proxyToPDDisaggregated(
 
 	// Set upstream connection info in metrics recorder
 	if metricsRecorder != nil {
-		metricsRecorder.SetUpstreamConnectionInfo(modelServerName, modelRouteName)
+		metricsRecorder.BindDestination(modelRouteName, metrics.BackendTypeModelServer, modelServerName, ctx.UpstreamModel)
 	}
 
 	// Try multiple prefill/decode pairs
@@ -1315,6 +1367,7 @@ func (r *Router) proxyToPDDisaggregated(
 		}
 		prefillPod := ctx.PrefillPods[i].GetPod()
 		decodePod := ctx.DecodePods[i].GetPod()
+		accesslog.SetUpstreamInfo(c, 0, i+1)
 
 		// Build addresses for prefill and decode pods
 		prefillAddr := net.JoinHostPort(prefillPod.Status.PodIP, strconv.Itoa(int(port)))
@@ -1335,6 +1388,9 @@ func (r *Router) proxyToPDDisaggregated(
 
 		// Execute the PD disaggregated proxy operation
 		outputTokens, err := kvConnector.Proxy(c, modelRequest, prefillAddr, decodeAddr, hooks)
+		if c.Writer.Written() {
+			accesslog.SetUpstreamInfo(c, c.Writer.Status(), 0)
+		}
 
 		if err != nil {
 			klog.Errorf("proxy failed for prefill pod %s, decode pod %s: %v",

--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -448,6 +448,9 @@ func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest) error 
 				var proxyErr *externalProxyError
 				if errors.As(err, &proxyErr) {
 					accesslog.SetError(c, proxyErr.reason, proxyErr.message)
+					if proxyErr.origin != "" {
+						accesslog.SetErrorOrigin(c, proxyErr.origin)
+					}
 					accesslog.SetErrorOrigin(c, "router")
 					c.Set("finishReason", proxyErr.reason)
 					if !c.Writer.Written() {
@@ -1030,10 +1033,15 @@ type externalProxyError struct {
 	statusCode int
 	reason     string
 	message    string
+	origin     string
 }
 
 func newExternalProxyError(statusCode int, reason, message string) *externalProxyError {
-	return &externalProxyError{statusCode: statusCode, reason: reason, message: message}
+	origin := "router"
+	if reason == "upstream_response" {
+		origin = "upstream"
+	}
+	return &externalProxyError{statusCode: statusCode, reason: reason, message: message, origin: origin}
 }
 
 func (e *externalProxyError) Error() string {

--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -938,10 +938,7 @@ func (r *Router) proxyExternalProvider(
 	defer accesslog.MarkUpstreamEnd(c)
 
 	providerName := fmt.Sprintf("%s/%s", provider.Namespace, provider.Name)
-	upstreamModel := modelName
-	if provider.Spec.Model != nil && *provider.Spec.Model != "" {
-		upstreamModel = *provider.Spec.Model
-	}
+	upstreamModel := providers.UpstreamModelName(provider, modelName)
 	accesslog.SetBackendInfo(c, metrics.BackendTypeExternalProvider, providerName, upstreamModel)
 
 	modelRouteName := ""

--- a/pkg/kthena-router/router/router_test.go
+++ b/pkg/kthena-router/router/router_test.go
@@ -780,11 +780,15 @@ func TestRouter_HandlerFunc_AggregatedMode(t *testing.T) {
 }
 
 func TestRouter_HandlerFunc_InferencePoolAccessLogDestination(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
 	backendHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
 		var reqBody ModelRequest
 		json.Unmarshal(body, &reqBody)
 		assert.Equal(t, "pool-model", reqBody["model"])
+		close(started)
+		<-release
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprint(w, `{"id":"pool-response"}`)
 	})
@@ -850,7 +854,34 @@ func TestRouter_HandlerFunc_InferencePoolAccessLogDestination(t *testing.T) {
 	accessCtx := accesslog.NewAccessLogContext("pool-request", http.MethodPost, c.Request.URL.Path, c.Request.Proto, "pool-model")
 	c.Set(accesslog.AccessLogContextKey, accessCtx)
 
-	router.HandlerFunc()(c)
+	activeLabels := []string{
+		metrics.DestinationLabelValueNone,
+		metrics.DestinationLabelValueNone,
+		metrics.BackendTypeInferencePool,
+		"default/pool",
+		metrics.DestinationLabelValueNone,
+	}
+	activeBefore := externalGaugeValue(t, &router.metrics.ActiveUpstreamRequests, activeLabels...)
+	done := make(chan struct{})
+	go func() {
+		router.HandlerFunc()(c)
+		close(done)
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		close(release)
+		t.Fatal("timed out waiting for inference pool upstream request")
+	}
+	assert.Equal(t, activeBefore+1, externalGaugeValue(t, &router.metrics.ActiveUpstreamRequests, activeLabels...))
+
+	close(release)
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for inference pool request completion")
+	}
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, metrics.BackendTypeInferencePool, accessCtx.BackendType)
@@ -858,6 +889,7 @@ func TestRouter_HandlerFunc_InferencePoolAccessLogDestination(t *testing.T) {
 	assert.Equal(t, metrics.DestinationLabelValueNone, accessCtx.UpstreamModel)
 	assert.Equal(t, 1, accessCtx.UpstreamAttempts)
 	assert.Equal(t, http.StatusOK, accessCtx.UpstreamStatusCode)
+	assert.Equal(t, activeBefore, externalGaugeValue(t, &router.metrics.ActiveUpstreamRequests, activeLabels...))
 }
 
 func TestRouter_HandlerFunc_ExternalOpenAIProvider(t *testing.T) {
@@ -1700,15 +1732,30 @@ func countMetricsWithModelPrefix(t *testing.T, prefix string) int {
 func requestCounterValue(t *testing.T, router *Router, model, path, statusCode, errorType string) float64 {
 	t.Helper()
 
-	counter, err := router.metrics.RequestsTotal.GetMetricWithLabelValues(model, path, statusCode, errorType)
-	if err != nil {
-		t.Fatalf("GetMetricWithLabelValues: %v", err)
+	metricsCh := make(chan prometheus.Metric)
+	go func() {
+		router.metrics.RequestsTotal.Collect(metricsCh)
+		close(metricsCh)
+	}()
+
+	var value float64
+	for collected := range metricsCh {
+		metric := &dto.Metric{}
+		if err := collected.Write(metric); err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+		labels := make(map[string]string, len(metric.Label))
+		for _, label := range metric.Label {
+			labels[label.GetName()] = label.GetValue()
+		}
+		if labels[metrics.LabelModel] == model &&
+			labels[metrics.LabelPath] == path &&
+			labels[metrics.LabelStatusCode] == statusCode &&
+			labels[metrics.LabelErrorType] == errorType {
+			value += metric.GetCounter().GetValue()
+		}
 	}
-	metric := &dto.Metric{}
-	if err := counter.Write(metric); err != nil {
-		t.Fatalf("Write: %v", err)
-	}
-	return metric.GetCounter().GetValue()
+	return value
 }
 
 func TestRequestFinishReason(t *testing.T) {

--- a/pkg/kthena-router/router/router_test.go
+++ b/pkg/kthena-router/router/router_test.go
@@ -859,7 +859,7 @@ func TestRouter_HandlerFunc_InferencePoolAccessLogDestination(t *testing.T) {
 		metrics.DestinationLabelValueNone,
 		metrics.BackendTypeInferencePool,
 		"default/pool",
-		metrics.DestinationLabelValueNone,
+		"pool-model",
 	}
 	activeBefore := externalGaugeValue(t, &router.metrics.ActiveUpstreamRequests, activeLabels...)
 	done := make(chan struct{})
@@ -886,7 +886,7 @@ func TestRouter_HandlerFunc_InferencePoolAccessLogDestination(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, metrics.BackendTypeInferencePool, accessCtx.BackendType)
 	assert.Equal(t, "default/pool", accessCtx.BackendName)
-	assert.Equal(t, metrics.DestinationLabelValueNone, accessCtx.UpstreamModel)
+	assert.Equal(t, "pool-model", accessCtx.UpstreamModel)
 	assert.Equal(t, 1, accessCtx.UpstreamAttempts)
 	assert.Equal(t, http.StatusOK, accessCtx.UpstreamStatusCode)
 	assert.Equal(t, activeBefore, externalGaugeValue(t, &router.metrics.ActiveUpstreamRequests, activeLabels...))

--- a/pkg/kthena-router/router/router_test.go
+++ b/pkg/kthena-router/router/router_test.go
@@ -779,6 +779,87 @@ func TestRouter_HandlerFunc_AggregatedMode(t *testing.T) {
 	assert.Equal(t, float64(1), requestCounterValue(t, router, "test-model", "/v1/chat/completions", "200", "successful_request")-requestsBefore)
 }
 
+func TestRouter_HandlerFunc_InferencePoolAccessLogDestination(t *testing.T) {
+	backendHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var reqBody ModelRequest
+		json.Unmarshal(body, &reqBody)
+		assert.Equal(t, "pool-model", reqBody["model"])
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"id":"pool-response"}`)
+	})
+	router, store, backend := setupTestRouter(t, backendHandler)
+	defer backend.Close()
+
+	backendURL, _ := url.Parse(backend.URL)
+	backendPort, _ := strconv.Atoi(backendURL.Port())
+	pool := &inferencev1.InferencePool{
+		ObjectMeta: v1.ObjectMeta{Name: "pool", Namespace: "default"},
+		Spec: inferencev1.InferencePoolSpec{
+			TargetPorts: []inferencev1.Port{{Number: inferencev1.PortNumber(backendPort)}},
+			Selector: inferencev1.LabelSelector{MatchLabels: map[inferencev1.LabelKey]inferencev1.LabelValue{
+				"app": "pool",
+			}},
+			EndpointPickerRef: inferencev1.EndpointPickerRef{Name: "pool-picker"},
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "pool-pod",
+			Namespace: "default",
+			Labels:    map[string]string{"app": "pool"},
+		},
+		Status: corev1.PodStatus{PodIP: backendURL.Hostname(), Phase: corev1.PodRunning},
+	}
+	pathType := gatewayv1.PathMatchPathPrefix
+	pathPrefix := "/v1"
+	parentKind := gatewayv1.Kind("Gateway")
+	backendGroup := inferencePoolBackendGroup
+	backendKind := inferencePoolBackendKind
+	route := &gatewayv1.HTTPRoute{
+		ObjectMeta: v1.ObjectMeta{Name: "pool-route", Namespace: "default"},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{ParentRefs: []gatewayv1.ParentReference{{
+				Name: "gw",
+				Kind: &parentKind,
+			}}},
+			Rules: []gatewayv1.HTTPRouteRule{{
+				Matches: []gatewayv1.HTTPRouteMatch{{Path: &gatewayv1.HTTPPathMatch{
+					Type:  &pathType,
+					Value: &pathPrefix,
+				}}},
+				BackendRefs: []gatewayv1.HTTPBackendRef{{BackendRef: gatewayv1.BackendRef{
+					BackendObjectReference: gatewayv1.BackendObjectReference{
+						Group: &backendGroup,
+						Kind:  &backendKind,
+						Name:  "pool",
+					},
+				}}},
+			}},
+		},
+	}
+	assert.NoError(t, store.AddOrUpdateInferencePool(pool))
+	assert.NoError(t, store.AddOrUpdatePod(pod, nil))
+	assert.NoError(t, store.AddOrUpdateHTTPRoute(route))
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request, _ = http.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewBufferString(`{"model":"pool-model","prompt":"hello"}`))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Set(GatewayKey, "default/gw")
+	accessCtx := accesslog.NewAccessLogContext("pool-request", http.MethodPost, c.Request.URL.Path, c.Request.Proto, "pool-model")
+	c.Set(accesslog.AccessLogContextKey, accessCtx)
+
+	router.HandlerFunc()(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, metrics.BackendTypeInferencePool, accessCtx.BackendType)
+	assert.Equal(t, "default/pool", accessCtx.BackendName)
+	assert.Equal(t, metrics.DestinationLabelValueNone, accessCtx.UpstreamModel)
+	assert.Equal(t, 1, accessCtx.UpstreamAttempts)
+	assert.Equal(t, http.StatusOK, accessCtx.UpstreamStatusCode)
+}
+
 func TestRouter_HandlerFunc_ExternalOpenAIProvider(t *testing.T) {
 	providerModel := "gpt-4o-mini"
 	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -912,6 +993,11 @@ func TestRouter_HandlerFunc_ExternalOpenAIResponsesProvider(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Contains(t, w.Body.String(), `"id":"resp_1"`)
+	assert.Equal(t, metrics.BackendTypeExternalProvider, accessCtx.BackendType)
+	assert.Equal(t, "default/responses-provider", accessCtx.BackendName)
+	assert.Equal(t, providerModel, accessCtx.UpstreamModel)
+	assert.Equal(t, 1, accessCtx.UpstreamAttempts)
+	assert.Equal(t, http.StatusOK, accessCtx.UpstreamStatusCode)
 	assert.Equal(t, 3, accessCtx.OutputTokens)
 }
 
@@ -2374,6 +2460,11 @@ func TestProxy_RetryBodyNotDrained(t *testing.T) {
 		// first attempt, so this would be an empty string.
 		assert.Contains(t, receivedBodies[1], "test prompt for retry path", "retry attempt sent empty body (body reuse regression)")
 	}
+	assert.Equal(t, metrics.BackendTypeModelServer, accessCtx.BackendType)
+	assert.Equal(t, "default/ms-retry", accessCtx.BackendName)
+	assert.Equal(t, "base-model", accessCtx.UpstreamModel)
+	assert.Equal(t, 2, accessCtx.UpstreamAttempts)
+	assert.Equal(t, http.StatusOK, accessCtx.UpstreamStatusCode)
 }
 
 func TestRouter_HandlerFunc_ListModels(t *testing.T) {

--- a/pkg/kthena-router/scheduler/framework/interface.go
+++ b/pkg/kthena-router/scheduler/framework/interface.go
@@ -38,6 +38,7 @@ type Context struct {
 
 	// ModelServer information for efficient PDGroup scheduling
 	ModelServerName types.NamespacedName
+	UpstreamModel   string
 	PDGroup         *aiv1alpha1.PDGroup
 	// 1. In PD Disaggregated mode, both DecodePods and PrefillPods are set.
 	DecodePods  []*datastore.PodInfo

--- a/test/e2e/utils/metrics.go
+++ b/test/e2e/utils/metrics.go
@@ -32,30 +32,47 @@ func MatchMetricLabels(metricLabels []*dto.LabelPair, wantLabels map[string]stri
 	return true
 }
 
-// GetCounterValue returns the counter value for the named metric and labels, or 0 if not found.
+// GetCounterValue returns the sum of counter values matching the named metric and labels.
 func GetCounterValue(metrics map[string]*dto.MetricFamily, metricName string, labels map[string]string) float64 {
 	mf, ok := metrics[metricName]
 	if !ok {
 		return 0
 	}
+	var value float64
 	for _, m := range mf.GetMetric() {
 		if MatchMetricLabels(m.GetLabel(), labels) {
-			return m.GetCounter().GetValue()
+			value += m.GetCounter().GetValue()
 		}
 	}
-	return 0
+	return value
 }
 
-// GetHistogramCount returns the histogram sample count for the named metric and labels, or 0 if not found.
+// GetGaugeValue returns the sum of gauge values matching the named metric and labels.
+func GetGaugeValue(metrics map[string]*dto.MetricFamily, metricName string, labels map[string]string) float64 {
+	mf, ok := metrics[metricName]
+	if !ok {
+		return 0
+	}
+	var value float64
+	for _, m := range mf.GetMetric() {
+		if MatchMetricLabels(m.GetLabel(), labels) {
+			value += m.GetGauge().GetValue()
+		}
+	}
+	return value
+}
+
+// GetHistogramCount returns the sum of histogram sample counts matching the named metric and labels.
 func GetHistogramCount(metrics map[string]*dto.MetricFamily, metricName string, labels map[string]string) uint64 {
 	mf, ok := metrics[metricName]
 	if !ok {
 		return 0
 	}
+	var count uint64
 	for _, m := range mf.GetMetric() {
 		if MatchMetricLabels(m.GetLabel(), labels) {
-			return m.GetHistogram().GetSampleCount()
+			count += m.GetHistogram().GetSampleCount()
 		}
 	}
-	return 0
+	return count
 }

--- a/test/e2e/utils/metrics.go
+++ b/test/e2e/utils/metrics.go
@@ -25,7 +25,8 @@ func MatchMetricLabels(metricLabels []*dto.LabelPair, wantLabels map[string]stri
 		labelMap[lp.GetName()] = lp.GetValue()
 	}
 	for k, v := range wantLabels {
-		if labelMap[k] != v {
+		actual, exists := labelMap[k]
+		if !exists || actual != v {
 			return false
 		}
 	}

--- a/test/e2e/utils/metrics_test.go
+++ b/test/e2e/utils/metrics_test.go
@@ -1,0 +1,113 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"testing"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetMetricValueAggregatesMatchingDestinationSeries(t *testing.T) {
+	tests := []struct {
+		name       string
+		metricName string
+		metrics    []*dto.Metric
+		getValue   func(map[string]*dto.MetricFamily, string, map[string]string) float64
+		labels     map[string]string
+		want       float64
+	}{
+		{
+			name:       "Counter",
+			metricName: "kthena_router_requests_total",
+			metrics: []*dto.Metric{
+				metricWithCounter(2, "model", "shared-model", "backend_type", "model_server", "backend_name", "default/ms"),
+				metricWithCounter(3, "model", "shared-model", "backend_type", "external_provider", "backend_name", "default/provider"),
+				metricWithCounter(7, "model", "other-model", "backend_type", "model_server", "backend_name", "default/other"),
+			},
+			getValue: GetCounterValue,
+			labels:   map[string]string{"model": "shared-model"},
+			want:     5,
+		},
+		{
+			name:       "Histogram",
+			metricName: "kthena_router_request_duration_seconds",
+			metrics: []*dto.Metric{
+				metricWithHistogram(4, "model", "shared-model", "backend_type", "model_server", "backend_name", "default/ms"),
+				metricWithHistogram(6, "model", "shared-model", "backend_type", "inference_pool", "backend_name", "default/pool"),
+				metricWithHistogram(9, "model", "other-model", "backend_type", "model_server", "backend_name", "default/other"),
+			},
+			getValue: func(metrics map[string]*dto.MetricFamily, metricName string, labels map[string]string) float64 {
+				return float64(GetHistogramCount(metrics, metricName, labels))
+			},
+			labels: map[string]string{"model": "shared-model"},
+			want:   10,
+		},
+		{
+			name:       "Gauge",
+			metricName: "kthena_router_active_upstream_requests",
+			metrics: []*dto.Metric{
+				metricWithGauge(1, "backend_type", "external_provider", "backend_name", "default/provider-a"),
+				metricWithGauge(2, "backend_type", "external_provider", "backend_name", "default/provider-b"),
+				metricWithGauge(8, "backend_type", "model_server", "backend_name", "default/model-server"),
+			},
+			getValue: GetGaugeValue,
+			labels:   map[string]string{"backend_type": "external_provider"},
+			want:     3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metrics := map[string]*dto.MetricFamily{
+				tt.metricName: {Metric: tt.metrics},
+			}
+			assert.Equal(t, tt.want, tt.getValue(metrics, tt.metricName, tt.labels))
+		})
+	}
+}
+
+func metricWithCounter(value float64, labels ...string) *dto.Metric {
+	return &dto.Metric{
+		Label:   metricLabels(labels...),
+		Counter: &dto.Counter{Value: &value},
+	}
+}
+
+func metricWithHistogram(count uint64, labels ...string) *dto.Metric {
+	return &dto.Metric{
+		Label:     metricLabels(labels...),
+		Histogram: &dto.Histogram{SampleCount: &count},
+	}
+}
+
+func metricWithGauge(value float64, labels ...string) *dto.Metric {
+	return &dto.Metric{
+		Label: metricLabels(labels...),
+		Gauge: &dto.Gauge{Value: &value},
+	}
+}
+
+func metricLabels(labels ...string) []*dto.LabelPair {
+	pairs := make([]*dto.LabelPair, 0, len(labels)/2)
+	for i := 0; i < len(labels); i += 2 {
+		name, value := labels[i], labels[i+1]
+		pairs = append(pairs, &dto.LabelPair{Name: &name, Value: &value})
+	}
+	return pairs
+}

--- a/test/e2e/utils/metrics_test.go
+++ b/test/e2e/utils/metrics_test.go
@@ -23,6 +23,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestMatchMetricLabelsRequiresLabelPresence(t *testing.T) {
+	labels := metricLabels("present", "")
+
+	assert.True(t, MatchMetricLabels(labels, map[string]string{"present": ""}))
+	assert.False(t, MatchMetricLabels(labels, map[string]string{"missing": ""}))
+}
+
 func TestGetMetricValueAggregatesMatchingDestinationSeries(t *testing.T) {
 	tests := []struct {
 		name       string


### PR DESCRIPTION
/kind feature

**Stack**

- #1369 — core ExternalModelProvider API, controller, routing, and protocol proxying
- This PR — destination-aware observability and token accounting
- #1371 — Mock E2E coverage, user guide, proposal, and examples

This PR is intentionally stacked on #1369. Until #1369 merges, GitHub's diff against `main` also includes the core layer. Review the observability-only delta here:

https://github.com/Oxidaner/kthena/compare/feat/external-model-provider-implementation...feat/external-provider-observability

**What this PR does**

- Adds destination labels for ModelServer, InferencePool, and external-provider requests: `model_route`, `backend_type`, `backend_name`, and `upstream_model`.
- Records upstream attempts, status codes, backend identity, and error origin in structured access logs.
- Keeps pre-dispatch input metrics and rate limiting based on the Router's local text estimate.
- Uses provider-reported usage for per-user accounting and provider-reported output tokens for output rate limiting, access logs, and metrics.
- Adds unit coverage for OpenAI Chat Completions, OpenAI Responses, and Anthropic usage, streaming, errors, active gauges, and non-text inputs.
- Documents the metric labels and token-accounting behavior.

**Dependencies**

Depends on #1369. Mock E2E and documentation are in #1371.

**Testing**

- `GOCACHE=/tmp/kthena-go-build go test ./pkg/kthena-router/... ./test/e2e/utils -count=1`
- `make gen-check`
- `GOCACHE=/tmp/kthena-go-build make build`
- `make test-docs`