### PR TITLE
router: generate a fresh SGLang bootstrap room per retry

### DIFF
--- a/pkg/kthena-router/connectors/sglang.go
+++ b/pkg/kthena-router/connectors/sglang.go
@@ -48,6 +48,8 @@ const ConnectorTypeSGLang v1alpha1.KVConnectorType = "sglang"
 //
 //	https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/managers/scheduler.py
 type SGLangConnector struct {
+	// newBootstrapRoom is injectable for deterministic tests; production
+	// connectors always use rand.Int63.
 	newBootstrapRoom func() int64
 }
 

--- a/pkg/kthena-router/connectors/sglang.go
+++ b/pkg/kthena-router/connectors/sglang.go
@@ -48,15 +48,13 @@ const ConnectorTypeSGLang v1alpha1.KVConnectorType = "sglang"
 //
 //	https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/managers/scheduler.py
 type SGLangConnector struct {
-	bootstrapRoom int64
+	newBootstrapRoom func() int64
 }
 
-// NewSGLangConnector creates a new SGLang connector with a unique bootstrap room id.
+// NewSGLangConnector creates a new SGLang connector.
 func NewSGLangConnector() KVConnector {
 	return &SGLangConnector{
-		// rand.Int63 returns a non-negative 63-bit integer suitable for use as
-		// sglang's bootstrap_room (Python int).
-		bootstrapRoom: rand.Int63(),
+		newBootstrapRoom: rand.Int63,
 	}
 }
 
@@ -80,6 +78,10 @@ func (s *SGLangConnector) Name() string {
 // The decode request carries bootstrap_host = prefillHost so the decode receiver can
 // locate the prefill's bootstrap server; both requests carry the same bootstrap_room.
 func (s *SGLangConnector) Proxy(c *gin.Context, reqBody map[string]interface{}, prefillAddr, decodeAddr string, hooks *OnFlightHooks) (int, error) {
+	// A bootstrap room identifies one prefill/decode attempt. Generate it here
+	// so retries cannot observe state left behind by an earlier worker pair.
+	bootstrapRoom := s.newBootstrapRoom()
+
 	// Retrieve optional metrics recorder from context.
 	var metricsRecorder *metrics.RequestMetricsRecorder
 	if recorder, exists := c.Get("metricsRecorder"); exists {
@@ -111,7 +113,7 @@ func (s *SGLangConnector) Proxy(c *gin.Context, reqBody map[string]interface{}, 
 	// against a different upstream pod by the router's PD retry loop.
 	decodeBody := cloneReqBody(reqBody)
 	decodeBody = addTokenUsage(c, decodeBody)
-	decodeBody["bootstrap_room"] = s.bootstrapRoom
+	decodeBody["bootstrap_room"] = bootstrapRoom
 	decodeBody["bootstrap_host"] = prefillHost
 	decodeRequest, err := buildRequest(c.Request, decodeBody)
 	if err != nil {
@@ -123,7 +125,7 @@ func (s *SGLangConnector) Proxy(c *gin.Context, reqBody map[string]interface{}, 
 	// decode receiver; it does not need bootstrap_host.
 	prefillBody := cloneReqBody(reqBody)
 	preparePrefillBody(prefillBody)
-	prefillBody["bootstrap_room"] = s.bootstrapRoom
+	prefillBody["bootstrap_room"] = bootstrapRoom
 	prefillRequest, err := buildRequest(req, prefillBody)
 	if err != nil {
 		return http.StatusInternalServerError, err
@@ -156,7 +158,7 @@ func (s *SGLangConnector) Proxy(c *gin.Context, reqBody map[string]interface{}, 
 	prefillCh := make(chan prefillOutcome, 1)
 
 	go func() {
-		err := s.prefill(prefillRequest.WithContext(prefillCtx), prefillAddr)
+		err := s.prefill(prefillRequest.WithContext(prefillCtx), prefillAddr, bootstrapRoom)
 		// Decrement the prefill pod's on-flight counter as soon as prefill finishes,
 		// so the scheduler gets an accurate view even while decode is still running.
 		if hooks != nil && hooks.DecrPrefill != nil {
@@ -167,7 +169,7 @@ func (s *SGLangConnector) Proxy(c *gin.Context, reqBody map[string]interface{}, 
 
 	// Run decode in the current goroutine so that streaming writes reach the
 	// gin.Context from the request-handling goroutine.
-	result, decodeErr := s.decode(c, decodeRequest, decodeAddr)
+	result, decodeErr := s.decode(c, decodeRequest, decodeAddr, bootstrapRoom)
 
 	if hooks != nil && hooks.DecrDecode != nil {
 		hooks.DecrDecode()
@@ -199,24 +201,24 @@ func (s *SGLangConnector) Proxy(c *gin.Context, reqBody map[string]interface{}, 
 	}
 
 	if prefillResult.err != nil {
-		klog.Errorf("sglang prefill error (bootstrap_room=%d): %v", s.bootstrapRoom, prefillResult.err)
+		klog.Errorf("sglang prefill error (bootstrap_room=%d): %v", bootstrapRoom, prefillResult.err)
 		return http.StatusInternalServerError, prefillResult.err
 	}
 
 	return result, decodeErr
 }
 
-func (s *SGLangConnector) prefill(req *http.Request, prefillAddr string) error {
+func (s *SGLangConnector) prefill(req *http.Request, prefillAddr string, bootstrapRoom int64) error {
 	req.URL.Host = prefillAddr
 	req.URL.Scheme = "http"
-	klog.V(4).Infof("sglang prefill: sending to %s (bootstrap_room=%d)", req.URL.String(), s.bootstrapRoom)
+	klog.V(4).Infof("sglang prefill: sending to %s (bootstrap_room=%d)", req.URL.String(), bootstrapRoom)
 	return prefillerProxy(nil, req)
 }
 
-func (s *SGLangConnector) decode(c *gin.Context, req *http.Request, decodeAddr string) (int, error) {
+func (s *SGLangConnector) decode(c *gin.Context, req *http.Request, decodeAddr string, bootstrapRoom int64) (int, error) {
 	req.URL.Host = decodeAddr
 	req.URL.Scheme = "http"
-	klog.V(4).Infof("sglang decode: sending to %s (bootstrap_room=%d)", req.URL.String(), s.bootstrapRoom)
+	klog.V(4).Infof("sglang decode: sending to %s (bootstrap_room=%d)", req.URL.String(), bootstrapRoom)
 	return decoderProxy(c, req)
 }
 

--- a/pkg/kthena-router/connectors/sglang_test.go
+++ b/pkg/kthena-router/connectors/sglang_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package connectors
 
 import (
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -26,20 +27,28 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// TestSGLangConnectorRetryBodyNotDrained checks that calling Proxy() twice on
-// the same connector instance — as proxyToPDDisaggregated does during PD
-// retries when the scheduler reselects the same prefill pod for a different
-// decode pod — sends a non-empty body to both backends on both attempts.
-func TestSGLangConnectorRetryBodyNotDrained(t *testing.T) {
+// TestSGLangConnectorRetryIsolation checks that calling Proxy() twice on the
+// same connector instance rebuilds both request bodies and assigns a fresh
+// bootstrap room to each PD attempt.
+func TestSGLangConnectorRetryIsolation(t *testing.T) {
 	var prefillCalls, decodeCalls int32
 	var prefillBodyLens [2]int64
 	var decodeBodyLens [2]int64
+	var prefillRooms [2]int64
+	var decodeRooms [2]int64
 
 	prefillServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		idx := atomic.AddInt32(&prefillCalls, 1) - 1
 		body, _ := io.ReadAll(r.Body)
 		if idx < 2 {
 			prefillBodyLens[idx] = int64(len(body))
+			var payload struct {
+				BootstrapRoom int64 `json:"bootstrap_room"`
+			}
+			if err := json.Unmarshal(body, &payload); err != nil {
+				t.Errorf("failed to decode prefill request: %v", err)
+			}
+			prefillRooms[idx] = payload.BootstrapRoom
 		}
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -50,6 +59,13 @@ func TestSGLangConnectorRetryBodyNotDrained(t *testing.T) {
 		body, _ := io.ReadAll(r.Body)
 		if idx < 2 {
 			decodeBodyLens[idx] = int64(len(body))
+			var payload struct {
+				BootstrapRoom int64 `json:"bootstrap_room"`
+			}
+			if err := json.Unmarshal(body, &payload); err != nil {
+				t.Errorf("failed to decode decode request: %v", err)
+			}
+			decodeRooms[idx] = payload.BootstrapRoom
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -57,7 +73,11 @@ func TestSGLangConnectorRetryBodyNotDrained(t *testing.T) {
 	}))
 	defer decodeServer.Close()
 
-	connector := NewSGLangConnector()
+	connector := NewSGLangConnector().(*SGLangConnector)
+	var nextRoom int64
+	connector.newBootstrapRoom = func() int64 {
+		return atomic.AddInt64(&nextRoom, 1)
+	}
 
 	reqBody := map[string]interface{}{
 		"model":      "test-model",
@@ -99,6 +119,14 @@ func TestSGLangConnectorRetryBodyNotDrained(t *testing.T) {
 	}
 	if decodeBodyLens[1] == 0 {
 		t.Error("second Proxy call sent empty body to decode backend — request body was drained and reused")
+	}
+	for i := range prefillRooms {
+		if prefillRooms[i] != decodeRooms[i] {
+			t.Errorf("attempt %d used different bootstrap rooms: prefill=%d decode=%d", i, prefillRooms[i], decodeRooms[i])
+		}
+	}
+	if prefillRooms[0] == prefillRooms[1] {
+		t.Errorf("retry reused bootstrap room %d", prefillRooms[0])
 	}
 }
 

--- a/pkg/kthena-router/connectors/sglang_test.go
+++ b/pkg/kthena-router/connectors/sglang_test.go
@@ -97,13 +97,11 @@ func TestSGLangConnectorRetryIsolation(t *testing.T) {
 	prefillAddr := prefillServer.Listener.Addr().String()
 	decodeAddr := decodeServer.Listener.Addr().String()
 
-	// First call — simulates retry iteration 0.
+	// First call simulates the initial PD attempt.
 	if _, err := connector.Proxy(makeCtx(), reqBody, prefillAddr, decodeAddr, nil); err != nil {
 		t.Fatalf("first Proxy call failed: %v", err)
 	}
-	// Second call with the SAME prefill addr — simulates the scheduler reselecting
-	// the same prefill pod for a different decode pod on retry. This is the path
-	// where the previous (cached) request would have a drained body.
+	// The second call simulates another attempt on the same connector.
 	if _, err := connector.Proxy(makeCtx(), reqBody, prefillAddr, decodeAddr, nil); err != nil {
 		t.Fatalf("second Proxy call failed: %v", err)
 	}


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

Generate the SGLang `bootstrap_room` inside each `Proxy` call instead of storing one room on the connector. This gives every PD worker-pair retry an isolated bootstrap session while keeping the prefill and decode requests within one attempt on the same room.

The retry regression test now captures both upstream request bodies and verifies that:

- prefill and decode use the same room within an attempt;
- successive attempts use different rooms;
- request bodies remain reusable across retries.

**Which issue(s) this PR fixes**:
Fixes #1423

**Bug evidence (required for bug-related PRs)**:

The production router creates one connector before entering `proxyToPDDisaggregated`, then calls the same connector once per worker-pair attempt. Before this change, `NewSGLangConnector` generated and stored one `bootstrapRoom`, so every `Proxy` call injected the same value into both upstream requests.

The regression test exercises the production `Proxy` request-building path twice on the same connector and captures the JSON received by both HTTP backends. The issue has not yet been reproduced on a real SGLang cluster; the confirmed behavior is cross-attempt room reuse.

**Special notes for your reviewer**:

The room generator is kept on the connector for deterministic testing, but the generated room itself is local to each `Proxy` invocation.

**Does this PR introduce a user-facing change?**:
```release-note
SGLang PD retries now use a fresh bootstrap room for each worker-pair attempt.
```