### PR TITLE
router: return 503 when backends are unavailable

### DIFF
--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -58,7 +58,22 @@ const (
 	// Context keys for gin context
 	GatewayKey = "gatewayKey"
 	PromptKey  = "promptKey" // store parsed ChatMessage, which will be reused
+
+	successfulRequestFinishReason = "successful_request"
+	failedRequestFinishReason     = "request_failed"
 )
+
+func requestFinishReason(c *gin.Context) string {
+	if reason, exists := c.Get("finishReason"); exists {
+		if value, ok := reason.(string); ok && value != "" {
+			return value
+		}
+	}
+	if c.Writer.Status() >= http.StatusBadRequest {
+		return failedRequestFinishReason
+	}
+	return successfulRequestFinishReason
+}
 
 func getEnvBool(key string, fallback bool) bool {
 	if value, ok := os.LookupEnv(key); ok {
@@ -292,11 +307,7 @@ func (r *Router) HandlerFunc() gin.HandlerFunc {
 			r.metrics.DecActiveDownstreamRequests(metricsModel)
 			if metricsRecorder != nil {
 				statusCode := strconv.Itoa(c.Writer.Status())
-				reason := "successful_request"
-				if r, exists := c.Get("finishReason"); exists {
-					reason = r.(string)
-				}
-				metricsRecorder.Finish(statusCode, reason)
+				metricsRecorder.Finish(statusCode, requestFinishReason(c))
 			}
 		}()
 
@@ -421,11 +432,13 @@ func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest) error 
 		if modelServer == nil {
 			accesslog.SetError(c, "pod_discovery", fmt.Sprintf("can't find model server: %v", modelServerName))
 			c.AbortWithStatusJSON(http.StatusNotFound, fmt.Sprintf("can't find model server: %v", modelServerName))
+			c.Set("finishReason", "pod_discovery")
 			return fmt.Errorf("can't find model server: %v", modelServerName)
 		}
 		if len(pods) == 0 {
 			accesslog.SetError(c, "pod_discovery", fmt.Sprintf("no available pods for model server: %v", modelServerName))
 			c.AbortWithStatusJSON(http.StatusServiceUnavailable, fmt.Sprintf("no available pods for model server: %v", modelServerName))
+			c.Set("finishReason", "pod_discovery")
 			return fmt.Errorf("no available pods for model server: %v", modelServerName)
 		}
 
@@ -445,6 +458,7 @@ func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest) error 
 			klog.Errorf("failed to get inference pool: %v", inferencePoolName)
 			accesslog.SetError(c, "inference_pool_discovery", fmt.Sprintf("can't find inference pool: %v", inferencePoolName))
 			c.AbortWithStatusJSON(http.StatusNotFound, fmt.Sprintf("can't find inference pool: %v", inferencePoolName))
+			c.Set("finishReason", "inference_pool_discovery")
 			return fmt.Errorf("can't find inference pool: %v", inferencePoolName)
 		}
 
@@ -452,14 +466,22 @@ func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest) error 
 		pods, err = r.store.GetPodsByInferencePool(inferencePoolName)
 		if err != nil {
 			klog.Errorf("failed to get pods for inference pool: %v, %v", inferencePoolName, err)
+			if r.store.GetInferencePool(inferencePoolKey) == nil {
+				accesslog.SetError(c, "inference_pool_discovery", fmt.Sprintf("can't find inference pool: %v", inferencePoolName))
+				c.AbortWithStatusJSON(http.StatusNotFound, fmt.Sprintf("can't find inference pool: %v", inferencePoolName))
+				c.Set("finishReason", "inference_pool_discovery")
+				return fmt.Errorf("can't find inference pool %v: %w", inferencePoolName, err)
+			}
 			accesslog.SetError(c, "pod_discovery", fmt.Sprintf("failed to get pods for inference pool: %v", inferencePoolName))
 			c.AbortWithStatusJSON(http.StatusInternalServerError, fmt.Sprintf("failed to get pods for inference pool: %v", inferencePoolName))
+			c.Set("finishReason", "pod_discovery")
 			return fmt.Errorf("failed to get pods for inference pool %v: %w", inferencePoolName, err)
 		}
 		if len(pods) == 0 {
 			klog.Errorf("no available pods for inference pool: %v", inferencePoolName)
 			accesslog.SetError(c, "pod_discovery", fmt.Sprintf("no available pods for inference pool: %v", inferencePoolName))
 			c.AbortWithStatusJSON(http.StatusServiceUnavailable, fmt.Sprintf("no available pods for inference pool: %v", inferencePoolName))
+			c.Set("finishReason", "pod_discovery")
 			return fmt.Errorf("no available pods for inference pool: %v", inferencePoolName)
 		}
 
@@ -468,6 +490,7 @@ func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest) error 
 			klog.Errorf("inference pool %v has no target ports", inferencePoolName)
 			accesslog.SetError(c, "port_discovery", fmt.Sprintf("inference pool %v has no target ports", inferencePoolName))
 			c.AbortWithStatusJSON(http.StatusBadRequest, fmt.Sprintf("inference pool %v has no target ports", inferencePoolName))
+			c.Set("finishReason", "port_discovery")
 			return fmt.Errorf("inference pool %v has no target ports", inferencePoolName)
 		}
 		// Use the first target port
@@ -749,6 +772,7 @@ func (r *Router) proxy(
 		return nil
 	}
 	c.AbortWithStatusJSON(http.StatusServiceUnavailable, "request to all pods failed")
+	c.Set("finishReason", "proxy")
 	return fmt.Errorf("request to all pods failed")
 }
 

--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -417,6 +417,11 @@ func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest) error 
 		pods, modelServer, err = r.getPodsAndServer(modelServerName)
 		if err != nil || len(pods) == 0 {
 			klog.Errorf("failed to get pods and model server: %v, %v", modelServerName, err)
+			if modelServer != nil {
+				accesslog.SetError(c, "pod_discovery", fmt.Sprintf("no available pods for model server: %v", modelServerName))
+				c.AbortWithStatusJSON(http.StatusServiceUnavailable, fmt.Sprintf("no available pods for model server: %v", modelServerName))
+				return fmt.Errorf("no available pods for model server: %v", modelServerName)
+			}
 			accesslog.SetError(c, "pod_discovery", fmt.Sprintf("can't find model server: %v", modelServerName))
 			c.AbortWithStatusJSON(http.StatusNotFound, fmt.Sprintf("can't find model server: %v", modelServerName))
 			return fmt.Errorf("can't find model server: %v", modelServerName)
@@ -445,9 +450,9 @@ func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest) error 
 		pods, err = r.store.GetPodsByInferencePool(inferencePoolName)
 		if err != nil || len(pods) == 0 {
 			klog.Errorf("failed to get pods for inference pool: %v, %v", inferencePoolName, err)
-			accesslog.SetError(c, "pod_discovery", fmt.Sprintf("can't find pods for inference pool: %v", inferencePoolName))
-			c.AbortWithStatusJSON(http.StatusNotFound, fmt.Sprintf("can't find pods for inference pool: %v", inferencePoolName))
-			return fmt.Errorf("can't find pods for inference pool: %v", inferencePoolName)
+			accesslog.SetError(c, "pod_discovery", fmt.Sprintf("no available pods for inference pool: %v", inferencePoolName))
+			c.AbortWithStatusJSON(http.StatusServiceUnavailable, fmt.Sprintf("no available pods for inference pool: %v", inferencePoolName))
+			return fmt.Errorf("no available pods for inference pool: %v", inferencePoolName)
 		}
 
 		// Get target port from InferencePool
@@ -540,7 +545,9 @@ func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest) error 
 	if err := r.proxyModelEndpoint(c, req, ctx, modelRequest, port); err != nil {
 		klog.Errorf("request failed reqID: %s: %v", c.Request.Header.Get("x-request-id"), err)
 		accesslog.SetError(c, "proxy", "request processing failed")
-		c.AbortWithStatusJSON(http.StatusInternalServerError, "request processing failed")
+		if !c.Writer.Written() {
+			c.AbortWithStatusJSON(http.StatusInternalServerError, "request processing failed")
+		}
 		return err
 	}
 	return nil
@@ -569,13 +576,14 @@ func ParseModelRequest(c *gin.Context) (ModelRequest, error) {
 }
 
 func (r *Router) getPodsAndServer(modelServerName types.NamespacedName) ([]*datastore.PodInfo, *v1alpha1.ModelServer, error) {
-	pods, err := r.store.GetPodsByModelServer(modelServerName)
-	if err != nil || len(pods) == 0 {
-		return nil, nil, fmt.Errorf("can't find target pods of model server: %v, err: %v", modelServerName, err)
-	}
 	modelServer := r.store.GetModelServer(modelServerName)
 	if modelServer == nil {
 		return nil, nil, fmt.Errorf("can't find model server: %v", modelServerName)
+	}
+
+	pods, err := r.store.GetPodsByModelServer(modelServerName)
+	if err != nil || len(pods) == 0 {
+		return nil, modelServer, fmt.Errorf("can't find target pods of model server: %v, err: %v", modelServerName, err)
 	}
 	return pods, modelServer, nil
 }
@@ -732,7 +740,7 @@ func (r *Router) proxy(
 		r.scheduler.RunPostHooks(ctx, i)
 		return nil
 	}
-	c.AbortWithStatusJSON(http.StatusNotFound, "request to all pods failed")
+	c.AbortWithStatusJSON(http.StatusServiceUnavailable, "request to all pods failed")
 	return fmt.Errorf("request to all pods failed")
 }
 

--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -448,8 +448,14 @@ func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest) error 
 
 		// Get pods from InferencePool
 		pods, err = r.store.GetPodsByInferencePool(inferencePoolName)
-		if err != nil || len(pods) == 0 {
+		if err != nil {
 			klog.Errorf("failed to get pods for inference pool: %v, %v", inferencePoolName, err)
+			accesslog.SetError(c, "pod_discovery", fmt.Sprintf("failed to get pods for inference pool: %v", inferencePoolName))
+			c.AbortWithStatusJSON(http.StatusInternalServerError, fmt.Sprintf("failed to get pods for inference pool: %v", inferencePoolName))
+			return fmt.Errorf("failed to get pods for inference pool %v: %w", inferencePoolName, err)
+		}
+		if len(pods) == 0 {
+			klog.Errorf("no available pods for inference pool: %v", inferencePoolName)
 			accesslog.SetError(c, "pod_discovery", fmt.Sprintf("no available pods for inference pool: %v", inferencePoolName))
 			c.AbortWithStatusJSON(http.StatusServiceUnavailable, fmt.Sprintf("no available pods for inference pool: %v", inferencePoolName))
 			return fmt.Errorf("no available pods for inference pool: %v", inferencePoolName)
@@ -582,8 +588,11 @@ func (r *Router) getPodsAndServer(modelServerName types.NamespacedName) ([]*data
 	}
 
 	pods, err := r.store.GetPodsByModelServer(modelServerName)
-	if err != nil || len(pods) == 0 {
-		return nil, modelServer, fmt.Errorf("can't find target pods of model server: %v, err: %v", modelServerName, err)
+	if err != nil {
+		return nil, nil, fmt.Errorf("can't find target pods of model server: %v, err: %w", modelServerName, err)
+	}
+	if len(pods) == 0 {
+		return nil, modelServer, fmt.Errorf("can't find target pods of model server: %v", modelServerName)
 	}
 	return pods, modelServer, nil
 }

--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -415,16 +415,18 @@ func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest) error 
 		klog.V(4).Infof("modelServer is %v, is_lora: %v", modelServerName, isLora)
 
 		pods, modelServer, err = r.getPodsAndServer(modelServerName)
-		if err != nil || len(pods) == 0 {
+		if err != nil {
 			klog.Errorf("failed to get pods and model server: %v, %v", modelServerName, err)
-			if modelServer != nil {
-				accesslog.SetError(c, "pod_discovery", fmt.Sprintf("no available pods for model server: %v", modelServerName))
-				c.AbortWithStatusJSON(http.StatusServiceUnavailable, fmt.Sprintf("no available pods for model server: %v", modelServerName))
-				return fmt.Errorf("no available pods for model server: %v", modelServerName)
-			}
+		}
+		if modelServer == nil {
 			accesslog.SetError(c, "pod_discovery", fmt.Sprintf("can't find model server: %v", modelServerName))
 			c.AbortWithStatusJSON(http.StatusNotFound, fmt.Sprintf("can't find model server: %v", modelServerName))
 			return fmt.Errorf("can't find model server: %v", modelServerName)
+		}
+		if len(pods) == 0 {
+			accesslog.SetError(c, "pod_discovery", fmt.Sprintf("no available pods for model server: %v", modelServerName))
+			c.AbortWithStatusJSON(http.StatusServiceUnavailable, fmt.Sprintf("no available pods for model server: %v", modelServerName))
+			return fmt.Errorf("no available pods for model server: %v", modelServerName)
 		}
 
 		model := modelServer.Spec.Model
@@ -590,9 +592,6 @@ func (r *Router) getPodsAndServer(modelServerName types.NamespacedName) ([]*data
 	pods, err := r.store.GetPodsByModelServer(modelServerName)
 	if err != nil {
 		return nil, nil, fmt.Errorf("can't find target pods of model server: %v, err: %w", modelServerName, err)
-	}
-	if len(pods) == 0 {
-		return nil, modelServer, fmt.Errorf("can't find target pods of model server: %v", modelServerName)
 	}
 	return pods, modelServer, nil
 }

--- a/pkg/kthena-router/router/router_test.go
+++ b/pkg/kthena-router/router/router_test.go
@@ -96,6 +96,19 @@ func setupTestRouter(t *testing.T, backendHandler http.Handler) (*Router, datast
 	return router, store, backend
 }
 
+type modelServerDeletedStore struct {
+	datastore.Store
+	modelServer *aiv1alpha1.ModelServer
+}
+
+func (s *modelServerDeletedStore) GetModelServer(types.NamespacedName) *aiv1alpha1.ModelServer {
+	return s.modelServer
+}
+
+func (s *modelServerDeletedStore) GetPodsByModelServer(name types.NamespacedName) ([]*datastore.PodInfo, error) {
+	return nil, fmt.Errorf("model server not found: %v", name)
+}
+
 func TestRouter_HandleHTTPRoute_PathPrefix(t *testing.T) {
 	pathType := gatewayv1.PathMatchPathPrefix
 	kind := gatewayv1.Kind("Gateway")
@@ -1005,56 +1018,104 @@ func TestRouter_HandlerFunc_BackendUnavailable(t *testing.T) {
 	}
 }
 
-func TestRouter_HandlerFunc_InferencePoolWithoutPods(t *testing.T) {
-	router, store, backend := setupTestRouter(t, nil)
-	defer backend.Close()
-
-	pathType := gatewayv1.PathMatchPathPrefix
-	pathValue := "/"
-	gatewayKind := gatewayv1.Kind("Gateway")
-	poolGroup := inferencePoolBackendGroup
-	poolKind := inferencePoolBackendKind
-	httpRoute := &gatewayv1.HTTPRoute{
-		ObjectMeta: v1.ObjectMeta{Name: "route-unavailable", Namespace: "default"},
-		Spec: gatewayv1.HTTPRouteSpec{
-			CommonRouteSpec: gatewayv1.CommonRouteSpec{
-				ParentRefs: []gatewayv1.ParentReference{{Name: "gw", Kind: &gatewayKind}},
+func TestRouter_HandlerFunc_InferencePoolPodDiscovery(t *testing.T) {
+	tests := []struct {
+		name             string
+		matchLabels      map[inferencev1.LabelKey]inferencev1.LabelValue
+		expectedStatus   int
+		expectedResponse string
+	}{
+		{
+			name: "no matching pods is unavailable",
+			matchLabels: map[inferencev1.LabelKey]inferencev1.LabelValue{
+				"app": "missing",
 			},
-			Rules: []gatewayv1.HTTPRouteRule{{
-				Matches: []gatewayv1.HTTPRouteMatch{{
-					Path: &gatewayv1.HTTPPathMatch{Type: &pathType, Value: &pathValue},
-				}},
-				BackendRefs: []gatewayv1.HTTPBackendRef{{
-					BackendRef: gatewayv1.BackendRef{
-						BackendObjectReference: gatewayv1.BackendObjectReference{
-							Group: &poolGroup,
-							Kind:  &poolKind,
-							Name:  "pool-unavailable",
-						},
-					},
-				}},
-			}},
+			expectedStatus:   http.StatusServiceUnavailable,
+			expectedResponse: "no available pods for inference pool",
+		},
+		{
+			name: "invalid selector is an internal error",
+			matchLabels: map[inferencev1.LabelKey]inferencev1.LabelValue{
+				"invalid key": "value",
+			},
+			expectedStatus:   http.StatusInternalServerError,
+			expectedResponse: "failed to get pods for inference pool",
 		},
 	}
-	inferencePool := &inferencev1.InferencePool{
-		ObjectMeta: v1.ObjectMeta{Name: "pool-unavailable", Namespace: "default"},
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			router, store, backend := setupTestRouter(t, nil)
+			defer backend.Close()
+
+			pathType := gatewayv1.PathMatchPathPrefix
+			pathValue := "/"
+			gatewayKind := gatewayv1.Kind("Gateway")
+			poolGroup := inferencePoolBackendGroup
+			poolKind := inferencePoolBackendKind
+			httpRoute := &gatewayv1.HTTPRoute{
+				ObjectMeta: v1.ObjectMeta{Name: "route-unavailable", Namespace: "default"},
+				Spec: gatewayv1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{
+						ParentRefs: []gatewayv1.ParentReference{{Name: "gw", Kind: &gatewayKind}},
+					},
+					Rules: []gatewayv1.HTTPRouteRule{{
+						Matches: []gatewayv1.HTTPRouteMatch{{
+							Path: &gatewayv1.HTTPPathMatch{Type: &pathType, Value: &pathValue},
+						}},
+						BackendRefs: []gatewayv1.HTTPBackendRef{{
+							BackendRef: gatewayv1.BackendRef{
+								BackendObjectReference: gatewayv1.BackendObjectReference{
+									Group: &poolGroup,
+									Kind:  &poolKind,
+									Name:  "pool-unavailable",
+								},
+							},
+						}},
+					}},
+				},
+			}
+			inferencePool := &inferencev1.InferencePool{
+				ObjectMeta: v1.ObjectMeta{Name: "pool-unavailable", Namespace: "default"},
+				Spec: inferencev1.InferencePoolSpec{
+					Selector: inferencev1.LabelSelector{MatchLabels: tt.matchLabels},
+				},
+			}
+			assert.NoError(t, store.AddOrUpdateHTTPRoute(httpRoute))
+			assert.NoError(t, store.AddOrUpdateInferencePool(inferencePool))
+
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Set(GatewayKey, "default/gw")
+			requestBody := `{"model":"inference-model","prompt":"hello"}`
+			var err error
+			c.Request, err = http.NewRequest(http.MethodPost, "/custom", bytes.NewBufferString(requestBody))
+			assert.NoError(t, err)
+			c.Request.Header.Set("Content-Type", "application/json")
+
+			router.HandlerFunc()(c)
+
+			assert.Equal(t, tt.expectedStatus, w.Code)
+			assert.Contains(t, w.Body.String(), tt.expectedResponse)
+		})
 	}
-	assert.NoError(t, store.AddOrUpdateHTTPRoute(httpRoute))
-	assert.NoError(t, store.AddOrUpdateInferencePool(inferencePool))
+}
 
-	w := httptest.NewRecorder()
-	c, _ := gin.CreateTestContext(w)
-	c.Set(GatewayKey, "default/gw")
-	requestBody := `{"model":"inference-model","prompt":"hello"}`
-	var err error
-	c.Request, err = http.NewRequest(http.MethodPost, "/custom", bytes.NewBufferString(requestBody))
-	assert.NoError(t, err)
-	c.Request.Header.Set("Content-Type", "application/json")
+func TestRouter_GetPodsAndServer_ModelServerDeletedDuringPodLookup(t *testing.T) {
+	modelServerName := types.NamespacedName{Name: "deleted", Namespace: "default"}
+	modelServer := &aiv1alpha1.ModelServer{
+		ObjectMeta: v1.ObjectMeta{Name: modelServerName.Name, Namespace: modelServerName.Namespace},
+	}
+	router := &Router{store: &modelServerDeletedStore{
+		Store:       datastore.New(),
+		modelServer: modelServer,
+	}}
 
-	router.HandlerFunc()(c)
+	pods, foundModelServer, err := router.getPodsAndServer(modelServerName)
 
-	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
-	assert.Contains(t, w.Body.String(), "no available pods for inference pool")
+	assert.Error(t, err)
+	assert.Nil(t, pods)
+	assert.Nil(t, foundModelServer)
 }
 
 func TestRouter_HandlerFunc_ScheduleFailure(t *testing.T) {

--- a/pkg/kthena-router/router/router_test.go
+++ b/pkg/kthena-router/router/router_test.go
@@ -29,6 +29,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -107,6 +108,23 @@ func (s *modelServerDeletedStore) GetModelServer(types.NamespacedName) *aiv1alph
 
 func (s *modelServerDeletedStore) GetPodsByModelServer(name types.NamespacedName) ([]*datastore.PodInfo, error) {
 	return nil, fmt.Errorf("model server not found: %v", name)
+}
+
+type inferencePoolDeletedStore struct {
+	datastore.Store
+	inferencePool *inferencev1.InferencePool
+	getCalls      atomic.Int32
+}
+
+func (s *inferencePoolDeletedStore) GetInferencePool(string) *inferencev1.InferencePool {
+	if s.getCalls.Add(1) == 1 {
+		return s.inferencePool
+	}
+	return nil
+}
+
+func (s *inferencePoolDeletedStore) GetPodsByInferencePool(name types.NamespacedName) ([]*datastore.PodInfo, error) {
+	return nil, fmt.Errorf("inferencepool not found: %v", name)
 }
 
 func TestRouter_HandleHTTPRoute_PathPrefix(t *testing.T) {
@@ -903,6 +921,45 @@ func requestCounterValue(t *testing.T, router *Router, model, path, statusCode, 
 	return metric.GetCounter().GetValue()
 }
 
+func TestRequestFinishReason(t *testing.T) {
+	tests := []struct {
+		name           string
+		status         int
+		explicitReason string
+		expectedReason string
+	}{
+		{
+			name:           "successful response",
+			status:         http.StatusOK,
+			expectedReason: successfulRequestFinishReason,
+		},
+		{
+			name:           "unclassified error response",
+			status:         http.StatusServiceUnavailable,
+			expectedReason: failedRequestFinishReason,
+		},
+		{
+			name:           "explicit reason takes precedence",
+			status:         http.StatusServiceUnavailable,
+			explicitReason: "pod_discovery",
+			expectedReason: "pod_discovery",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Status(tt.status)
+			if tt.explicitReason != "" {
+				c.Set("finishReason", tt.explicitReason)
+			}
+
+			assert.Equal(t, tt.expectedReason, requestFinishReason(c))
+		})
+	}
+}
+
 func TestRouter_HandlerFunc_UnknownModelMetricsUseBoundedLabel(t *testing.T) {
 	router, _, backend := setupTestRouter(t, nil)
 	defer backend.Close()
@@ -934,17 +991,20 @@ func TestRouter_HandlerFunc_BackendUnavailable(t *testing.T) {
 		addPod           bool
 		expectedStatus   int
 		expectedResponse string
+		expectedReason   string
 	}{
 		{
 			name:             "missing model server remains not found",
 			expectedStatus:   http.StatusNotFound,
 			expectedResponse: "can't find model server",
+			expectedReason:   "pod_discovery",
 		},
 		{
 			name:             "model server without pods is unavailable",
 			addModelServer:   true,
 			expectedStatus:   http.StatusServiceUnavailable,
 			expectedResponse: "no available pods for model server",
+			expectedReason:   "pod_discovery",
 		},
 		{
 			name:             "all backend requests fail",
@@ -952,6 +1012,7 @@ func TestRouter_HandlerFunc_BackendUnavailable(t *testing.T) {
 			addPod:           true,
 			expectedStatus:   http.StatusServiceUnavailable,
 			expectedResponse: "request to all pods failed",
+			expectedReason:   "proxy",
 		},
 	}
 
@@ -1003,6 +1064,10 @@ func TestRouter_HandlerFunc_BackendUnavailable(t *testing.T) {
 			}
 			store.AddOrUpdateModelRoute(modelRoute)
 
+			requestsBefore := requestCounterValue(
+				t, router, "unavailable-model", "/v1/chat/completions",
+				strconv.Itoa(tt.expectedStatus), tt.expectedReason,
+			)
 			w := httptest.NewRecorder()
 			c, _ := gin.CreateTestContext(w)
 			requestBody := `{"model":"unavailable-model","prompt":"hello"}`
@@ -1014,6 +1079,10 @@ func TestRouter_HandlerFunc_BackendUnavailable(t *testing.T) {
 
 			assert.Equal(t, tt.expectedStatus, w.Code)
 			assert.Contains(t, w.Body.String(), tt.expectedResponse)
+			assert.Equal(t, float64(1), requestCounterValue(
+				t, router, "unavailable-model", "/v1/chat/completions",
+				strconv.Itoa(tt.expectedStatus), tt.expectedReason,
+			)-requestsBefore)
 		})
 	}
 }
@@ -1022,8 +1091,10 @@ func TestRouter_HandlerFunc_InferencePoolPodDiscovery(t *testing.T) {
 	tests := []struct {
 		name             string
 		matchLabels      map[inferencev1.LabelKey]inferencev1.LabelValue
+		deleteDuringRead bool
 		expectedStatus   int
 		expectedResponse string
+		expectedReason   string
 	}{
 		{
 			name: "no matching pods is unavailable",
@@ -1032,6 +1103,7 @@ func TestRouter_HandlerFunc_InferencePoolPodDiscovery(t *testing.T) {
 			},
 			expectedStatus:   http.StatusServiceUnavailable,
 			expectedResponse: "no available pods for inference pool",
+			expectedReason:   "pod_discovery",
 		},
 		{
 			name: "invalid selector is an internal error",
@@ -1040,6 +1112,14 @@ func TestRouter_HandlerFunc_InferencePoolPodDiscovery(t *testing.T) {
 			},
 			expectedStatus:   http.StatusInternalServerError,
 			expectedResponse: "failed to get pods for inference pool",
+			expectedReason:   "pod_discovery",
+		},
+		{
+			name:             "pool deleted during pod lookup is not found",
+			deleteDuringRead: true,
+			expectedStatus:   http.StatusNotFound,
+			expectedResponse: "can't find inference pool",
+			expectedReason:   "inference_pool_discovery",
 		},
 	}
 
@@ -1083,7 +1163,17 @@ func TestRouter_HandlerFunc_InferencePoolPodDiscovery(t *testing.T) {
 			}
 			assert.NoError(t, store.AddOrUpdateHTTPRoute(httpRoute))
 			assert.NoError(t, store.AddOrUpdateInferencePool(inferencePool))
+			if tt.deleteDuringRead {
+				router.store = &inferencePoolDeletedStore{
+					Store:         store,
+					inferencePool: inferencePool,
+				}
+			}
 
+			requestsBefore := requestCounterValue(
+				t, router, metrics.UnknownModel, "/custom",
+				strconv.Itoa(tt.expectedStatus), tt.expectedReason,
+			)
 			w := httptest.NewRecorder()
 			c, _ := gin.CreateTestContext(w)
 			c.Set(GatewayKey, "default/gw")
@@ -1097,6 +1187,10 @@ func TestRouter_HandlerFunc_InferencePoolPodDiscovery(t *testing.T) {
 
 			assert.Equal(t, tt.expectedStatus, w.Code)
 			assert.Contains(t, w.Body.String(), tt.expectedResponse)
+			assert.Equal(t, float64(1), requestCounterValue(
+				t, router, metrics.UnknownModel, "/custom",
+				strconv.Itoa(tt.expectedStatus), tt.expectedReason,
+			)-requestsBefore)
 		})
 	}
 }

--- a/pkg/kthena-router/router/router_test.go
+++ b/pkg/kthena-router/router/router_test.go
@@ -42,6 +42,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 
+	inferencev1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	aiv1alpha1 "github.com/volcano-sh/kthena/pkg/apis/networking/v1alpha1"
@@ -911,6 +912,149 @@ func TestRouter_HandlerFunc_UnknownModelMetricsUseBoundedLabel(t *testing.T) {
 
 	assert.Equal(t, 0, countMetricsWithModelPrefix(t, prefix))
 	assert.Equal(t, float64(3), requestCounterValue(t, router, metrics.UnknownModel, "/v1/chat/completions", "404", "route_not_found")-requestsBefore)
+}
+
+func TestRouter_HandlerFunc_BackendUnavailable(t *testing.T) {
+	tests := []struct {
+		name             string
+		addModelServer   bool
+		addPod           bool
+		expectedStatus   int
+		expectedResponse string
+	}{
+		{
+			name:             "missing model server remains not found",
+			expectedStatus:   http.StatusNotFound,
+			expectedResponse: "can't find model server",
+		},
+		{
+			name:             "model server without pods is unavailable",
+			addModelServer:   true,
+			expectedStatus:   http.StatusServiceUnavailable,
+			expectedResponse: "no available pods for model server",
+		},
+		{
+			name:             "all backend requests fail",
+			addModelServer:   true,
+			addPod:           true,
+			expectedStatus:   http.StatusServiceUnavailable,
+			expectedResponse: "request to all pods failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			backendHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusServiceUnavailable)
+			})
+			router, store, backend := setupTestRouter(t, backendHandler)
+			defer backend.Close()
+
+			backendURL, err := url.Parse(backend.URL)
+			assert.NoError(t, err)
+			backendPort, err := strconv.Atoi(backendURL.Port())
+			assert.NoError(t, err)
+
+			modelServer := &aiv1alpha1.ModelServer{
+				ObjectMeta: v1.ObjectMeta{Name: "ms-unavailable", Namespace: "default"},
+				Spec: aiv1alpha1.ModelServerSpec{
+					Model:        func(s string) *string { return &s }("base-model"),
+					WorkloadPort: aiv1alpha1.WorkloadPort{Port: int32(backendPort)},
+				},
+			}
+			modelRoute := &aiv1alpha1.ModelRoute{
+				ObjectMeta: v1.ObjectMeta{Name: "mr-unavailable", Namespace: "default"},
+				Spec: aiv1alpha1.ModelRouteSpec{
+					ModelName: "unavailable-model",
+					Rules: []*aiv1alpha1.Rule{
+						{TargetModels: []*aiv1alpha1.TargetModel{{ModelServerName: modelServer.Name}}},
+					},
+				},
+			}
+
+			if tt.addModelServer {
+				podNames := sets.New[types.NamespacedName]()
+				var pod *corev1.Pod
+				if tt.addPod {
+					podName := types.NamespacedName{Name: "pod-unavailable", Namespace: "default"}
+					podNames.Insert(podName)
+					pod = &corev1.Pod{
+						ObjectMeta: v1.ObjectMeta{Name: podName.Name, Namespace: podName.Namespace},
+						Status:     corev1.PodStatus{PodIP: backendURL.Hostname(), Phase: corev1.PodRunning},
+					}
+				}
+				store.AddOrUpdateModelServer(modelServer, podNames)
+				if pod != nil {
+					store.AddOrUpdatePod(pod, []*aiv1alpha1.ModelServer{modelServer})
+				}
+			}
+			store.AddOrUpdateModelRoute(modelRoute)
+
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			requestBody := `{"model":"unavailable-model","prompt":"hello"}`
+			c.Request, err = http.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewBufferString(requestBody))
+			assert.NoError(t, err)
+			c.Request.Header.Set("Content-Type", "application/json")
+
+			router.HandlerFunc()(c)
+
+			assert.Equal(t, tt.expectedStatus, w.Code)
+			assert.Contains(t, w.Body.String(), tt.expectedResponse)
+		})
+	}
+}
+
+func TestRouter_HandlerFunc_InferencePoolWithoutPods(t *testing.T) {
+	router, store, backend := setupTestRouter(t, nil)
+	defer backend.Close()
+
+	pathType := gatewayv1.PathMatchPathPrefix
+	pathValue := "/"
+	gatewayKind := gatewayv1.Kind("Gateway")
+	poolGroup := inferencePoolBackendGroup
+	poolKind := inferencePoolBackendKind
+	httpRoute := &gatewayv1.HTTPRoute{
+		ObjectMeta: v1.ObjectMeta{Name: "route-unavailable", Namespace: "default"},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{{Name: "gw", Kind: &gatewayKind}},
+			},
+			Rules: []gatewayv1.HTTPRouteRule{{
+				Matches: []gatewayv1.HTTPRouteMatch{{
+					Path: &gatewayv1.HTTPPathMatch{Type: &pathType, Value: &pathValue},
+				}},
+				BackendRefs: []gatewayv1.HTTPBackendRef{{
+					BackendRef: gatewayv1.BackendRef{
+						BackendObjectReference: gatewayv1.BackendObjectReference{
+							Group: &poolGroup,
+							Kind:  &poolKind,
+							Name:  "pool-unavailable",
+						},
+					},
+				}},
+			}},
+		},
+	}
+	inferencePool := &inferencev1.InferencePool{
+		ObjectMeta: v1.ObjectMeta{Name: "pool-unavailable", Namespace: "default"},
+	}
+	assert.NoError(t, store.AddOrUpdateHTTPRoute(httpRoute))
+	assert.NoError(t, store.AddOrUpdateInferencePool(inferencePool))
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Set(GatewayKey, "default/gw")
+	requestBody := `{"model":"inference-model","prompt":"hello"}`
+	var err error
+	c.Request, err = http.NewRequest(http.MethodPost, "/custom", bytes.NewBufferString(requestBody))
+	assert.NoError(t, err)
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	router.HandlerFunc()(c)
+
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+	assert.Contains(t, w.Body.String(), "no available pods for inference pool")
 }
 
 func TestRouter_HandlerFunc_ScheduleFailure(t *testing.T) {

--- a/test/e2e/utils/chat.go
+++ b/test/e2e/utils/chat.go
@@ -373,16 +373,16 @@ func SendChatRequestWithURL(t *testing.T, url string, modelName string, messages
 	return resp
 }
 
-// SendChatRequestUntilRouterProgrammed polls until the Kthena Router has programmed the route (stops returning 404).
-// We don't retry on 503 because it only occurs when the client disconnects before receiving a response.
+// SendChatRequestUntilRouterProgrammed polls until the Kthena Router has programmed the route
+// and has an available backend (stops returning 404 or 503).
 func SendChatRequestUntilRouterProgrammed(t *testing.T, modelName string, messages []ChatMessage) *http.Response {
 	var finalResp *http.Response
 	ctx := context.Background()
 
 	err := wait.PollUntilContextTimeout(ctx, 1*time.Second, 60*time.Second, true, func(ctx context.Context) (bool, error) {
 		resp := SendChatRequest(t, modelName, messages)
-		if resp.StatusCode == http.StatusNotFound {
-			t.Logf("Route not yet programmed (404), retrying...")
+		if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusServiceUnavailable {
+			t.Logf("Route or backend not ready (%d), retrying...", resp.StatusCode)
 			resp.Body.Close()
 			return false, nil
 		}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Return HTTP 503 instead of 404 when a route is matched but has no available backend pods, or when requests to all selected pods fail. Keep HTTP 404 for missing routes and ModelServer resources.

Update the E2E readiness helper to retry while either the route or backend is not ready.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Prepared with AI assistance. The changes were reviewed and verified locally.

Tested with:
```console
go test ./pkg/kthena-router/router ./test/e2e/utils
go test -race ./pkg/kthena-router/router
make lint
```

**Does this PR introduce a user-facing change?**:
```release-note
Return HTTP 503 when a matched route has no available backend instead of reporting HTTP 404.
```
