### PR TITLE
workload: validate plugin scope target

### DIFF
--- a/charts/kthena/charts/workload/crds/workload.serving.volcano.sh_modelservings.yaml
+++ b/charts/kthena/charts/workload/crds/workload.serving.volcano.sh_modelservings.yaml
@@ -67,10 +67,13 @@ spec:
                             type: string
                           type: array
                         target:
-                          description: |-
-                            Target limits the plugin to specific pod target (Entry/Worker/All).
-                            kubebuilder:default=All
-                            kubebuilder:validation:Enum={All,Entry,Worker}
+                          default: All
+                          description: Target limits the plugin to specific pod target
+                            (Entry/Worker/All).
+                          enum:
+                          - All
+                          - Entry
+                          - Worker
                           type: string
                       type: object
                     type:

--- a/docs/kthena/docs/reference/crd/workload.serving.volcano.sh.md
+++ b/docs/kthena/docs/reference/crd/workload.serving.volcano.sh.md
@@ -677,7 +677,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `roles` _string array_ | Roles limits the plugin to the specified role names. |  |  |
-| `target` _[PluginTarget](#plugintarget)_ | Target limits the plugin to specific pod target (Entry/Worker/All).<br />kubebuilder:default=All<br />kubebuilder:validation:Enum=\{All,Entry,Worker\} |  |  |
+| `target` _[PluginTarget](#plugintarget)_ | Target limits the plugin to specific pod target (Entry/Worker/All). | All | Enum: [All Entry Worker] <br /> |
 
 
 #### PluginSpec

--- a/pkg/apis/workload/v1alpha1/model_serving_types.go
+++ b/pkg/apis/workload/v1alpha1/model_serving_types.go
@@ -92,8 +92,9 @@ type PluginScope struct {
 	// +optional
 	Roles []string `json:"roles,omitempty"`
 	// Target limits the plugin to specific pod target (Entry/Worker/All).
-	// kubebuilder:default=All
-	// kubebuilder:validation:Enum={All,Entry,Worker}
+	// +optional
+	// +kubebuilder:default=All
+	// +kubebuilder:validation:Enum={All,Entry,Worker}
 	Target PluginTarget `json:"target,omitempty"`
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fixes the kubebuilder markers for ModelServing.spec.plugins[].scope.target so the generated CRD applies the intended default and enum validation.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

NONE

**Does this PR introduce a user-facing change?**:

```release-note
NONE