### PR TITLE
Fix router metrics for unknown models

### DIFF
--- a/pkg/kthena-router/datastore/store.go
+++ b/pkg/kthena-router/datastore/store.go
@@ -275,6 +275,8 @@ type Store interface {
 	// GetModelNames returns all model names registered via ModelRoutes,
 	// including both base model names and LoRA adapter names.
 	GetModelNames() []string
+	// HasModel reports whether a base model or LoRA adapter is registered.
+	HasModel(name string) bool
 
 	// Debug interface methods
 	GetAllModelRoutes() map[string]*aiv1alpha1.ModelRoute
@@ -1954,6 +1956,18 @@ func (s *store) GetModelNames() []string {
 	}
 	sort.Strings(names)
 	return names
+}
+
+// HasModel reports whether a base model or LoRA adapter is registered.
+func (s *store) HasModel(name string) bool {
+	s.routeMutex.RLock()
+	defer s.routeMutex.RUnlock()
+
+	if _, exists := s.routes[name]; exists {
+		return true
+	}
+	_, exists := s.loraRoutes[name]
+	return exists
 }
 
 // GetAllModelServers returns all ModelServers in the store

--- a/pkg/kthena-router/debug/handlers_test.go
+++ b/pkg/kthena-router/debug/handlers_test.go
@@ -333,6 +333,11 @@ func (m *MockStore) GetModelNames() []string {
 	return args.Get(0).([]string)
 }
 
+func (m *MockStore) HasModel(name string) bool {
+	args := m.Called(name)
+	return args.Bool(0)
+}
+
 func (m *MockStore) SyncOnFlightCounts() {}
 
 func (m *MockStore) IncrPodOnFlightRequests(podName types.NamespacedName) {}

--- a/pkg/kthena-router/metrics/metrics.go
+++ b/pkg/kthena-router/metrics/metrics.go
@@ -40,6 +40,8 @@ const (
 	LabelUserID      = "user_id"
 	LabelStage       = "stage"
 
+	UnknownModel = "unknown"
+
 	// kvcache-aware error stage values
 	StageTokenize = "tokenize"
 	StageRedis    = "redis"

--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -279,13 +279,21 @@ func (r *Router) HandlerFunc() gin.HandlerFunc {
 
 		// Create metrics recorder for this request
 		path := c.Request.URL.Path
-		metricsRecorder := metrics.NewRequestMetricsRecorder(r.metrics, modelName, path)
+		metricsModel := modelName
+		var gatewayKey string
+		if key, exists := c.Get(GatewayKey); exists {
+			if k, ok := key.(string); ok {
+				gatewayKey = k
+			}
+		}
+		if _, _, _, err := r.store.MatchModelServer(modelName, c.Request, gatewayKey); err != nil {
+			if _, matched := r.findHTTPRouteMatch(c, gatewayKey); !matched {
+				metricsModel = metrics.UnknownModel
+			}
+		}
+		metricsRecorder := metrics.NewRequestMetricsRecorder(r.metrics, metricsModel, path)
 
-		// Increment downstream request count at request start
-		r.metrics.IncActiveDownstreamRequests(modelName)
 		defer func() {
-			// Decrement downstream request count when request completes
-			r.metrics.DecActiveDownstreamRequests(modelName)
 			if metricsRecorder != nil {
 				statusCode := strconv.Itoa(c.Writer.Status())
 				reason := "successful_request"
@@ -316,12 +324,10 @@ func (r *Router) HandlerFunc() gin.HandlerFunc {
 
 		// Calculate and set input tokens for access log
 		accesslog.SetTokenCounts(c, inputTokens, 0)
+		metricsRecorder.RecordInputTokens(inputTokens)
 
 		// Mark end of request processing phase
 		accesslog.MarkRequestProcessingEnd(c)
-
-		// Record input tokens immediately
-		metricsRecorder.RecordInputTokens(inputTokens)
 
 		// Apply rate limiting using the unified rate limiter
 		if err := r.loadRateLimiter.RateLimit(modelName, promptStr); err != nil {
@@ -358,6 +364,8 @@ func (r *Router) HandlerFunc() gin.HandlerFunc {
 
 		// Store metrics recorder in context for use in other functions
 		c.Set("metricsRecorder", metricsRecorder)
+		r.metrics.IncActiveDownstreamRequests(metricsModel)
+		defer r.metrics.DecActiveDownstreamRequests(metricsModel)
 
 		// step 3.1: direct load balancing when neither fairness scheduling nor
 		// session boost is enabled.
@@ -460,6 +468,7 @@ func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest) error 
 	} else {
 		accesslog.SetError(c, "route_not_found", "route not found")
 		c.AbortWithStatusJSON(http.StatusNotFound, "route not found")
+		c.Set("finishReason", "route_not_found")
 		return fmt.Errorf("route not found")
 	}
 

--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -279,21 +279,17 @@ func (r *Router) HandlerFunc() gin.HandlerFunc {
 
 		// Create metrics recorder for this request
 		path := c.Request.URL.Path
-		metricsModel := modelName
-		var gatewayKey string
-		if key, exists := c.Get(GatewayKey); exists {
-			if k, ok := key.(string); ok {
-				gatewayKey = k
-			}
-		}
-		if _, _, _, err := r.store.MatchModelServer(modelName, c.Request, gatewayKey); err != nil {
-			if _, matched := r.findHTTPRouteMatch(c, gatewayKey); !matched {
-				metricsModel = metrics.UnknownModel
-			}
+		metricsModel := metrics.UnknownModel
+		if r.store.HasModel(modelName) {
+			metricsModel = modelName
 		}
 		metricsRecorder := metrics.NewRequestMetricsRecorder(r.metrics, metricsModel, path)
 
+		// Increment downstream request count at request start
+		r.metrics.IncActiveDownstreamRequests(metricsModel)
 		defer func() {
+			// Decrement downstream request count when request completes
+			r.metrics.DecActiveDownstreamRequests(metricsModel)
 			if metricsRecorder != nil {
 				statusCode := strconv.Itoa(c.Writer.Status())
 				reason := "successful_request"
@@ -324,10 +320,12 @@ func (r *Router) HandlerFunc() gin.HandlerFunc {
 
 		// Calculate and set input tokens for access log
 		accesslog.SetTokenCounts(c, inputTokens, 0)
-		metricsRecorder.RecordInputTokens(inputTokens)
 
 		// Mark end of request processing phase
 		accesslog.MarkRequestProcessingEnd(c)
+
+		// Record input tokens immediately
+		metricsRecorder.RecordInputTokens(inputTokens)
 
 		// Apply rate limiting using the unified rate limiter
 		if err := r.loadRateLimiter.RateLimit(modelName, promptStr); err != nil {
@@ -364,8 +362,6 @@ func (r *Router) HandlerFunc() gin.HandlerFunc {
 
 		// Store metrics recorder in context for use in other functions
 		c.Set("metricsRecorder", metricsRecorder)
-		r.metrics.IncActiveDownstreamRequests(metricsModel)
-		defer r.metrics.DecActiveDownstreamRequests(metricsModel)
 
 		// step 3.1: direct load balancing when neither fairness scheduling nor
 		// session boost is enabled.

--- a/pkg/kthena-router/router/router_test.go
+++ b/pkg/kthena-router/router/router_test.go
@@ -28,10 +28,12 @@ import (
 	"net/url"
 	"os"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"istio.io/istio/pkg/util/sets"
 	corev1 "k8s.io/api/core/v1"
@@ -847,6 +849,92 @@ func TestRouter_HandlerFunc_ModelNotFound(t *testing.T) {
 
 	assert.Equal(t, http.StatusNotFound, w.Code)
 	assert.Contains(t, w.Body.String(), "route not found")
+}
+
+func metricModelCount(t *testing.T, name, prefix string) int {
+	t.Helper()
+
+	families, err := prometheus.DefaultGatherer.Gather()
+	assert.NoError(t, err)
+
+	count := 0
+	for _, family := range families {
+		if family.GetName() != name {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			for _, label := range metric.GetLabel() {
+				if label.GetName() == metrics.LabelModel && strings.HasPrefix(label.GetValue(), prefix) {
+					count++
+				}
+			}
+		}
+	}
+	return count
+}
+
+func requestCounterValue(t *testing.T, labels map[string]string) float64 {
+	t.Helper()
+
+	families, err := prometheus.DefaultGatherer.Gather()
+	assert.NoError(t, err)
+
+	for _, family := range families {
+		if family.GetName() != "kthena_router_requests_total" {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			matched := true
+			for name, value := range labels {
+				found := false
+				for _, label := range metric.GetLabel() {
+					if label.GetName() == name && label.GetValue() == value {
+						found = true
+						break
+					}
+				}
+				if !found {
+					matched = false
+					break
+				}
+			}
+			if matched {
+				return metric.GetCounter().GetValue()
+			}
+		}
+	}
+	return 0
+}
+
+func TestRouter_HandlerFunc_UnknownModelMetricsUseBoundedLabel(t *testing.T) {
+	router, _, backend := setupTestRouter(t, nil)
+	defer backend.Close()
+
+	prefix := "cardinality-proof-test-"
+	requestLabels := map[string]string{
+		metrics.LabelModel:      metrics.UnknownModel,
+		metrics.LabelPath:       "/v1/chat/completions",
+		metrics.LabelStatusCode: "404",
+		metrics.LabelErrorType:  "route_not_found",
+	}
+	requestsBefore := requestCounterValue(t, requestLabels)
+
+	for i := 0; i < 3; i++ {
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		reqBody := fmt.Sprintf(`{"model":"%s%d","prompt":"hello"}`, prefix, i)
+		c.Request, _ = http.NewRequest("POST", "/v1/chat/completions", bytes.NewBufferString(reqBody))
+		c.Request.Header.Set("Content-Type", "application/json")
+
+		router.HandlerFunc()(c)
+
+		assert.Equal(t, http.StatusNotFound, w.Code)
+		assert.Contains(t, w.Body.String(), "route not found")
+	}
+
+	assert.Equal(t, 0, metricModelCount(t, "kthena_router_requests_total", prefix))
+	assert.Equal(t, 0, metricModelCount(t, "kthena_router_active_downstream_requests", prefix))
+	assert.Equal(t, float64(3), requestCounterValue(t, requestLabels)-requestsBefore)
 }
 
 func TestRouter_HandlerFunc_ScheduleFailure(t *testing.T) {

--- a/pkg/kthena-router/router/router_test.go
+++ b/pkg/kthena-router/router/router_test.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"istio.io/istio/pkg/util/sets"
 	corev1 "k8s.io/api/core/v1"
@@ -720,6 +721,7 @@ func TestRouter_HandlerFunc_AggregatedMode(t *testing.T) {
 	reqBody := `{"model": "test-model", "prompt": "hello"}`
 	c.Request, _ = http.NewRequest("POST", "/v1/chat/completions", bytes.NewBufferString(reqBody))
 	c.Request.Header.Set("Content-Type", "application/json")
+	requestsBefore := requestCounterValue(t, router, "test-model", "/v1/chat/completions", "200", "successful_request")
 
 	// 4. Execute handler
 	router.HandlerFunc()(c)
@@ -727,6 +729,7 @@ func TestRouter_HandlerFunc_AggregatedMode(t *testing.T) {
 	// 5. Assertions
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Contains(t, w.Body.String(), `"id":"response-id"`)
+	assert.Equal(t, float64(1), requestCounterValue(t, router, "test-model", "/v1/chat/completions", "200", "successful_request")-requestsBefore)
 }
 
 func TestRouter_HandlerFunc_DisaggregatedMode(t *testing.T) {
@@ -851,17 +854,16 @@ func TestRouter_HandlerFunc_ModelNotFound(t *testing.T) {
 	assert.Contains(t, w.Body.String(), "route not found")
 }
 
-func metricModelCount(t *testing.T, name, prefix string) int {
+func countMetricsWithModelPrefix(t *testing.T, prefix string) int {
 	t.Helper()
 
 	families, err := prometheus.DefaultGatherer.Gather()
-	assert.NoError(t, err)
+	if err != nil {
+		t.Fatalf("Gather: %v", err)
+	}
 
 	count := 0
 	for _, family := range families {
-		if family.GetName() != name {
-			continue
-		}
 		for _, metric := range family.GetMetric() {
 			for _, label := range metric.GetLabel() {
 				if label.GetName() == metrics.LabelModel && strings.HasPrefix(label.GetValue(), prefix) {
@@ -873,37 +875,18 @@ func metricModelCount(t *testing.T, name, prefix string) int {
 	return count
 }
 
-func requestCounterValue(t *testing.T, labels map[string]string) float64 {
+func requestCounterValue(t *testing.T, router *Router, model, path, statusCode, errorType string) float64 {
 	t.Helper()
 
-	families, err := prometheus.DefaultGatherer.Gather()
-	assert.NoError(t, err)
-
-	for _, family := range families {
-		if family.GetName() != "kthena_router_requests_total" {
-			continue
-		}
-		for _, metric := range family.GetMetric() {
-			matched := true
-			for name, value := range labels {
-				found := false
-				for _, label := range metric.GetLabel() {
-					if label.GetName() == name && label.GetValue() == value {
-						found = true
-						break
-					}
-				}
-				if !found {
-					matched = false
-					break
-				}
-			}
-			if matched {
-				return metric.GetCounter().GetValue()
-			}
-		}
+	counter, err := router.metrics.RequestsTotal.GetMetricWithLabelValues(model, path, statusCode, errorType)
+	if err != nil {
+		t.Fatalf("GetMetricWithLabelValues: %v", err)
 	}
-	return 0
+	metric := &dto.Metric{}
+	if err := counter.Write(metric); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	return metric.GetCounter().GetValue()
 }
 
 func TestRouter_HandlerFunc_UnknownModelMetricsUseBoundedLabel(t *testing.T) {
@@ -911,13 +894,7 @@ func TestRouter_HandlerFunc_UnknownModelMetricsUseBoundedLabel(t *testing.T) {
 	defer backend.Close()
 
 	prefix := "cardinality-proof-test-"
-	requestLabels := map[string]string{
-		metrics.LabelModel:      metrics.UnknownModel,
-		metrics.LabelPath:       "/v1/chat/completions",
-		metrics.LabelStatusCode: "404",
-		metrics.LabelErrorType:  "route_not_found",
-	}
-	requestsBefore := requestCounterValue(t, requestLabels)
+	requestsBefore := requestCounterValue(t, router, metrics.UnknownModel, "/v1/chat/completions", "404", "route_not_found")
 
 	for i := 0; i < 3; i++ {
 		w := httptest.NewRecorder()
@@ -932,9 +909,8 @@ func TestRouter_HandlerFunc_UnknownModelMetricsUseBoundedLabel(t *testing.T) {
 		assert.Contains(t, w.Body.String(), "route not found")
 	}
 
-	assert.Equal(t, 0, metricModelCount(t, "kthena_router_requests_total", prefix))
-	assert.Equal(t, 0, metricModelCount(t, "kthena_router_active_downstream_requests", prefix))
-	assert.Equal(t, float64(3), requestCounterValue(t, requestLabels)-requestsBefore)
+	assert.Equal(t, 0, countMetricsWithModelPrefix(t, prefix))
+	assert.Equal(t, float64(3), requestCounterValue(t, router, metrics.UnknownModel, "/v1/chat/completions", "404", "route_not_found")-requestsBefore)
 }
 
 func TestRouter_HandlerFunc_ScheduleFailure(t *testing.T) {

--- a/test/e2e/router/shared.go
+++ b/test/e2e/router/shared.go
@@ -34,6 +34,7 @@ import (
 	workloadv1alpha1 "github.com/volcano-sh/kthena/pkg/apis/workload/v1alpha1"
 	backendmetrics "github.com/volcano-sh/kthena/pkg/kthena-router/backend/metrics"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/backend/sglang"
+	routermetrics "github.com/volcano-sh/kthena/pkg/kthena-router/metrics"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/scheduler/plugins"
 	routerutils "github.com/volcano-sh/kthena/pkg/kthena-router/utils"
 	routercontext "github.com/volcano-sh/kthena/test/e2e/router/context"
@@ -1517,7 +1518,8 @@ func TestMetricsShared(t *testing.T, testCtx *routercontext.RouterTestContext, t
 	t.Run("VerifyErrorMetrics", func(t *testing.T) {
 		nonExistentModel := "non-existent-model-xyz"
 		labels := map[string]string{
-			"model":       nonExistentModel,
+			"error_type":  "route_not_found",
+			"model":       routermetrics.UnknownModel,
 			"status_code": "404",
 		}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Prevents router metrics from using the request-provided model name before route validation.

Unknown model requests are now recorded under `model="unknown"` instead of creating one Prometheus series per user-provided model value. Route misses also set `error_type="route_not_found"` instead of keeping the default `successful_request`.

**Which issue(s) this PR fixes**:
Fixes #1378

**Special notes for your reviewer**:

I verified with Prometheus scraping the router in a local Docker Desktop Kubernetes cluster.

Before fix, 100 requests with unique unknown model names returned 404 and created raw model-labeled router series:


```
baseline samples: 47
samples after load: 1947
growth: 1900
raw model prefix samples: 1900
active_downstream raw model series: 100
404 requests labeled successful_request: 100
Prometheus raw model series: 1900
```

After fix, the same 100 requests returned 404 without creating raw model labels:
```
baseline samples: 47
samples after load: 64
growth: 17
raw model prefix samples: 0
unknown route_not_found request series: 1
successful_request 404 series: 0
Prometheus raw model series: 0
Prometheus unknown route_not_found count: 100
```
**Does this PR introduce a user-facing change?**:

```release-note
Router metrics now use a bounded `unknown` model label for unknown model route misses.
404 route misses are reported as `route_not_found`.