### PR TITLE
fix(router): cancel pending requests when fairness queue closes

### DIFF
--- a/pkg/kthena-router/datastore/fairness_queue.go
+++ b/pkg/kthena-router/datastore/fairness_queue.go
@@ -495,6 +495,7 @@ func (pq *RequestPriorityQueue) requeueRequest(req *Request) {
 	default:
 	}
 	heap.Push(pq, req)
+	pq.metricIncSize(req.ModelName, req.UserID)
 	pq.mu.Unlock()
 	select {
 	case pq.notifyCh <- struct{}{}:
@@ -608,11 +609,10 @@ func (pq *RequestPriorityQueue) Close() {
 
 	// Drain pending items and clear their metrics while holding the queue lock so
 	// concurrent PushRequest calls cannot add work after shutdown begins.
-	pending := make([]*Request, 0, len(pq.heap))
-	for len(pq.heap) > 0 {
-		req := heap.Pop(pq).(*Request)
+	pending := pq.heap
+	pq.heap = nil
+	for _, req := range pending {
 		pq.metricDecSize(req.ModelName, req.UserID)
-		pending = append(pending, req)
 	}
 	pq.mu.Unlock()
 

--- a/pkg/kthena-router/datastore/fairness_queue.go
+++ b/pkg/kthena-router/datastore/fairness_queue.go
@@ -155,6 +155,7 @@ type Request struct {
 	RequestTime         time.Time
 	NotifyChan          chan struct{}
 	CancelCh            <-chan struct{} // Request-scoped cancellation signal
+	Cancel              func()          // Cancels the request when the queue is shut down
 	Release             func()          // Set by the queue when a permit is acquired
 
 	// admitMu serializes admission (by the dequeue loop) against abandonment (by
@@ -165,6 +166,8 @@ type Request struct {
 	admitted  bool // admission committed: Release is set and about to be signalled
 	abandoned bool // caller gave up before admission; the loop must not admit
 }
+
+var errRequestQueueClosed = errors.New("request queue is closed")
 
 // commitAdmission runs fn under the request lock, but only if the caller has not
 // already abandoned the request. fn performs the admission side effects that must
@@ -329,6 +332,12 @@ func (pq *RequestPriorityQueue) PushRequest(r *Request) error {
 	pq.mu.Lock()
 	defer pq.mu.Unlock()
 
+	select {
+	case <-pq.stopCh:
+		return errRequestQueueClosed
+	default:
+	}
+
 	// In session-boost mode, promote requests whose session recently completed.
 	// Capture the session's completion time so boosted requests can be ordered by
 	// prefix-cache warmth (most recently completed first).
@@ -476,6 +485,15 @@ func (pq *RequestPriorityQueue) requeueRequest(req *Request) {
 		return
 	}
 	pq.mu.Lock()
+	select {
+	case <-pq.stopCh:
+		pq.mu.Unlock()
+		if req.Cancel != nil {
+			req.Cancel()
+		}
+		return
+	default:
+	}
 	heap.Push(pq, req)
 	pq.mu.Unlock()
 	select {
@@ -576,23 +594,34 @@ func (pq *RequestPriorityQueue) runSemaphoreMode(ctx context.Context) {
 	}
 }
 
-// Close stops the dequeue loop and drains pending items from the heap.
-// Callers waiting on NotifyChan will detect cancellation via their request-scoped signal.
+// Close stops the dequeue loop, cancels pending requests, and drains the heap.
 func (pq *RequestPriorityQueue) Close() {
 	pq.mu.Lock()
-	defer pq.mu.Unlock()
 	select {
 	case <-pq.stopCh:
 		// already closed
+		pq.mu.Unlock()
 		return
 	default:
 		close(pq.stopCh)
 	}
 
-	// Drain pending items: clear metrics for each remaining request
+	// Drain pending items and clear their metrics while holding the queue lock so
+	// concurrent PushRequest calls cannot add work after shutdown begins.
+	pending := make([]*Request, 0, len(pq.heap))
 	for len(pq.heap) > 0 {
 		req := heap.Pop(pq).(*Request)
 		pq.metricDecSize(req.ModelName, req.UserID)
+		pending = append(pending, req)
+	}
+	pq.mu.Unlock()
+
+	// Cancel outside the queue lock. Context cancellation can synchronously run
+	// callbacks, and those callbacks must not be able to deadlock queue shutdown.
+	for _, req := range pending {
+		if req.Cancel != nil {
+			req.Cancel()
+		}
 	}
 	klog.V(4).Info("fairness queue closed and drained")
 }

--- a/pkg/kthena-router/datastore/fairness_queue_test.go
+++ b/pkg/kthena-router/datastore/fairness_queue_test.go
@@ -474,6 +474,44 @@ func TestClose_DrainsPendingWaiters(t *testing.T) {
 	}
 }
 
+func TestClose_CancelsPendingWaiters(t *testing.T) {
+	pq := NewRequestPriorityQueue(nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	req := &Request{
+		ModelName:   "model-1",
+		RequestTime: time.Now(),
+		NotifyChan:  make(chan struct{}),
+		CancelCh:    ctx.Done(),
+		Cancel:      cancel,
+	}
+	if err := pq.PushRequest(req); err != nil {
+		t.Fatalf("PushRequest failed: %v", err)
+	}
+
+	pq.Close()
+
+	select {
+	case <-ctx.Done():
+		// Expected: queue shutdown cancels requests still waiting in the heap.
+	default:
+		t.Fatal("pending request was not cancelled when queue closed")
+	}
+}
+
+func TestPushRequestAfterClose(t *testing.T) {
+	pq := NewRequestPriorityQueue(nil)
+	pq.Close()
+
+	err := pq.PushRequest(&Request{ModelName: "model-1", RequestTime: time.Now()})
+	if err != errRequestQueueClosed {
+		t.Fatalf("expected %q, got %v", errRequestQueueClosed, err)
+	}
+	if pq.Len() != 0 {
+		t.Fatalf("closed queue accepted a request; length=%d", pq.Len())
+	}
+}
+
 func TestNewRequestPriorityQueueWithConfig(t *testing.T) {
 	cfg := FairnessQueueConfig{
 		MaxConcurrent:             5,

--- a/pkg/kthena-router/datastore/fairness_queue_test.go
+++ b/pkg/kthena-router/datastore/fairness_queue_test.go
@@ -21,6 +21,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	dto "github.com/prometheus/client_model/go"
 )
 
 func TestNewRequestPriorityQueue(t *testing.T) {
@@ -509,6 +511,40 @@ func TestPushRequestAfterClose(t *testing.T) {
 	}
 	if pq.Len() != 0 {
 		t.Fatalf("closed queue accepted a request; length=%d", pq.Len())
+	}
+}
+
+func TestRequeueRequestRestoresQueueSizeMetric(t *testing.T) {
+	const (
+		model = "requeue-metric-test-model"
+		user  = "requeue-metric-test-user"
+	)
+
+	pq := NewRequestPriorityQueue(nil)
+	defer pq.Close()
+
+	req := &Request{
+		UserID:      user,
+		ModelName:   model,
+		RequestTime: time.Now(),
+	}
+	if err := pq.PushRequest(req); err != nil {
+		t.Fatalf("PushRequest failed: %v", err)
+	}
+
+	if _, err := pq.popWhenAvailable(context.Background()); err != nil {
+		t.Fatalf("popWhenAvailable failed: %v", err)
+	}
+
+	pq.requeueRequest(req)
+
+	var metric dto.Metric
+	if err := pq.metrics.FairnessQueueSize.WithLabelValues(model, user).Write(&metric); err != nil {
+		t.Fatalf("failed to read queue size metric: %v", err)
+	}
+	got := metric.GetGauge().GetValue()
+	if got != 1 {
+		t.Fatalf("expected queue size metric to be restored to 1 after requeue, got %v", got)
 	}
 }
 

--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -1159,6 +1159,7 @@ func (r *Router) handleFairnessScheduling(c *gin.Context, modelRequest ModelRequ
 		RequestTime: time.Now(),
 		NotifyChan:  make(chan struct{}),
 		CancelCh:    reqCtx.Done(),
+		Cancel:      cancel,
 	}
 
 	if err := r.store.Enqueue(queueReq); err != nil {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fixes fairness queue shutdown handling:

- Cancels pending requests when a queue is closed.
- Rejects requests enqueued after queue shutdown.
- Prevents semaphore requeue paths from reinserting requests into closed queues.
- Adds regression tests for these scenarios.

Without this fix, requests can remain blocked until the fairness timeout after their `ModelRoute` is deleted.

**Which issue(s) this PR fixes**:  
Fixes #1376 

**Special notes for your reviewer**:

No API or CRD changes. Tests added for queue cancellation and enqueue-after-close behavior.

Validation:

```text
go test ./pkg/kthena-router/...
go test -race ./pkg/kthena-router/datastore
```

**Does this PR introduce a user-facing change?**:

No user-facing API change. Requests now terminate promptly when their queue is shut down.

```release-note
NONE
```