### PR TITLE
Support ModelRoute and ModelServer in kthena create manifest

### DIFF
--- a/cli/kthena/cmd/create.go
+++ b/cli/kthena/cmd/create.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/volcano-sh/kthena/client-go/clientset/versioned"
+	networkingv1alpha1 "github.com/volcano-sh/kthena/pkg/apis/networking/v1alpha1"
 	workloadv1alpha1 "github.com/volcano-sh/kthena/pkg/apis/workload/v1alpha1"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/engine"
@@ -279,7 +280,7 @@ func applyResources(yamlContent string) error {
 	return nil
 }
 
-func applyKthenaResource(ctx context.Context, client *versioned.Clientset, obj *unstructured.Unstructured) error {
+func applyKthenaResource(ctx context.Context, client versioned.Interface, obj *unstructured.Unstructured) error {
 	gvk := obj.GetObjectKind().GroupVersionKind()
 	resourceName := obj.GetName()
 	resourceNamespace := obj.GetNamespace()
@@ -323,6 +324,32 @@ func applyKthenaResource(ctx context.Context, client *versioned.Clientset, obj *
 		_, err = client.WorkloadV1alpha1().AutoscalingPolicies(resourceNamespace).Create(ctx, policy, metav1.CreateOptions{})
 		if err != nil {
 			return fmt.Errorf("failed to create AutoscalingPolicy: %v", err)
+		}
+
+	case "ModelRoute":
+		fmt.Printf("  Creating ModelRoute: %s in namespace %s\n", resourceName, resourceNamespace)
+		modelRoute := &networkingv1alpha1.ModelRoute{}
+		err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, modelRoute)
+		if err != nil {
+			return fmt.Errorf("failed to convert unstructured object to ModelRoute: %v", err)
+		}
+
+		_, err = client.NetworkingV1alpha1().ModelRoutes(resourceNamespace).Create(ctx, modelRoute, metav1.CreateOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to create ModelRoute: %v", err)
+		}
+
+	case "ModelServer":
+		fmt.Printf("  Creating ModelServer: %s in namespace %s\n", resourceName, resourceNamespace)
+		modelServer := &networkingv1alpha1.ModelServer{}
+		err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, modelServer)
+		if err != nil {
+			return fmt.Errorf("failed to convert unstructured object to ModelServer: %v", err)
+		}
+
+		_, err = client.NetworkingV1alpha1().ModelServers(resourceNamespace).Create(ctx, modelServer, metav1.CreateOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to create ModelServer: %v", err)
 		}
 
 	default:

--- a/cli/kthena/cmd/create_test.go
+++ b/cli/kthena/cmd/create_test.go
@@ -1,0 +1,115 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"context"
+	"testing"
+
+	"github.com/volcano-sh/kthena/client-go/clientset/versioned/fake"
+	networkingv1alpha1 "github.com/volcano-sh/kthena/pkg/apis/networking/v1alpha1"
+	workloadv1alpha1 "github.com/volcano-sh/kthena/pkg/apis/workload/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestApplyKthenaResource(t *testing.T) {
+	tests := []struct {
+		name       string
+		apiVersion string
+		kind       string
+		resource   string
+	}{
+		{
+			name:       "ModelServing",
+			apiVersion: workloadv1alpha1.SchemeGroupVersion.String(),
+			kind:       "ModelServing",
+			resource:   "modelservings",
+		},
+		{
+			name:       "ModelBooster",
+			apiVersion: workloadv1alpha1.SchemeGroupVersion.String(),
+			kind:       "ModelBooster",
+			resource:   "modelboosters",
+		},
+		{
+			name:       "AutoscalingPolicy",
+			apiVersion: workloadv1alpha1.SchemeGroupVersion.String(),
+			kind:       "AutoscalingPolicy",
+			resource:   "autoscalingpolicies",
+		},
+		{
+			name:       "ModelRoute",
+			apiVersion: networkingv1alpha1.SchemeGroupVersion.String(),
+			kind:       "ModelRoute",
+			resource:   "modelroutes",
+		},
+		{
+			name:       "ModelServer",
+			apiVersion: networkingv1alpha1.SchemeGroupVersion.String(),
+			kind:       "ModelServer",
+			resource:   "modelservers",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := fake.NewSimpleClientset()
+			obj := &unstructured.Unstructured{Object: map[string]interface{}{
+				"apiVersion": tt.apiVersion,
+				"kind":       tt.kind,
+				"metadata": map[string]interface{}{
+					"name":      "test-resource",
+					"namespace": "test-namespace",
+				},
+				"spec": map[string]interface{}{},
+			}}
+
+			if err := applyKthenaResource(context.Background(), client, obj); err != nil {
+				t.Fatalf("applyKthenaResource() error = %v", err)
+			}
+
+			actions := client.Actions()
+			if len(actions) != 1 {
+				t.Fatalf("expected 1 client action, got %d", len(actions))
+			}
+			action := actions[0]
+			if action.GetVerb() != "create" {
+				t.Errorf("expected create action, got %q", action.GetVerb())
+			}
+			if action.GetResource().Resource != tt.resource {
+				t.Errorf("expected resource %q, got %q", tt.resource, action.GetResource().Resource)
+			}
+			if action.GetNamespace() != "test-namespace" {
+				t.Errorf("expected namespace %q, got %q", "test-namespace", action.GetNamespace())
+			}
+		})
+	}
+}
+
+func TestApplyKthenaResourceRejectsUnsupportedKind(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(networkingv1alpha1.SchemeGroupVersion.WithKind("Unsupported"))
+	obj.SetName("test-resource")
+	obj.SetNamespace(metav1.NamespaceDefault)
+
+	err := applyKthenaResource(context.Background(), client, obj)
+	if err == nil || err.Error() != "unsupported resource type: Unsupported" {
+		t.Fatalf("expected unsupported resource error, got %v", err)
+	}
+}


### PR DESCRIPTION
/kind enhancement

**What this PR does / why we need it**:

Extends `kthena create manifest` to create `ModelRoute` and `ModelServer` resources rendered from manifest templates. This completes the CLI create path for networking resources that are already supported by `kthena get` and `kthena describe`.

Adds unit tests covering both networking resource types and the existing unsupported-kind error path.

**Which issue(s) this PR fixes**:

Fixes #1415

**Bug evidence (required for bug-related PRs)**:

N/A

**Special notes for your reviewer**:

This change was prepared with assistance from Codex. The resulting diff and tests were reviewed locally.

**Does this PR introduce a user-facing change?**:

```release-note
`kthena create manifest` now supports creating ModelRoute and ModelServer resources.
```
