### PR TITLE
cli: add best practice templates for DeepSeek-R1-Distill and Qwen models

### DIFF
--- a/cli/kthena/cmd/templates_test.go
+++ b/cli/kthena/cmd/templates_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractManifestDescriptionFromContent(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		expected string
+	}{
+		{
+			name:     "Description Header",
+			content:  "# Description: Template for DeepSeek model deployment\napiVersion: workload.serving.volcano.sh/v1alpha1",
+			expected: "Template for DeepSeek model deployment",
+		},
+		{
+			name:     "Generic Comment Description",
+			content:  "# Model description: Qwen 32B model\napiVersion: workload.serving.volcano.sh/v1alpha1",
+			expected: "Model description: Qwen 32B model",
+		},
+		{
+			name:     "No Description Comment",
+			content:  "apiVersion: workload.serving.volcano.sh/v1alpha1\nkind: ModelBooster",
+			expected: "No description available",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractManifestDescriptionFromContent(tt.content)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/cli/kthena/helm/templates/Qwen/QwQ-32B-NPU.yaml
+++ b/cli/kthena/helm/templates/Qwen/QwQ-32B-NPU.yaml
@@ -1,0 +1,34 @@
+# Description: Template for QwQ 32B model deployment with vLLM backend on Ascend NPU
+apiVersion: workload.serving.volcano.sh/v1alpha1
+kind: ModelBooster
+metadata:
+  annotations:
+    api.kubernetes.io/name: {{ .Values.annotationName | default "example" | quote }}
+  name: {{ .Values.name | default "qwq-32b" | quote }}
+  {{- if .Values.namespace }}
+  namespace: {{ .Values.namespace | quote }}
+  {{- end }}
+spec:
+  name: {{ .Values.modelName | default .Values.name | default "qwq-32b" | quote }}
+  owner: {{ .Values.owner | default "example" | quote }}
+  backend:
+    name: {{ .Values.backendName | default "qwq-32b-vllm" | quote }}
+    type: {{ .Values.backendType | default "vLLM" | quote }}
+    modelURI: {{ .Values.modelURI | default "hf://Qwen/QwQ-32B" | quote }}
+    cacheURI: {{ .Values.cacheURI | default "hostpath://mnt/cache" | quote }}
+    minReplicas: {{ .Values.minReplicas | default 1 }}
+    maxReplicas: {{ .Values.maxReplicas | default 1 }}
+    workers:
+      - type: {{ .Values.workerType | default "server" | quote }}
+        image: {{ .Values.workerImage | default "quay.io/ascend/vllm-ascend:v0.12.0rc1" | quote }}
+        replicas: {{ .Values.workerReplicas | default 1 }}
+        pods: {{ .Values.workerPods | default 1 }}
+        config:
+          served-model-name: {{ .Values.modelName | default .Values.name | default "qwq-32b" | quote }}
+          tensor-parallel-size: {{ .Values.tensorParallelSize | default 4 }}
+          enforce-eager: ""
+          gpu-memory-utilization: {{ .Values.gpuMemoryUtilization | default "0.85" }}
+          max-model-len: {{ .Values.maxModelLen | default "2048" }}
+        resources:
+          limits:
+            huawei.com/ascend-1980: {{ .Values.npuLimit | default "4" | quote }}

--- a/cli/kthena/helm/templates/Qwen/QwQ-32B.yaml
+++ b/cli/kthena/helm/templates/Qwen/QwQ-32B.yaml
@@ -1,0 +1,34 @@
+# Description: Template for QwQ 32B model deployment with vLLM backend
+apiVersion: workload.serving.volcano.sh/v1alpha1
+kind: ModelBooster
+metadata:
+  annotations:
+    api.kubernetes.io/name: {{ .Values.annotationName | default "example" | quote }}
+  name: {{ .Values.name | default "qwq-32b" | quote }}
+  {{- if .Values.namespace }}
+  namespace: {{ .Values.namespace | quote }}
+  {{- end }}
+spec:
+  name: {{ .Values.modelName | default .Values.name | default "qwq-32b" | quote }}
+  owner: {{ .Values.owner | default "example" | quote }}
+  backend:
+    name: {{ .Values.backendName | default "qwq-32b-vllm" | quote }}
+    type: {{ .Values.backendType | default "vLLM" | quote }}
+    modelURI: {{ .Values.modelURI | default "hf://Qwen/QwQ-32B" | quote }}
+    cacheURI: {{ .Values.cacheURI | default "hostpath://mnt/cache" | quote }}
+    minReplicas: {{ .Values.minReplicas | default 1 }}
+    maxReplicas: {{ .Values.maxReplicas | default 1 }}
+    workers:
+      - type: {{ .Values.workerType | default "server" | quote }}
+        image: {{ .Values.workerImage | default "vllm/vllm-openai:latest" | quote }}
+        replicas: {{ .Values.workerReplicas | default 1 }}
+        pods: {{ .Values.workerPods | default 1 }}
+        config:
+          served-model-name: {{ .Values.modelName | default .Values.name | default "qwq-32b" | quote }}
+          tensor-parallel-size: {{ .Values.tensorParallelSize | default 4 }}
+          enforce-eager: ""  # Enable PyTorch eager mode if GPU compute capability is below 8.0
+          gpu-memory-utilization: {{ .Values.gpuMemoryUtilization | default "0.85" }}  # Set GPU memory utilization to 85%
+          max-model-len: {{ .Values.maxModelLen | default "2048" }}
+        resources:
+          limits:
+            nvidia.com/gpu: {{ .Values.gpuLimit | default "4" | quote }}

--- a/cli/kthena/helm/templates/Qwen/Qwen2.5-32B-Instruct-NPU.yaml
+++ b/cli/kthena/helm/templates/Qwen/Qwen2.5-32B-Instruct-NPU.yaml
@@ -1,0 +1,34 @@
+# Description: Template for Qwen2.5 32B Instruct model deployment with vLLM backend on Ascend NPU
+apiVersion: workload.serving.volcano.sh/v1alpha1
+kind: ModelBooster
+metadata:
+  annotations:
+    api.kubernetes.io/name: {{ .Values.annotationName | default "example" | quote }}
+  name: {{ .Values.name | default "qwen2-5-32b-instruct" | quote }}
+  {{- if .Values.namespace }}
+  namespace: {{ .Values.namespace | quote }}
+  {{- end }}
+spec:
+  name: {{ .Values.modelName | default .Values.name | default "qwen2-5-32b-instruct" | quote }}
+  owner: {{ .Values.owner | default "example" | quote }}
+  backend:
+    name: {{ .Values.backendName | default "qwen2-5-32b-instruct-vllm" | quote }}
+    type: {{ .Values.backendType | default "vLLM" | quote }}
+    modelURI: {{ .Values.modelURI | default "hf://Qwen/Qwen2.5-32B-Instruct" | quote }}
+    cacheURI: {{ .Values.cacheURI | default "hostpath://mnt/cache" | quote }}
+    minReplicas: {{ .Values.minReplicas | default 1 }}
+    maxReplicas: {{ .Values.maxReplicas | default 1 }}
+    workers:
+      - type: {{ .Values.workerType | default "server" | quote }}
+        image: {{ .Values.workerImage | default "quay.io/ascend/vllm-ascend:v0.12.0rc1" | quote }}
+        replicas: {{ .Values.workerReplicas | default 1 }}
+        pods: {{ .Values.workerPods | default 1 }}
+        config:
+          served-model-name: {{ .Values.modelName | default .Values.name | default "qwen2-5-32b-instruct" | quote }}
+          tensor-parallel-size: {{ .Values.tensorParallelSize | default 4 }}
+          enforce-eager: ""
+          gpu-memory-utilization: {{ .Values.gpuMemoryUtilization | default "0.85" }}
+          max-model-len: {{ .Values.maxModelLen | default "2048" }}
+        resources:
+          limits:
+            huawei.com/ascend-1980: {{ .Values.npuLimit | default "4" | quote }}

--- a/cli/kthena/helm/templates/Qwen/Qwen2.5-32B-Instruct.yaml
+++ b/cli/kthena/helm/templates/Qwen/Qwen2.5-32B-Instruct.yaml
@@ -1,0 +1,34 @@
+# Description: Template for Qwen2.5 32B Instruct model deployment with vLLM backend
+apiVersion: workload.serving.volcano.sh/v1alpha1
+kind: ModelBooster
+metadata:
+  annotations:
+    api.kubernetes.io/name: {{ .Values.annotationName | default "example" | quote }}
+  name: {{ .Values.name | default "qwen2-5-32b-instruct" | quote }}
+  {{- if .Values.namespace }}
+  namespace: {{ .Values.namespace | quote }}
+  {{- end }}
+spec:
+  name: {{ .Values.modelName | default .Values.name | default "qwen2-5-32b-instruct" | quote }}
+  owner: {{ .Values.owner | default "example" | quote }}
+  backend:
+    name: {{ .Values.backendName | default "qwen2-5-32b-instruct-vllm" | quote }}
+    type: {{ .Values.backendType | default "vLLM" | quote }}
+    modelURI: {{ .Values.modelURI | default "hf://Qwen/Qwen2.5-32B-Instruct" | quote }}
+    cacheURI: {{ .Values.cacheURI | default "hostpath://mnt/cache" | quote }}
+    minReplicas: {{ .Values.minReplicas | default 1 }}
+    maxReplicas: {{ .Values.maxReplicas | default 1 }}
+    workers:
+      - type: {{ .Values.workerType | default "server" | quote }}
+        image: {{ .Values.workerImage | default "vllm/vllm-openai:latest" | quote }}
+        replicas: {{ .Values.workerReplicas | default 1 }}
+        pods: {{ .Values.workerPods | default 1 }}
+        config:
+          served-model-name: {{ .Values.modelName | default .Values.name | default "qwen2-5-32b-instruct" | quote }}
+          tensor-parallel-size: {{ .Values.tensorParallelSize | default 4 }}
+          enforce-eager: ""  # Enable PyTorch eager mode if GPU compute capability is below 8.0
+          gpu-memory-utilization: {{ .Values.gpuMemoryUtilization | default "0.85" }}  # Set GPU memory utilization to 85%
+          max-model-len: {{ .Values.maxModelLen | default "2048" }}
+        resources:
+          limits:
+            nvidia.com/gpu: {{ .Values.gpuLimit | default "4" | quote }}

--- a/cli/kthena/helm/templates/Qwen/Qwen2.5-72B-Instruct-NPU.yaml
+++ b/cli/kthena/helm/templates/Qwen/Qwen2.5-72B-Instruct-NPU.yaml
@@ -1,0 +1,34 @@
+# Description: Template for Qwen2.5 72B Instruct model deployment with vLLM backend on Ascend NPU
+apiVersion: workload.serving.volcano.sh/v1alpha1
+kind: ModelBooster
+metadata:
+  annotations:
+    api.kubernetes.io/name: {{ .Values.annotationName | default "example" | quote }}
+  name: {{ .Values.name | default "qwen2-5-72b-instruct" | quote }}
+  {{- if .Values.namespace }}
+  namespace: {{ .Values.namespace | quote }}
+  {{- end }}
+spec:
+  name: {{ .Values.modelName | default .Values.name | default "qwen2-5-72b-instruct" | quote }}
+  owner: {{ .Values.owner | default "example" | quote }}
+  backend:
+    name: {{ .Values.backendName | default "qwen2-5-72b-instruct-vllm" | quote }}
+    type: {{ .Values.backendType | default "vLLM" | quote }}
+    modelURI: {{ .Values.modelURI | default "hf://Qwen/Qwen2.5-72B-Instruct" | quote }}
+    cacheURI: {{ .Values.cacheURI | default "hostpath://mnt/cache" | quote }}
+    minReplicas: {{ .Values.minReplicas | default 1 }}
+    maxReplicas: {{ .Values.maxReplicas | default 1 }}
+    workers:
+      - type: {{ .Values.workerType | default "server" | quote }}
+        image: {{ .Values.workerImage | default "quay.io/ascend/vllm-ascend:v0.12.0rc1" | quote }}
+        replicas: {{ .Values.workerReplicas | default 1 }}
+        pods: {{ .Values.workerPods | default 1 }}
+        config:
+          served-model-name: {{ .Values.modelName | default .Values.name | default "qwen2-5-72b-instruct" | quote }}
+          tensor-parallel-size: {{ .Values.tensorParallelSize | default 8 }}
+          enforce-eager: ""
+          gpu-memory-utilization: {{ .Values.gpuMemoryUtilization | default "0.85" }}
+          max-model-len: {{ .Values.maxModelLen | default "2048" }}
+        resources:
+          limits:
+            huawei.com/ascend-1980: {{ .Values.npuLimit | default "8" | quote }}

--- a/cli/kthena/helm/templates/Qwen/Qwen2.5-72B-Instruct.yaml
+++ b/cli/kthena/helm/templates/Qwen/Qwen2.5-72B-Instruct.yaml
@@ -1,0 +1,34 @@
+# Description: Template for Qwen2.5 72B Instruct model deployment with vLLM backend
+apiVersion: workload.serving.volcano.sh/v1alpha1
+kind: ModelBooster
+metadata:
+  annotations:
+    api.kubernetes.io/name: {{ .Values.annotationName | default "example" | quote }}
+  name: {{ .Values.name | default "qwen2-5-72b-instruct" | quote }}
+  {{- if .Values.namespace }}
+  namespace: {{ .Values.namespace | quote }}
+  {{- end }}
+spec:
+  name: {{ .Values.modelName | default .Values.name | default "qwen2-5-72b-instruct" | quote }}
+  owner: {{ .Values.owner | default "example" | quote }}
+  backend:
+    name: {{ .Values.backendName | default "qwen2-5-72b-instruct-vllm" | quote }}
+    type: {{ .Values.backendType | default "vLLM" | quote }}
+    modelURI: {{ .Values.modelURI | default "hf://Qwen/Qwen2.5-72B-Instruct" | quote }}
+    cacheURI: {{ .Values.cacheURI | default "hostpath://mnt/cache" | quote }}
+    minReplicas: {{ .Values.minReplicas | default 1 }}
+    maxReplicas: {{ .Values.maxReplicas | default 1 }}
+    workers:
+      - type: {{ .Values.workerType | default "server" | quote }}
+        image: {{ .Values.workerImage | default "vllm/vllm-openai:latest" | quote }}
+        replicas: {{ .Values.workerReplicas | default 1 }}
+        pods: {{ .Values.workerPods | default 1 }}
+        config:
+          served-model-name: {{ .Values.modelName | default .Values.name | default "qwen2-5-72b-instruct" | quote }}
+          tensor-parallel-size: {{ .Values.tensorParallelSize | default 8 }}
+          enforce-eager: ""  # Enable PyTorch eager mode if GPU compute capability is below 8.0
+          gpu-memory-utilization: {{ .Values.gpuMemoryUtilization | default "0.85" }}  # Set GPU memory utilization to 85%
+          max-model-len: {{ .Values.maxModelLen | default "2048" }}
+        resources:
+          limits:
+            nvidia.com/gpu: {{ .Values.gpuLimit | default "8" | quote }}

--- a/cli/kthena/helm/templates/Qwen/Qwen2.5-Coder-32B-Instruct-NPU.yaml
+++ b/cli/kthena/helm/templates/Qwen/Qwen2.5-Coder-32B-Instruct-NPU.yaml
@@ -1,0 +1,34 @@
+# Description: Template for Qwen2.5 Coder 32B Instruct model deployment with vLLM backend on Ascend NPU
+apiVersion: workload.serving.volcano.sh/v1alpha1
+kind: ModelBooster
+metadata:
+  annotations:
+    api.kubernetes.io/name: {{ .Values.annotationName | default "example" | quote }}
+  name: {{ .Values.name | default "qwen2-5-coder-32b-instruct" | quote }}
+  {{- if .Values.namespace }}
+  namespace: {{ .Values.namespace | quote }}
+  {{- end }}
+spec:
+  name: {{ .Values.modelName | default .Values.name | default "qwen2-5-coder-32b-instruct" | quote }}
+  owner: {{ .Values.owner | default "example" | quote }}
+  backend:
+    name: {{ .Values.backendName | default "qwen2-5-coder-32b-instruct-vllm" | quote }}
+    type: {{ .Values.backendType | default "vLLM" | quote }}
+    modelURI: {{ .Values.modelURI | default "hf://Qwen/Qwen2.5-Coder-32B-Instruct" | quote }}
+    cacheURI: {{ .Values.cacheURI | default "hostpath://mnt/cache" | quote }}
+    minReplicas: {{ .Values.minReplicas | default 1 }}
+    maxReplicas: {{ .Values.maxReplicas | default 1 }}
+    workers:
+      - type: {{ .Values.workerType | default "server" | quote }}
+        image: {{ .Values.workerImage | default "quay.io/ascend/vllm-ascend:v0.12.0rc1" | quote }}
+        replicas: {{ .Values.workerReplicas | default 1 }}
+        pods: {{ .Values.workerPods | default 1 }}
+        config:
+          served-model-name: {{ .Values.modelName | default .Values.name | default "qwen2-5-coder-32b-instruct" | quote }}
+          tensor-parallel-size: {{ .Values.tensorParallelSize | default 4 }}
+          enforce-eager: ""
+          gpu-memory-utilization: {{ .Values.gpuMemoryUtilization | default "0.85" }}
+          max-model-len: {{ .Values.maxModelLen | default "2048" }}
+        resources:
+          limits:
+            huawei.com/ascend-1980: {{ .Values.npuLimit | default "4" | quote }}

--- a/cli/kthena/helm/templates/Qwen/Qwen2.5-Coder-32B-Instruct.yaml
+++ b/cli/kthena/helm/templates/Qwen/Qwen2.5-Coder-32B-Instruct.yaml
@@ -1,0 +1,34 @@
+# Description: Template for Qwen2.5 Coder 32B Instruct model deployment with vLLM backend
+apiVersion: workload.serving.volcano.sh/v1alpha1
+kind: ModelBooster
+metadata:
+  annotations:
+    api.kubernetes.io/name: {{ .Values.annotationName | default "example" | quote }}
+  name: {{ .Values.name | default "qwen2-5-coder-32b-instruct" | quote }}
+  {{- if .Values.namespace }}
+  namespace: {{ .Values.namespace | quote }}
+  {{- end }}
+spec:
+  name: {{ .Values.modelName | default .Values.name | default "qwen2-5-coder-32b-instruct" | quote }}
+  owner: {{ .Values.owner | default "example" | quote }}
+  backend:
+    name: {{ .Values.backendName | default "qwen2-5-coder-32b-instruct-vllm" | quote }}
+    type: {{ .Values.backendType | default "vLLM" | quote }}
+    modelURI: {{ .Values.modelURI | default "hf://Qwen/Qwen2.5-Coder-32B-Instruct" | quote }}
+    cacheURI: {{ .Values.cacheURI | default "hostpath://mnt/cache" | quote }}
+    minReplicas: {{ .Values.minReplicas | default 1 }}
+    maxReplicas: {{ .Values.maxReplicas | default 1 }}
+    workers:
+      - type: {{ .Values.workerType | default "server" | quote }}
+        image: {{ .Values.workerImage | default "vllm/vllm-openai:latest" | quote }}
+        replicas: {{ .Values.workerReplicas | default 1 }}
+        pods: {{ .Values.workerPods | default 1 }}
+        config:
+          served-model-name: {{ .Values.modelName | default .Values.name | default "qwen2-5-coder-32b-instruct" | quote }}
+          tensor-parallel-size: {{ .Values.tensorParallelSize | default 4 }}
+          enforce-eager: ""  # Enable PyTorch eager mode if GPU compute capability is below 8.0
+          gpu-memory-utilization: {{ .Values.gpuMemoryUtilization | default "0.85" }}  # Set GPU memory utilization to 85%
+          max-model-len: {{ .Values.maxModelLen | default "2048" }}
+        resources:
+          limits:
+            nvidia.com/gpu: {{ .Values.gpuLimit | default "4" | quote }}

--- a/cli/kthena/helm/templates/deepseek-ai/DeepSeek-R1-Distill-Llama-70B-NPU.yaml
+++ b/cli/kthena/helm/templates/deepseek-ai/DeepSeek-R1-Distill-Llama-70B-NPU.yaml
@@ -1,0 +1,34 @@
+# Description: Template for DeepSeek R1 Distill Llama 70B model deployment with vLLM backend on Ascend NPU
+apiVersion: workload.serving.volcano.sh/v1alpha1
+kind: ModelBooster
+metadata:
+  annotations:
+    api.kubernetes.io/name: {{ .Values.annotationName | default "example" | quote }}
+  name: {{ .Values.name | default "deepseek-r1-distill-llama-70b" | quote }}
+  {{- if .Values.namespace }}
+  namespace: {{ .Values.namespace | quote }}
+  {{- end }}
+spec:
+  name: {{ .Values.modelName | default .Values.name | default "deepseek-r1-distill-llama-70b" | quote }}
+  owner: {{ .Values.owner | default "example" | quote }}
+  backend:
+    name: {{ .Values.backendName | default "deepseek-r1-distill-llama-70b-vllm" | quote }}
+    type: {{ .Values.backendType | default "vLLM" | quote }}
+    modelURI: {{ .Values.modelURI | default "hf://deepseek-ai/DeepSeek-R1-Distill-Llama-70B" | quote }}
+    cacheURI: {{ .Values.cacheURI | default "hostpath://mnt/cache" | quote }}
+    minReplicas: {{ .Values.minReplicas | default 1 }}
+    maxReplicas: {{ .Values.maxReplicas | default 1 }}
+    workers:
+      - type: {{ .Values.workerType | default "server" | quote }}
+        image: {{ .Values.workerImage | default "quay.io/ascend/vllm-ascend:v0.12.0rc1" | quote }}
+        replicas: {{ .Values.workerReplicas | default 1 }}
+        pods: {{ .Values.workerPods | default 1 }}
+        config:
+          served-model-name: {{ .Values.modelName | default .Values.name | default "deepseek-r1-distill-llama-70b" | quote }}
+          tensor-parallel-size: {{ .Values.tensorParallelSize | default 8 }}
+          enforce-eager: ""
+          gpu-memory-utilization: {{ .Values.gpuMemoryUtilization | default "0.85" }}
+          max-model-len: {{ .Values.maxModelLen | default "2048" }}
+        resources:
+          limits:
+            huawei.com/ascend-1980: {{ .Values.npuLimit | default "8" | quote }}

--- a/cli/kthena/helm/templates/deepseek-ai/DeepSeek-R1-Distill-Llama-70B.yaml
+++ b/cli/kthena/helm/templates/deepseek-ai/DeepSeek-R1-Distill-Llama-70B.yaml
@@ -1,0 +1,34 @@
+# Description: Template for DeepSeek R1 Distill Llama 70B model deployment with vLLM backend
+apiVersion: workload.serving.volcano.sh/v1alpha1
+kind: ModelBooster
+metadata:
+  annotations:
+    api.kubernetes.io/name: {{ .Values.annotationName | default "example" | quote }}
+  name: {{ .Values.name | default "deepseek-r1-distill-llama-70b" | quote }}
+  {{- if .Values.namespace }}
+  namespace: {{ .Values.namespace | quote }}
+  {{- end }}
+spec:
+  name: {{ .Values.modelName | default .Values.name | default "deepseek-r1-distill-llama-70b" | quote }}
+  owner: {{ .Values.owner | default "example" | quote }}
+  backend:
+    name: {{ .Values.backendName | default "deepseek-r1-distill-llama-70b-vllm" | quote }}
+    type: {{ .Values.backendType | default "vLLM" | quote }}
+    modelURI: {{ .Values.modelURI | default "hf://deepseek-ai/DeepSeek-R1-Distill-Llama-70B" | quote }}
+    cacheURI: {{ .Values.cacheURI | default "hostpath://mnt/cache" | quote }}
+    minReplicas: {{ .Values.minReplicas | default 1 }}
+    maxReplicas: {{ .Values.maxReplicas | default 1 }}
+    workers:
+      - type: {{ .Values.workerType | default "server" | quote }}
+        image: {{ .Values.workerImage | default "vllm/vllm-openai:latest" | quote }}
+        replicas: {{ .Values.workerReplicas | default 1 }}
+        pods: {{ .Values.workerPods | default 1 }}
+        config:
+          served-model-name: {{ .Values.modelName | default .Values.name | default "deepseek-r1-distill-llama-70b" | quote }}
+          tensor-parallel-size: {{ .Values.tensorParallelSize | default 8 }}
+          enforce-eager: ""  # Enable PyTorch eager mode if GPU compute capability is below 8.0
+          gpu-memory-utilization: {{ .Values.gpuMemoryUtilization | default "0.85" }}  # Set GPU memory utilization to 85%
+          max-model-len: {{ .Values.maxModelLen | default "2048" }}
+        resources:
+          limits:
+            nvidia.com/gpu: {{ .Values.gpuLimit | default "8" | quote }}

--- a/cli/kthena/helm/templates/deepseek-ai/DeepSeek-R1-Distill-Llama-8B-NPU.yaml
+++ b/cli/kthena/helm/templates/deepseek-ai/DeepSeek-R1-Distill-Llama-8B-NPU.yaml
@@ -1,0 +1,32 @@
+# Description: Template for DeepSeek R1 Distill Llama 8B model deployment with vLLM backend on Ascend NPU
+apiVersion: workload.serving.volcano.sh/v1alpha1
+kind: ModelBooster
+metadata:
+  annotations:
+    api.kubernetes.io/name: {{ .Values.annotationName | default "example" | quote }}
+  name: {{ .Values.name | default "deepseek-r1-distill-llama-8b" | quote }}
+  {{- if .Values.namespace }}
+  namespace: {{ .Values.namespace | quote }}
+  {{- end }}
+spec:
+  name: {{ .Values.modelName | default .Values.name | default "deepseek-r1-distill-llama-8b" | quote }}
+  owner: {{ .Values.owner | default "example" | quote }}
+  backend:
+    name: {{ .Values.backendName | default "deepseek-r1-distill-llama-8b-vllm" | quote }}
+    type: {{ .Values.backendType | default "vLLM" | quote }}
+    modelURI: {{ .Values.modelURI | default "hf://deepseek-ai/DeepSeek-R1-Distill-Llama-8B" | quote }}
+    cacheURI: {{ .Values.cacheURI | default "hostpath://mnt/cache" | quote }}
+    minReplicas: {{ .Values.minReplicas | default 1 }}
+    maxReplicas: {{ .Values.maxReplicas | default 1 }}
+    workers:
+      - type: {{ .Values.workerType | default "server" | quote }}
+        image: {{ .Values.workerImage | default "quay.io/ascend/vllm-ascend:v0.12.0rc1" | quote }}
+        replicas: {{ .Values.workerReplicas | default 1 }}
+        pods: {{ .Values.workerPods | default 1 }}
+        config:
+          served-model-name: {{ .Values.modelName | default .Values.name | default "deepseek-r1-distill-llama-8b" | quote }}
+          tensor-parallel-size: {{ .Values.tensorParallelSize | default 1 }}
+          enforce-eager: ""
+        resources:
+          limits:
+            huawei.com/ascend-1980: {{ .Values.npuLimit | default "1" | quote }}

--- a/cli/kthena/helm/templates/deepseek-ai/DeepSeek-R1-Distill-Llama-8B.yaml
+++ b/cli/kthena/helm/templates/deepseek-ai/DeepSeek-R1-Distill-Llama-8B.yaml
@@ -1,0 +1,32 @@
+# Description: Template for DeepSeek R1 Distill Llama 8B model deployment with vLLM backend
+apiVersion: workload.serving.volcano.sh/v1alpha1
+kind: ModelBooster
+metadata:
+  annotations:
+    api.kubernetes.io/name: {{ .Values.annotationName | default "example" | quote }}
+  name: {{ .Values.name | default "deepseek-r1-distill-llama-8b" | quote }}
+  {{- if .Values.namespace }}
+  namespace: {{ .Values.namespace | quote }}
+  {{- end }}
+spec:
+  name: {{ .Values.modelName | default .Values.name | default "deepseek-r1-distill-llama-8b" | quote }}
+  owner: {{ .Values.owner | default "example" | quote }}
+  backend:
+    name: {{ .Values.backendName | default "deepseek-r1-distill-llama-8b-vllm" | quote }}
+    type: {{ .Values.backendType | default "vLLM" | quote }}
+    modelURI: {{ .Values.modelURI | default "hf://deepseek-ai/DeepSeek-R1-Distill-Llama-8B" | quote }}
+    cacheURI: {{ .Values.cacheURI | default "hostpath://mnt/cache" | quote }}
+    minReplicas: {{ .Values.minReplicas | default 1 }}
+    maxReplicas: {{ .Values.maxReplicas | default 1 }}
+    workers:
+      - type: {{ .Values.workerType | default "server" | quote }}
+        image: {{ .Values.workerImage | default "vllm/vllm-openai:latest" | quote }}
+        replicas: {{ .Values.workerReplicas | default 1 }}
+        pods: {{ .Values.workerPods | default 1 }}
+        config:
+          served-model-name: {{ .Values.modelName | default .Values.name | default "deepseek-r1-distill-llama-8b" | quote }}
+          tensor-parallel-size: {{ .Values.tensorParallelSize | default 1 }}
+          enforce-eager: ""  # Enable PyTorch eager mode if GPU compute capability is below 8.0
+        resources:
+          limits:
+            nvidia.com/gpu: {{ .Values.gpuLimit | default "1" | quote }}

--- a/cli/kthena/helm/templates/deepseek-ai/DeepSeek-R1-Distill-Qwen-14B-NPU.yaml
+++ b/cli/kthena/helm/templates/deepseek-ai/DeepSeek-R1-Distill-Qwen-14B-NPU.yaml
@@ -1,0 +1,32 @@
+# Description: Template for DeepSeek R1 Distill Qwen 14B model deployment with vLLM backend on Ascend NPU
+apiVersion: workload.serving.volcano.sh/v1alpha1
+kind: ModelBooster
+metadata:
+  annotations:
+    api.kubernetes.io/name: {{ .Values.annotationName | default "example" | quote }}
+  name: {{ .Values.name | default "deepseek-r1-distill-qwen-14b" | quote }}
+  {{- if .Values.namespace }}
+  namespace: {{ .Values.namespace | quote }}
+  {{- end }}
+spec:
+  name: {{ .Values.modelName | default .Values.name | default "deepseek-r1-distill-qwen-14b" | quote }}
+  owner: {{ .Values.owner | default "example" | quote }}
+  backend:
+    name: {{ .Values.backendName | default "deepseek-r1-distill-qwen-14b-vllm" | quote }}
+    type: {{ .Values.backendType | default "vLLM" | quote }}
+    modelURI: {{ .Values.modelURI | default "hf://deepseek-ai/DeepSeek-R1-Distill-Qwen-14B" | quote }}
+    cacheURI: {{ .Values.cacheURI | default "hostpath://mnt/cache" | quote }}
+    minReplicas: {{ .Values.minReplicas | default 1 }}
+    maxReplicas: {{ .Values.maxReplicas | default 1 }}
+    workers:
+      - type: {{ .Values.workerType | default "server" | quote }}
+        image: {{ .Values.workerImage | default "quay.io/ascend/vllm-ascend:v0.12.0rc1" | quote }}
+        replicas: {{ .Values.workerReplicas | default 1 }}
+        pods: {{ .Values.workerPods | default 1 }}
+        config:
+          served-model-name: {{ .Values.modelName | default .Values.name | default "deepseek-r1-distill-qwen-14b" | quote }}
+          tensor-parallel-size: {{ .Values.tensorParallelSize | default 2 }}
+          enforce-eager: ""
+        resources:
+          limits:
+            huawei.com/ascend-1980: {{ .Values.npuLimit | default "2" | quote }}

--- a/cli/kthena/helm/templates/deepseek-ai/DeepSeek-R1-Distill-Qwen-14B.yaml
+++ b/cli/kthena/helm/templates/deepseek-ai/DeepSeek-R1-Distill-Qwen-14B.yaml
@@ -1,0 +1,34 @@
+# Description: Template for DeepSeek R1 Distill Qwen 14B model deployment with vLLM backend
+apiVersion: workload.serving.volcano.sh/v1alpha1
+kind: ModelBooster
+metadata:
+  annotations:
+    api.kubernetes.io/name: {{ .Values.annotationName | default "example" | quote }}
+  name: {{ .Values.name | default "deepseek-r1-distill-qwen-14b" | quote }}
+  {{- if .Values.namespace }}
+  namespace: {{ .Values.namespace | quote }}
+  {{- end }}
+spec:
+  name: {{ .Values.modelName | default .Values.name | default "deepseek-r1-distill-qwen-14b" | quote }}
+  owner: {{ .Values.owner | default "example" | quote }}
+  backend:
+    name: {{ .Values.backendName | default "deepseek-r1-distill-qwen-14b-vllm" | quote }}
+    type: {{ .Values.backendType | default "vLLM" | quote }}
+    modelURI: {{ .Values.modelURI | default "hf://deepseek-ai/DeepSeek-R1-Distill-Qwen-14B" | quote }}
+    cacheURI: {{ .Values.cacheURI | default "hostpath://mnt/cache" | quote }}
+    minReplicas: {{ .Values.minReplicas | default 1 }}
+    maxReplicas: {{ .Values.maxReplicas | default 1 }}
+    workers:
+      - type: {{ .Values.workerType | default "server" | quote }}
+        image: {{ .Values.workerImage | default "vllm/vllm-openai:latest" | quote }}
+        replicas: {{ .Values.workerReplicas | default 1 }}
+        pods: {{ .Values.workerPods | default 1 }}
+        config:
+          served-model-name: {{ .Values.modelName | default .Values.name | default "deepseek-r1-distill-qwen-14b" | quote }}
+          tensor-parallel-size: {{ .Values.tensorParallelSize | default 2 }}
+          enforce-eager: ""  # Enable PyTorch eager mode if GPU compute capability is below 8.0
+          gpu-memory-utilization: {{ .Values.gpuMemoryUtilization | default "0.85" }}  # Set GPU memory utilization to 85%
+          max-model-len: {{ .Values.maxModelLen | default "2048" }}
+        resources:
+          limits:
+            nvidia.com/gpu: {{ .Values.gpuLimit | default "2" | quote }}


### PR DESCRIPTION
### What type of PR is this?
/kind feature

### What this PR does / why we need it:
Adds curated CLI workload templates for popular open-weights models requested in #331, supporting both GPU (NVIDIA) and Ascend NPU hardware targets.

Specifically, this adds deployment templates for:
- DeepSeek-R1-Distill-Llama-70B
- DeepSeek-R1-Distill-Qwen-14B
- DeepSeek-R1-Distill-Llama-8B
- QwQ-32B
- Qwen2.5-Coder-32B-Instruct
- Qwen2.5-32B-Instruct
- Qwen2.5-72B-Instruct

### Which issue(s) this PR fixes:
Fixes #331

### Special notes for your reviewer:
None

### Does this PR introduce a user-facing change?
```release-note
cli: added best practice templates for DeepSeek-R1-Distill and Qwen models
```
