### PR TITLE
test: avoid retrying expected LoRA 404

### DIFF
--- a/test/e2e/router/shared.go
+++ b/test/e2e/router/shared.go
@@ -1329,8 +1329,8 @@ func TestModelRouteLoraShared(t *testing.T, testCtx *routercontext.RouterTestCon
 		require.NoError(t, err, "Failed to read response body")
 
 		// Non-existent LoRA adapter should return 404
-		assert.Equal(t, http.StatusNotFound, resp.StatusCode, "Expected HTTP 404 status code for non-existent LoRA adapter")
-		assert.Contains(t, string(body), "route not found", "Expected route-not-found response body")
+		require.Equal(t, http.StatusNotFound, resp.StatusCode, "Expected HTTP 404 status code for non-existent LoRA adapter")
+		require.Contains(t, string(body), "route not found", "Expected route-not-found response body")
 		t.Logf("Non-existent adapter error handling verified: StatusCode=%d, Response=%s", resp.StatusCode, body)
 	})
 

--- a/test/e2e/router/shared.go
+++ b/test/e2e/router/shared.go
@@ -1323,11 +1323,15 @@ func TestModelRouteLoraShared(t *testing.T, testCtx *routercontext.RouterTestCon
 			utils.NewChatMessage("user", "Hello"),
 		}
 
-		resp := utils.SendChatRequestWithRetry(t, utils.DefaultRouterURL, "lora-NonExistent", messages, nil)
+		resp := utils.SendChatRequest(t, "lora-NonExistent", messages)
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err, "Failed to read response body")
 
 		// Non-existent LoRA adapter should return 404
-		assert.Equal(t, 404, resp.StatusCode, "Expected HTTP 404 status code for non-existent LoRA adapter")
-		t.Logf("Non-existent adapter error handling verified: StatusCode=%d, Response=%s", resp.StatusCode, resp.Body)
+		assert.Equal(t, http.StatusNotFound, resp.StatusCode, "Expected HTTP 404 status code for non-existent LoRA adapter")
+		assert.Contains(t, string(body), "route not found", "Expected route-not-found response body")
+		t.Logf("Non-existent adapter error handling verified: StatusCode=%d, Response=%s", resp.StatusCode, body)
 	})
 
 	// Unload LoRA adapters after test is complete


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

The nonexistent LoRA adapter test expects the router to return HTTP 404, but it used the generic chat retry helper. That helper only treats HTTP 200 as terminal, so every correct 404 response triggered all 10 attempts and nine backoff sleeps (1s + 2s + 4s + 8s + five 10s sleeps), adding 65 seconds to the test.

Retrying also weakens this negative test: transient 5xx responses can be ignored as long as the final attempt returns 404. Use the existing single-request helper instead so the test observes the first response, fails immediately on an unexpected status, and verifies both the 404 status and `route not found` response body.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

This only changes E2E test behavior; it does not change the router runtime.

AI assistance was used to investigate and prepare this change. I reviewed the diff and verified the router E2E package compiles.

Tested with:

```console
go test -c -o /tmp/kthena-router-e2e.test ./test/e2e/router
git diff --check
```

A targeted Kind rerun was attempted, but local setup stopped during the controller-manager image build because the host disk was full and Docker BuildKit returned a storage I/O error.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
