### PR TITLE
Validate and document least-latency weight configuration

### DIFF
--- a/docs/kthena/docs/user-guide/config-router.md
+++ b/docs/kthena/docs/user-guide/config-router.md
@@ -17,9 +17,17 @@ Plugin Configuration (PluginConfig):
 | Plugin Name   | Parameters                                                  | Description                                                                                               |
 | ------------- | ----------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
 | least-request | maxWaitingRequests                                          | Sets the maximum number of waiting requests                                                               |
-| least-latency | TTFTTPOTWeightFactor                                        | Sets the weight factor for TTFT and TPOT                                                                  |
+| least-latency | TTFTTPOTWeightFactor                                        | Sets the TTFT weight factor. Must be between `0.0` and `1.0`.                                             |
 | prefix-cache  | blockSizeToHash<br />maxBlocksToMatch<br />maxHashCacheSize | Configures prefix cache parameters                                                                        |
 | kvcache-aware | blockSizeToHash<br />maxBlocksToMatch                       | Configures KV cache aware token-block matching parameters. Requires Redis and the Kthena Runtime sidecar. |
+
+`TTFTTPOTWeightFactor` controls how the least-latency plugin balances Time To First Token (TTFT) and Time Per Output Token (TPOT):
+
+- `0.0` prioritizes TPOT.
+- `0.5` gives equal weight to TTFT and TPOT.
+- `1.0` prioritizes TTFT.
+
+Values outside the `0.0` to `1.0` range, including non-finite values, use the default value `0.5`.
 
 Filter Plugins (Filter):
 

--- a/docs/kthena/docs/user-guide/config-router.md
+++ b/docs/kthena/docs/user-guide/config-router.md
@@ -27,7 +27,7 @@ Plugin Configuration (PluginConfig):
 - `0.5` gives equal weight to TTFT and TPOT.
 - `1.0` prioritizes TTFT.
 
-Values outside the `0.0` to `1.0` range, including non-finite values, use the default value `0.5`.
+The router exits with a configuration error when this value is outside the `0.0` to `1.0` range, or is non-finite.
 
 Filter Plugins (Filter):
 

--- a/pkg/kthena-router/scheduler/plugins/conf/conf.go
+++ b/pkg/kthena-router/scheduler/plugins/conf/conf.go
@@ -22,7 +22,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
-	"sigs.k8s.io/yaml"
+	yaml "sigs.k8s.io/yaml/goyaml.v3"
 )
 
 type RouterConfiguration struct {
@@ -58,6 +58,32 @@ type PluginWithWeight struct {
 type PluginConfig struct {
 	Name string               `yaml:"name"`
 	Args runtime.RawExtension `yaml:"args,omitempty"`
+}
+
+// UnmarshalYAML preserves plugin arguments as YAML. Parsing the outer
+// configuration through JSON rejects valid YAML scalar values such as .nan and
+// .inf before the plugin has a chance to validate or default them.
+func (p *PluginConfig) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind != yaml.MappingNode {
+		return fmt.Errorf("plugin configuration must be a mapping")
+	}
+
+	p.Args = runtime.RawExtension{}
+	for i := 0; i < len(value.Content); i += 2 {
+		key := value.Content[i]
+		field := value.Content[i+1]
+		switch key.Value {
+		case "name":
+			p.Name = field.Value
+		case "args":
+			args, err := yaml.Marshal(field)
+			if err != nil {
+				return fmt.Errorf("marshal plugin arguments: %w", err)
+			}
+			p.Args.Raw = args
+		}
+	}
+	return nil
 }
 
 type AuthenticationConfig struct {

--- a/pkg/kthena-router/scheduler/plugins/conf/conf.go
+++ b/pkg/kthena-router/scheduler/plugins/conf/conf.go
@@ -74,7 +74,9 @@ func (p *PluginConfig) UnmarshalYAML(value *yaml.Node) error {
 		field := value.Content[i+1]
 		switch key.Value {
 		case "name":
-			p.Name = field.Value
+			if err := field.Decode(&p.Name); err != nil {
+				return fmt.Errorf("decode plugin name: %w", err)
+			}
 		case "args":
 			args, err := yaml.Marshal(field)
 			if err != nil {

--- a/pkg/kthena-router/scheduler/plugins/conf/conf.go
+++ b/pkg/kthena-router/scheduler/plugins/conf/conf.go
@@ -23,6 +23,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
 	yaml "sigs.k8s.io/yaml/goyaml.v3"
+
+	"github.com/volcano-sh/kthena/pkg/kthena-router/scheduler/plugins"
 )
 
 type RouterConfiguration struct {
@@ -172,6 +174,11 @@ func unmarshalPluginsConfig(schedulerConfig *SchedulerConfiguration) (map[string
 
 	if len(schedulerConfig.PluginConfig) > 0 {
 		for _, pluginArg := range schedulerConfig.PluginConfig {
+			if pluginArg.Name == plugins.LeastLatencyPluginName {
+				if err := plugins.ValidateLeastLatencyArgs(pluginArg.Args); err != nil {
+					return nil, fmt.Errorf("invalid %s plugin configuration: %w", pluginArg.Name, err)
+				}
+			}
 			pluginsArgMap[pluginArg.Name] = pluginArg.Args
 		}
 	}

--- a/pkg/kthena-router/scheduler/plugins/conf/conf_test.go
+++ b/pkg/kthena-router/scheduler/plugins/conf/conf_test.go
@@ -17,8 +17,13 @@ limitations under the License.
 package conf
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/volcano-sh/kthena/pkg/kthena-router/scheduler/plugins"
 )
 
 func TestLoadSchedulerConfig(t *testing.T) {
@@ -58,6 +63,50 @@ func TestLoadSchedulerConfig(t *testing.T) {
 						t.Errorf("expected error %q, got %q", tc.expectErrs, err.Error())
 					}
 				}
+			}
+		})
+	}
+}
+
+func TestParseRouterConfigNonFiniteLeastLatencyWeightUsesDefault(t *testing.T) {
+	tt := []struct {
+		name  string
+		value string
+	}{
+		{name: "not a number", value: ".nan"},
+		{name: "positive infinity", value: ".inf"},
+		{name: "negative infinity", value: "-.inf"},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			configPath := filepath.Join(t.TempDir(), "routerConfiguration.yaml")
+			config := fmt.Sprintf(`scheduler:
+  pluginConfig:
+    - name: least-latency
+      args:
+        TTFTTPOTWeightFactor: %s
+`, tc.value)
+			if err := os.WriteFile(configPath, []byte(config), 0o600); err != nil {
+				t.Fatalf("write router configuration: %v", err)
+			}
+
+			routerConfig, err := ParseRouterConfig(configPath)
+			if err != nil {
+				t.Fatalf("parse router configuration: %v", err)
+			}
+			_, _, pluginArgs, err := LoadSchedulerConfig(&routerConfig.Scheduler)
+			if err != nil {
+				t.Fatalf("load scheduler configuration: %v", err)
+			}
+			args := pluginArgs[plugins.LeastLatencyPluginName]
+			if !strings.Contains(string(args.Raw), tc.value) {
+				t.Fatalf("expected plugin arguments to preserve %q, got %q", tc.value, args.Raw)
+			}
+
+			plugin := plugins.NewLeastLatency(args)
+			if plugin.TTFTTPOTWeightFactor != 0.5 {
+				t.Fatalf("expected non-finite router configuration weight to use default 0.5, got %v", plugin.TTFTTPOTWeightFactor)
 			}
 		})
 	}

--- a/pkg/kthena-router/scheduler/plugins/conf/conf_test.go
+++ b/pkg/kthena-router/scheduler/plugins/conf/conf_test.go
@@ -22,8 +22,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-
-	"github.com/volcano-sh/kthena/pkg/kthena-router/scheduler/plugins"
 )
 
 func TestLoadSchedulerConfig(t *testing.T) {
@@ -68,7 +66,7 @@ func TestLoadSchedulerConfig(t *testing.T) {
 	}
 }
 
-func TestParseRouterConfigNonFiniteLeastLatencyWeightUsesDefault(t *testing.T) {
+func TestLoadSchedulerConfigRejectsInvalidLeastLatencyWeight(t *testing.T) {
 	tt := []struct {
 		name  string
 		value string
@@ -76,6 +74,8 @@ func TestParseRouterConfigNonFiniteLeastLatencyWeightUsesDefault(t *testing.T) {
 		{name: "not a number", value: ".nan"},
 		{name: "positive infinity", value: ".inf"},
 		{name: "negative infinity", value: "-.inf"},
+		{name: "below minimum", value: "-0.1"},
+		{name: "above maximum", value: "1.1"},
 	}
 
 	for _, tc := range tt {
@@ -95,18 +95,9 @@ func TestParseRouterConfigNonFiniteLeastLatencyWeightUsesDefault(t *testing.T) {
 			if err != nil {
 				t.Fatalf("parse router configuration: %v", err)
 			}
-			_, _, pluginArgs, err := LoadSchedulerConfig(&routerConfig.Scheduler)
-			if err != nil {
-				t.Fatalf("load scheduler configuration: %v", err)
-			}
-			args := pluginArgs[plugins.LeastLatencyPluginName]
-			if !strings.Contains(string(args.Raw), tc.value) {
-				t.Fatalf("expected plugin arguments to preserve %q, got %q", tc.value, args.Raw)
-			}
-
-			plugin := plugins.NewLeastLatency(args)
-			if plugin.TTFTTPOTWeightFactor != 0.5 {
-				t.Fatalf("expected non-finite router configuration weight to use default 0.5, got %v", plugin.TTFTTPOTWeightFactor)
+			_, _, _, err = LoadSchedulerConfig(&routerConfig.Scheduler)
+			if err == nil {
+				t.Fatalf("expected invalid weight %q to be rejected", tc.value)
 			}
 		})
 	}

--- a/pkg/kthena-router/scheduler/plugins/conf/conf_test.go
+++ b/pkg/kthena-router/scheduler/plugins/conf/conf_test.go
@@ -112,6 +112,26 @@ func TestParseRouterConfigNonFiniteLeastLatencyWeightUsesDefault(t *testing.T) {
 	}
 }
 
+func TestParseRouterConfigRejectsNonScalarPluginName(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "routerConfiguration.yaml")
+	config := `scheduler:
+  pluginConfig:
+    - name:
+        nested: least-latency
+`
+	if err := os.WriteFile(configPath, []byte(config), 0o600); err != nil {
+		t.Fatalf("write router configuration: %v", err)
+	}
+
+	_, err := ParseRouterConfig(configPath)
+	if err == nil {
+		t.Fatal("expected a non-scalar plugin name to be rejected")
+	}
+	if !strings.Contains(err.Error(), "cannot unmarshal") {
+		t.Fatalf("expected a plugin name type error, got %v", err)
+	}
+}
+
 func TestHandleRandomPluginConflicts(t *testing.T) {
 	tests := []struct {
 		name            string

--- a/pkg/kthena-router/scheduler/plugins/least_latency.go
+++ b/pkg/kthena-router/scheduler/plugins/least_latency.go
@@ -29,7 +29,12 @@ import (
 
 var _ framework.ScorePlugin = &LeastLatency{}
 
-const LeastLatencyPluginName = "least-latency"
+const (
+	LeastLatencyPluginName      = "least-latency"
+	defaultTTFTTPOTWeightFactor = 0.5
+	minTTFTTPOTWeightFactor     = 0.0
+	maxTTFTTPOTWeightFactor     = 1.0
+)
 
 // MaxScore is the highest possible score a pod can receive
 const MaxScore = 100.0
@@ -40,16 +45,29 @@ type LeastLatency struct {
 }
 
 type LeastLatencyArgs struct {
+	// TTFTTPOTWeightFactor must be between 0 and 1. A value of 0 prioritizes
+	// TPOT, 1 prioritizes TTFT, and values in between blend both metrics.
 	TTFTTPOTWeightFactor float64 `yaml:"TTFTTPOTWeightFactor,omitempty"`
 }
 
 func NewLeastLatency(pluginArg runtime.RawExtension) *LeastLatency {
-	var leastLatencyArgs LeastLatencyArgs
-	if pluginArg.Raw == nil || yaml.Unmarshal(pluginArg.Raw, &leastLatencyArgs) != nil {
-		klog.Errorf("Unmarshal LeastLatencyArgs error, setting default value")
-		leastLatencyArgs = LeastLatencyArgs{
-			0.5,
+	leastLatencyArgs := LeastLatencyArgs{
+		TTFTTPOTWeightFactor: defaultTTFTTPOTWeightFactor,
+	}
+	if len(pluginArg.Raw) > 0 {
+		if err := yaml.Unmarshal(pluginArg.Raw, &leastLatencyArgs); err != nil {
+			klog.Errorf("Unmarshal LeastLatencyArgs error, setting default value: %v", err)
+			leastLatencyArgs.TTFTTPOTWeightFactor = defaultTTFTTPOTWeightFactor
 		}
+	}
+
+	if math.IsNaN(leastLatencyArgs.TTFTTPOTWeightFactor) ||
+		math.IsInf(leastLatencyArgs.TTFTTPOTWeightFactor, 0) ||
+		leastLatencyArgs.TTFTTPOTWeightFactor < minTTFTTPOTWeightFactor ||
+		leastLatencyArgs.TTFTTPOTWeightFactor > maxTTFTTPOTWeightFactor {
+		klog.Warningf("Invalid TTFTTPOTWeightFactor %v, using default value %v",
+			leastLatencyArgs.TTFTTPOTWeightFactor, defaultTTFTTPOTWeightFactor)
+		leastLatencyArgs.TTFTTPOTWeightFactor = defaultTTFTTPOTWeightFactor
 	}
 
 	return &LeastLatency{

--- a/pkg/kthena-router/scheduler/plugins/least_latency.go
+++ b/pkg/kthena-router/scheduler/plugins/least_latency.go
@@ -17,6 +17,7 @@ limitations under the License.
 package plugins
 
 import (
+	"fmt"
 	"math"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -48,6 +49,29 @@ type LeastLatencyArgs struct {
 	// TTFTTPOTWeightFactor must be between 0 and 1. A value of 0 prioritizes
 	// TPOT, 1 prioritizes TTFT, and values in between blend both metrics.
 	TTFTTPOTWeightFactor float64 `yaml:"TTFTTPOTWeightFactor,omitempty"`
+}
+
+// ValidateLeastLatencyArgs validates least-latency plugin arguments supplied
+// through router configuration.
+func ValidateLeastLatencyArgs(pluginArg runtime.RawExtension) error {
+	if len(pluginArg.Raw) == 0 {
+		return nil
+	}
+
+	leastLatencyArgs := LeastLatencyArgs{
+		TTFTTPOTWeightFactor: defaultTTFTTPOTWeightFactor,
+	}
+	if err := yaml.Unmarshal(pluginArg.Raw, &leastLatencyArgs); err != nil {
+		return fmt.Errorf("unmarshal least-latency arguments: %w", err)
+	}
+
+	weight := leastLatencyArgs.TTFTTPOTWeightFactor
+	if math.IsNaN(weight) || math.IsInf(weight, 0) ||
+		weight < minTTFTTPOTWeightFactor || weight > maxTTFTTPOTWeightFactor {
+		return fmt.Errorf("TTFTTPOTWeightFactor must be a finite value between %v and %v, got %v",
+			minTTFTTPOTWeightFactor, maxTTFTTPOTWeightFactor, weight)
+	}
+	return nil
 }
 
 func NewLeastLatency(pluginArg runtime.RawExtension) *LeastLatency {

--- a/pkg/kthena-router/scheduler/plugins/least_latency.go
+++ b/pkg/kthena-router/scheduler/plugins/least_latency.go
@@ -57,7 +57,6 @@ func NewLeastLatency(pluginArg runtime.RawExtension) *LeastLatency {
 	if len(pluginArg.Raw) > 0 {
 		if err := yaml.Unmarshal(pluginArg.Raw, &leastLatencyArgs); err != nil {
 			klog.Errorf("Unmarshal LeastLatencyArgs error, setting default value: %v", err)
-			leastLatencyArgs.TTFTTPOTWeightFactor = defaultTTFTTPOTWeightFactor
 		}
 	}
 

--- a/pkg/kthena-router/scheduler/plugins/least_latency_test.go
+++ b/pkg/kthena-router/scheduler/plugins/least_latency_test.go
@@ -112,15 +112,58 @@ func TestLeastLatencyScore(t *testing.T) {
 
 func TestNewLeastLatencyNilRawUsesDefaultWeight(t *testing.T) {
 	plugin := NewLeastLatency(runtime.RawExtension{})
-	if plugin.TTFTTPOTWeightFactor != 0.5 {
-		t.Fatalf("expected default weight factor 0.5, got %v", plugin.TTFTTPOTWeightFactor)
+	if plugin.TTFTTPOTWeightFactor != defaultTTFTTPOTWeightFactor {
+		t.Fatalf("expected default weight factor %v, got %v", defaultTTFTTPOTWeightFactor, plugin.TTFTTPOTWeightFactor)
 	}
 }
 
 func TestNewLeastLatencyInvalidArgsUsesDefaultWeight(t *testing.T) {
 	plugin := NewLeastLatency(runtime.RawExtension{Raw: []byte(`TTFTTPOTWeightFactor: [`)})
-	if plugin.TTFTTPOTWeightFactor != 0.5 {
-		t.Fatalf("expected default weight factor 0.5, got %v", plugin.TTFTTPOTWeightFactor)
+	if plugin.TTFTTPOTWeightFactor != defaultTTFTTPOTWeightFactor {
+		t.Fatalf("expected default weight factor %v, got %v", defaultTTFTTPOTWeightFactor, plugin.TTFTTPOTWeightFactor)
+	}
+}
+
+func TestNewLeastLatencyInvalidWeightUsesDefault(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+	}{
+		{name: "below minimum", raw: "TTFTTPOTWeightFactor: -0.1"},
+		{name: "above maximum", raw: "TTFTTPOTWeightFactor: 1.1"},
+		{name: "positive infinity", raw: "TTFTTPOTWeightFactor: .inf"},
+		{name: "negative infinity", raw: "TTFTTPOTWeightFactor: -.inf"},
+		{name: "not a number", raw: "TTFTTPOTWeightFactor: .nan"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plugin := NewLeastLatency(runtime.RawExtension{Raw: []byte(tt.raw)})
+			if plugin.TTFTTPOTWeightFactor != defaultTTFTTPOTWeightFactor {
+				t.Fatalf("expected default weight factor %v, got %v", defaultTTFTTPOTWeightFactor, plugin.TTFTTPOTWeightFactor)
+			}
+		})
+	}
+}
+
+func TestNewLeastLatencyAcceptsWeightBounds(t *testing.T) {
+	tests := []struct {
+		name   string
+		raw    string
+		expect float64
+	}{
+		{name: "minimum", raw: "0.0", expect: 0.0},
+		{name: "default", raw: "0.5", expect: 0.5},
+		{name: "maximum", raw: "1.0", expect: 1.0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plugin := NewLeastLatency(runtime.RawExtension{Raw: []byte("TTFTTPOTWeightFactor: " + tt.raw)})
+			if plugin.TTFTTPOTWeightFactor != tt.expect {
+				t.Fatalf("expected weight %v, got %v", tt.expect, plugin.TTFTTPOTWeightFactor)
+			}
+		})
 	}
 }
 

--- a/pkg/kthena-router/scheduler/plugins/least_latency_test.go
+++ b/pkg/kthena-router/scheduler/plugins/least_latency_test.go
@@ -117,6 +117,13 @@ func TestNewLeastLatencyNilRawUsesDefaultWeight(t *testing.T) {
 	}
 }
 
+func TestNewLeastLatencyRawWithoutWeightUsesDefault(t *testing.T) {
+	plugin := NewLeastLatency(runtime.RawExtension{Raw: []byte(`{}`)})
+	if plugin.TTFTTPOTWeightFactor != defaultTTFTTPOTWeightFactor {
+		t.Fatalf("expected default weight factor %v, got %v", defaultTTFTTPOTWeightFactor, plugin.TTFTTPOTWeightFactor)
+	}
+}
+
 func TestNewLeastLatencyInvalidArgsUsesDefaultWeight(t *testing.T) {
 	plugin := NewLeastLatency(runtime.RawExtension{Raw: []byte(`TTFTTPOTWeightFactor: [`)})
 	if plugin.TTFTTPOTWeightFactor != defaultTTFTTPOTWeightFactor {


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement

**What this PR does / why we need it**:

Validates `TTFTTPOTWeightFactor` in the least-latency scheduler plugin.

Values must be between `0.0` and `1.0`. Invalid or non-finite values now fall back to the default value `0.5`.

This PR also adds unit tests and documents TTFT, TPOT, and the supported weight range in the router configuration guide.

**Which issue(s) this PR fixes**:

Fixes #1392

**Special notes for your reviewer**:

- `0.0` prioritizes TPOT.
- `0.5` balances TTFT and TPOT.
- `1.0` prioritizes TTFT.
- Invalid values preserve the existing plugin behavior by falling back to `0.5`.
- `go test ./pkg/kthena-router/...` passes.

**Does this PR introduce a user-facing change?**:

Yes. Invalid `TTFTTPOTWeightFactor` values now use the default value instead of producing out-of-range scheduler scores.

```release-note
Least-latency scheduler weight values are now validated and documented.