### PR TITLE
fix: PD scheduler bypassing least-request pod filters

### DIFF
--- a/pkg/kthena-router/scheduler/scheduler_impl.go
+++ b/pkg/kthena-router/scheduler/scheduler_impl.go
@@ -165,7 +165,6 @@ func (s *SchedulerImpl) Schedule(ctx *framework.Context, pods []*datastore.PodIn
 				continue
 			}
 
-
 			selectedPods, err = s.RunFilterPlugins(selectedPods, ctx)
 			if err != nil {
 				klog.V(4).InfoS("prefill pods were filtered out", "decode instance", decodePodName, "error", err)
@@ -190,7 +189,6 @@ func (s *SchedulerImpl) Schedule(ctx *framework.Context, pods []*datastore.PodIn
 
 		return nil
 	}
-
 
 	pods, err := s.RunFilterPlugins(pods, ctx)
 	if err != nil {

--- a/pkg/kthena-router/scheduler/scheduler_impl.go
+++ b/pkg/kthena-router/scheduler/scheduler_impl.go
@@ -123,12 +123,6 @@ func (s *SchedulerImpl) Schedule(ctx *framework.Context, pods []*datastore.PodIn
 		s.store.SyncOnFlightCounts()
 	}
 
-	// first filter out invalid pods that wonot be selected to loadbalance to.
-	pods, err := s.RunFilterPlugins(pods, ctx)
-	if err != nil {
-		return err
-	}
-
 	if ctx.PDGroup != nil {
 		// Use optimized PDGroup scheduling with pre-categorized pods from store
 		klog.V(4).Info("Using optimized PD disaggregated scheduling")
@@ -141,6 +135,14 @@ func (s *SchedulerImpl) Schedule(ctx *framework.Context, pods []*datastore.PodIn
 
 		if len(decodePods) == 0 {
 			return fmt.Errorf("no decode pod found")
+		}
+
+		// The initial pod list contains both prefill and decode roles. Filter the
+		// role-specific list after retrieving it from the store so overloaded
+		// decode pods cannot bypass filters in the optimized PD path.
+		decodePods, err = s.RunFilterPlugins(decodePods, ctx)
+		if err != nil {
+			return err
 		}
 
 		klog.V(4).Info("Running score plugins for decode pod")
@@ -163,6 +165,13 @@ func (s *SchedulerImpl) Schedule(ctx *framework.Context, pods []*datastore.PodIn
 				continue
 			}
 
+
+			selectedPods, err = s.RunFilterPlugins(selectedPods, ctx)
+			if err != nil {
+				klog.V(4).InfoS("prefill pods were filtered out", "decode instance", decodePodName, "error", err)
+				continue
+			}
+
 			klog.V(4).Info("Running score plugins for prefill pod")
 			scores = s.RunScorePlugins(selectedPods, ctx)
 			bestPrefillPod := TopNPodInfos(scores, 1)
@@ -180,6 +189,12 @@ func (s *SchedulerImpl) Schedule(ctx *framework.Context, pods []*datastore.PodIn
 		}
 
 		return nil
+	}
+
+
+	pods, err := s.RunFilterPlugins(pods, ctx)
+	if err != nil {
+		return err
 	}
 
 	klog.V(4).Info("Running score plugins for PD aggregated pod")

--- a/pkg/kthena-router/scheduler/scheduler_impl_test.go
+++ b/pkg/kthena-router/scheduler/scheduler_impl_test.go
@@ -319,3 +319,55 @@ func createTestPodInfo(name string) *datastore.PodInfo {
 		},
 	}
 }
+
+func TestPDSchedulerFiltersOverloadedDecodePod(t *testing.T) {
+	store := datastore.New()
+	modelServer := &aiv1alpha1.ModelServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-model-server", Namespace: "default"},
+		Spec: aiv1alpha1.ModelServerSpec{
+			WorkloadSelector: &aiv1alpha1.WorkloadSelector{
+				PDGroup: &aiv1alpha1.PDGroup{
+					GroupKey:      "pd-group",
+					DecodeLabels:  map[string]string{"role": "decode"},
+					PrefillLabels: map[string]string{"role": "prefill"},
+				},
+			},
+		},
+	}
+	modelServerName := types.NamespacedName{Namespace: "default", Name: "test-model-server"}
+	require.NoError(t, store.AddOrUpdateModelServer(modelServer, nil))
+
+	decodePod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "decode-pod-0", Namespace: "default", Labels: map[string]string{
+			"pd-group": "group-1", "role": "decode",
+		}},
+		Status: corev1.PodStatus{PodIP: "10.0.0.1"},
+	}
+	prefillPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "prefill-pod-0", Namespace: "default", Labels: map[string]string{
+			"pd-group": "group-1", "role": "prefill",
+		}},
+		Status: corev1.PodStatus{PodIP: "10.0.0.2"},
+	}
+	require.NoError(t, store.AddOrUpdatePod(decodePod, []*aiv1alpha1.ModelServer{modelServer}))
+	require.NoError(t, store.AddOrUpdatePod(prefillPod, []*aiv1alpha1.ModelServer{modelServer}))
+
+	pods, err := store.GetPodsByModelServer(modelServerName)
+	require.NoError(t, err)
+	for _, pod := range pods {
+		if pod.Pod.Name == "decode-pod-0" {
+			pod.RequestWaitingNum = 20
+		}
+	}
+
+	ctx := &framework.Context{
+		Prompt:          &common.ChatMessage{},
+		ModelServerName: modelServerName,
+		PDGroup:         modelServer.Spec.WorkloadSelector.PDGroup,
+	}
+
+	// Expected behavior: the only decode pod exceeds the default threshold of
+	// 10 and must be filtered out before PD pairing.
+	err = NewScheduler(store, nil).Schedule(ctx, pods)
+	require.Error(t, err)
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The PD scheduling path reloaded decode and prefill pods from the datastore after the initial filtering step. This allowed overloaded pods to bypass the `least-request` filter and receive traffic.

This PR applies filter plugins to decode pods and prefill candidates before scoring and pairing. It also adds a regression test for overloaded decode pods.

**Which issue(s) this PR fixes**:

Fixes #1384 

**Special notes for your reviewer**:

- Non-PD scheduling behavior remains unchanged.
- Added `TestPDSchedulerFiltersOverloadedDecodePod`.
- Verified with:

  ```bash
  go test ./pkg/kthena-router/...
  ```

**Does this PR introduce a user-facing change?**:

Yes. PD scheduling now honors the configured `least-request` filter for decode and prefill pods.