### PR TITLE
docs: fix CRD references, typos, links, and duplicate sidebar entries

### DIFF
--- a/docs/kthena/docs/architecture/autoscaler.mdx
+++ b/docs/kthena/docs/architecture/autoscaler.mdx
@@ -42,7 +42,7 @@ Heterogeneous Instances Autoscale employs a greedy algorithm with a doubling str
 Based on the multiplication principle, the `capacity` is divided into multiple chunks according to powers of `costExpansionRate`. These chunks serve as scaling batches. At the batch level, batches from different serving instances are mixed and sorted in ascending order by cost. The sorted batches are then expanded into corresponding instance combinations, resulting in a scaling sequence `seq` with length equal to the capacity.
 
 $$
-seq = sorted(\bigcup_{i=1}^{N} P^k \cdot c_i \mid k \in (0,1,\ldots,M_i) \cup (C_i - \sum_{k=0}^{M_i} P^k) \cdot c_i)
+seq = sorted(\bigcup_{i=1}^{N} \{ P^k \cdot c_i \mid k \in \{0,1,\ldots,M_i\} \} \cup \{ (C_i - \sum_{k=0}^{M_i} P^k) \cdot c_i \})
 $$
 
 Where:

--- a/docs/kthena/docs/architecture/model-booster-controller.md
+++ b/docs/kthena/docs/architecture/model-booster-controller.md
@@ -5,7 +5,7 @@ import modelBoosterControllerArchitecture from '../assets/diagrams/architecture/
 
 ## Overview
 
-As an optional component of the Kthena project, the Model Booster Controller primarily provides users with a convenient deployment form - `Model`. Based on the `Model CR` (Model Custom Resource) information provided by users, this component can automatically configure and deploy the components required for inference services, such as router routing rules, inference engine instances, and dynamic scaling configurations.
+As an optional component of the Kthena project, the Model Booster Controller primarily provides users with a convenient deployment form - `ModelBooster`. Based on the `ModelBooster CR` (ModelBooster Custom Resource) information provided by users, this component can automatically configure and deploy the components required for inference services, such as router routing rules, inference engine instances, and dynamic scaling configurations.
 
 ## Feature Description
 
@@ -38,11 +38,11 @@ Read the [Model Booster CR Examples](https://github.com/volcano-sh/kthena/tree/m
 
 ## Limitations
 
-The `Model` can only cover most inference service scenarios and will be continuously updated. Some scenarios are not yet supported and require manual configuration of relevant CRDs. 
+The `ModelBooster` can only cover most inference service scenarios and will be continuously updated. Some scenarios are not yet supported and require manual configuration of relevant CRDs. 
 
 Please note the following limitations when using the Model Booster:
-- Each `Model` can create only one `Model Route`.
-- Rate limiting for `Model Route` is not supported.
-- Topology configuration for `Model Infer` is not supported.
+- Each `ModelBooster` can create only one `ModelRoute`.
+- Rate limiting for `ModelRoute` is not supported.
+- Topology configuration for `ModelServing` is not supported.
 
-In these cases, you can manually create `Model Infer`, `Model Server`, and `Model Route` resources as needed.
+In these cases, you can manually create `ModelServing`, `ModelServer`, and `ModelRoute` resources as needed.

--- a/docs/kthena/docs/architecture/model-serving-controller.mdx
+++ b/docs/kthena/docs/architecture/model-serving-controller.mdx
@@ -8,7 +8,7 @@ ModelServing Controller is the controller for the serving workload `ModelServing
 ## Model Serving Overview
 
 `ModelServing` represents the optimal deployment paradigm for distributed serving scenarios involving large models, offering flexible and user-friendly workload configurations with
-Prefilling Decoding Disaggregation and parallel serving services like Pipeline Parallelism (PP) and Tensor Parallelism (TP).
+Prefill-Decode Disaggregation and parallel serving services like Pipeline Parallelism (PP) and Tensor Parallelism (TP).
 
 ## Model Serving Architecture
 

--- a/docs/kthena/docs/user-guide/modelserving-plugin-framework.md
+++ b/docs/kthena/docs/user-guide/modelserving-plugin-framework.md
@@ -114,7 +114,7 @@ Kthena ships with a built-in demo plugin `demo-pod-tweaks` that can set `runtime
 **Example: Using the demo plugin**
 
 ```yaml
-apiVersion: workload.kthena.io/v1alpha1
+apiVersion: workload.serving.volcano.sh/v1alpha1
 kind: ModelServing
 metadata:
   name: llama-8b

--- a/docs/kthena/docs/user-guide/rate-limit.md
+++ b/docs/kthena/docs/user-guide/rate-limit.md
@@ -7,7 +7,7 @@ Unlike traditional microservices that use request count or connection-based rate
 Kthena Router provides powerful rate-limiting capabilities to control the traffic flow to your backend models. This is essential for preventing service overload, managing costs, and ensuring fair usage. Rate limiting is configured directly within the **ModelRoute** Custom Resource (CR).
 
 The router supports two main types of rate limiting:
-- **Local Rate Limiting**: Enforces limits on a per-router-instance basis. It\'s simple to configure and effective for basic load protection.
+- **Local Rate Limiting**: Enforces limits on a per-router-instance basis. It's simple to configure and effective for basic load protection.
 - **Global Rate Limiting**: Enforces a shared limit across all router instances, using a central store like Redis. This is ideal for providing consistent limits in a scaled-out environment.
 
 Limits are based on the number of input/output tokens over a specific time window (second, minute, hour, day, or month).
@@ -89,7 +89,7 @@ curl http://$ROUTER_IP/v1/completions \
 "input token rate limit exceeded"
 
 # 5. Clean up
-kubectl delete -f https://github.com/volcano-sh/kthena/blob/main/examples/kthena-router/ModelRouteWithRateLimit.yaml
+kubectl delete -f https://raw.githubusercontent.com/volcano-sh/kthena/main/examples/kthena-router/ModelRouteWithRateLimit.yaml
 ```
 
 ### 2. Global Rate Limiting
@@ -135,10 +135,10 @@ The test process is similar to local rate limiting. Even if your requests are ha
 
 ```bash
 # 1. Deploy Redis service
-kubectl apply -f https://github.com/volcano-sh/kthena/blob/main/examples/redis/redis-standalone.yaml
+kubectl apply -f https://raw.githubusercontent.com/volcano-sh/kthena/main/examples/redis/redis-standalone.yaml
 
 # 2. Apply the ModelRoute yaml above
-kubectl apply -f https://github.com/volcano-sh/kthena/blob/main/examples/kthena-router/ModelRouteWithGlobalRateLimit.yaml
+kubectl apply -f https://raw.githubusercontent.com/volcano-sh/kthena/main/examples/kthena-router/ModelRouteWithGlobalRateLimit.yaml
 
 # 3. Scale up the replicas of the router to 3 to demonstrate global rate limiting
 kubectl scale deployment kthena-router -n kthena-system --replicas=3
@@ -160,7 +160,7 @@ curl http://$ROUTER_IP/v1/completions \
 "input token rate limit exceeded"
 
 # 6. Clean up
-kubectl delete -f https://github.com/volcano-sh/kthena/blob/main/examples/kthena-router/ModelRouteWithGlobalRateLimit.yaml
+kubectl delete -f https://raw.githubusercontent.com/volcano-sh/kthena/main/examples/kthena-router/ModelRouteWithGlobalRateLimit.yaml
 ```
 
 By leveraging local and global rate limiting, Kthena gives you fine-grained control over your AI service traffic, enabling robust, scalable, and cost-effective model deployments.

--- a/docs/kthena/docs/user-guide/runtime.md
+++ b/docs/kthena/docs/user-guide/runtime.md
@@ -106,7 +106,7 @@ spec:
     workers:
       - type: server
         image: openeuler/vllm-ascend:latest
-        replicase: 1
+        replicas: 1
         pods: 1
         resources:
           limits:
@@ -167,7 +167,7 @@ spec:
     workers:
       - type: server
         image: openeuler/vllm-ascend:latest
-        replicase: 1
+        replicas: 1
         pods: 1
 ```
 

--- a/docs/kthena/sidebars.ts
+++ b/docs/kthena/sidebars.ts
@@ -57,7 +57,6 @@ const sidebars: SidebarsConfig = {
           ],
         },
         'user-guide/multi-node-inference',
-        'user-guide/network-topology',
         {
           type: 'doc',
           label: 'Autoscaler',
@@ -94,7 +93,6 @@ const sidebars: SidebarsConfig = {
           ],
         },
         'user-guide/runtime',
-        'user-guide/binpack-scale-down',
         {
           type: 'category',
           label: 'Prefill Decode Disaggregation',

--- a/docs/kthena/versioned_docs/version-v0.1.0/architecture/autoscaler.mdx
+++ b/docs/kthena/versioned_docs/version-v0.1.0/architecture/autoscaler.mdx
@@ -42,7 +42,7 @@ Heterogeneous Instances Autoscale employs a greedy algorithm with a doubling str
 Based on the multiplication principle, the `capacity` is divided into multiple chunks according to powers of `costExpansionRate`. These chunks serve as scaling batches. At the batch level, batches from different serving instances are mixed and sorted in ascending order by cost. The sorted batches are then expanded into corresponding instance combinations, resulting in a scaling sequence `seq` with length equal to the capacity.
 
 $$
-seq = sorted(\bigcup_{i=1}^{N} P^k \cdot c_i \mid k \in (0,1,\ldots,M_i) \cup (C_i - \sum_{k=0}^{M_i} P^k) \cdot c_i)
+seq = sorted(\bigcup_{i=1}^{N} \{ P^k \cdot c_i \mid k \in \{0,1,\ldots,M_i\} \} \cup \{ (C_i - \sum_{k=0}^{M_i} P^k) \cdot c_i \})
 $$
 
 Where:

--- a/docs/kthena/versioned_docs/version-v0.1.0/architecture/model-booster-controller.md
+++ b/docs/kthena/versioned_docs/version-v0.1.0/architecture/model-booster-controller.md
@@ -5,7 +5,7 @@ import modelBoosterControllerArchitecture from '../assets/diagrams/architecture/
 
 ## Overview
 
-As an optional component of the Kthena project, the Model Booster Controller primarily provides users with a convenient deployment form - `Model`. Based on the `Model CR` (Model Custom Resource) information provided by users, this component can automatically configure and deploy the components required for inference services, such as router routing rules, inference engine instances, and dynamic scaling configurations.
+As an optional component of the Kthena project, the Model Booster Controller primarily provides users with a convenient deployment form - `ModelBooster`. Based on the `ModelBooster CR` (ModelBooster Custom Resource) information provided by users, this component can automatically configure and deploy the components required for inference services, such as router routing rules, inference engine instances, and dynamic scaling configurations.
 
 ## Feature Description
 
@@ -21,13 +21,13 @@ Read the [examples](https://github.com/volcano-sh/kthena/blob/main/examples/mode
 
 ## Limitations
 
-The `Model` can only cover most inference service scenarios and will be continuously updated. Some scenarios are not yet supported and require manual configuration of relevant CRDs. 
+The `ModelBooster` can only cover most inference service scenarios and will be continuously updated. Some scenarios are not yet supported and require manual configuration of relevant CRDs. 
 
 Please note the following limitations when using the Model Booster:
-- Each `Model` can create only one `Model Route`.
-- Rate limiting for `Model Route` is not supported.
-- Topology configuration for `Model Infer` is not supported.
+- Each `ModelBooster` can create only one `ModelRoute`.
+- Rate limiting for `ModelRoute` is not supported.
+- Topology configuration for `ModelServing` is not supported.
 - The `panicPolicy` configuration for `AutoscalingPolicy` is not supported.
 - Behavior configuration for `AutoscalingPolicy` is not supported.
 
-In these cases, you can manually create `Model Infer`, `Model Server`, `Model Route`, `AutoscalingPolicy`, `AutoscalingPolicyBinding` resources as needed.
+In these cases, you can manually create `ModelServing`, `ModelServer`, `ModelRoute`, `AutoscalingPolicy`, `AutoscalingPolicyBinding` resources as needed.

--- a/docs/kthena/versioned_docs/version-v0.1.0/architecture/model-serving-controller.mdx
+++ b/docs/kthena/versioned_docs/version-v0.1.0/architecture/model-serving-controller.mdx
@@ -8,7 +8,7 @@ ModelServing Controller is the controller for the serving workload `ModelServing
 ## Model Serving Overview
 
 `ModelServing` represents the optimal deployment paradigm for distributed serving scenarios involving large models, offering flexible and user-friendly workload configurations with
-Prefilling Decoding Disaggregation and parallel serving services like Pipeline Parallelism (PP) and Tensor Parallelism (TP).
+Prefill-Decode Disaggregation and parallel serving services like Pipeline Parallelism (PP) and Tensor Parallelism (TP).
 
 ## Model Serving Architecture
 

--- a/docs/kthena/versioned_docs/version-v0.1.0/user-guide/rate-limit.md
+++ b/docs/kthena/versioned_docs/version-v0.1.0/user-guide/rate-limit.md
@@ -7,7 +7,7 @@ Unlike traditional microservices that use request count or connection-based rate
 Kthena Router provides powerful rate-limiting capabilities to control the traffic flow to your backend models. This is essential for preventing service overload, managing costs, and ensuring fair usage. Rate limiting is configured directly within the **ModelRoute** Custom Resource (CR).
 
 The router supports two main types of rate limiting:
-- **Local Rate Limiting**: Enforces limits on a per-router-instance basis. It\'s simple to configure and effective for basic load protection.
+- **Local Rate Limiting**: Enforces limits on a per-router-instance basis. It's simple to configure and effective for basic load protection.
 - **Global Rate Limiting**: Enforces a shared limit across all router instances, using a central store like Redis. This is ideal for providing consistent limits in a scaled-out environment.
 
 Limits are based on the number of input/output tokens over a specific time window (second, minute, hour, day, or month).
@@ -67,7 +67,7 @@ To test this, you can set a low limit (e.g., `inputTokensPerUnit: 10`) and send 
 
 ```bash
 # 1. Apply the ModelRoute yaml above
-kubectl apply -f https://github.com/volcano-sh/kthena/blob/main/examples/kthena-router/ModelRouteWithRateLimit.yaml
+kubectl apply -f https://raw.githubusercontent.com/volcano-sh/kthena/main/examples/kthena-router/ModelRouteWithRateLimit.yaml
 
 # 2. Scale down the replicas of the router to 1 to demonstrate local rate limiting
 kubectl scale deployment networking-kthena-router -n kthena-system --replicas=1
@@ -89,7 +89,7 @@ curl http://$ROUTER_IP/v1/completions \
 "input token rate limit exceeded"
 
 # 5. Clean up
-kubectl delete -f https://github.com/volcano-sh/kthena/blob/main/examples/kthena-router/ModelRouteWithRateLimit.yaml
+kubectl delete -f https://raw.githubusercontent.com/volcano-sh/kthena/main/examples/kthena-router/ModelRouteWithRateLimit.yaml
 ```
 
 ### 2. Global Rate Limiting
@@ -135,10 +135,10 @@ The test process is similar to local rate limiting. Even if your requests are ha
 
 ```bash
 # 1. Deploy Redis service
-kubectl apply -f https://github.com/volcano-sh/kthena/blob/main/examples/redis/redis-standalone.yaml
+kubectl apply -f https://raw.githubusercontent.com/volcano-sh/kthena/main/examples/redis/redis-standalone.yaml
 
 # 2. Apply the ModelRoute yaml above
-kubectl apply -f https://github.com/volcano-sh/kthena/blob/main/examples/kthena-router/ModelRouteWithGlobalRateLimit.yaml
+kubectl apply -f https://raw.githubusercontent.com/volcano-sh/kthena/main/examples/kthena-router/ModelRouteWithGlobalRateLimit.yaml
 
 # 3. Scale up the replicas of the router to 3 to demonstrate global rate limiting
 kubectl scale deployment networking-kthena-router -n kthena-system --replicas=3
@@ -160,7 +160,7 @@ curl http://$ROUTER_IP/v1/completions \
 "input token rate limit exceeded"
 
 # 6. Clean up
-kubectl delete -f https://github.com/volcano-sh/kthena/blob/main/examples/kthena-router/ModelRouteWithGlobalRateLimit.yaml
+kubectl delete -f https://raw.githubusercontent.com/volcano-sh/kthena/main/examples/kthena-router/ModelRouteWithGlobalRateLimit.yaml
 ```
 
 By leveraging local and global rate limiting, Kthena gives you fine-grained control over your AI service traffic, enabling robust, scalable, and cost-effective model deployments.

--- a/docs/kthena/versioned_docs/version-v0.1.0/user-guide/runtime.md
+++ b/docs/kthena/versioned_docs/version-v0.1.0/user-guide/runtime.md
@@ -105,7 +105,7 @@ spec:
     workers:
       - type: server
         image: openeuler/vllm-ascend:latest
-        replicase: 1
+        replicas: 1
         pods: 1
         resources:
           limits:
@@ -166,7 +166,7 @@ spec:
     workers:
       - type: server
         image: openeuler/vllm-ascend:latest
-        replicase: 1
+        replicas: 1
         pods: 1
 ```
 

--- a/docs/kthena/versioned_docs/version-v0.2.0/architecture/autoscaler.mdx
+++ b/docs/kthena/versioned_docs/version-v0.2.0/architecture/autoscaler.mdx
@@ -42,7 +42,7 @@ Heterogeneous Instances Autoscale employs a greedy algorithm with a doubling str
 Based on the multiplication principle, the `capacity` is divided into multiple chunks according to powers of `costExpansionRate`. These chunks serve as scaling batches. At the batch level, batches from different serving instances are mixed and sorted in ascending order by cost. The sorted batches are then expanded into corresponding instance combinations, resulting in a scaling sequence `seq` with length equal to the capacity.
 
 $$
-seq = sorted(\bigcup_{i=1}^{N} P^k \cdot c_i \mid k \in (0,1,\ldots,M_i) \cup (C_i - \sum_{k=0}^{M_i} P^k) \cdot c_i)
+seq = sorted(\bigcup_{i=1}^{N} \{ P^k \cdot c_i \mid k \in \{0,1,\ldots,M_i\} \} \cup \{ (C_i - \sum_{k=0}^{M_i} P^k) \cdot c_i \})
 $$
 
 Where:

--- a/docs/kthena/versioned_docs/version-v0.2.0/architecture/model-booster-controller.md
+++ b/docs/kthena/versioned_docs/version-v0.2.0/architecture/model-booster-controller.md
@@ -5,7 +5,7 @@ import modelBoosterControllerArchitecture from '../assets/diagrams/architecture/
 
 ## Overview
 
-As an optional component of the Kthena project, the Model Booster Controller primarily provides users with a convenient deployment form - `Model`. Based on the `Model CR` (Model Custom Resource) information provided by users, this component can automatically configure and deploy the components required for inference services, such as router routing rules, inference engine instances, and dynamic scaling configurations.
+As an optional component of the Kthena project, the Model Booster Controller primarily provides users with a convenient deployment form - `ModelBooster`. Based on the `ModelBooster CR` (ModelBooster Custom Resource) information provided by users, this component can automatically configure and deploy the components required for inference services, such as router routing rules, inference engine instances, and dynamic scaling configurations.
 
 ## Feature Description
 
@@ -39,13 +39,13 @@ Read the [Model Booster CR Examples](https://github.com/volcano-sh/kthena/tree/m
 
 ## Limitations
 
-The `Model` can only cover most inference service scenarios and will be continuously updated. Some scenarios are not yet supported and require manual configuration of relevant CRDs. 
+The `ModelBooster` can only cover most inference service scenarios and will be continuously updated. Some scenarios are not yet supported and require manual configuration of relevant CRDs. 
 
 Please note the following limitations when using the Model Booster:
-- Each `Model` can create only one `Model Route`.
-- Rate limiting for `Model Route` is not supported.
-- Topology configuration for `Model Infer` is not supported.
+- Each `ModelBooster` can create only one `ModelRoute`.
+- Rate limiting for `ModelRoute` is not supported.
+- Topology configuration for `ModelServing` is not supported.
 - The `panicPolicy` configuration for `AutoscalingPolicy` is not supported.
 - Behavior configuration for `AutoscalingPolicy` is not supported.
 
-In these cases, you can manually create `Model Infer`, `Model Server`, `Model Route`, `AutoscalingPolicy`, `AutoscalingPolicyBinding` resources as needed.
+In these cases, you can manually create `ModelServing`, `ModelServer`, `ModelRoute`, `AutoscalingPolicy`, `AutoscalingPolicyBinding` resources as needed.

--- a/docs/kthena/versioned_docs/version-v0.2.0/architecture/model-serving-controller.mdx
+++ b/docs/kthena/versioned_docs/version-v0.2.0/architecture/model-serving-controller.mdx
@@ -8,7 +8,7 @@ ModelServing Controller is the controller for the serving workload `ModelServing
 ## Model Serving Overview
 
 `ModelServing` represents the optimal deployment paradigm for distributed serving scenarios involving large models, offering flexible and user-friendly workload configurations with
-Prefilling Decoding Disaggregation and parallel serving services like Pipeline Parallelism (PP) and Tensor Parallelism (TP).
+Prefill-Decode Disaggregation and parallel serving services like Pipeline Parallelism (PP) and Tensor Parallelism (TP).
 
 ## Model Serving Architecture
 

--- a/docs/kthena/versioned_docs/version-v0.2.0/user-guide/rate-limit.md
+++ b/docs/kthena/versioned_docs/version-v0.2.0/user-guide/rate-limit.md
@@ -7,7 +7,7 @@ Unlike traditional microservices that use request count or connection-based rate
 Kthena Router provides powerful rate-limiting capabilities to control the traffic flow to your backend models. This is essential for preventing service overload, managing costs, and ensuring fair usage. Rate limiting is configured directly within the **ModelRoute** Custom Resource (CR).
 
 The router supports two main types of rate limiting:
-- **Local Rate Limiting**: Enforces limits on a per-router-instance basis. It\'s simple to configure and effective for basic load protection.
+- **Local Rate Limiting**: Enforces limits on a per-router-instance basis. It's simple to configure and effective for basic load protection.
 - **Global Rate Limiting**: Enforces a shared limit across all router instances, using a central store like Redis. This is ideal for providing consistent limits in a scaled-out environment.
 
 Limits are based on the number of input/output tokens over a specific time window (second, minute, hour, day, or month).
@@ -89,7 +89,7 @@ curl http://$ROUTER_IP/v1/completions \
 "input token rate limit exceeded"
 
 # 5. Clean up
-kubectl delete -f https://github.com/volcano-sh/kthena/blob/main/examples/kthena-router/ModelRouteWithRateLimit.yaml
+kubectl delete -f https://raw.githubusercontent.com/volcano-sh/kthena/main/examples/kthena-router/ModelRouteWithRateLimit.yaml
 ```
 
 ### 2. Global Rate Limiting
@@ -135,10 +135,10 @@ The test process is similar to local rate limiting. Even if your requests are ha
 
 ```bash
 # 1. Deploy Redis service
-kubectl apply -f https://github.com/volcano-sh/kthena/blob/main/examples/redis/redis-standalone.yaml
+kubectl apply -f https://raw.githubusercontent.com/volcano-sh/kthena/main/examples/redis/redis-standalone.yaml
 
 # 2. Apply the ModelRoute yaml above
-kubectl apply -f https://github.com/volcano-sh/kthena/blob/main/examples/kthena-router/ModelRouteWithGlobalRateLimit.yaml
+kubectl apply -f https://raw.githubusercontent.com/volcano-sh/kthena/main/examples/kthena-router/ModelRouteWithGlobalRateLimit.yaml
 
 # 3. Scale up the replicas of the router to 3 to demonstrate global rate limiting
 kubectl scale deployment kthena-router -n kthena-system --replicas=3
@@ -160,7 +160,7 @@ curl http://$ROUTER_IP/v1/completions \
 "input token rate limit exceeded"
 
 # 6. Clean up
-kubectl delete -f https://github.com/volcano-sh/kthena/blob/main/examples/kthena-router/ModelRouteWithGlobalRateLimit.yaml
+kubectl delete -f https://raw.githubusercontent.com/volcano-sh/kthena/main/examples/kthena-router/ModelRouteWithGlobalRateLimit.yaml
 ```
 
 By leveraging local and global rate limiting, Kthena gives you fine-grained control over your AI service traffic, enabling robust, scalable, and cost-effective model deployments.

--- a/docs/kthena/versioned_docs/version-v0.2.0/user-guide/runtime.md
+++ b/docs/kthena/versioned_docs/version-v0.2.0/user-guide/runtime.md
@@ -105,7 +105,7 @@ spec:
     workers:
       - type: server
         image: openeuler/vllm-ascend:latest
-        replicase: 1
+        replicas: 1
         pods: 1
         resources:
           limits:
@@ -166,7 +166,7 @@ spec:
     workers:
       - type: server
         image: openeuler/vllm-ascend:latest
-        replicase: 1
+        replicas: 1
         pods: 1
 ```
 

--- a/docs/kthena/versioned_docs/version-v0.3.0/architecture/autoscaler.mdx
+++ b/docs/kthena/versioned_docs/version-v0.3.0/architecture/autoscaler.mdx
@@ -42,7 +42,7 @@ Heterogeneous Instances Autoscale employs a greedy algorithm with a doubling str
 Based on the multiplication principle, the `capacity` is divided into multiple chunks according to powers of `costExpansionRate`. These chunks serve as scaling batches. At the batch level, batches from different serving instances are mixed and sorted in ascending order by cost. The sorted batches are then expanded into corresponding instance combinations, resulting in a scaling sequence `seq` with length equal to the capacity.
 
 $$
-seq = sorted(\bigcup_{i=1}^{N} P^k \cdot c_i \mid k \in (0,1,\ldots,M_i) \cup (C_i - \sum_{k=0}^{M_i} P^k) \cdot c_i)
+seq = sorted(\bigcup_{i=1}^{N} \{ P^k \cdot c_i \mid k \in \{0,1,\ldots,M_i\} \} \cup \{ (C_i - \sum_{k=0}^{M_i} P^k) \cdot c_i \})
 $$
 
 Where:

--- a/docs/kthena/versioned_docs/version-v0.3.0/architecture/model-booster-controller.md
+++ b/docs/kthena/versioned_docs/version-v0.3.0/architecture/model-booster-controller.md
@@ -5,7 +5,7 @@ import modelBoosterControllerArchitecture from '../assets/diagrams/architecture/
 
 ## Overview
 
-As an optional component of the Kthena project, the Model Booster Controller primarily provides users with a convenient deployment form - `Model`. Based on the `Model CR` (Model Custom Resource) information provided by users, this component can automatically configure and deploy the components required for inference services, such as router routing rules, inference engine instances, and dynamic scaling configurations.
+As an optional component of the Kthena project, the Model Booster Controller primarily provides users with a convenient deployment form - `ModelBooster`. Based on the `ModelBooster CR` (ModelBooster Custom Resource) information provided by users, this component can automatically configure and deploy the components required for inference services, such as router routing rules, inference engine instances, and dynamic scaling configurations.
 
 ## Feature Description
 
@@ -39,13 +39,13 @@ Read the [Model Booster CR Examples](https://github.com/volcano-sh/kthena/tree/m
 
 ## Limitations
 
-The `Model` can only cover most inference service scenarios and will be continuously updated. Some scenarios are not yet supported and require manual configuration of relevant CRDs. 
+The `ModelBooster` can only cover most inference service scenarios and will be continuously updated. Some scenarios are not yet supported and require manual configuration of relevant CRDs. 
 
 Please note the following limitations when using the Model Booster:
-- Each `Model` can create only one `Model Route`.
-- Rate limiting for `Model Route` is not supported.
-- Topology configuration for `Model Infer` is not supported.
+- Each `ModelBooster` can create only one `ModelRoute`.
+- Rate limiting for `ModelRoute` is not supported.
+- Topology configuration for `ModelServing` is not supported.
 - The `panicPolicy` configuration for `AutoscalingPolicy` is not supported.
 - Behavior configuration for `AutoscalingPolicy` is not supported.
 
-In these cases, you can manually create `Model Infer`, `Model Server`, `Model Route`, `AutoscalingPolicy`, `AutoscalingPolicyBinding` resources as needed.
+In these cases, you can manually create `ModelServing`, `ModelServer`, `ModelRoute`, `AutoscalingPolicy`, `AutoscalingPolicyBinding` resources as needed.

--- a/docs/kthena/versioned_docs/version-v0.3.0/architecture/model-serving-controller.mdx
+++ b/docs/kthena/versioned_docs/version-v0.3.0/architecture/model-serving-controller.mdx
@@ -8,7 +8,7 @@ ModelServing Controller is the controller for the serving workload `ModelServing
 ## Model Serving Overview
 
 `ModelServing` represents the optimal deployment paradigm for distributed serving scenarios involving large models, offering flexible and user-friendly workload configurations with
-Prefilling Decoding Disaggregation and parallel serving services like Pipeline Parallelism (PP) and Tensor Parallelism (TP).
+Prefill-Decode Disaggregation and parallel serving services like Pipeline Parallelism (PP) and Tensor Parallelism (TP).
 
 ## Model Serving Architecture
 

--- a/docs/kthena/versioned_docs/version-v0.3.0/user-guide/modelserving-plugin-framework.md
+++ b/docs/kthena/versioned_docs/version-v0.3.0/user-guide/modelserving-plugin-framework.md
@@ -114,7 +114,7 @@ Kthena ships with a built-in demo plugin `demo-pod-tweaks` that can set `runtime
 **Example: Using the demo plugin**
 
 ```yaml
-apiVersion: workload.kthena.io/v1alpha1
+apiVersion: workload.serving.volcano.sh/v1alpha1
 kind: ModelServing
 metadata:
   name: llama-8b

--- a/docs/kthena/versioned_docs/version-v0.3.0/user-guide/rate-limit.md
+++ b/docs/kthena/versioned_docs/version-v0.3.0/user-guide/rate-limit.md
@@ -7,7 +7,7 @@ Unlike traditional microservices that use request count or connection-based rate
 Kthena Router provides powerful rate-limiting capabilities to control the traffic flow to your backend models. This is essential for preventing service overload, managing costs, and ensuring fair usage. Rate limiting is configured directly within the **ModelRoute** Custom Resource (CR).
 
 The router supports two main types of rate limiting:
-- **Local Rate Limiting**: Enforces limits on a per-router-instance basis. It\'s simple to configure and effective for basic load protection.
+- **Local Rate Limiting**: Enforces limits on a per-router-instance basis. It's simple to configure and effective for basic load protection.
 - **Global Rate Limiting**: Enforces a shared limit across all router instances, using a central store like Redis. This is ideal for providing consistent limits in a scaled-out environment.
 
 Limits are based on the number of input/output tokens over a specific time window (second, minute, hour, day, or month).
@@ -89,7 +89,7 @@ curl http://$ROUTER_IP/v1/completions \
 "input token rate limit exceeded"
 
 # 5. Clean up
-kubectl delete -f https://github.com/volcano-sh/kthena/blob/main/examples/kthena-router/ModelRouteWithRateLimit.yaml
+kubectl delete -f https://raw.githubusercontent.com/volcano-sh/kthena/main/examples/kthena-router/ModelRouteWithRateLimit.yaml
 ```
 
 ### 2. Global Rate Limiting
@@ -135,10 +135,10 @@ The test process is similar to local rate limiting. Even if your requests are ha
 
 ```bash
 # 1. Deploy Redis service
-kubectl apply -f https://github.com/volcano-sh/kthena/blob/main/examples/redis/redis-standalone.yaml
+kubectl apply -f https://raw.githubusercontent.com/volcano-sh/kthena/main/examples/redis/redis-standalone.yaml
 
 # 2. Apply the ModelRoute yaml above
-kubectl apply -f https://github.com/volcano-sh/kthena/blob/main/examples/kthena-router/ModelRouteWithGlobalRateLimit.yaml
+kubectl apply -f https://raw.githubusercontent.com/volcano-sh/kthena/main/examples/kthena-router/ModelRouteWithGlobalRateLimit.yaml
 
 # 3. Scale up the replicas of the router to 3 to demonstrate global rate limiting
 kubectl scale deployment kthena-router -n kthena-system --replicas=3
@@ -160,7 +160,7 @@ curl http://$ROUTER_IP/v1/completions \
 "input token rate limit exceeded"
 
 # 6. Clean up
-kubectl delete -f https://github.com/volcano-sh/kthena/blob/main/examples/kthena-router/ModelRouteWithGlobalRateLimit.yaml
+kubectl delete -f https://raw.githubusercontent.com/volcano-sh/kthena/main/examples/kthena-router/ModelRouteWithGlobalRateLimit.yaml
 ```
 
 By leveraging local and global rate limiting, Kthena gives you fine-grained control over your AI service traffic, enabling robust, scalable, and cost-effective model deployments.

--- a/docs/kthena/versioned_docs/version-v0.3.0/user-guide/runtime.md
+++ b/docs/kthena/versioned_docs/version-v0.3.0/user-guide/runtime.md
@@ -105,7 +105,7 @@ spec:
     workers:
       - type: server
         image: openeuler/vllm-ascend:latest
-        replicase: 1
+        replicas: 1
         pods: 1
         resources:
           limits:
@@ -166,7 +166,7 @@ spec:
     workers:
       - type: server
         image: openeuler/vllm-ascend:latest
-        replicase: 1
+        replicas: 1
         pods: 1
 ```
 

--- a/docs/kthena/versioned_docs/version-v0.4.0/architecture/autoscaler.mdx
+++ b/docs/kthena/versioned_docs/version-v0.4.0/architecture/autoscaler.mdx
@@ -42,7 +42,7 @@ Heterogeneous Instances Autoscale employs a greedy algorithm with a doubling str
 Based on the multiplication principle, the `capacity` is divided into multiple chunks according to powers of `costExpansionRate`. These chunks serve as scaling batches. At the batch level, batches from different serving instances are mixed and sorted in ascending order by cost. The sorted batches are then expanded into corresponding instance combinations, resulting in a scaling sequence `seq` with length equal to the capacity.
 
 $$
-seq = sorted(\bigcup_{i=1}^{N} P^k \cdot c_i \mid k \in (0,1,\ldots,M_i) \cup (C_i - \sum_{k=0}^{M_i} P^k) \cdot c_i)
+seq = sorted(\bigcup_{i=1}^{N} \{ P^k \cdot c_i \mid k \in \{0,1,\ldots,M_i\} \} \cup \{ (C_i - \sum_{k=0}^{M_i} P^k) \cdot c_i \})
 $$
 
 Where:

--- a/docs/kthena/versioned_docs/version-v0.4.0/architecture/model-booster-controller.md
+++ b/docs/kthena/versioned_docs/version-v0.4.0/architecture/model-booster-controller.md
@@ -5,7 +5,7 @@ import modelBoosterControllerArchitecture from '../assets/diagrams/architecture/
 
 ## Overview
 
-As an optional component of the Kthena project, the Model Booster Controller primarily provides users with a convenient deployment form - `Model`. Based on the `Model CR` (Model Custom Resource) information provided by users, this component can automatically configure and deploy the components required for inference services, such as router routing rules, inference engine instances, and dynamic scaling configurations.
+As an optional component of the Kthena project, the Model Booster Controller primarily provides users with a convenient deployment form - `ModelBooster`. Based on the `ModelBooster CR` (ModelBooster Custom Resource) information provided by users, this component can automatically configure and deploy the components required for inference services, such as router routing rules, inference engine instances, and dynamic scaling configurations.
 
 ## Feature Description
 
@@ -39,13 +39,13 @@ Read the [Model Booster CR Examples](https://github.com/volcano-sh/kthena/tree/m
 
 ## Limitations
 
-The `Model` can only cover most inference service scenarios and will be continuously updated. Some scenarios are not yet supported and require manual configuration of relevant CRDs. 
+The `ModelBooster` can only cover most inference service scenarios and will be continuously updated. Some scenarios are not yet supported and require manual configuration of relevant CRDs. 
 
 Please note the following limitations when using the Model Booster:
-- Each `Model` can create only one `Model Route`.
-- Rate limiting for `Model Route` is not supported.
-- Topology configuration for `Model Infer` is not supported.
+- Each `ModelBooster` can create only one `ModelRoute`.
+- Rate limiting for `ModelRoute` is not supported.
+- Topology configuration for `ModelServing` is not supported.
 - The `panicPolicy` configuration for `AutoscalingPolicy` is not supported.
 - Behavior configuration for `AutoscalingPolicy` is not supported.
 
-In these cases, you can manually create `Model Infer`, `Model Server`, `Model Route`, `AutoscalingPolicy`, `AutoscalingPolicyBinding` resources as needed.
+In these cases, you can manually create `ModelServing`, `ModelServer`, `ModelRoute`, `AutoscalingPolicy`, `AutoscalingPolicyBinding` resources as needed.

--- a/docs/kthena/versioned_docs/version-v0.4.0/architecture/model-serving-controller.mdx
+++ b/docs/kthena/versioned_docs/version-v0.4.0/architecture/model-serving-controller.mdx
@@ -8,7 +8,7 @@ ModelServing Controller is the controller for the serving workload `ModelServing
 ## Model Serving Overview
 
 `ModelServing` represents the optimal deployment paradigm for distributed serving scenarios involving large models, offering flexible and user-friendly workload configurations with
-Prefilling Decoding Disaggregation and parallel serving services like Pipeline Parallelism (PP) and Tensor Parallelism (TP).
+Prefill-Decode Disaggregation and parallel serving services like Pipeline Parallelism (PP) and Tensor Parallelism (TP).
 
 ## Model Serving Architecture
 

--- a/docs/kthena/versioned_docs/version-v0.4.0/user-guide/modelserving-plugin-framework.md
+++ b/docs/kthena/versioned_docs/version-v0.4.0/user-guide/modelserving-plugin-framework.md
@@ -114,7 +114,7 @@ Kthena ships with a built-in demo plugin `demo-pod-tweaks` that can set `runtime
 **Example: Using the demo plugin**
 
 ```yaml
-apiVersion: workload.kthena.io/v1alpha1
+apiVersion: workload.serving.volcano.sh/v1alpha1
 kind: ModelServing
 metadata:
   name: llama-8b

--- a/docs/kthena/versioned_docs/version-v0.4.0/user-guide/rate-limit.md
+++ b/docs/kthena/versioned_docs/version-v0.4.0/user-guide/rate-limit.md
@@ -7,7 +7,7 @@ Unlike traditional microservices that use request count or connection-based rate
 Kthena Router provides powerful rate-limiting capabilities to control the traffic flow to your backend models. This is essential for preventing service overload, managing costs, and ensuring fair usage. Rate limiting is configured directly within the **ModelRoute** Custom Resource (CR).
 
 The router supports two main types of rate limiting:
-- **Local Rate Limiting**: Enforces limits on a per-router-instance basis. It\'s simple to configure and effective for basic load protection.
+- **Local Rate Limiting**: Enforces limits on a per-router-instance basis. It's simple to configure and effective for basic load protection.
 - **Global Rate Limiting**: Enforces a shared limit across all router instances, using a central store like Redis. This is ideal for providing consistent limits in a scaled-out environment.
 
 Limits are based on the number of input/output tokens over a specific time window (second, minute, hour, day, or month).
@@ -89,7 +89,7 @@ curl http://$ROUTER_IP/v1/completions \
 "input token rate limit exceeded"
 
 # 5. Clean up
-kubectl delete -f https://github.com/volcano-sh/kthena/blob/main/examples/kthena-router/ModelRouteWithRateLimit.yaml
+kubectl delete -f https://raw.githubusercontent.com/volcano-sh/kthena/main/examples/kthena-router/ModelRouteWithRateLimit.yaml
 ```
 
 ### 2. Global Rate Limiting
@@ -135,10 +135,10 @@ The test process is similar to local rate limiting. Even if your requests are ha
 
 ```bash
 # 1. Deploy Redis service
-kubectl apply -f https://github.com/volcano-sh/kthena/blob/main/examples/redis/redis-standalone.yaml
+kubectl apply -f https://raw.githubusercontent.com/volcano-sh/kthena/main/examples/redis/redis-standalone.yaml
 
 # 2. Apply the ModelRoute yaml above
-kubectl apply -f https://github.com/volcano-sh/kthena/blob/main/examples/kthena-router/ModelRouteWithGlobalRateLimit.yaml
+kubectl apply -f https://raw.githubusercontent.com/volcano-sh/kthena/main/examples/kthena-router/ModelRouteWithGlobalRateLimit.yaml
 
 # 3. Scale up the replicas of the router to 3 to demonstrate global rate limiting
 kubectl scale deployment kthena-router -n kthena-system --replicas=3
@@ -160,7 +160,7 @@ curl http://$ROUTER_IP/v1/completions \
 "input token rate limit exceeded"
 
 # 6. Clean up
-kubectl delete -f https://github.com/volcano-sh/kthena/blob/main/examples/kthena-router/ModelRouteWithGlobalRateLimit.yaml
+kubectl delete -f https://raw.githubusercontent.com/volcano-sh/kthena/main/examples/kthena-router/ModelRouteWithGlobalRateLimit.yaml
 ```
 
 By leveraging local and global rate limiting, Kthena gives you fine-grained control over your AI service traffic, enabling robust, scalable, and cost-effective model deployments.

--- a/docs/kthena/versioned_docs/version-v0.4.0/user-guide/runtime.md
+++ b/docs/kthena/versioned_docs/version-v0.4.0/user-guide/runtime.md
@@ -105,7 +105,7 @@ spec:
     workers:
       - type: server
         image: openeuler/vllm-ascend:latest
-        replicase: 1
+        replicas: 1
         pods: 1
         resources:
           limits:
@@ -166,7 +166,7 @@ spec:
     workers:
       - type: server
         image: openeuler/vllm-ascend:latest
-        replicase: 1
+        replicas: 1
         pods: 1
 ```
 

--- a/docs/kthena/versioned_sidebars/version-v0.4.0-sidebars.json
+++ b/docs/kthena/versioned_sidebars/version-v0.4.0-sidebars.json
@@ -45,7 +45,6 @@
           ]
         },
         "user-guide/multi-node-inference",
-        "user-guide/network-topology",
         {
           "type": "doc",
           "label": "Autoscaler",
@@ -80,7 +79,6 @@
           ]
         },
         "user-guide/runtime",
-        "user-guide/binpack-scale-down",
         {
           "type": "category",
           "label": "Prefill Decode Disaggregation",


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

### What this PR does / why we need it

This PR fixes several stale and incorrect pieces of documentation that were identified while working on the v1.0.0 documentation versioning effort.

The fixes have been applied to both the current ("next") documentation and the corresponding versioned documentation where the same issues existed, keeping the documentation consistent across releases.

### Changes included

* Corrected the ModelServing API group:

  * `workload.kthena.io` → `workload.serving.volcano.sh`
* Fixed `replicase` → `replicas` typos in Runtime guide YAML examples.
* Updated GitHub `blob` URLs to `raw.githubusercontent.com` for `kubectl apply -f` / `kubectl delete -f` examples so the commands work correctly.
* Removed an escaped apostrophe (`It\'s` → `It's`).
* Updated Model Booster documentation to use the correct CRD names (`ModelBooster`, `ModelRoute`, `ModelServing`, and `ModelServer`) where appropriate.
* Corrected **"Prefilling Decoding Disaggregation"** to **"Prefill-Decode Disaggregation"**.
* Fixed the autoscaler mathematical notation using proper set-builder braces.
* Removed duplicate navigation entries from the current sidebar and the affected versioned sidebar.

These fixes were also applied to the corresponding versioned documentation where the same issues existed.

### Which issue(s) this PR fixes

Fixes #1383

### Special notes for your reviewer

* Applied the same documentation fixes to the affected versioned documentation to keep current and historical documentation consistent.
* Only documentation containing the same verified issues was modified; no unrelated historical content was changed.
* Browser-only GitHub `blob` links were intentionally left unchanged. Only URLs used by `kubectl apply -f` / `kubectl delete -f` were converted to raw content URLs.
* Documentation was validated with:

  * `npm run typecheck`
  * `npm run build`
* The documentation builds successfully without introducing broken links or MDX errors.
* No unrelated formatting or whitespace changes were included.

### Does this PR introduce a user-facing change?

Improves both the current and versioned Kthena documentation by fixing incorrect CRD references, YAML typos, non-functional `kubectl` example URLs, terminology inconsistencies, mathematical notation, and duplicate sidebar entries.
