### PR TITLE
router: match namespaced KV cache owners

### DIFF
--- a/pkg/kthena-router/scheduler/plugins/kvcache_aware.go
+++ b/pkg/kthena-router/scheduler/plugins/kvcache_aware.go
@@ -259,7 +259,7 @@ func (t *KVCacheAware) Score(ctx *framework.Context, pods []*datastore.PodInfo) 
 
 	candidateNames := make(map[string]struct{}, len(pods))
 	for _, p := range pods {
-		candidateNames[p.GetPodNamespacedName().Name] = struct{}{}
+		candidateNames[podCacheOwnerIdentifier(p)] = struct{}{}
 	}
 	for hash, podNames := range blockToPods {
 		kept := podNames[:0]
@@ -281,8 +281,7 @@ func (t *KVCacheAware) Score(ctx *framework.Context, pods []*datastore.PodInfo) 
 	}
 	scoreResults := make(map[*datastore.PodInfo]int, len(podScores))
 	for _, pod := range pods {
-		podName := pod.GetPodNamespacedName()
-		podScoreKey := fmt.Sprintf("%s.%s", podName.Name, podName.Namespace)
+		podScoreKey := podCacheOwnerIdentifier(pod)
 		if score, exists := podScores[podScoreKey]; exists {
 			scoreResults[pod] = score
 		}
@@ -343,6 +342,11 @@ func (t *KVCacheAware) queryRedisForBlocks(blockHashes []uint64, modelName strin
 
 	klog.V(4).Infof("KVCacheAware.queryRedis: total blocks with hits: %d/%d", len(blockToPods), len(blockHashes))
 	return blockToPods, nil
+}
+
+func podCacheOwnerIdentifier(pod *datastore.PodInfo) string {
+	podName := pod.GetPodNamespacedName()
+	return fmt.Sprintf("%s.%s", podName.Name, podName.Namespace)
 }
 
 func (t *KVCacheAware) startGC() {

--- a/pkg/kthena-router/scheduler/plugins/kvcache_aware.go
+++ b/pkg/kthena-router/scheduler/plugins/kvcache_aware.go
@@ -344,6 +344,7 @@ func (t *KVCacheAware) queryRedisForBlocks(blockHashes []uint64, modelName strin
 	return blockToPods, nil
 }
 
+// podCacheOwnerIdentifier matches the pod.namespace Redis owner format written by the Runtime.
 func podCacheOwnerIdentifier(pod *datastore.PodInfo) string {
 	podName := pod.GetPodNamespacedName()
 	return fmt.Sprintf("%s.%s", podName.Name, podName.Namespace)

--- a/pkg/kthena-router/scheduler/plugins/kvcache_aware_test.go
+++ b/pkg/kthena-router/scheduler/plugins/kvcache_aware_test.go
@@ -734,7 +734,7 @@ func TestKVCacheAware_Score_Core(t *testing.T) {
 	}
 }
 
-func TestKVCacheAware_ScoreMatchesNamespacedRedisOwner(t *testing.T) {
+func TestKVCacheAware_ScoreMatchesOnlyNamespacedRedisOwner(t *testing.T) {
 	tokenizerServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/tokenize" {
 			http.NotFound(w, r)
@@ -793,6 +793,22 @@ func TestKVCacheAware_ScoreMatchesNamespacedRedisOwner(t *testing.T) {
 
 	if score := scores[pod]; score != 100 {
 		t.Fatalf("namespaced Redis owner score = %d, want 100; all scores: %v", score, scores)
+	}
+
+	if err := redisClient.HDel(context.Background(), key, podName+"."+namespace).Err(); err != nil {
+		t.Fatalf("failed to remove namespaced Redis owner: %v", err)
+	}
+	if err := redisClient.HSet(context.Background(), key, podName, time.Now().Unix()).Err(); err != nil {
+		t.Fatalf("failed to seed bare Redis owner: %v", err)
+	}
+
+	scores = plugin.Score(&framework.Context{
+		Model:  model,
+		Prompt: &common.ChatMessage{Text: "hello"},
+	}, []*datastore.PodInfo{pod})
+
+	if score, exists := scores[pod]; exists {
+		t.Fatalf("bare Redis owner matched namespaced pod with score %d; all scores: %v", score, scores)
 	}
 }
 

--- a/pkg/kthena-router/scheduler/plugins/kvcache_aware_test.go
+++ b/pkg/kthena-router/scheduler/plugins/kvcache_aware_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"strings"
 	"testing"
@@ -729,6 +731,68 @@ func TestKVCacheAware_Score_Core(t *testing.T) {
 				t.Errorf("Expected scores %v, got %v", tt.expectedScores, resultMap)
 			}
 		})
+	}
+}
+
+func TestKVCacheAware_ScoreMatchesNamespacedRedisOwner(t *testing.T) {
+	tokenizerServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/tokenize" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"count":1,"max_model_len":2048,"tokens":[1]}`)
+	}))
+	defer tokenizerServer.Close()
+
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("failed to start miniredis: %v", err)
+	}
+	defer mr.Close()
+
+	redisClient := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer redisClient.Close()
+
+	const (
+		model     = "test-model"
+		podName   = "pod-1"
+		namespace = "test-namespace"
+	)
+	pod := datastore.NewPodInfo(&v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: namespace,
+		},
+		Status: v1.PodStatus{PodIP: "127.0.0.1"},
+	}, tokenization.EngineVLLM)
+
+	endpointTemplate := strings.Replace(tokenizerServer.URL, "127.0.0.1", "%s", 1)
+	processor := &TokenBlockProcessor{blockSize: 1}
+	blockHashes := processor.TokensToBlockHashes([]uint32{1}, 1)
+	key := KVCacheAwareBlock{ModelName: model, ChunkHash: blockHashes[0]}.String(kvCacheKeyPrefix)
+	if err := redisClient.HSet(context.Background(), key, podName+"."+namespace, time.Now().Unix()).Err(); err != nil {
+		t.Fatalf("failed to seed redis: %v", err)
+	}
+
+	plugin := &KVCacheAware{
+		name:             KVCacheAwarePluginName,
+		maxBlocksToMatch: 1,
+		keyPrefix:        kvCacheKeyPrefix,
+		redisClient:      redisClient,
+		processor:        processor,
+		tokenizerManager: tokenization.NewTokenizerManager(tokenization.TokenizerManagerConfig{
+			EndpointTemplates: map[string]string{tokenization.EngineVLLM: endpointTemplate},
+		}),
+	}
+
+	scores := plugin.Score(&framework.Context{
+		Model:  model,
+		Prompt: &common.ChatMessage{Text: "hello"},
+	}, []*datastore.PodInfo{pod})
+
+	if score := scores[pod]; score != 100 {
+		t.Fatalf("namespaced Redis owner score = %d, want 100; all scores: %v", score, scores)
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fixes KV-cache-aware scoring for namespaced Redis owner identifiers.

The Runtime records KV-cache owners as `pod-name.namespace`, while candidate filtering previously compared those identifiers against Pod names without namespaces. As a result, valid owners were removed before score calculation and warmed Pods received no KV-cache score.

This PR:

- uses the same `pod-name.namespace` identifier for candidate filtering and final score lookup;
- centralizes identifier construction in `podCacheOwnerIdentifier`;
- documents the Runtime's namespaced Redis owner contract;
- adds a `Score()`-level regression test covering tokenization, Redis lookup, candidate filtering, final score mapping, and rejection of ambiguous bare Pod names.

**Which issue(s) this PR fixes**:

Fixes #1421

**Bug evidence (required for bug-related PRs)**:

The official workload passes `$(POD_NAME).$(NAMESPACE)` to the Runtime:

https://github.com/volcano-sh/kthena/blob/c153f0e1168cdd5e8b80c6606875eeea2b8c40d3/examples/model-serving/gpu-kvcache-aware.yaml#L94-L105

The Runtime writes that identifier directly as the Redis Hash field:

https://github.com/volcano-sh/kthena/blob/c153f0e1168cdd5e8b80c6606875eeea2b8c40d3/python/kthena/runtime/kv_cache_manager.py#L117-L123

The Router preserves Redis owners unchanged, but candidate filtering compared them against Pod names without namespaces:

https://github.com/volcano-sh/kthena/blob/c153f0e1168cdd5e8b80c6606875eeea2b8c40d3/pkg/kthena-router/scheduler/plugins/kvcache_aware.go#L260-L275

The final score lookup expects the namespaced identifier again:

https://github.com/volcano-sh/kthena/blob/c153f0e1168cdd5e8b80c6606875eeea2b8c40d3/pkg/kthena-router/scheduler/plugins/kvcache_aware.go#L282-L289

Reproduction:

1. Create a candidate Pod named `pod-1` in namespace `test-namespace`.
2. Store a matching block in Redis with owner `pod-1.test-namespace`.
3. Call `KVCacheAware.Score()` with that Pod.
4. Before this change, candidate filtering removes the owner and returns an empty score map.
5. After this change, the Pod receives a score of `100`.

Validation:

```text
go test ./pkg/kthena-router/scheduler/plugins -run TestKVCacheAware_ScoreMatchesOnlyNamespacedRedisOwner -count=1
go test ./pkg/kthena-router/scheduler/... -count=1
go vet ./pkg/kthena-router/scheduler/...
```

All commands pass.

**Special notes for your reviewer**:

The fix intentionally preserves the existing Runtime and Redis identifier format. It only makes candidate filtering use the same identifier format already used by Redis and the final score lookup. Bare Pod names are not matched because they are ambiguous across namespaces.

**Does this PR introduce a user-facing change?**:

```release-note
Fixed KV-cache-aware routing so namespaced Redis cache owners are matched to eligible Pods correctly.
```
