### PR TITLE
controller: read latest object from API server before status retry

### DIFF
--- a/pkg/model-booster-controller/controller/model_booster_controller.go
+++ b/pkg/model-booster-controller/controller/model_booster_controller.go
@@ -254,8 +254,21 @@ func (mc *ModelBoosterController) isModelServingActive(model *workload.ModelBoos
 
 // updateModelBoosterStatus updates model status.
 func (mc *ModelBoosterController) updateModelBoosterStatus(ctx context.Context, modelBooster *workload.ModelBooster) error {
+	// Status updates within a single reconcile can happen back to back, and the
+	// informer cache does not always catch up between them. Read from the cache
+	// on the first attempt (cheap, and correct in the common case); if that
+	// attempt conflicts, the cache is known to be stale for this object, so
+	// subsequent attempts read directly from the API server instead of retrying
+	// against the same stale resourceVersion.
+	readFromAPI := false
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		latest, err := mc.modelBoosterLister.ModelBoosters(modelBooster.Namespace).Get(modelBooster.Name)
+		var latest *workload.ModelBooster
+		var err error
+		if readFromAPI {
+			latest, err = mc.client.WorkloadV1alpha1().ModelBoosters(modelBooster.Namespace).Get(ctx, modelBooster.Name, metav1.GetOptions{})
+		} else {
+			latest, err = mc.modelBoosterLister.ModelBoosters(modelBooster.Namespace).Get(modelBooster.Name)
+		}
 		if err != nil {
 			return err
 		}
@@ -266,6 +279,7 @@ func (mc *ModelBoosterController) updateModelBoosterStatus(ctx context.Context, 
 		updated.Status.ObservedGeneration = updated.Generation
 		res, err := mc.client.WorkloadV1alpha1().ModelBoosters(updated.Namespace).UpdateStatus(ctx, updated, metav1.UpdateOptions{})
 		if err != nil {
+			readFromAPI = true
 			return err
 		}
 		modelBooster.Status = res.Status

--- a/pkg/model-booster-controller/controller/model_booster_controller.go
+++ b/pkg/model-booster-controller/controller/model_booster_controller.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	networkingv1alpha1 "github.com/volcano-sh/kthena/pkg/apis/networking/v1alpha1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -279,7 +280,10 @@ func (mc *ModelBoosterController) updateModelBoosterStatus(ctx context.Context, 
 		updated.Status.ObservedGeneration = updated.Generation
 		res, err := mc.client.WorkloadV1alpha1().ModelBoosters(updated.Namespace).UpdateStatus(ctx, updated, metav1.UpdateOptions{})
 		if err != nil {
-			readFromAPI = true
+			if apierrors.IsConflict(err) {
+				klog.V(4).Infof("ModelBooster %s/%s status update conflicted (informer cache may be stale), retrying with a fresh read from the API server: %v", updated.Namespace, updated.Name, err)
+				readFromAPI = true
+			}
 			return err
 		}
 		modelBooster.Status = res.Status

--- a/pkg/model-serving-controller/controller/model_serving_controller.go
+++ b/pkg/model-serving-controller/controller/model_serving_controller.go
@@ -2095,9 +2095,21 @@ func (c *ModelServingController) getPodGroupsByIndex(indexName, indexValue strin
 
 // UpdateModelServingStatus update replicas in modelServing status.
 func (c *ModelServingController) UpdateModelServingStatus(ms *workloadv1alpha1.ModelServing, revision string) error {
+	// Status updates within a single reconcile can happen back to back, and the
+	// informer cache does not always catch up between them. Read from the cache
+	// on the first attempt (cheap, and correct in the common case); if that
+	// attempt conflicts, the cache is known to be stale for this object, so
+	// subsequent attempts read directly from the API server instead of retrying
+	// against the same stale resourceVersion.
+	readFromAPI := false
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		// Get latest modelserving from informer store
-		latestMS, getErr := c.modelServingLister.ModelServings(ms.Namespace).Get(ms.Name)
+		var latestMS *workloadv1alpha1.ModelServing
+		var getErr error
+		if readFromAPI {
+			latestMS, getErr = c.modelServingClient.WorkloadV1alpha1().ModelServings(ms.Namespace).Get(context.TODO(), ms.Name, metav1.GetOptions{})
+		} else {
+			latestMS, getErr = c.modelServingLister.ModelServings(ms.Namespace).Get(ms.Name)
+		}
 		if getErr != nil {
 			return getErr
 		}
@@ -2124,6 +2136,9 @@ func (c *ModelServingController) UpdateModelServingStatus(ms *workloadv1alpha1.M
 					copy.Status.UpdateRevision = revision
 					copy.Status.LabelSelector = selector
 					_, updateErr := c.modelServingClient.WorkloadV1alpha1().ModelServings(copy.GetNamespace()).UpdateStatus(context.TODO(), copy, metav1.UpdateOptions{})
+					if updateErr != nil {
+						readFromAPI = true
+					}
 					return updateErr
 				}
 				return nil
@@ -2272,6 +2287,7 @@ func (c *ModelServingController) UpdateModelServingStatus(ms *workloadv1alpha1.M
 		if shouldUpdate {
 			_, err := c.modelServingClient.WorkloadV1alpha1().ModelServings(copy.GetNamespace()).UpdateStatus(context.TODO(), copy, metav1.UpdateOptions{})
 			if err != nil {
+				readFromAPI = true
 				return err
 			}
 			// Clean up old revisions only after roles have been updated (revision status changed)

--- a/pkg/model-serving-controller/controller/model_serving_controller.go
+++ b/pkg/model-serving-controller/controller/model_serving_controller.go
@@ -2136,7 +2136,8 @@ func (c *ModelServingController) UpdateModelServingStatus(ms *workloadv1alpha1.M
 					copy.Status.UpdateRevision = revision
 					copy.Status.LabelSelector = selector
 					_, updateErr := c.modelServingClient.WorkloadV1alpha1().ModelServings(copy.GetNamespace()).UpdateStatus(context.TODO(), copy, metav1.UpdateOptions{})
-					if updateErr != nil {
+					if apierrors.IsConflict(updateErr) {
+						klog.V(4).Infof("ModelServing %s/%s status update conflicted (informer cache may be stale), retrying with a fresh read from the API server: %v", copy.Namespace, copy.Name, updateErr)
 						readFromAPI = true
 					}
 					return updateErr
@@ -2287,7 +2288,10 @@ func (c *ModelServingController) UpdateModelServingStatus(ms *workloadv1alpha1.M
 		if shouldUpdate {
 			_, err := c.modelServingClient.WorkloadV1alpha1().ModelServings(copy.GetNamespace()).UpdateStatus(context.TODO(), copy, metav1.UpdateOptions{})
 			if err != nil {
-				readFromAPI = true
+				if apierrors.IsConflict(err) {
+					klog.V(4).Infof("ModelServing %s/%s status update conflicted (informer cache may be stale), retrying with a fresh read from the API server: %v", copy.Namespace, copy.Name, err)
+					readFromAPI = true
+				}
 				return err
 			}
 			// Clean up old revisions only after roles have been updated (revision status changed)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`UpdateModelServingStatus` runs inside a `retry.RetryOnConflict` loop and, on every attempt, re-reads the `ModelServing` object from the informer lister before recomputing status. That read is cheap and correct in the common case, but the informer cache can still lag behind the API server at the moment of a write. When an external actor mutates the same object concurrently — the autoscaler updating `spec.replicas` via `Update`/`Patch` (`pkg/autoscaler/util/client.go`, `pkg/autoscaler/controller/autoscale_controller.go`), or the LWS/ModelBooster handlers writing through the same client (`lws_controller.go`, `model_serving_handler.go`) — the controller's `UpdateStatus` call can hit a genuine 409 conflict. Because every retry attempt kept reading from the same lister, it kept resubmitting a status built from the same stale `resourceVersion`, so the retry loop exhausted `retry.DefaultRetry` and surfaced "the object has been modified; please apply your changes to the latest version and try again" instead of converging.

This PR keeps the lister read on the first attempt (no extra API cost on the conflict-free path) and switches to a direct `Get` from the API server only once an attempt observes `apierrors.IsConflict`, so subsequent retries operate on a fresh object instead of the same stale one.

**Which issue(s) this PR fixes**:

Related to #108 (closed on 2026-08-19 with no linked fix). That issue reports the same symptom — an "object has been modified" error from `updateStatus` — but was closed without a recorded fix, so I'm not marking this as closing it automatically. Flagging here for a maintainer to confirm whether #108 should be reopened/linked to this PR, or whether it was tracking something else.

**Special notes for your reviewer**:

- Removed ModelBooster changes as requested.
- Added `TestUpdateModelServingStatusStaleListerOnConflict`, which seeds the informer indexer at Generation 3 and the fake API server at Generation 4, forces a 409 on the first `UpdateStatus` call via `PrependReactor`, and asserts the retry re-reads live data (`status.observedGeneration` ends up 4, not 3). The existing `TestUpdateModelServingStatus*` cases don't exercise this because `client-go`'s fake tracker doesn't enforce optimistic concurrency, so `readFromAPI` was never toggled by any prior test.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
