### PR TITLE
fix(router): parse chat messages with array content instead of dropping them

### DIFF
--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -313,8 +313,15 @@ func (r *Router) HandlerFunc() gin.HandlerFunc {
 
 		prompt, err := utils.ParsePrompt(modelRequest)
 		if err != nil {
-			accesslog.SetError(c, "prompt_parsing", "prompt not found")
-			c.AbortWithStatusJSON(http.StatusNotFound, "prompt not found")
+			// A body with no prompt at all keeps the existing 404, but a body that
+			// carries a prompt the router cannot parse is a client error, so it is
+			// answered with 400 and the reason rather than "prompt not found".
+			status, msg := http.StatusBadRequest, err.Error()
+			if errors.Is(err, utils.ErrPromptNotFound) {
+				status, msg = http.StatusNotFound, "prompt not found"
+			}
+			accesslog.SetError(c, "prompt_parsing", msg)
+			c.AbortWithStatusJSON(status, msg)
 			c.Set("finishReason", "prompt_parsing")
 			return
 		}

--- a/pkg/kthena-router/utils/utils.go
+++ b/pkg/kthena-router/utils/utils.go
@@ -71,9 +71,9 @@ func ParsePrompt(body map[string]interface{}) (*common.ChatMessage, error) {
 				continue
 			}
 
-			content, ok := msgMap["content"].(string)
-			if !ok {
-				continue
+			content, err := parseMessageContent(msgMap["content"])
+			if err != nil {
+				return nil, err
 			}
 
 			msgs = append(msgs, common.Message{
@@ -82,12 +82,52 @@ func ParsePrompt(body map[string]interface{}) (*common.ChatMessage, error) {
 			})
 		}
 
+		if len(msgs) == 0 {
+			return nil, fmt.Errorf("messages contains no usable message")
+		}
+
 		return &common.ChatMessage{
 			Messages: msgs,
 		}, nil
 	}
 
 	return nil, fmt.Errorf("prompt or messages not found in request body")
+}
+
+// parseMessageContent extracts the text of a single chat message. The OpenAI chat
+// completions API allows "content" to be a plain string, an array of content parts,
+// or null (for assistant messages that only carry tool_calls), so all three forms
+// have to be accepted here. Anything else is a malformed request.
+func parseMessageContent(content interface{}) (string, error) {
+	switch c := content.(type) {
+	case nil:
+		// A message with null content still occupies a turn in the conversation,
+		// so it is kept with an empty content rather than dropped.
+		return "", nil
+	case string:
+		return c, nil
+	case []interface{}:
+		var text strings.Builder
+		for _, part := range c {
+			partMap, ok := part.(map[string]interface{})
+			if !ok {
+				return "", fmt.Errorf("message content part is not an object")
+			}
+			// Non-text parts (image_url, input_audio, ...) carry no text and are
+			// skipped; only their text siblings contribute to the prompt.
+			if partType, ok := partMap["type"].(string); !ok || partType != "text" {
+				continue
+			}
+			partText, ok := partMap["text"].(string)
+			if !ok {
+				return "", fmt.Errorf("text content part has no string text field")
+			}
+			text.WriteString(partText)
+		}
+		return text.String(), nil
+	default:
+		return "", fmt.Errorf("message content is neither a string nor a list of content parts")
+	}
 }
 
 func GetPromptString(chatMessage *common.ChatMessage) string {

--- a/pkg/kthena-router/utils/utils.go
+++ b/pkg/kthena-router/utils/utils.go
@@ -17,6 +17,7 @@ limitations under the License.
 package utils
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -35,6 +36,11 @@ var (
 	TTFT              = "TTFT"
 )
 
+// ErrPromptNotFound is returned when the request body carries neither a "prompt"
+// nor a "messages" field. It is distinct from a malformed prompt so that callers
+// can answer "absent" and "present but invalid" with different status codes.
+var ErrPromptNotFound = errors.New("prompt or messages not found in request body")
+
 func GetNamespaceName(obj metav1.Object) types.NamespacedName {
 	return types.NamespacedName{
 		Namespace: obj.GetNamespace(),
@@ -42,6 +48,10 @@ func GetNamespaceName(obj metav1.Object) types.NamespacedName {
 	}
 }
 
+// ParsePrompt extracts the prompt from a chat completions or completions request
+// body. Every error other than ErrPromptNotFound means the body is malformed: no
+// message is ever dropped silently, because a dropped message yields a prompt that
+// looks valid to the caller while no longer matching what the client sent.
 func ParsePrompt(body map[string]interface{}) (*common.ChatMessage, error) {
 	if prompt, ok := body["prompt"]; ok {
 		promptStr, ok := prompt.(string)
@@ -58,22 +68,25 @@ func ParsePrompt(body map[string]interface{}) (*common.ChatMessage, error) {
 		if !ok {
 			return nil, fmt.Errorf("messages is not a list")
 		}
+		if len(messageList) == 0 {
+			return nil, fmt.Errorf("messages list is empty")
+		}
 
 		msgs := make([]common.Message, 0, len(messageList))
-		for _, message := range messageList {
+		for i, message := range messageList {
 			msgMap, ok := message.(map[string]interface{})
 			if !ok {
-				continue
+				return nil, fmt.Errorf("message at index %d is not an object", i)
 			}
 
 			role, ok := msgMap["role"].(string)
 			if !ok {
-				continue
+				return nil, fmt.Errorf("message at index %d has no string role field", i)
 			}
 
 			content, err := parseMessageContent(msgMap["content"])
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("message at index %d: %w", i, err)
 			}
 
 			msgs = append(msgs, common.Message{
@@ -82,16 +95,12 @@ func ParsePrompt(body map[string]interface{}) (*common.ChatMessage, error) {
 			})
 		}
 
-		if len(msgs) == 0 {
-			return nil, fmt.Errorf("messages contains no usable message")
-		}
-
 		return &common.ChatMessage{
 			Messages: msgs,
 		}, nil
 	}
 
-	return nil, fmt.Errorf("prompt or messages not found in request body")
+	return nil, ErrPromptNotFound
 }
 
 // parseMessageContent extracts the text of a single chat message. The OpenAI chat
@@ -102,11 +111,17 @@ func parseMessageContent(content interface{}) (string, error) {
 	switch c := content.(type) {
 	case nil:
 		// A message with null content still occupies a turn in the conversation,
-		// so it is kept with an empty content rather than dropped.
+		// so it is kept with an empty content rather than dropped. Note that a
+		// missing "content" key also lands here, so a message that omits content
+		// entirely is kept the same way; the two are not distinguishable from the
+		// decoded map, and neither contributes any text to the prompt.
 		return "", nil
 	case string:
 		return c, nil
 	case []interface{}:
+		// Text parts are concatenated verbatim, with no separator inserted between
+		// them, which is how the server side reassembles them too. Any spacing has
+		// to come from the parts themselves.
 		var text strings.Builder
 		for _, part := range c {
 			partMap, ok := part.(map[string]interface{})

--- a/pkg/kthena-router/utils/utils_test.go
+++ b/pkg/kthena-router/utils/utils_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package utils
 
 import (
+	"errors"
 	"os"
 	"reflect"
 	"testing"
@@ -198,6 +199,48 @@ func TestParsePrompt(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "message is not an object",
+			body: map[string]interface{}{
+				"messages": []interface{}{"hi"},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "message without a role",
+			body: map[string]interface{}{
+				"messages": []interface{}{
+					map[string]interface{}{"content": "hi"},
+				},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "message with a non-string role",
+			body: map[string]interface{}{
+				"messages": []interface{}{
+					map[string]interface{}{"role": 1, "content": "hi"},
+				},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "message without a content key is kept",
+			body: map[string]interface{}{
+				"messages": []interface{}{
+					map[string]interface{}{"role": "assistant"},
+				},
+			},
+			want: &common.ChatMessage{
+				Messages: []common.Message{
+					{Role: "assistant", Content: ""},
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "empty message list",
 			body: map[string]interface{}{
 				"messages": []interface{}{},
@@ -232,6 +275,59 @@ func TestParsePrompt(t *testing.T) {
 			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("ParsePrompt() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestParsePromptErrorKind pins down which failures are "prompt absent" and which
+// are "prompt malformed", since the router answers the two with different status
+// codes (404 and 400 respectively).
+func TestParsePromptErrorKind(t *testing.T) {
+	tests := []struct {
+		name         string
+		body         map[string]interface{}
+		wantNotFound bool
+	}{
+		{
+			name:         "neither prompt nor messages",
+			body:         map[string]interface{}{"foo": "bar"},
+			wantNotFound: true,
+		},
+		{
+			name:         "messages is not a list",
+			body:         map[string]interface{}{"messages": "not a list"},
+			wantNotFound: false,
+		},
+		{
+			name:         "empty message list",
+			body:         map[string]interface{}{"messages": []interface{}{}},
+			wantNotFound: false,
+		},
+		{
+			name: "malformed content",
+			body: map[string]interface{}{
+				"messages": []interface{}{
+					map[string]interface{}{"role": "user", "content": 123},
+				},
+			},
+			wantNotFound: false,
+		},
+		{
+			name:         "prompt is not a string",
+			body:         map[string]interface{}{"prompt": 123},
+			wantNotFound: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParsePrompt(tt.body)
+			if err == nil {
+				t.Fatalf("ParsePrompt() error = nil, want an error")
+			}
+			if got := errors.Is(err, ErrPromptNotFound); got != tt.wantNotFound {
+				t.Errorf("errors.Is(err, ErrPromptNotFound) = %v, want %v (err = %v)", got, tt.wantNotFound, err)
 			}
 		})
 	}

--- a/pkg/kthena-router/utils/utils_test.go
+++ b/pkg/kthena-router/utils/utils_test.go
@@ -91,6 +91,121 @@ func TestParsePrompt(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "message content as text parts",
+			body: map[string]interface{}{
+				"messages": []interface{}{
+					map[string]interface{}{
+						"role": "user",
+						"content": []interface{}{
+							map[string]interface{}{"type": "text", "text": "hi "},
+							map[string]interface{}{"type": "text", "text": "there"},
+						},
+					},
+				},
+			},
+			want: &common.ChatMessage{
+				Messages: []common.Message{
+					{Role: "user", Content: "hi there"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "message content mixes text and image parts",
+			body: map[string]interface{}{
+				"messages": []interface{}{
+					map[string]interface{}{
+						"role": "user",
+						"content": []interface{}{
+							map[string]interface{}{"type": "text", "text": "describe this"},
+							map[string]interface{}{
+								"type":      "image_url",
+								"image_url": map[string]interface{}{"url": "https://example.com/a.png"},
+							},
+						},
+					},
+				},
+			},
+			want: &common.ChatMessage{
+				Messages: []common.Message{
+					{Role: "user", Content: "describe this"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "assistant message with null content is kept",
+			body: map[string]interface{}{
+				"messages": []interface{}{
+					map[string]interface{}{
+						"role":    "user",
+						"content": "what is the weather",
+					},
+					map[string]interface{}{
+						"role":       "assistant",
+						"content":    nil,
+						"tool_calls": []interface{}{map[string]interface{}{"id": "call_1"}},
+					},
+				},
+			},
+			want: &common.ChatMessage{
+				Messages: []common.Message{
+					{Role: "user", Content: "what is the weather"},
+					{Role: "assistant", Content: ""},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "message content of unsupported type",
+			body: map[string]interface{}{
+				"messages": []interface{}{
+					map[string]interface{}{
+						"role":    "user",
+						"content": 123,
+					},
+				},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "text content part without text field",
+			body: map[string]interface{}{
+				"messages": []interface{}{
+					map[string]interface{}{
+						"role": "user",
+						"content": []interface{}{
+							map[string]interface{}{"type": "text"},
+						},
+					},
+				},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "message content part is not an object",
+			body: map[string]interface{}{
+				"messages": []interface{}{
+					map[string]interface{}{
+						"role":    "user",
+						"content": []interface{}{"hi"},
+					},
+				},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "empty message list",
+			body: map[string]interface{}{
+				"messages": []interface{}{},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
 			name: "messages not a list",
 			body: map[string]interface{}{
 				"messages": "not a list",


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`ParsePrompt` only accepted chat messages whose `content` is a JSON string. The OpenAI chat completions API also allows `content` to be an array of content parts, and allows `content: null` on assistant turns that only carry `tool_calls`. Both forms failed the `msgMap["content"].(string)` assertion and were silently skipped by the `continue`, with no error and no log line.

When every message in a request uses content parts, `ParsePrompt` returned a `*common.ChatMessage` with an empty `Messages` slice and a `nil` error, so the caller treated it as a valid prompt. `GetPromptString` then produced `""`, and that empty string is what the rest of the request path works with:

- `promptStr` is passed to `r.tokenizer.CalculateTokenNum` and to `r.loadRateLimiter.RateLimit(modelName, promptStr)` ([router.go#L314-L342](https://github.com/volcano-sh/kthena/blob/19406609/pkg/kthena-router/router/router.go#L314-L342)). `RateLimit` recomputes tokens from the same empty prompt and calls `inputLimiter.AllowN(time.Now(), 0)` ([ratelimit.go#L103-L117](https://github.com/volcano-sh/kthena/blob/19406609/pkg/kthena-router/filters/ratelimit/ratelimit.go#L103-L117)), which always allows and consumes no quota, so the model's `inputTokenLimit` never applies to these requests. The `len(promptStr) / 4` fallback does not help because the string itself is empty.
- `metricsRecorder.RecordInputTokens(inputTokens)` and `accesslog.SetTokenCounts` record 0, so `input_tokens` under-reports.
- `prefix_cache.go` hashes `utils.GetPromptString(ctx.Prompt)` ([prefix_cache.go#L174](https://github.com/volcano-sh/kthena/blob/19406609/pkg/kthena-router/scheduler/plugins/prefix_cache.go#L174)), so every such request hashes the same empty prompt and unrelated conversations collide on one prefix-cache entry.

A partially-parts request is worse than the all-parts one: the message is dropped from the middle of the conversation, so the reconstructed ChatML prompt is a plausible-looking but wrong prefix, and the routing decision is made on a conversation the user never sent.

This PR handles the three content forms the API defines:

- `string` — unchanged.
- `[]interface{}` — the `text` of each `type: "text"` part is concatenated. Non-text parts (`image_url`, `input_audio`, ...) carry no text and contribute nothing; no placeholder is invented for them, so two requests that differ only in an image still hash alike. That is the same behaviour a text-only tokenizer would give and can be revisited separately if multimodal prefix affinity is wanted.
- `nil` — the message is kept with empty content instead of being dropped, so a tool-calling turn is not removed from the middle of the conversation.
- anything else — a malformed request, which now returns an error instead of silently dropping the message.

A message list that yields nothing usable also returns an error now, so the caller's existing 4xx path handles it instead of routing a phantom empty prompt.

**Which issue(s) this PR fixes**:
Fixes #1416

**Bug evidence (required for bug-related PRs)**:

The trigger is an ordinary user action: sending a chat completion whose `content` is an array of content parts, which is what the OpenAI SDKs emit for multimodal requests and what several clients emit unconditionally. Using the existing rate limit example, `examples/kthena-router/ModelRouteWithRateLimit.yaml` (10 input tokens per minute):

```yaml
spec:
  modelName: "deepseek-r1-with-rate-limit"
  rules:
  - name: "default"
    targetModels:
    - modelServerName: "deepseek-r1-1-5b"
  rateLimit:
    inputTokensPerUnit: 10
    outputTokensPerUnit: 5000
    unit: minute
```

Send the same prompt twice, once as a plain string and once as a text content part:

```bash
# string content: consumes quota, second call returns "input token rate limit exceeded"
curl -s localhost:8080/v1/chat/completions -H 'Content-Type: application/json' -d '{
  "model": "deepseek-r1-with-rate-limit",
  "messages": [{"role": "user", "content": "write a long essay about kubernetes scheduling"}]
}'

# parts content: identical text, but accounted as 0 input tokens and never rate limited
curl -s localhost:8080/v1/chat/completions -H 'Content-Type: application/json' -d '{
  "model": "deepseek-r1-with-rate-limit",
  "messages": [{"role": "user", "content": [
    {"type": "text", "text": "write a long essay about kubernetes scheduling"}
  ]}]
}'
```

The parts request reports `input_tokens: 0` in the access log and is forwarded to the backend indefinitely, because the whole chain runs on an empty prompt string. The chain is traceable in the source at `19406609`:

1. `ParsePrompt` drops the message at the `content` string assertion, [utils.go#L74-L77](https://github.com/volcano-sh/kthena/blob/19406609/pkg/kthena-router/utils/utils.go#L74-L77), and returns `&ChatMessage{Messages: []}` with a `nil` error.
2. The handler treats that as valid and derives `promptStr = ""`, [router.go#L314-L323](https://github.com/volcano-sh/kthena/blob/19406609/pkg/kthena-router/router/router.go#L314-L323).
3. `RateLimit` recomputes tokens from that empty string and calls `AllowN(time.Now(), 0)`, which always allows and consumes nothing, [ratelimit.go#L101-L117](https://github.com/volcano-sh/kthena/blob/19406609/pkg/kthena-router/filters/ratelimit/ratelimit.go#L101-L117).

The empty `Messages` slice with a `nil` error at step 1 is directly observable — the tests added in this PR reproduce it against the current `main`:

```
--- FAIL: TestParsePrompt/message_content_as_text_parts
    ParsePrompt() got = &{ []}, want &{ [{user hi there}]}
--- FAIL: TestParsePrompt/assistant_message_with_null_content_is_kept
    ParsePrompt() got = &{ [{user what is the weather}]}, want &{ [{user what is the weather} {assistant }]}
--- FAIL: TestParsePrompt/message_content_of_unsupported_type
    ParsePrompt() error = <nil>, wantErr true
```

They cover text parts, mixed text and image parts, null content with `tool_calls`, a non-object content part, a text part without a `text` field, an unsupported content type, and an empty message list, and all pass with the fix.

**Special notes for your reviewer**:

The one behaviour change beyond the parsing fix is that a `messages` list which produces no usable message now returns an error rather than an empty `ChatMessage`. The caller already maps a `ParsePrompt` error to a 4xx response, so this only affects requests that were previously routed with an empty prompt. Happy to drop that part if it is felt to be out of scope for the fix.

Non-text content parts deliberately contribute no text to the prompt. If prefix-cache scoring should distinguish requests that differ only by an image, that needs a separate decision about what to hash for those parts.

**Does this PR introduce a user-facing change?**:
```release-note
Fix kthena-router silently dropping chat messages whose `content` is an array of content parts or null, which caused those requests to be accounted as zero input tokens, bypass input token rate limiting, and collide on a single prefix-cache entry.
```
