### PR TITLE
Make scheduler pod selection deterministic for equal scores

### DIFF
--- a/pkg/kthena-router/scheduler/scheduler_impl.go
+++ b/pkg/kthena-router/scheduler/scheduler_impl.go
@@ -273,7 +273,16 @@ func TopNPodInfos(m map[*datastore.PodInfo]int, n int) []*datastore.PodInfo {
 	}
 
 	sort.Slice(list, func(i, j int) bool {
-		return list[i].score > list[j].score
+		if list[i].score != list[j].score {
+			return list[i].score > list[j].score
+		}
+
+		left := list[i].pod.GetPodNamespacedName()
+		right := list[j].pod.GetPodNamespacedName()
+		if left.Namespace != right.Namespace {
+			return left.Namespace < right.Namespace
+		}
+		return left.Name < right.Name
 	})
 
 	res := []*datastore.PodInfo{}

--- a/pkg/kthena-router/scheduler/scheduler_impl_test.go
+++ b/pkg/kthena-router/scheduler/scheduler_impl_test.go
@@ -117,6 +117,33 @@ func TestTopNPodInfosOrdering(t *testing.T) {
 	assert.Equal(t, "pod1", result[2].Pod.Name)
 }
 
+// TestTopNPodInfosTieBreak verifies that equal-score pods are ordered by their
+// namespace and pod name instead of depending on Go map iteration order.
+func TestTopNPodInfosTieBreak(t *testing.T) {
+	podA := createTestPodInfo("pod-z")
+	podA.Pod.Namespace = "namespace-a"
+	podB := createTestPodInfo("pod-a")
+	podB.Pod.Namespace = "namespace-a"
+	podC := createTestPodInfo("pod-a")
+	podC.Pod.Namespace = "namespace-b"
+
+	scores := map[*datastore.PodInfo]int{
+		podA: 100,
+		podB: 100,
+		podC: 100,
+	}
+
+	result := TopNPodInfos(scores, 3)
+
+	require.Len(t, result, 3)
+	assert.Equal(t, "namespace-a", result[0].Pod.Namespace)
+	assert.Equal(t, "pod-a", result[0].Pod.Name)
+	assert.Equal(t, "namespace-a", result[1].Pod.Namespace)
+	assert.Equal(t, "pod-z", result[1].Pod.Name)
+	assert.Equal(t, "namespace-b", result[2].Pod.Namespace)
+	assert.Equal(t, "pod-a", result[2].Pod.Name)
+}
+
 // TestSchedulePDGroup uses table-driven tests to validate PD scheduling behavior.
 // It covers both graceful degradation (no prefill pods) and the happy path (valid prefill pod).
 func TestSchedulePDGroup(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement

**What this PR does / why we need it**:

`TopNPodInfos` previously sorted pods only by score. When multiple pods had equal scores, their order depended on Go map iteration, which is nondeterministic.

This PR adds deterministic tie-breaking using:

1. Namespace
2. Pod name

It also adds regression coverage for equal-score pods.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

- Score ordering remains unchanged.
- Equal-score pods are now ordered consistently by namespace and pod name.
- Verified with:

  ```bash
  go test ./pkg/kthena-router/...
  ```

**Does this PR introduce a user-facing change?**:

Yes. Requests now receive deterministic pod selection when multiple pods have equal scheduler scores.

```release-note
Scheduler pod selection is now deterministic for equal-score pods.
```