### PR TITLE
router: keep matched gateway listener stable

### DIFF
--- a/cmd/kthena-router/app/router.go
+++ b/cmd/kthena-router/app/router.go
@@ -393,7 +393,8 @@ func (lm *ListenerManager) findBestMatchingListener(port int32, hostname string)
 	for i := range portInfo.Listeners {
 		listener := &portInfo.Listeners[i]
 		if listener.Hostname != nil && strings.EqualFold(*listener.Hostname, hostname) {
-			return listener, true
+			matched := *listener
+			return &matched, true
 		}
 	}
 
@@ -410,14 +411,16 @@ func (lm *ListenerManager) findBestMatchingListener(port int32, hostname string)
 		}
 	}
 	if wildcardMatch != nil {
-		return wildcardMatch, true
+		matched := *wildcardMatch
+		return &matched, true
 	}
 
 	// If no exact/wildcard match, try a listener without hostname restriction.
 	for i := range portInfo.Listeners {
 		listener := &portInfo.Listeners[i]
 		if listener.Hostname == nil {
-			return listener, true
+			matched := *listener
+			return &matched, true
 		}
 	}
 

--- a/cmd/kthena-router/app/router_listener_test.go
+++ b/cmd/kthena-router/app/router_listener_test.go
@@ -16,7 +16,12 @@ limitations under the License.
 
 package app
 
-import "testing"
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
 
 func TestWildcardHostnameMatch(t *testing.T) {
 	tests := []struct {
@@ -126,4 +131,60 @@ func TestFindBestMatchingListener(t *testing.T) {
 			t.Fatalf("expected default-gw, got %s", listener.GatewayKey)
 		}
 	})
+}
+
+func TestMatchedListenerIsStableAfterGatewayUpdate(t *testing.T) {
+	requestHost := "request.example.com"
+	otherHost := "other.example.com"
+	target := ListenerConfig{
+		GatewayKey:   "default/target",
+		ListenerName: "http",
+		Port:         80,
+		Hostname:     &requestHost,
+		Protocol:     string(gatewayv1.HTTPProtocolType),
+	}
+	other := ListenerConfig{
+		GatewayKey:   "default/other",
+		ListenerName: "http",
+		Port:         80,
+		Hostname:     &otherHost,
+		Protocol:     string(gatewayv1.HTTPProtocolType),
+	}
+	lm := &ListenerManager{
+		server: &Server{Port: "8080"},
+		portListeners: map[int32]*PortListenerInfo{
+			80: {Listeners: []ListenerConfig{target, other}},
+		},
+		gatewayListeners: map[string][]ListenerConfig{
+			target.GatewayKey: {target},
+		},
+	}
+
+	matched, found := lm.findBestMatchingListener(80, requestHost)
+	if !found {
+		t.Fatalf("expected listener to be found")
+	}
+
+	updatedHost := gatewayv1.Hostname("updated.example.com")
+	gateway := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "target",
+		},
+		Spec: gatewayv1.GatewaySpec{
+			Listeners: []gatewayv1.Listener{
+				{
+					Name:     "http",
+					Port:     80,
+					Protocol: gatewayv1.HTTPProtocolType,
+					Hostname: &updatedHost,
+				},
+			},
+		},
+	}
+	lm.StartListenersForGateway(gateway)
+
+	if matched.GatewayKey != target.GatewayKey {
+		t.Fatalf("matched listener changed to %q after update", matched.GatewayKey)
+	}
 }


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

`findBestMatchingListener` returned a pointer into the shared listener slice. A Gateway update can compact that slice after the lock is released, causing an in-flight request to observe another listener's `GatewayKey`.

This returns a snapshot of the matched listener while holding the read lock and adds a regression test for the update path.

**Which issue(s) this PR fixes**:
Fixes #<issue-number>

**Bug evidence**:

This can happen when multiple Gateways share a listener port:

1. Configure two Gateways on port 80 with different hostnames.
2. Send requests matching the first Gateway.
3. Update that Gateway's listener hostname while requests are in flight.
4. The update removes and compacts the shared listener slice.
5. A request that already matched the first listener can read the second listener's `GatewayKey`.

The request middleware keeps the returned listener after matching:
https://github.com/volcano-sh/kthena/blob/c93972a57762f14df6018cdcf464f023450c059a/cmd/kthena-router/app/router.go#L249-L258

The old matching code returned pointers into `portInfo.Listeners`:
https://github.com/volcano-sh/kthena/blob/c93972a57762f14df6018cdcf464f023450c059a/cmd/kthena-router/app/router.go#L376-L428

Gateway updates reuse the same slice backing array:
https://github.com/volcano-sh/kthena/blob/c93972a57762f14df6018cdcf464f023450c059a/cmd/kthena-router/app/router.go#L493-L509

Before the fix, the regression reports:

    matched listener changed to "default/other" after update

Expected: the request keeps the Gateway selected during listener matching.

Actual: the returned listener can change after a concurrent Gateway update.

**Special notes for your reviewer**:

Tested with `go test ./cmd/kthena-router/...`.

E2E was not run locally because Helm is unavailable.

**Does this PR introduce a user-facing change?**:

```release-note
NONE