### PR TITLE
feat[cleanup]: implement GetPodGroupsByIndex method in PodGroupManager and update ModelServingController to use it

### DIFF
--- a/pkg/model-serving-controller/controller/model_serving_controller.go
+++ b/pkg/model-serving-controller/controller/model_serving_controller.go
@@ -75,6 +75,7 @@ type PodGroupManager interface {
 	CleanupPodGroups(ctx context.Context, ms *workloadv1alpha1.ModelServing) error
 	HasPodGroupCRD() bool
 	GetPodGroupInformer() cache.SharedIndexInformer
+	GetPodGroupsByIndex(indexName, indexValue string) ([]*schedulingv1beta1.PodGroup, error)
 	Run(parentCtx context.Context) error
 	GenerateTaskName(roleName string, roleIndex int) string
 	AnnotatePodWithPodGroup(pod *corev1.Pod, ms *workloadv1alpha1.ModelServing, groupName, taskName string)
@@ -1995,13 +1996,10 @@ func (c *ModelServingController) isServingGroupDeleted(ms *workloadv1alpha1.Mode
 		klog.Errorf("failed to get service, err:%v", err)
 		return false
 	}
-	pgs := []*schedulingv1beta1.PodGroup{}
-	if c.podGroupManager.HasPodGroupCRD() {
-		pgs, err = c.getPodGroupsByIndex(GroupNameKey, groupNameValue)
-		if err != nil {
-			klog.Errorf("failed to get podGroup, err: %v", err)
-			return false
-		}
+	pgs, err := c.podGroupManager.GetPodGroupsByIndex(GroupNameKey, groupNameValue)
+	if err != nil {
+		klog.Errorf("failed to get podGroup, err: %v", err)
+		return false
 	}
 	return len(pgs) == 0 && len(pods) == 0 && len(services) == 0
 }
@@ -2070,40 +2068,6 @@ func (c *ModelServingController) getServicesByIndex(indexName, indexValue string
 		services = append(services, svc)
 	}
 	return services, nil
-}
-
-// TODO: move to podgroup manager
-func (c *ModelServingController) getPodGroupsByIndex(indexName, indexValue string) ([]*schedulingv1beta1.PodGroup, error) {
-	if c.podGroupManager == nil || !c.podGroupManager.HasPodGroupCRD() {
-		return nil, nil
-	}
-
-	podGroupInformer := c.podGroupManager.GetPodGroupInformer()
-	if podGroupInformer == nil {
-		return nil, fmt.Errorf("podGroup informer is not initialized")
-	}
-	indexer := podGroupInformer.GetIndexer()
-	if indexer == nil {
-		return nil, fmt.Errorf("podGroup informer indexer is not initialized")
-	}
-	if _, exists := indexer.GetIndexers()[indexName]; !exists {
-		return nil, fmt.Errorf("podGroup indexer %s not found", indexName)
-	}
-	objs, err := indexer.ByIndex(indexName, indexValue)
-	if err != nil {
-		return nil, err
-	}
-
-	var podGroups []*schedulingv1beta1.PodGroup
-	for _, obj := range objs {
-		podGroup, ok := obj.(*schedulingv1beta1.PodGroup)
-		if !ok {
-			klog.Errorf("unexpected object type in podGroup indexer: %T", obj)
-			continue
-		}
-		podGroups = append(podGroups, podGroup)
-	}
-	return podGroups, nil
 }
 
 // UpdateModelServingStatus update replicas in modelServing status.

--- a/pkg/model-serving-controller/controller/model_serving_controller_test.go
+++ b/pkg/model-serving-controller/controller/model_serving_controller_test.go
@@ -172,6 +172,10 @@ func (f *fakePodGroupManager) GetPodGroupInformer() cache.SharedIndexInformer {
 	return nil
 }
 
+func (f *fakePodGroupManager) GetPodGroupsByIndex(indexName, indexValue string) ([]*schedulingv1beta1.PodGroup, error) {
+	return nil, nil
+}
+
 func (f *fakePodGroupManager) Run(parentCtx context.Context) error {
 	return nil
 }

--- a/pkg/model-serving-controller/podgroupmanager/manager.go
+++ b/pkg/model-serving-controller/podgroupmanager/manager.go
@@ -167,6 +167,41 @@ func (m *Manager) GetPodGroupInformer() cache.SharedIndexInformer {
 	return m.PodGroupInformer
 }
 
+// GetPodGroupsByIndex returns PodGroups matching the given informer index.
+// Returns nil, nil when the PodGroup CRD is unavailable.
+func (m *Manager) GetPodGroupsByIndex(indexName, indexValue string) ([]*schedulingv1beta1.PodGroup, error) {
+	if !m.HasPodGroupCRD() {
+		return nil, nil
+	}
+
+	podGroupInformer := m.GetPodGroupInformer()
+	if podGroupInformer == nil {
+		return nil, fmt.Errorf("podGroup informer is not initialized")
+	}
+	indexer := podGroupInformer.GetIndexer()
+	if indexer == nil {
+		return nil, fmt.Errorf("podGroup informer indexer is not initialized")
+	}
+	if _, exists := indexer.GetIndexers()[indexName]; !exists {
+		return nil, fmt.Errorf("podGroup indexer %s not found", indexName)
+	}
+	objs, err := indexer.ByIndex(indexName, indexValue)
+	if err != nil {
+		return nil, err
+	}
+
+	var podGroups []*schedulingv1beta1.PodGroup
+	for _, obj := range objs {
+		podGroup, ok := obj.(*schedulingv1beta1.PodGroup)
+		if !ok {
+			klog.Errorf("unexpected object type in podGroup indexer: %T", obj)
+			continue
+		}
+		podGroups = append(podGroups, podGroup)
+	}
+	return podGroups, nil
+}
+
 func (m *Manager) GetPodGroupLister() volcanoschedulerlister.PodGroupLister {
 	m.lock.Lock()
 	defer m.lock.Unlock()


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Moves `getPodGroupsByIndex` from `ModelServingController` into `podgroupmanager.Manager`, where PodGroup informer access already lives. The controller now calls `PodGroupManager.GetPodGroupsByIndex`
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

- Addresses the TODO on the old controller helper.

**Does this PR introduce a user-facing change?**:
