### PR TITLE
fix: serve webhook TLS from the in-memory certificate

### DIFF
--- a/charts/kthena/charts/workload/templates/kthena-controller-manager/component/deployment.yaml
+++ b/charts/kthena/charts/workload/templates/kthena-controller-manager/component/deployment.yaml
@@ -58,20 +58,24 @@ spec:
             - name: webhook-certs
               mountPath: /etc/tls
               readOnly: true
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: 8443
+              scheme: HTTPS
+            {{- toYaml .Values.controllerManager.probes.startup | nindent 12 }}
           livenessProbe:
             httpGet:
               path: /healthz
               port: 8443
               scheme: HTTPS
-            initialDelaySeconds: 5
-            periodSeconds: 10
+            {{- toYaml .Values.controllerManager.probes.liveness | nindent 12 }}
           readinessProbe:
             httpGet:
               path: /healthz
               port: 8443
               scheme: HTTPS
-            initialDelaySeconds: 5
-            periodSeconds: 10
+            {{- toYaml .Values.controllerManager.probes.readiness | nindent 12 }}
       volumes:
         - name: webhook-certs
           secret:

--- a/charts/kthena/charts/workload/values.yaml
+++ b/charts/kthena/charts/workload/values.yaml
@@ -22,6 +22,19 @@ controllerManager:
     requests:
       cpu: 100m
       memory: 128Mi
+  # probes tunes the health checks for the controller manager container. The startup
+  # probe guards the bootstrap window so that the liveness probe cannot restart the
+  # container before the webhook server has begun listening on 8443.
+  probes:
+    startup:
+      periodSeconds: 5
+      failureThreshold: 30
+    liveness:
+      initialDelaySeconds: 5
+      periodSeconds: 10
+    readiness:
+      initialDelaySeconds: 5
+      periodSeconds: 10
   # controllers specifies which controllers to enable
   # Available options: modelserving, modelbooster, autoscaler
   # If empty or not specified, all controllers are enabled

--- a/cmd/kthena-controller-manager/main.go
+++ b/cmd/kthena-controller-manager/main.go
@@ -117,8 +117,8 @@ func main() {
 const validatingWebhookName = "kthena-controller-manager-validating-webhook"
 const mutatingWebhookName = "kthena-controller-manager-mutating-webhook"
 
-// ensureWebhookCertificate generates a certificate into the secret and returns the CA bundle.
-func ensureWebhookCertificate(ctx context.Context, kubeClient kubernetes.Interface, wc webhookConfig) ([]byte, error) {
+// ensureWebhookCertificate generates a certificate into the secret and returns the bundle.
+func ensureWebhookCertificate(ctx context.Context, kubeClient kubernetes.Interface, wc webhookConfig) (*webhookcert.CertBundle, error) {
 	namespace := getNamespace()
 	dnsNames := []string{
 		fmt.Sprintf("%s.%s.svc", wc.serviceName, namespace),
@@ -126,6 +126,50 @@ func ensureWebhookCertificate(ctx context.Context, kubeClient kubernetes.Interfa
 	}
 	klog.Infof("Auto-generating certificate for webhook server (secret=%s service=%s)", wc.certSecretName, wc.serviceName)
 	return webhookcert.EnsureCertificate(ctx, kubeClient, namespace, wc.certSecretName, dnsNames)
+}
+
+// resolveServingCert returns the TLS material the webhook server should serve with,
+// following the precedence: existing secret -> mounted cert files -> generate.
+//
+// Every branch returns the key pair in memory. The server must never depend on the
+// generated secret being projected into the pod, because kubelet only refreshes an
+// already-mounted optional secret on its sync loop (a minute by default), which is
+// far longer than the liveness probe tolerates.
+func resolveServingCert(ctx context.Context, kubeClient kubernetes.Interface, wc webhookConfig) (*webhookcert.CertBundle, error) {
+	namespace := getNamespace()
+
+	// 1. An existing secret is authoritative: it is the copy every replica agrees on.
+	bundle, err := webhookcert.LoadCertBundleFromSecret(ctx, kubeClient, namespace, wc.certSecretName)
+	if err != nil {
+		klog.Warningf("Error reading cert bundle from secret %s: %v", wc.certSecretName, err)
+	} else if bundle != nil && len(bundle.CertPEM) > 0 && len(bundle.KeyPEM) > 0 {
+		klog.Infof("Loaded serving certificate from secret %s", wc.certSecretName)
+		return bundle, nil
+	}
+
+	// 2. Fall back to cert files supplied by an external cert manager. CAPEM is left
+	// empty on purpose: that CA is published by whoever manages the files (for example
+	// cert-manager's ca-injector), so we must not overwrite the webhook configurations.
+	if fileExists(wc.tlsCertFile) && fileExists(wc.tlsPrivateKey) {
+		klog.Infof("Loading serving certificate from %s and %s", wc.tlsCertFile, wc.tlsPrivateKey)
+		return loadCertBundleFromFiles(wc.tlsCertFile, wc.tlsPrivateKey)
+	}
+
+	// 3. Nothing exists yet: generate and persist so other replicas reuse this pair.
+	return ensureWebhookCertificate(ctx, kubeClient, wc)
+}
+
+// loadCertBundleFromFiles reads an externally managed key pair off disk.
+func loadCertBundleFromFiles(certFile, keyFile string) (*webhookcert.CertBundle, error) {
+	certPEM, err := os.ReadFile(certFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read cert file %s: %w", certFile, err)
+	}
+	keyPEM, err := os.ReadFile(keyFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read key file %s: %w", keyFile, err)
+	}
+	return &webhookcert.CertBundle{CertPEM: certPEM, KeyPEM: keyPEM}, nil
 }
 
 func setupWebhook(ctx context.Context, wc webhookConfig) error {
@@ -148,35 +192,22 @@ func setupWebhook(ctx context.Context, wc webhookConfig) error {
 		return err
 	}
 
-	// Secret -> File -> Generate precedence for CA bundle selection
-	namespace := getNamespace()
-	var caBundle []byte
-
-	// 1. Try secret first.
-	if bundle, err := webhookcert.LoadCertBundleFromSecret(ctx, kubeClient, namespace, wc.certSecretName); err != nil {
-		klog.Warningf("Error reading CA bundle from secret %s: %v", wc.certSecretName, err)
-	} else if bundle != nil {
-		klog.Infof("Loaded CA bundle from secret %s", wc.certSecretName)
-		caBundle = bundle.CAPEM
+	bundle, err := resolveServingCert(ctx, kubeClient, wc)
+	if err != nil {
+		return fmt.Errorf("failed to obtain webhook serving certificate: %w", err)
 	}
 
-	// 2. If not from secret, try existing cert file.
-	if caBundle == nil {
-		if !fileExists(wc.tlsPrivateKey) || !fileExists(wc.tlsCertFile) {
-			b, err := ensureWebhookCertificate(ctx, kubeClient, wc)
-			if err != nil {
-				klog.Fatalf("Failed to auto-generate webhook certificates: %v", err)
-			}
-			caBundle = b
-		}
+	servingCert, err := tls.X509KeyPair(bundle.CertPEM, bundle.KeyPEM)
+	if err != nil {
+		return fmt.Errorf("failed to build webhook TLS key pair: %w", err)
 	}
 
-	if caBundle != nil {
+	if len(bundle.CAPEM) > 0 {
 		// Always update both webhook configurations with the chosen CA bundle
-		if err := webhookcert.UpdateValidatingWebhookCABundle(ctx, kubeClient, validatingWebhookName, caBundle); err != nil {
+		if err := webhookcert.UpdateValidatingWebhookCABundle(ctx, kubeClient, validatingWebhookName, bundle.CAPEM); err != nil {
 			klog.Warningf("Failed to update ValidatingWebhookConfiguration CA bundle: %v", err)
 		}
-		if err := webhookcert.UpdateMutatingWebhookCABundle(ctx, kubeClient, mutatingWebhookName, caBundle); err != nil {
+		if err := webhookcert.UpdateMutatingWebhookCABundle(ctx, kubeClient, mutatingWebhookName, bundle.CAPEM); err != nil {
 			klog.Warningf("Failed to update MutatingWebhookConfiguration CA bundle: %v", err)
 		}
 	}
@@ -208,19 +239,15 @@ func setupWebhook(ctx context.Context, wc webhookConfig) error {
 		ReadTimeout:  time.Duration(wc.webhookTimeout) * time.Second,
 		WriteTimeout: time.Duration(wc.webhookTimeout) * time.Second,
 		TLSConfig: &tls.Config{
-			MinVersion: tls.VersionTLS12,
+			MinVersion:   tls.VersionTLS12,
+			Certificates: []tls.Certificate{servingCert},
 		},
-	}
-
-	// Wait for both cert and key files to exist (in case they are mounted by Kubernetes)
-	ok := waitForCertsReady(wc.tlsPrivateKey, wc.tlsCertFile)
-	if !ok {
-		return fmt.Errorf("TLS cert/key files not found, webhook server cannot start")
 	}
 
 	go func() {
 		klog.Infof("Starting webhook server on %s", server.Addr)
-		if err := server.ListenAndServeTLS(wc.tlsCertFile, wc.tlsPrivateKey); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		// Certificates are already loaded into TLSConfig, so no file paths are needed.
+		if err := server.ListenAndServeTLS("", ""); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			klog.Fatalf("failed to start unified webhook server: %v", err)
 		}
 	}()
@@ -247,22 +274,6 @@ func fileExists(path string) bool {
 	}
 	_, err := os.Stat(path)
 	return err == nil
-}
-
-func waitForCertsReady(keyFile, CertFile string) bool {
-	waitTimeout := 30 * time.Second
-	waitInterval := 500 * time.Millisecond
-	start := time.Now()
-	for {
-		if fileExists(CertFile) && fileExists(keyFile) {
-			return true
-		}
-		if time.Since(start) > waitTimeout {
-			klog.Warningf("timeout waiting for TLS cert/key files to appear at %s and %s", keyFile, CertFile)
-			return false
-		}
-		time.Sleep(waitInterval)
-	}
 }
 
 func parseControllers(controllers []string) map[string]bool {

--- a/cmd/kthena-router/main.go
+++ b/cmd/kthena-router/main.go
@@ -18,12 +18,12 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"flag"
 	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
-	"time"
 
 	"github.com/spf13/pflag"
 	"k8s.io/client-go/kubernetes"
@@ -121,8 +121,8 @@ func main() {
 	app.NewServer(routerPort, tlsCert != "" && tlsKey != "", tlsCert, tlsKey, enableGatewayAPI, enableGatewayAPIInferenceExtension, debugPort, kubeAPIQPS, kubeAPIBurst).Run(ctx)
 }
 
-// ensureWebhookCertificate generates a certificate secret if needed and returns the CA bundle.
-func ensureWebhookCertificate(ctx context.Context, kubeClient kubernetes.Interface, secretName, serviceName string) ([]byte, error) {
+// ensureWebhookCertificate generates a certificate secret if needed and returns the bundle.
+func ensureWebhookCertificate(ctx context.Context, kubeClient kubernetes.Interface, secretName, serviceName string) (*webhookcert.CertBundle, error) {
 	namespace := getNamespace()
 	dnsNames := []string{
 		fmt.Sprintf("%s.%s.svc", serviceName, namespace),
@@ -130,6 +130,49 @@ func ensureWebhookCertificate(ctx context.Context, kubeClient kubernetes.Interfa
 	}
 	klog.Infof("Auto-generating certificate for webhook server (secret=%s service=%s)", secretName, serviceName)
 	return webhookcert.EnsureCertificate(ctx, kubeClient, namespace, secretName, dnsNames)
+}
+
+// resolveServingCert returns the TLS material the webhook server should serve with,
+// following the precedence: existing secret -> mounted cert files -> generate.
+//
+// Every branch returns the key pair in memory so the server never has to wait for a
+// freshly created secret to be projected into the pod. See resolveServingCert in
+// cmd/kthena-controller-manager for the full reasoning.
+func resolveServingCert(ctx context.Context, kubeClient kubernetes.Interface, secretName, serviceName, certFile, keyFile string) (*webhookcert.CertBundle, error) {
+	namespace := getNamespace()
+
+	// 1. An existing secret is authoritative: it is the copy every replica agrees on.
+	bundle, err := webhookcert.LoadCertBundleFromSecret(ctx, kubeClient, namespace, secretName)
+	if err != nil {
+		klog.Warningf("Error reading cert bundle from secret %s: %v", secretName, err)
+	} else if bundle != nil && len(bundle.CertPEM) > 0 && len(bundle.KeyPEM) > 0 {
+		klog.Infof("Loaded serving certificate from secret %s", secretName)
+		return bundle, nil
+	}
+
+	// 2. Fall back to cert files supplied by an external cert manager. CAPEM is left
+	// empty on purpose: that CA is published by whoever manages the files, so we must
+	// not overwrite the webhook configuration.
+	if fileExists(certFile) && fileExists(keyFile) {
+		klog.Infof("Loading serving certificate from %s and %s", certFile, keyFile)
+		return loadCertBundleFromFiles(certFile, keyFile)
+	}
+
+	// 3. Nothing exists yet: generate and persist so other replicas reuse this pair.
+	return ensureWebhookCertificate(ctx, kubeClient, secretName, serviceName)
+}
+
+// loadCertBundleFromFiles reads an externally managed key pair off disk.
+func loadCertBundleFromFiles(certFile, keyFile string) (*webhookcert.CertBundle, error) {
+	certPEM, err := os.ReadFile(certFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read cert file %s: %w", certFile, err)
+	}
+	keyPEM, err := os.ReadFile(keyFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read key file %s: %w", keyFile, err)
+	}
+	return &webhookcert.CertBundle{CertPEM: certPEM, KeyPEM: keyPEM}, nil
 }
 
 // runWebhook starts the webhook server and manages certificate acquisition with precedence:
@@ -151,31 +194,19 @@ func runWebhook(ctx context.Context, port int, certFile, keyFile, secretName, se
 		klog.Fatalf("Failed to get kube client: %v", err)
 	}
 
-	namespace := getNamespace()
-	var caBundle []byte
-
-	// 1. Try secret first.
-	if bundle, err := webhookcert.LoadCertBundleFromSecret(ctx, kubeClient, namespace, secretName); err != nil {
-		klog.Warningf("Error reading CA bundle from secret %s: %v", secretName, err)
-	} else if bundle != nil {
-		klog.Infof("Loaded CA bundle from secret %s", secretName)
-		caBundle = bundle.CAPEM
+	bundle, err := resolveServingCert(ctx, kubeClient, secretName, serviceName, certFile, keyFile)
+	if err != nil {
+		klog.Fatalf("Failed to obtain webhook serving certificate: %v", err)
 	}
 
-	// 2. If not from secret, try existing cert file.
-	if caBundle == nil {
-		if !fileExists(certFile) || !fileExists(keyFile) {
-			b, err := ensureWebhookCertificate(ctx, kubeClient, secretName, serviceName)
-			if err != nil {
-				klog.Fatalf("Failed to auto-generate webhook certificates: %v", err)
-			}
-			caBundle = b
-		}
+	servingCert, err := tls.X509KeyPair(bundle.CertPEM, bundle.KeyPEM)
+	if err != nil {
+		klog.Fatalf("Failed to build webhook TLS key pair: %v", err)
 	}
 
-	if caBundle != nil {
+	if len(bundle.CAPEM) > 0 {
 		// attempt to update the ValidatingWebhookConfiguration CA bundle.
-		if err := webhookcert.UpdateValidatingWebhookCABundle(ctx, kubeClient, validatingWebhookConfigurationName, caBundle); err != nil {
+		if err := webhookcert.UpdateValidatingWebhookCABundle(ctx, kubeClient, validatingWebhookConfigurationName, bundle.CAPEM); err != nil {
 			klog.Warningf("Failed to update ValidatingWebhookConfiguration CA bundle: %v", err)
 		} else {
 			klog.Infof("Updated ValidatingWebhookConfiguration %s CA bundle", validatingWebhookConfigurationName)
@@ -183,31 +214,8 @@ func runWebhook(ctx context.Context, port int, certFile, keyFile, secretName, se
 	}
 
 	validator := webhook.NewKthenaRouterValidator(kubeClient, port)
-
-	// Wait for both cert and key files to exist (in case they are mounted by Kubernetes)
-	ok := waitForCertsReady(keyFile, certFile)
-	if !ok {
-		klog.Fatalf("TLS cert/key files not found, webhook server cannot start")
-		return
-	}
-	go validator.Run(ctx, certFile, keyFile)
+	go validator.Run(ctx, servingCert)
 	klog.Infof("Webhook server running on port %d", port)
-}
-
-func waitForCertsReady(keyFile, CertFile string) bool {
-	waitTimeout := 30 * time.Second
-	waitInterval := 500 * time.Millisecond
-	start := time.Now()
-	for {
-		if fileExists(CertFile) && fileExists(keyFile) {
-			return true
-		}
-		if time.Since(start) > waitTimeout {
-			klog.Warningf("timeout waiting for TLS cert/key files to appear at %s and %s", keyFile, CertFile)
-			return false
-		}
-		time.Sleep(waitInterval)
-	}
 }
 
 // getNamespace returns the current pod namespace or "default".

--- a/pkg/kthena-router/webhook/validator.go
+++ b/pkg/kthena-router/webhook/validator.go
@@ -59,7 +59,10 @@ func NewKthenaRouterValidator(kubeClient kubernetes.Interface, port int) *Kthena
 	}
 }
 
-func (v *KthenaRouterValidator) Run(ctx context.Context, tlsCertFile, tlsPrivateKey string) {
+// Run serves the validating webhook with the supplied key pair. The caller passes an
+// already-parsed certificate rather than file paths so that the server can start as
+// soon as the certificate is known, without waiting for it to appear on disk.
+func (v *KthenaRouterValidator) Run(ctx context.Context, servingCert tls.Certificate) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/validate/modelroute", v.HandleModelRoute)
 	mux.HandleFunc("/validate/modelserver", v.HandleModelServer)
@@ -70,11 +73,15 @@ func (v *KthenaRouterValidator) Run(ctx context.Context, tlsCertFile, tlsPrivate
 		}
 	})
 	v.httpServer.Handler = mux
+	if v.httpServer.TLSConfig == nil {
+		v.httpServer.TLSConfig = &tls.Config{MinVersion: tls.VersionTLS12}
+	}
+	v.httpServer.TLSConfig.Certificates = []tls.Certificate{servingCert}
 
 	// Start server
 	klog.Infof("Starting webhook server on %s", v.httpServer.Addr)
 	go func() {
-		if err := v.httpServer.ListenAndServeTLS(tlsCertFile, tlsPrivateKey); err != nil && err != http.ErrServerClosed {
+		if err := v.httpServer.ListenAndServeTLS("", ""); err != nil && err != http.ErrServerClosed {
 			klog.Fatalf("failed to listen and serve validating webhook: %v", err)
 		}
 	}()

--- a/pkg/webhook/cert/secret.go
+++ b/pkg/webhook/cert/secret.go
@@ -40,8 +40,11 @@ const (
 // EnsureCertificate ensures that a certificate exists for the webhook server.
 // If the secret doesn't exist, it generates a new certificate and creates the secret.
 // If the secret already exists, it returns without error (reusing existing certificate).
-// Returns the CA bundle bytes that can be used to update webhook configurations.
-func EnsureCertificate(ctx context.Context, kubeClient kubernetes.Interface, namespace, secretName string, dnsNames []string) ([]byte, error) {
+//
+// The full bundle is returned - not just the CA - so that callers can serve TLS
+// straight from memory instead of waiting for kubelet to project the freshly
+// created secret onto disk.
+func EnsureCertificate(ctx context.Context, kubeClient kubernetes.Interface, namespace, secretName string, dnsNames []string) (*CertBundle, error) {
 	if len(dnsNames) == 0 {
 		return nil, fmt.Errorf("dnsNames cannot be empty")
 	}
@@ -51,13 +54,9 @@ func EnsureCertificate(ctx context.Context, kubeClient kubernetes.Interface, nam
 	// Try to get the existing secret
 	secret, err := kubeClient.CoreV1().Secrets(namespace).Get(ctx, secretName, metav1.GetOptions{})
 	if err == nil {
-		// Secret exists, use it and return the CA bundle
+		// Secret exists, reuse the certificate it already holds
 		klog.Infof("Found existing secret %s/%s, using existing certificate", namespace, secretName)
-		caBundle, ok := secret.Data[CAKey]
-		if !ok {
-			return nil, fmt.Errorf("secret %s/%s does not contain %s", namespace, secretName, CAKey)
-		}
-		return caBundle, nil
+		return bundleFromSecret(secret)
 	}
 
 	if !apierrors.IsNotFound(err) {
@@ -88,23 +87,41 @@ func EnsureCertificate(ctx context.Context, kubeClient kubernetes.Interface, nam
 	_, err = kubeClient.CoreV1().Secrets(namespace).Create(ctx, secret, metav1.CreateOptions{})
 	if err != nil {
 		if apierrors.IsAlreadyExists(err) {
-			// Another pod created the secret concurrently, fetch it to get the CA bundle
-			klog.Infof("Secret %s/%s was created by another pod, fetching CA bundle", namespace, secretName)
+			// Another pod created the secret concurrently. Its certificate wins, so that
+			// every replica serves the same key pair.
+			klog.Infof("Secret %s/%s was created by another pod, fetching its certificate", namespace, secretName)
 			secret, err = kubeClient.CoreV1().Secrets(namespace).Get(ctx, secretName, metav1.GetOptions{})
 			if err != nil {
 				return nil, fmt.Errorf("failed to get secret after concurrent creation: %w", err)
 			}
-			caBundle, ok := secret.Data[CAKey]
-			if !ok {
-				return nil, fmt.Errorf("secret %s/%s does not contain %s", namespace, secretName, CAKey)
-			}
-			return caBundle, nil
+			return bundleFromSecret(secret)
 		}
 		return nil, fmt.Errorf("failed to create secret %s/%s: %w", namespace, secretName, err)
 	}
 
 	klog.Infof("Successfully created secret %s/%s with generated certificate", namespace, secretName)
-	return certBundle.CAPEM, nil
+	return certBundle, nil
+}
+
+// bundleFromSecret extracts a complete serving bundle from a TLS secret. The
+// certificate and key are required because the caller serves TLS with them; the
+// CA is required because it is what gets published to the webhook configurations.
+func bundleFromSecret(secret *corev1.Secret) (*CertBundle, error) {
+	bundle := &CertBundle{
+		CertPEM: secret.Data[TLSCertKey],
+		KeyPEM:  secret.Data[TLSKeyKey],
+		CAPEM:   secret.Data[CAKey],
+	}
+	for key, value := range map[string][]byte{
+		TLSCertKey: bundle.CertPEM,
+		TLSKeyKey:  bundle.KeyPEM,
+		CAKey:      bundle.CAPEM,
+	} {
+		if len(value) == 0 {
+			return nil, fmt.Errorf("secret %s/%s does not contain %s", secret.Namespace, secret.Name, key)
+		}
+	}
+	return bundle, nil
 }
 
 // UpdateValidatingWebhookCABundle updates the ValidatingWebhookConfiguration with the provided CA bundle

--- a/pkg/webhook/cert/secret_test.go
+++ b/pkg/webhook/cert/secret_test.go
@@ -18,6 +18,7 @@ package cert
 
 import (
 	"context"
+	"crypto/tls"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -31,9 +32,23 @@ func TestEnsureCertificateCreatesSecret(t *testing.T) {
 	client := fake.NewSimpleClientset()
 	ctx := context.Background()
 
-	caBundle, err := EnsureCertificate(ctx, client, "default", "webhook-certs", []string{"webhook.default.svc"})
+	bundle, err := EnsureCertificate(ctx, client, "default", "webhook-certs", []string{"webhook.default.svc"})
 	assert.NoError(t, err)
-	assert.NotEmpty(t, caBundle)
+	assert.NotEmpty(t, bundle.CertPEM)
+	assert.NotEmpty(t, bundle.KeyPEM)
+	assert.NotEmpty(t, bundle.CAPEM)
+
+	// The returned pair must be directly usable for serving. This is what lets the
+	// webhook server start without waiting for the secret to be projected onto disk.
+	_, err = tls.X509KeyPair(bundle.CertPEM, bundle.KeyPEM)
+	assert.NoError(t, err)
+
+	// What we return must match what we persisted, so every replica serves the same pair.
+	stored, err := client.CoreV1().Secrets("default").Get(ctx, "webhook-certs", metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, stored.Data[TLSCertKey], bundle.CertPEM)
+	assert.Equal(t, stored.Data[TLSKeyKey], bundle.KeyPEM)
+	assert.Equal(t, stored.Data[CAKey], bundle.CAPEM)
 }
 
 func TestEnsureCertificateReusesExistingSecret(t *testing.T) {
@@ -46,15 +61,42 @@ func TestEnsureCertificateReusesExistingSecret(t *testing.T) {
 			Namespace: "default",
 		},
 		Data: map[string][]byte{
-			CAKey: []byte("existing-ca"),
+			TLSCertKey: []byte("existing-cert"),
+			TLSKeyKey:  []byte("existing-key"),
+			CAKey:      []byte("existing-ca"),
 		},
 	}
 	_, err := client.CoreV1().Secrets("default").Create(ctx, existingSecret, metav1.CreateOptions{})
 	assert.NoError(t, err)
 
-	caBundle, err := EnsureCertificate(ctx, client, "default", "webhook-certs", []string{"webhook.default.svc"})
+	bundle, err := EnsureCertificate(ctx, client, "default", "webhook-certs", []string{"webhook.default.svc"})
 	assert.NoError(t, err)
-	assert.Equal(t, []byte("existing-ca"), caBundle)
+	assert.Equal(t, []byte("existing-cert"), bundle.CertPEM)
+	assert.Equal(t, []byte("existing-key"), bundle.KeyPEM)
+	assert.Equal(t, []byte("existing-ca"), bundle.CAPEM)
+}
+
+func TestEnsureCertificateRejectsIncompleteSecret(t *testing.T) {
+	// A secret carrying only the CA cannot be served from, so it must be reported
+	// rather than silently accepted.
+	for _, tt := range []struct {
+		name string
+		data map[string][]byte
+	}{
+		{name: "missing cert", data: map[string][]byte{TLSKeyKey: []byte("k"), CAKey: []byte("ca")}},
+		{name: "missing key", data: map[string][]byte{TLSCertKey: []byte("c"), CAKey: []byte("ca")}},
+		{name: "missing ca", data: map[string][]byte{TLSCertKey: []byte("c"), TLSKeyKey: []byte("k")}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			client := fake.NewSimpleClientset(&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "webhook-certs", Namespace: "default"},
+				Data:       tt.data,
+			})
+
+			_, err := EnsureCertificate(context.Background(), client, "default", "webhook-certs", []string{"webhook.default.svc"})
+			assert.Error(t, err)
+		})
+	}
 }
 
 func TestEnsureCertificateRequiresDNSNames(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

On a fresh Helm install the `kthena-controller-manager` Pod always restarts exactly once before becoming ready.

The webhook certificate Secret does not exist yet at install time. The chart mounts it with `optional: true`, so kubelet mounts an empty `/etc/tls` and the controller generates the certificate itself. It then **discarded the key pair it had just generated** and blocked in `waitForCertsReady()` for up to 30s, waiting for kubelet to project those same bytes back onto disk.

That wait cannot reliably succeed: kubelet only refreshes an already-mounted optional Secret on its pod sync loop (`--sync-frequency`, one minute by default), which is longer than the 30s budget.

Because `/healthz` is served by the same TLS server that only starts listening *after* the wait, nothing answers on 8443 during the window, and two mechanisms race to kill the container:

| t | event |
|---|---|
| ~2s | Secret created via the API; `waitForCertsReady` begins its 30s budget |
| 5s / 15s / 25s | liveness probe fails ×3 → kubelet kills at ~25s |
| ~32s | wait times out → `setupWebhook` returns error → `os.Exit(1)` |

The probe usually wins, which is why it presents as a liveness kill. On restart the Secret already exists and is projected at mount time, so it never recurs — hence exactly one restart, every fresh install.

This is not purely cosmetic: for that window the webhook is not serving, so the `ValidatingWebhookConfiguration` fails on any CR applied during install. Note that raising `initialDelaySeconds` alone would not fix it — it just hands the kill to the `os.Exit(1)` path.

**The fix**: resolve the serving certificate to an in-memory `CertBundle` and hand it to the server via `TLSConfig.Certificates`, so it starts as soon as the certificate is known and never depends on file projection. The precedence is unchanged: existing Secret → mounted cert files → generate.

- `EnsureCertificate()` now returns the full bundle rather than just the CA, so callers have the key pair to serve with.
- For the externally managed **file** path the CA bundle is deliberately left empty, so cert-manager's ca-injector stays authoritative over the webhook configurations. This preserves existing behaviour.
- A `startupProbe` is added as defence in depth, with all three probes exposed through values. Defaults are chosen so rendered liveness/readiness are byte-identical to before.

**Which issue(s) this PR fixes**:
Fixes #1319

**Special notes for your reviewer**:

Three behaviour changes worth your attention:

1. **The serving source changed when both a Secret and mounted files exist.** Previously TLS was served from the *files* while the CA was taken from the Secret; now both come from the Secret. In the chart's own setup these are identical bytes, but a user mounting custom files over a same-named Secret would see a difference.
2. **Stricter Secret validation** — a Secret carrying only `ca.crt` is now rejected, because it cannot be served from.
3. **`KthenaRouterValidator.Run()` signature changed** to take a parsed `tls.Certificate` instead of file paths. No callers outside this repo, but it is a public API break.

`kthena-router` carried a copy of the same logic and is fixed identically in a separate commit — there the timeout called `klog.Fatalf`, taking down the whole router process rather than just the webhook. **Happy to split that into its own PR if you'd prefer**; it is only in scope here because the shared `EnsureCertificate` signature change touches both callers.

**Known limitation (pre-existing, not a regression):** the certificate is read once at startup, so a rotated cert still needs a pod restart. `ListenAndServeTLS` also read its files only at startup, so this is unchanged. Happy to follow up with a `GetCertificate` callback that reloads on rotation if wanted.

**Verification status** — being explicit so nothing is taken on trust:

- [x] `go build ./...`, `go vet`, `gofmt` clean
- [x] Unit tests pass, including new coverage that the returned bundle forms a valid `tls.X509KeyPair` and that incomplete Secrets are rejected
- [x] `helm template` diffed: liveness/readiness output byte-identical to before, only `startupProbe` added
- [x] Built image confirmed to contain the change (old `timeout waiting for TLS cert/key files` string gone, new paths present)
- [ ] **Before/after Pod logs from a fresh kind install — not yet captured.** I will attach them as a follow-up comment. Until then the timeline above is derived from code analysis rather than an instrumented run, and I would not want it treated as measured.

Marking this as a draft until those logs are attached.

**Does this PR introduce a user-facing change?**:

```release-note
Fixed `kthena-controller-manager` and `kthena-router` restarting once on a fresh install: the webhook server no longer waits for the generated TLS Secret to be projected onto disk and now serves the certificate it already holds in memory. A `startupProbe` was added to the controller manager, and its probe timings are now configurable via `controllerManager.probes`.
```
