### PR TITLE
feat(cleanup/refactor): add unit tests for calMaxScaleDown function and refactor its implementation

### DIFF
--- a/pkg/model-serving-controller/controller/model_serving_controller.go
+++ b/pkg/model-serving-controller/controller/model_serving_controller.go
@@ -1370,8 +1370,6 @@ func (c *ModelServingController) manageRollingUpdate(ctx context.Context, ms *wo
 			return fmt.Errorf("failed to calculate maxUnavailable: %v", err)
 		}
 
-		// TODO(hzxuzhonghu): reuse calMaxScaleDown
-
 		// Calculate the minimum number of available ServingGroups required
 		// Refer to https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/deployment/rolling.go
 		// Check if we can scale down. We can scale down in the following 2 cases:
@@ -1379,8 +1377,7 @@ func (c *ModelServingController) manageRollingUpdate(ctx context.Context, ms *wo
 		//   since that won't further increase unavailability.
 		// * New servingGroup has scaled up and its replicas become ready, then we can scale down old servingGroups
 		//   in a further step.
-		minAvailable := int(*ms.Spec.Replicas) - maxUnavailable
-		maxScaleDown = len(servingGroupList) - minAvailable - newServingGroupUnavailableCount
+		maxScaleDown = calMaxScaleDown(int(*ms.Spec.Replicas), len(servingGroupList), maxUnavailable, newServingGroupUnavailableCount)
 		if maxScaleDown <= 0 {
 			klog.V(4).Infof("No ServingGroups can be updated for ModelServing %s/%s: maxScaleDown=%d",
 				ms.Namespace, ms.Name, maxScaleDown)
@@ -1553,7 +1550,7 @@ func (c *ModelServingController) rolesToDeleteForRoleRollingUpdate(ms *workloadv
 			continue
 		}
 		hasOutdatedRoles = true
-		maxScaleDown, err := calMaxScaleDown(roleSpec, outdatedRoles, len(roleList), newUnavailable)
+		maxScaleDown, err := calMaxScaleDownForRole(roleSpec, outdatedRoles, len(roleList), newUnavailable)
 		if err != nil {
 			klog.Errorf("failed to calculate maxScaleDown for role %s in ServingGroup %s: %v", roleSpec.Name, sg.Name, err)
 		}
@@ -2879,7 +2876,22 @@ func (c *ModelServingController) RegisterModelServingDebugEndpoints(mux *http.Se
 	mux.HandleFunc("/debug/modelserving/cache", c.handleModelServingDatastoreCacheDump)
 }
 
-func calMaxScaleDown(role workloadv1alpha1.Role, outdatedRoles []datastore.Role, allReplicas, newUnavailable int) (int, error) {
+// calMaxScaleDown returns how many outdated replicas can be terminated without
+// dropping below expectedReplicas - maxUnavailable, after accounting for
+// already-unavailable new replicas. The result is clamped to >= 0.
+func calMaxScaleDown(expectedReplicas, allReplicas, maxUnavailable, newUnavailable int) int {
+	minAvailable := expectedReplicas - maxUnavailable
+	if minAvailable < 0 {
+		minAvailable = 0
+	}
+	maxScaleDown := allReplicas - minAvailable - newUnavailable
+	if maxScaleDown < 0 {
+		maxScaleDown = 0
+	}
+	return maxScaleDown
+}
+
+func calMaxScaleDownForRole(role workloadv1alpha1.Role, outdatedRoles []datastore.Role, allReplicas, newUnavailable int) (int, error) {
 	maxUnavailable, configured, err := utils.GetMaxUnavailableForRole(role)
 	if err != nil {
 		return 0, fmt.Errorf("failed to calculate maxUnavailable for role %s: %v", role.Name, err)
@@ -2891,13 +2903,5 @@ func calMaxScaleDown(role workloadv1alpha1.Role, outdatedRoles []datastore.Role,
 	if role.Replicas != nil {
 		expectedReplicas = int(*role.Replicas)
 	}
-	minAvailable := expectedReplicas - maxUnavailable
-	if minAvailable < 0 {
-		minAvailable = 0
-	}
-	maxScaleDown := allReplicas - minAvailable - newUnavailable
-	if maxScaleDown < 0 {
-		maxScaleDown = 0
-	}
-	return maxScaleDown, nil
+	return calMaxScaleDown(expectedReplicas, allReplicas, maxUnavailable, newUnavailable), nil
 }

--- a/pkg/model-serving-controller/controller/model_serving_controller_test.go
+++ b/pkg/model-serving-controller/controller/model_serving_controller_test.go
@@ -7968,3 +7968,55 @@ func TestResolveRoleTemplateHash_ReturnsEmptyWhenControllerRevisionNotFound(t *t
 	hash := controller.resolveRoleTemplateHash(ms, roleName, pod)
 	assert.Equal(t, "", hash)
 }
+
+func TestCalMaxScaleDown(t *testing.T) {
+	tests := []struct {
+		name             string
+		expectedReplicas int
+		allReplicas      int
+		maxUnavailable   int
+		newUnavailable   int
+		want             int
+	}{
+		{
+			name:             "normal budget",
+			expectedReplicas: 3,
+			allReplicas:      3,
+			maxUnavailable:   1,
+			newUnavailable:   0,
+			want:             1, // 3 - (3-1) - 0 = 1
+		},
+		{
+			name:             "budget exhausted clamps to zero",
+			expectedReplicas: 3,
+			allReplicas:      3,
+			maxUnavailable:   1,
+			newUnavailable:   1,
+			want:             0, // 3 - 2 - 1 = 0
+		},
+		{
+			name:             "minAvailable clamps when maxUnavailable exceeds expected",
+			expectedReplicas: 2,
+			allReplicas:      2,
+			maxUnavailable:   5,
+			newUnavailable:   0,
+			want:             2, // minAvailable=0 => 2 - 0 - 0 = 2
+		},
+		{
+			name:             "newUnavailable reduces budget",
+			expectedReplicas: 5,
+			allReplicas:      5,
+			maxUnavailable:   2,
+			newUnavailable:   1,
+			want:             1, // 5 - (5-2) - 1 = 1
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := calMaxScaleDown(tt.expectedReplicas, tt.allReplicas, tt.maxUnavailable, tt.newUnavailable)
+			if got != tt.want {
+				t.Fatalf("calMaxScaleDown() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
Refactor / cleanup

**What this PR does / why we need it:**
ServingGroup rolling update was computing maxScaleDown inline, while Role rolling update already had `calMaxScaleDown`. Same formula, two copies. This extracts a shared helper and uses it in both places, so the math can’t drift. Behavior stays the same for normal configs.

**Which issue(s) this PR fixes:** Fixes #
*(no linked issue — closes the `TODO(hzxuzhonghu): reuse calMaxScaleDown`)*

**Special notes for your reviewer:**
- `calMaxScaleDown` = pure math
- `calMaxScaleDownForRole` = Role wrapper (maxUnavailable lookup + “not configured → delete all outdated”)

**Does this PR introduce a user-facing change?:**
No