### PR TITLE
fix: validate modelroute target entries and guard nil targets

### DIFF
--- a/pkg/kthena-router/datastore/store.go
+++ b/pkg/kthena-router/datastore/store.go
@@ -1469,6 +1469,12 @@ func (s *store) selectDestination(targets []*aiv1alpha1.TargetModel) (*aiv1alpha
 }
 
 func toWeightedSlice(targets []*aiv1alpha1.TargetModel) ([]uint32, error) {
+	if len(targets) == 0 {
+		return nil, fmt.Errorf("no target models specified")
+	}
+	if targets[0] == nil {
+		return nil, fmt.Errorf("target model cannot be nil")
+	}
 	var isWeighted bool
 	if targets[0].Weight != nil {
 		isWeighted = true
@@ -1477,6 +1483,9 @@ func toWeightedSlice(targets []*aiv1alpha1.TargetModel) ([]uint32, error) {
 	res := make([]uint32, len(targets))
 
 	for i, target := range targets {
+		if target == nil {
+			return nil, fmt.Errorf("target model cannot be nil")
+		}
 		if (isWeighted && target.Weight == nil) || (!isWeighted && target.Weight != nil) {
 			return nil, fmt.Errorf("the weight field in targetModel must be either fully specified or not specified")
 		}

--- a/pkg/kthena-router/datastore/store_test.go
+++ b/pkg/kthena-router/datastore/store_test.go
@@ -1935,6 +1935,15 @@ func TestToWeightedSlice_MixedWeights(t *testing.T) {
 	assert.Contains(t, err.Error(), "weight field in targetModel must be either fully specified or not specified")
 }
 
+func TestToWeightedSlice_NilTarget(t *testing.T) {
+	targets := []*aiv1alpha1.TargetModel{
+		nil,
+	}
+	_, err := toWeightedSlice(targets)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "target model cannot be nil")
+}
+
 func TestSelectFromWeightedSlice_EmptyWeights(t *testing.T) {
 	_, err := selectFromWeightedSlice([]uint32{})
 	assert.Error(t, err)

--- a/pkg/kthena-router/webhook/validator.go
+++ b/pkg/kthena-router/webhook/validator.go
@@ -183,8 +183,14 @@ func (v *KthenaRouterValidator) validateModelRoute(modelRoute *networkingv1alpha
 			continue
 		}
 		totalWeight := uint32(0)
+		hasValidTarget := false
 		for j, targetModel := range rule.TargetModels {
 			targetModelField := ruleField.Child("targetModels").Index(j)
+			if targetModel == nil {
+				allErrs = append(allErrs, field.Invalid(targetModelField, targetModel, "target model must not be nil"))
+				continue
+			}
+			hasValidTarget = true
 			if targetModel.ModelServerName == "" {
 				allErrs = append(allErrs, field.Invalid(targetModelField.Child("modelServerName"), targetModel.ModelServerName, "modelServerName cannot be an empty string"))
 			}
@@ -194,7 +200,7 @@ func (v *KthenaRouterValidator) validateModelRoute(modelRoute *networkingv1alpha
 				totalWeight += 100
 			}
 		}
-		if totalWeight == 0 {
+		if hasValidTarget && totalWeight == 0 {
 			allErrs = append(allErrs, field.Invalid(ruleField.Child("targetModels"), totalWeight, "total weight must be greater than zero"))
 		}
 		if rule.ModelMatch != nil {

--- a/pkg/kthena-router/webhook/validator_test.go
+++ b/pkg/kthena-router/webhook/validator_test.go
@@ -476,6 +476,32 @@ func TestValidateModelRoute(t *testing.T) {
 			expectedReason: "validation failed:\n  - spec.rules[0]: Invalid value: null: rule must not be nil",
 		},
 		{
+			name: "invalid model route - nil targetModel in targetModels",
+			modelRoute: &networkingv1alpha1.ModelRoute{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "networking.serving.volcano.sh/v1alpha1",
+					Kind:       "ModelRoute",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "default",
+				},
+				Spec: networkingv1alpha1.ModelRouteSpec{
+					ModelName: "test-model",
+					Rules: []*networkingv1alpha1.Rule{
+						{
+							Name: "test-rule",
+							TargetModels: []*networkingv1alpha1.TargetModel{
+								nil,
+							},
+						},
+					},
+				},
+			},
+			expectValid:    false,
+			expectedReason: "validation failed:\n  - spec.rules[0].targetModels[0]: Invalid value: null: target model must not be nil",
+		},
+		{
 			name: "invalid model route - combined errors: missing model name and empty targetModels",
 			modelRoute: &networkingv1alpha1.ModelRoute{
 				TypeMeta: metav1.TypeMeta{


### PR DESCRIPTION
## Summary
ModelRoute validation accepted targetModels entries with an empty modelServerName and did not explicitly reject nil target entries.

This change:
- Rejects nil targetModels entries in the validating webhook
- Rejects empty modelServerName in targetModels
- Adds datastore runtime guards against nil target entries in toWeightedSlice
- Adds unit tests covering nil target model validation and datastore destination selection

Fixes #1060

## Test Plan
- [x] Unit tests added in pkg/kthena-router/webhook/validator_test.go
- [x] Unit tests added in pkg/kthena-router/datastore/store_test.go
- [x] Ran go test ./pkg/kthena-router/... successfully