### PR TITLE
helm: support control-plane pod scheduling

### DIFF
--- a/charts/kthena/charts/networking/templates/kthena-router/component/deployment.yaml
+++ b/charts/kthena/charts/networking/templates/kthena-router/component/deployment.yaml
@@ -176,4 +176,20 @@ spec:
             optional: true
         {{- end }}
       serviceAccountName: kthena-router
+      {{- with .Values.kthenaRouter.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.kthenaRouter.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.kthenaRouter.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.kthenaRouter.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.kthenaRouter.terminationGracePeriodSeconds }}

--- a/charts/kthena/charts/networking/values.yaml
+++ b/charts/kthena/charts/networking/values.yaml
@@ -34,6 +34,14 @@ kthenaRouter:
     requests:
       cpu: 100m
       memory: 128Mi
+  # nodeSelector specifies node labels that the Kthena Router Pod must match.
+  nodeSelector: {}
+  # affinity specifies affinity and anti-affinity rules for the Kthena Router Pod.
+  affinity: {}
+  # tolerations specifies tolerations applied to the Kthena Router Pod.
+  tolerations: []
+  # topologySpreadConstraints specifies topology spread constraints for the Kthena Router Pod.
+  topologySpreadConstraints: []
   # -- The router will drain all in-flight requests before forcefully closing connections
   terminationGracePeriodSeconds: 330
   # -- Drain timeout for kthena-router graceful shutdown.

--- a/charts/kthena/charts/workload/templates/kthena-controller-manager/component/deployment.yaml
+++ b/charts/kthena/charts/workload/templates/kthena-controller-manager/component/deployment.yaml
@@ -78,3 +78,19 @@ spec:
             secretName: {{ .Values.controllerManager.webhook.tls.certSecretName }}
             optional: true
       serviceAccountName: kthena-controller-manager
+      {{- with .Values.controllerManager.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controllerManager.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controllerManager.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controllerManager.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/kthena/charts/workload/values.yaml
+++ b/charts/kthena/charts/workload/values.yaml
@@ -22,6 +22,14 @@ controllerManager:
     requests:
       cpu: 100m
       memory: 128Mi
+  # nodeSelector specifies node labels that the Controller Manager Pod must match.
+  nodeSelector: {}
+  # affinity specifies affinity and anti-affinity rules for the Controller Manager Pod.
+  affinity: {}
+  # tolerations specifies tolerations applied to the Controller Manager Pod.
+  tolerations: []
+  # topologySpreadConstraints specifies topology spread constraints for the Controller Manager Pod.
+  topologySpreadConstraints: []
   # controllers specifies which controllers to enable
   # Available options: modelserving, modelbooster, autoscaler
   # If empty or not specified, all controllers are enabled
@@ -54,4 +62,3 @@ controllerManager:
     accessKey: ""
     # secretKey is the secret key for the downloader.
     secretKey: ""
-

--- a/charts/kthena/values.schema.json
+++ b/charts/kthena/values.schema.json
@@ -1,6 +1,38 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
+  "definitions": {
+    "podScheduling": {
+      "type": "object",
+      "properties": {
+        "nodeSelector": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Node labels that the Pod must match."
+        },
+        "affinity": {
+          "type": "object",
+          "description": "Affinity and anti-affinity rules for the Pod."
+        },
+        "tolerations": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          },
+          "description": "Tolerations applied to the Pod."
+        },
+        "topologySpreadConstraints": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          },
+          "description": "Topology spread constraints for the Pod."
+        }
+      }
+    }
+  },
   "properties": {
     "global": {
       "type": "object",
@@ -21,6 +53,22 @@
         }
       },
       "required": ["certManagementMode"]
+    },
+    "networking": {
+      "type": "object",
+      "properties": {
+        "kthenaRouter": {
+          "$ref": "#/definitions/podScheduling"
+        }
+      }
+    },
+    "workload": {
+      "type": "object",
+      "properties": {
+        "controllerManager": {
+          "$ref": "#/definitions/podScheduling"
+        }
+      }
     }
   }
 }

--- a/charts/kthena/values.yaml
+++ b/charts/kthena/values.yaml
@@ -14,6 +14,14 @@ workload:
     # -- Reconcile interval in seconds for the autoscaler. Smaller values react
     # faster to traffic spikes but increase API server load. 0 uses the binary default (15).
     autoscalingSyncPeriodSeconds: 0
+    # -- Node labels that the Controller Manager Pod must match.
+    nodeSelector: {}
+    # -- Affinity and anti-affinity rules for the Controller Manager Pod.
+    affinity: {}
+    # -- Tolerations applied to the Controller Manager Pod.
+    tolerations: []
+    # -- Topology spread constraints for the Controller Manager Pod.
+    topologySpreadConstraints: []
     downloaderImage:
       # -- Image repository for the Downloader.
       repository: ghcr.io/volcano-sh/downloader
@@ -50,6 +58,14 @@ networking:
       tag: latest
       # -- Image pull policy for Kthena Router.
       pullPolicy: IfNotPresent
+    # -- Node labels that the Kthena Router Pod must match.
+    nodeSelector: {}
+    # -- Affinity and anti-affinity rules for the Kthena Router Pod.
+    affinity: {}
+    # -- Tolerations applied to the Kthena Router Pod.
+    tolerations: []
+    # -- Topology spread constraints for the Kthena Router Pod.
+    topologySpreadConstraints: []
     tls:
       # -- Enable TLS for Kthena Router server.
       enabled: false

--- a/docs/kthena/docs/getting-started/installation.md
+++ b/docs/kthena/docs/getting-started/installation.md
@@ -85,6 +85,72 @@ helm install kthena oci://ghcr.io/volcano-sh/charts/kthena \
   --set networking.kthenaRouter.tls.enabled=true
 ```
 
+### Control-plane Pod Scheduling
+
+The router and controller manager can be scheduled independently by configuring
+standard Kubernetes Pod scheduling fields. For example, the following values
+place both components on dedicated control-plane nodes while spreading replicas
+across zones and hosts:
+
+```yaml
+workload:
+  controllerManager:
+    nodeSelector:
+      node-role.kubernetes.io/control-plane: ""
+    tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: kthena-controller-manager
+                  app.kubernetes.io/instance: kthena
+              topologyKey: kubernetes.io/hostname
+    topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/component: kthena-controller-manager
+            app.kubernetes.io/instance: kthena
+
+networking:
+  kthenaRouter:
+    nodeSelector:
+      node-role.kubernetes.io/control-plane: ""
+    tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: kthena-router
+                  app.kubernetes.io/instance: kthena
+              topologyKey: kubernetes.io/hostname
+    topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/component: kthena-router
+            app.kubernetes.io/instance: kthena
+```
+
+Node taints are managed by the cluster administrator. The Helm chart configures
+the matching Pod-side `tolerations`; it does not add or remove taints on nodes.
+
 ### Common Configuration Parameters
 
 | Parameter                             | Description                                                    | Default |

--- a/docs/kthena/docs/reference/helm-chart-values.md
+++ b/docs/kthena/docs/reference/helm-chart-values.md
@@ -18,6 +18,7 @@ A Helm chart for deploying Kthena
 | global.certManagementMode | string | `"auto"` | Certificate Management Mode.<br/>  Three mutually exclusive options for managing TLS certificates:<br/>  - `auto`: Webhook servers generate self-signed certificates automatically.<br/>  - `cert-manager`: Use cert-manager to generate and manage certificates (requires cert-manager installation).<br/>  - `manual`: Provide your own certificates via caBundle. |
 | global.webhook.caBundle | string | `""` | CA bundle for webhook server certificates (base64-encoded).<br/> This is ONLY required when `certManagementMode` is set to "manual".<br/> You can generate it with: `cat /path/to/your/ca.crt | base64 | tr -d '\n'`<br/> |
 | networking.enabled | bool | `true` | Enable the networking subchart. |
+| networking.kthenaRouter.affinity | object | `{}` | Affinity and anti-affinity rules for the Kthena Router Pod. |
 | networking.kthenaRouter.debugPort | int | `15000` | Debug server port for Kthena Router (localhost only). |
 | networking.kthenaRouter.drainTimeout | string | `"5m"` | This should be less than terminationGracePeriodSeconds. |
 | networking.kthenaRouter.enabled | bool | `true` | Enable Kthena Router. |
@@ -31,6 +32,7 @@ A Helm chart for deploying Kthena
 | networking.kthenaRouter.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy for Kthena Router. |
 | networking.kthenaRouter.image.repository | string | `"ghcr.io/volcano-sh/kthena-router"` | Image repository for Kthena Router. |
 | networking.kthenaRouter.image.tag | string | `"latest"` | Image tag for Kthena Router. |
+| networking.kthenaRouter.nodeSelector | object | `{}` | Node labels that the Kthena Router Pod must match. |
 | networking.kthenaRouter.port | int | `8080` | Container port for Kthena Router. |
 | networking.kthenaRouter.sessionBoost.enabled | bool | `false` | Enable session-boost scheduling. Mutually exclusive with fairness. |
 | networking.kthenaRouter.sessionBoost.gracePeriod | string | `"0s"` | Wait time after a request completes for a same-session follow-up.<br/> Disabled by default (`0s`). |
@@ -42,12 +44,15 @@ A Helm chart for deploying Kthena
 | networking.kthenaRouter.tls.dnsName | string | `"your-domain.com"` | DNS name to use for the certificate. |
 | networking.kthenaRouter.tls.enabled | bool | `false` | Enable TLS for Kthena Router server. |
 | networking.kthenaRouter.tls.secretName | string | `"kthena-router-tls"` | Secret name to store the certificate and key. |
+| networking.kthenaRouter.tolerations | list | `[]` | Tolerations applied to the Kthena Router Pod. |
+| networking.kthenaRouter.topologySpreadConstraints | list | `[]` | Topology spread constraints for the Kthena Router Pod. |
 | networking.kthenaRouter.webhook.enabled | bool | `true` | Enable webhook for Kthena Router. |
 | networking.kthenaRouter.webhook.port | int | `8443` | Container port for Kthena Router webhook. |
 | networking.kthenaRouter.webhook.servicePort | int | `443` | Service port for Kthena Router webhook. |
 | networking.kthenaRouter.webhook.tls.certFile | string | `"/etc/tls/tls.crt"` | Certificate file path for the webhook. |
 | networking.kthenaRouter.webhook.tls.keyFile | string | `"/etc/tls/tls.key"` | Key file path for the webhook. |
 | networking.kthenaRouter.webhook.tls.secretName | string | `"kthena-router-webhook-certs"` | Secret name for storing webhook certificates. |
+| workload.controllerManager.affinity | object | `{}` | Affinity and anti-affinity rules for the Controller Manager Pod. |
 | workload.controllerManager.autoscalingSyncPeriodSeconds | int | `0` | Reconcile interval in seconds for the autoscaler. Smaller values react faster to traffic spikes but increase API server load. 0 uses the binary default (15). |
 | workload.controllerManager.debugPort | int | `0` | Debug server port for Controller Manager (set 0 to disable). |
 | workload.controllerManager.downloaderImage.repository | string | `"ghcr.io/volcano-sh/downloader"` | Image repository for the Downloader. |
@@ -55,8 +60,11 @@ A Helm chart for deploying Kthena
 | workload.controllerManager.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy for the Controller Manager. |
 | workload.controllerManager.image.repository | string | `"ghcr.io/volcano-sh/kthena-controller-manager"` | Image repository for the Controller Manager. |
 | workload.controllerManager.image.tag | string | `"latest"` | Image tag for the Controller Manager. |
+| workload.controllerManager.nodeSelector | object | `{}` | Node labels that the Controller Manager Pod must match. |
 | workload.controllerManager.runtimeImage.repository | string | `"ghcr.io/volcano-sh/runtime"` | Image repository for the Runtime. |
 | workload.controllerManager.runtimeImage.tag | string | `"latest"` | Image tag for the Runtime. |
+| workload.controllerManager.tolerations | list | `[]` | Tolerations applied to the Controller Manager Pod. |
+| workload.controllerManager.topologySpreadConstraints | list | `[]` | Topology spread constraints for the Controller Manager Pod. |
 | workload.controllerManager.webhook.enabled | bool | `true` | Enable webhook for the Controller Manager. |
 | workload.controllerManager.webhook.tls.certSecretName | string | `"kthena-controller-manager-webhook-certs"` | Secret name for storing webhook certificates. |
 | workload.controllerManager.webhook.tls.serviceName | string | `"kthena-controller-manager-webhook"` | Service name for the webhook. |


### PR DESCRIPTION
/kind enhancement

**What this PR does / why we need it**:

The Kthena Helm chart currently does not expose standard Pod scheduling settings for the `kthena-router` and `kthena-controller-manager` Deployments.

This change:

- adds component-scoped `nodeSelector`, `affinity`, `tolerations`, and `topologySpreadConstraints` values for both Deployments
- renders only non-empty scheduling values, keeping the default manifests unchanged
- validates the new value types in the parent chart schema without rejecting unrelated values
- documents the new settings and provides a complete control-plane scheduling example

**Which issue(s) this PR fixes**:

NONE

**Special notes for your reviewer**:

- Node taints remain managed by the cluster administrator; the chart configures the corresponding Pod tolerations.
- Default full-chart, router Deployment, and controller-manager Deployment render hashes remain unchanged.
- AI-assisted tooling was used during implementation; the submitted changes were reviewed and validated by the submitter.

Validation performed:

- `helm lint charts/kthena`
- `make gen-check`
- `make test-docs`
- all non-E2E and non-client-go Go packages via `go test`
- golangci-lint v1.64.8 built with the repository's Go 1.26 toolchain
- strict kubeconform validation for default and configured renders
- positive, isolation, subchart-disable, and invalid-schema Helm render scenarios

The local `make test` coverage wrapper could not complete because the installed Go 1.26 toolchain is missing `covdata`; the same package set passes without `-coverprofile`.

**Does this PR introduce a user-facing change?**:

```release-note
Add Helm values for configuring node selectors, affinity, tolerations, and topology spread constraints on the Kthena router and controller manager.
```
