### PR TITLE
feat(autoscaler): replace 60s sliding window with 24h archive for pre…

### DIFF
--- a/pkg/autoscaler/autoscaler/metric_collector.go
+++ b/pkg/autoscaler/autoscaler/metric_collector.go
@@ -60,7 +60,8 @@ func NewMetricCollector(target *v1alpha1.Target, policy *v1alpha1.AutoscalingPol
 		namespace = policy.Namespace
 	}
 	return &MetricCollector{
-		PastHistograms: datastructure.NewSnapshotSlidingWindow[map[string]HistogramInfo](util.SecondToTimestamp(util.SloQuantileSlidingWindowSeconds), util.SecondToTimestamp(util.SloQuantileDataKeepSeconds)),
+		// FIX: Swapped from 60s (SloQuantileSlidingWindowSeconds) to 24h (86400 seconds) for cold-start historical archive
+		PastHistograms: datastructure.NewSnapshotSlidingWindow[map[string]HistogramInfo](util.SecondToTimestamp(86400), util.SecondToTimestamp(86400)),
 		Target:         target,
 		Scope: Scope{
 			Namespace:     namespace,


### PR DESCRIPTION
This PR implements the foundational first step for #1361. Currently, the histogram only uses the last 60 seconds of data. This PR extends the sliding window to 24 hours (86400 seconds), acting as a cold-start offset to allow scaling based on longer-term patterns. The full regression model and 30-day archive requested in #1361 can be built in a follow-up PR once the datastore infrastructure is added."