### PR TITLE
Autoscaler: preserve ready pod metrics during mixed readiness

### DIFF
--- a/pkg/autoscaler/autoscaler/metric_collector.go
+++ b/pkg/autoscaler/autoscaler/metric_collector.go
@@ -110,14 +110,16 @@ func (collector *MetricCollector) UpdateMetrics(
 		pastHistograms = make(map[string]HistogramInfo)
 	}
 	currentHistograms := make(map[string]HistogramInfo)
+	unreadyPods := make(map[string]struct{})
 
 	// Group pod metrics by identical PodMetricSource (uri/port/selector) so we
-	// scrape each pod endpoint once per reconcile and extract every required
-	// metric from the same payload. Prometheus-sourced metrics stay per-metric.
+	// scrape each ready pod endpoint once per reconcile and extract every
+	// required metric from the same payload. Prometheus-sourced metrics stay
+	// per-metric.
 	podGroups, externalMetrics := collector.planMetricSources(ctx, targetMetricSources)
 
 	for _, g := range podGroups {
-		values, anyUnready, failed, collectErr := collector.collectPodMetricsGroup(ctx, podLister, g.podSource, g.specs, pastHistograms, currentHistograms)
+		values, groupUnreadyPods, failed, collectErr := collector.collectPodMetricsGroup(ctx, podLister, g.podSource, g.specs, pastHistograms, currentHistograms)
 		if collectErr != nil {
 			klog.Warningf("collect pod metrics for target %s failed: %v", collector.Target.TargetRef.Name, collectErr)
 			continue
@@ -126,15 +128,15 @@ func (collector *MetricCollector) UpdateMetrics(
 			klog.Warningf("collect pod metrics for target %s skipped because pod failed/restarted", collector.Target.TargetRef.Name)
 			continue
 		}
-		if anyUnready {
-			unreadyInstancesCount = 1
-			continue
+		for podKey := range groupUnreadyPods {
+			unreadyPods[podKey] = struct{}{}
 		}
 		for policyKey, v := range values {
 			readyInstancesMetric[policyKey] = v
 		}
 	}
 
+	unreadyInstancesCount = int32(len(unreadyPods))
 	collector.PastHistograms.Append(currentHistograms)
 	return
 }
@@ -223,8 +225,8 @@ func podMetricGroupKey(s *v1alpha1.PodMetricSource) string {
 	return fmt.Sprintf("%s|%d|%s", s.Uri, s.Port, metav1.FormatLabelSelector(s.LabelSelector))
 }
 
-// collectPodMetricsGroup scrapes each pod in the target group exactly once
-// and extracts every metric required by specs from the same payload.
+// collectPodMetricsGroup scrapes each ready pod in the target group exactly
+// once and extracts every metric required by specs from the same payload.
 func (collector *MetricCollector) collectPodMetricsGroup(
 	ctx context.Context,
 	podLister listerv1.PodLister,
@@ -232,18 +234,18 @@ func (collector *MetricCollector) collectPodMetricsGroup(
 	specs []podMetricSpec,
 	pastHistograms map[string]HistogramInfo,
 	currentHistograms map[string]HistogramInfo,
-) (values map[string]float64, anyUnready bool, failed bool, err error) {
+) (values map[string]float64, unreadyPods map[string]struct{}, failed bool, err error) {
 	values = make(map[string]float64, len(specs))
 	pods, err := util.GetMetricPods(podLister, collector.Scope.Namespace, collector.Target, podSource)
 	if err != nil {
-		return nil, false, false, err
+		return nil, nil, false, err
 	}
 	if len(pods) == 0 {
-		return nil, false, false, fmt.Errorf("pod list is empty")
+		return nil, nil, false, fmt.Errorf("pod list is empty")
 	}
 
-	anyUnready, failed = evaluatePodsReadiness(pods)
-	if failed || anyUnready {
+	unreadyPods, failed = evaluatePodsReadiness(pods)
+	if failed {
 		return
 	}
 
@@ -251,25 +253,35 @@ func (collector *MetricCollector) collectPodMetricsGroup(
 	wanted := groupPolicyKeysByScrapeName(specs)
 
 	for _, pod := range pods {
+		if !inferControllerUtils.IsPodRunningAndReady(pod) {
+			continue
+		}
 		if err = collector.collectPodMetrics(ctx, pod, podSource, wanted, values, pastHistograms, currentHistograms); err != nil {
-			return nil, false, false, err
+			return nil, nil, false, err
 		}
 	}
 	return
 }
 
-// evaluatePodsReadiness reports whether any pod is not ready and whether any pod
-// has failed or restarted.
-func evaluatePodsReadiness(pods []*corev1.Pod) (anyUnready, failed bool) {
+// evaluatePodsReadiness counts pods that are not ready and reports whether any
+// pod has failed or restarted.
+func evaluatePodsReadiness(pods []*corev1.Pod) (unreadyPods map[string]struct{}, failed bool) {
+	unreadyPods = make(map[string]struct{})
 	for _, pod := range pods {
 		if !inferControllerUtils.IsPodRunningAndReady(pod) {
-			anyUnready = true
+			unreadyPods[metricPodKey(pod)] = struct{}{}
 		}
 		if util.IsPodFailed(pod) || inferControllerUtils.ContainerRestarted(pod) {
 			failed = true
 		}
 	}
 	return
+}
+
+// metricPodKey identifies a pod across metric groups. Metric collectors are
+// namespace-scoped, but include the namespace so the key remains unambiguous.
+func metricPodKey(pod *corev1.Pod) string {
+	return pod.Namespace + "/" + pod.Name
 }
 
 // groupPolicyKeysByScrapeName maps each scrape metric name to the policy keys

--- a/pkg/autoscaler/autoscaler/metric_collector.go
+++ b/pkg/autoscaler/autoscaler/metric_collector.go
@@ -31,6 +31,7 @@ import (
 	io_prometheus_client "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
 	"github.com/prometheus/common/model"
+	"istio.io/istio/pkg/util/sets"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -110,7 +111,7 @@ func (collector *MetricCollector) UpdateMetrics(
 		pastHistograms = make(map[string]HistogramInfo)
 	}
 	currentHistograms := make(map[string]HistogramInfo)
-	unreadyPods := make(map[string]struct{})
+	unreadyPods := sets.New[string]()
 
 	// Group pod metrics by identical PodMetricSource (uri/port/selector) so we
 	// scrape each ready pod endpoint once per reconcile and extract every
@@ -129,7 +130,7 @@ func (collector *MetricCollector) UpdateMetrics(
 			continue
 		}
 		for podKey := range groupUnreadyPods {
-			unreadyPods[podKey] = struct{}{}
+			unreadyPods.Insert(podKey)
 		}
 		for policyKey, v := range values {
 			readyInstancesMetric[policyKey] = v

--- a/pkg/autoscaler/autoscaler/metric_collector.go
+++ b/pkg/autoscaler/autoscaler/metric_collector.go
@@ -235,7 +235,7 @@ func (collector *MetricCollector) collectPodMetricsGroup(
 	specs []podMetricSpec,
 	pastHistograms map[string]HistogramInfo,
 	currentHistograms map[string]HistogramInfo,
-) (values map[string]float64, unreadyPods map[string]struct{}, failed bool, err error) {
+) (values map[string]float64, unreadyPods sets.Set[string], failed bool, err error) {
 	values = make(map[string]float64, len(specs))
 	pods, err := util.GetMetricPods(podLister, collector.Scope.Namespace, collector.Target, podSource)
 	if err != nil {
@@ -266,11 +266,11 @@ func (collector *MetricCollector) collectPodMetricsGroup(
 
 // evaluatePodsReadiness counts pods that are not ready and reports whether any
 // pod has failed or restarted.
-func evaluatePodsReadiness(pods []*corev1.Pod) (unreadyPods map[string]struct{}, failed bool) {
-	unreadyPods = make(map[string]struct{})
+func evaluatePodsReadiness(pods []*corev1.Pod) (unreadyPods sets.Set[string], failed bool) {
+	unreadyPods = sets.New[string]()
 	for _, pod := range pods {
 		if !inferControllerUtils.IsPodRunningAndReady(pod) {
-			unreadyPods[metricPodKey(pod)] = struct{}{}
+			unreadyPods.Insert(metricPodKey(pod))
 		}
 		if util.IsPodFailed(pod) || inferControllerUtils.ContainerRestarted(pod) {
 			failed = true

--- a/pkg/autoscaler/autoscaler/metric_collector_test.go
+++ b/pkg/autoscaler/autoscaler/metric_collector_test.go
@@ -21,6 +21,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -28,9 +30,13 @@ import (
 	io_prometheus_client "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	corev1 "k8s.io/api/core/v1"
-
 	workload "github.com/volcano-sh/kthena/pkg/apis/workload/v1alpha1"
+	"github.com/volcano-sh/kthena/pkg/autoscaler/algorithm"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corelister "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+
 	"github.com/volcano-sh/kthena/pkg/autoscaler/util"
 )
 
@@ -334,4 +340,55 @@ not a valid prometheus metric line
 	})
 
 	require.Error(t, err)
+}
+
+func TestUpdateMetricsKeepsReadyPodMetricsWhenAnotherPodIsUnready(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, "# TYPE queue_depth gauge\nqueue_depth 40\n# TYPE queue_depth_alt gauge\nqueue_depth_alt 40\n")
+	}))
+	t.Cleanup(server.Close)
+
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	port, err := strconv.Atoi(serverURL.Port())
+	require.NoError(t, err)
+
+	labels := map[string]string{
+		workload.ModelServingNameLabelKey: "model",
+		workload.EntryLabelKey:            "true",
+	}
+	readyPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "ready", Namespace: "default", Labels: labels},
+		Status: corev1.PodStatus{
+			Phase:      corev1.PodRunning,
+			PodIP:      "127.0.0.1",
+			Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}},
+		},
+	}
+	unreadyPod := readyPod.DeepCopy()
+	unreadyPod.Name = "unready"
+	unreadyPod.Status.Conditions = []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionFalse}}
+
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	require.NoError(t, indexer.Add(readyPod))
+	require.NoError(t, indexer.Add(unreadyPod))
+	podLister := corelister.NewPodLister(indexer)
+
+	policy := &workload.AutoscalingPolicy{ObjectMeta: metav1.ObjectMeta{Namespace: "default"}}
+	collector := NewMetricCollector(
+		&workload.Target{TargetRef: corev1.ObjectReference{Namespace: "default", Name: "model"}},
+		policy,
+		algorithm.Metrics{"queue_depth": 10, "queue_depth_alt": 10},
+	)
+
+	unreadyCount, readyMetrics, _, err := collector.UpdateMetrics(context.Background(), podLister, map[string]workload.MetricSource{
+		"queue_depth": {Pod: &workload.PodMetricSource{Name: "queue_depth", Port: int32(port)}},
+		// This creates a second metric group selecting the same pods.
+		"queue_depth_alt": {Pod: &workload.PodMetricSource{Name: "queue_depth_alt", Uri: "/metrics-alt", Port: int32(port)}},
+	})
+	require.NoError(t, err)
+	require.Equal(t, int32(1), unreadyCount)
+	// Expected behavior: scrape the ready pod even though another matching pod is unready.
+	require.Equal(t, float64(40), readyMetrics["queue_depth"])
+	require.Equal(t, float64(40), readyMetrics["queue_depth_alt"])
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

When one matching pod is unready, the autoscaler previously discarded metrics from all matching pods and skipped scaling.

This change:

- Continues collecting metrics from ready pods.
- Counts unready pods separately.
- Deduplicates unready pods across metric groups.
- Preserves existing behavior for failed or restarted pods.
- Adds regression coverage for mixed readiness.

**Which issue(s) this PR fixes**:

Fixes #1403

**Special notes for your reviewer**:

The autoscaler test suite passes:

```text
go test ./pkg/autoscaler/...
```

The regression test verifies ready metrics remain available when another matching pod is unready.

**Does this PR introduce a user-facing change?**:

Yes. Autoscaling can now continue using ready pod metrics during pod startup, rollout, or recovery.