### PR TITLE
runtime: use Redis SCAN instead of KEYS

### DIFF
--- a/python/kthena/runtime/kv_cache_manager.py
+++ b/python/kthena/runtime/kv_cache_manager.py
@@ -170,7 +170,7 @@ class VLLMKVCacheRedisManager:
                     self.hash_mapping[engine_hash] = std_hash
             else:
                 pattern = f"{self.MAPPING_KEY_PREFIX}:*@{engine_hash}"
-                keys = await self.redis_client.keys(pattern)
+                keys = await self.redis_client.scan_keys(pattern)
                 if keys:
                     std_hash_str = await client.get(keys[0])
                     if std_hash_str:
@@ -217,8 +217,8 @@ class VLLMKVCacheRedisManager:
             matrix_pattern = f"{get_matrix_key_prefix()}:{model_name}@*"
             mapping_pattern = f"{self.MAPPING_KEY_PREFIX}:{pod_identifier}@*"
 
-            matrix_keys = await self.redis_client.keys(matrix_pattern)
-            mapping_keys = await self.redis_client.keys(mapping_pattern)
+            matrix_keys = await self.redis_client.scan_keys(matrix_pattern)
+            mapping_keys = await self.redis_client.scan_keys(mapping_pattern)
 
             if not matrix_keys:
                 if mapping_keys:

--- a/python/kthena/runtime/redis_client.py
+++ b/python/kthena/runtime/redis_client.py
@@ -23,6 +23,9 @@ from redis.exceptions import RedisError, ConnectionError, TimeoutError
 
 logger = logging.getLogger(__name__)
 
+# Keys returned per SCAN iteration. Bounds how long any single call holds the server.
+SCAN_BATCH_SIZE = 500
+
 
 class RedisConfig:
     def __init__(self):
@@ -123,6 +126,27 @@ class RedisClient:
             return result or []
         except (RedisError, ConnectionError, TimeoutError):
             return []
+
+    async def scan_keys(self, pattern: str, count: int = SCAN_BATCH_SIZE) -> List[str]:
+        """Return keys matching pattern, walking the keyspace with SCAN.
+
+        KEYS blocks the server until it has walked the whole keyspace, so it is not
+        safe on a Redis shared with the router. SCAN yields in bounded batches instead.
+        A key may be reported by more than one SCAN iteration, so results are deduped.
+        """
+        keys: List[str] = []
+        cursor = 0
+        try:
+            while True:
+                cursor, batch = await self._execute_with_retry(
+                    self._client.scan, cursor=cursor, match=pattern, count=count
+                )
+                keys.extend(batch)
+                if cursor == 0:
+                    break
+        except (RedisError, ConnectionError, TimeoutError):
+            return []
+        return list(dict.fromkeys(keys))
 
     async def get_connection(self):
         await self._ensure_connected()

--- a/python/kthena/runtime/redis_client.py
+++ b/python/kthena/runtime/redis_client.py
@@ -23,7 +23,8 @@ from redis.exceptions import RedisError, ConnectionError, TimeoutError
 
 logger = logging.getLogger(__name__)
 
-# Keys returned per SCAN iteration. Bounds how long any single call holds the server.
+# COUNT hint per SCAN iteration. Bounds the work the server does per round rather
+# than the number of keys returned, which Redis is free to vary.
 SCAN_BATCH_SIZE = 500
 
 
@@ -131,8 +132,9 @@ class RedisClient:
         """Return keys matching pattern, walking the keyspace with SCAN.
 
         KEYS blocks the server until it has walked the whole keyspace, so it is not
-        safe on a Redis shared with the router. SCAN yields in bounded batches instead.
-        A key may be reported by more than one SCAN iteration, so results are deduped.
+        safe on a Redis shared with the router. SCAN bounds the work per round instead.
+        A round may return any number of keys, including none while the cursor is still
+        non-zero, and a key may be reported more than once, so results are deduped.
         """
         keys: List[str] = []
         cursor = 0

--- a/python/kthena/tests/test_sglang_kv_cache_handler.py
+++ b/python/kthena/tests/test_sglang_kv_cache_handler.py
@@ -269,3 +269,14 @@ async def test_scan_keys_returns_empty_on_redis_error():
     client._client.scan = failing_scan
 
     assert await client.scan_keys("matrix:kv:block:qwen@*") == []
+
+
+@pytest.mark.asyncio
+async def test_scan_keys_handles_empty_round_before_cursor_returns_to_zero():
+    """SCAN may return nothing for a round while the cursor is still non-zero."""
+    client = _make_scanning_redis_client([(9, []), (0, ["matrix:kv:block:qwen@1"])])
+
+    assert await client.scan_keys("matrix:kv:block:qwen@*") == [
+        "matrix:kv:block:qwen@1"
+    ]
+    assert client._client.cursors == [0, 9]

--- a/python/kthena/tests/test_sglang_kv_cache_handler.py
+++ b/python/kthena/tests/test_sglang_kv_cache_handler.py
@@ -76,7 +76,7 @@ def _make_redis_client(pipeline: _FakePipeline, keys_result=None, get_results=No
     conn = _FakeRedisConn(pipeline, get_results=get_results)
     client = MagicMock()
     client.get_connection = AsyncMock(return_value=conn)
-    client.keys = AsyncMock(return_value=keys_result or [])
+    client.scan_keys = AsyncMock(return_value=keys_result or [])
     return client
 
 
@@ -175,9 +175,9 @@ async def test_all_blocks_cleared_clears_pod_from_matrix():
         keys_result=matrix_keys + mapping_keys,
     )
 
-    # `keys()` is called twice (matrix, then mapping). Stub it to return each
+    # `scan_keys()` is called twice (matrix, then mapping). Stub it to return each
     # set in order.
-    redis_client.keys = AsyncMock(side_effect=[matrix_keys, mapping_keys])
+    redis_client.scan_keys = AsyncMock(side_effect=[matrix_keys, mapping_keys])
 
     manager = SGLangKVCacheRedisManager(redis_client=redis_client)
     handler = SGLangKVCacheEventHandler(redis_manager=manager)
@@ -210,3 +210,62 @@ def test_sglang_and_vllm_managers_use_distinct_namespaces():
         VLLMKVCacheRedisManager.MAPPING_KEY_PREFIX
         != SGLangKVCacheRedisManager.MAPPING_KEY_PREFIX
     )
+
+
+class _FakeScanClient:
+    """Serves SCAN batches and records the cursors it was called with."""
+
+    def __init__(self, batches):
+        self._batches = list(batches)
+        self.cursors = []
+
+    async def scan(self, cursor=0, match=None, count=None):
+        self.cursors.append(cursor)
+        return self._batches.pop(0)
+
+
+def _make_scanning_redis_client(batches):
+    from kthena.runtime.redis_client import RedisClient
+
+    client = RedisClient()
+    client._client = _FakeScanClient(batches)
+    client._connected = True
+    return client
+
+
+@pytest.mark.asyncio
+async def test_scan_keys_walks_cursor_until_exhausted():
+    """A single SCAN round only covers part of the keyspace, so it must be followed."""
+    client = _make_scanning_redis_client(
+        [(7, ["matrix:kv:block:qwen@1"]), (0, ["matrix:kv:block:qwen@2"])]
+    )
+
+    keys = await client.scan_keys("matrix:kv:block:qwen@*")
+
+    assert keys == ["matrix:kv:block:qwen@1", "matrix:kv:block:qwen@2"]
+    assert client._client.cursors == [0, 7]
+
+
+@pytest.mark.asyncio
+async def test_scan_keys_dedupes_repeated_keys():
+    """SCAN may report the same key in more than one round."""
+    client = _make_scanning_redis_client(
+        [(3, ["matrix:kv:block:qwen@1"]), (0, ["matrix:kv:block:qwen@1"])]
+    )
+
+    assert await client.scan_keys("matrix:kv:block:qwen@*") == ["matrix:kv:block:qwen@1"]
+
+
+@pytest.mark.asyncio
+async def test_scan_keys_returns_empty_on_redis_error():
+    """Matches the previous keys() behaviour so callers need no new error handling."""
+    from redis.exceptions import RedisError
+
+    client = _make_scanning_redis_client([])
+
+    async def failing_scan(cursor=0, match=None, count=None):
+        raise RedisError("boom")
+
+    client._client.scan = failing_scan
+
+    assert await client.scan_keys("matrix:kv:block:qwen@*") == []


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement

**What this PR does / why we need it**:

`clear_all_blocks` walked the keyspace with `KEYS` twice. `KEYS` is O(N) over the whole keyspace and blocks the Redis server until it finishes, and that Redis is shared with the router's scoring path, which allows itself 5s per request.

This adds a `scan_keys` helper to `RedisClient` that walks the keyspace with cursor based `SCAN` in bounded batches, and switches the three call sites in `kv_cache_manager.py` to use it. `gcStaleFields` on the Go side already scans this same keyspace with a cursor, so this makes the runtime agent consistent with it.

`scan_keys` keeps the same contract as `keys`: it returns `[]` on Redis errors, so callers need no new error handling. Results are deduped because `SCAN` can report a key in more than one round.

**Which issue(s) this PR fixes**:
Fixes #1430

**Bug evidence (required for bug-related PRs)**:

This is a scaling hazard found by reading the code path, not a reproduced incident, so I want to be straightforward about what it does and does not show.

What is verifiable from the source:

- `clear_all_blocks` issues two `KEYS` calls: https://github.com/volcano-sh/kthena/blob/0c39f1458d26948bfd3b73416b7f81632199ce7c/python/kthena/runtime/kv_cache_manager.py#L217-L221
- it is on the event path, reached from `ALL_BLOCKS_CLEARED` for vLLM and for SGLang: https://github.com/volcano-sh/kthena/blob/0c39f1458d26948bfd3b73416b7f81632199ce7c/python/kthena/runtime/kv_cache_manager.py#L308-L312 and https://github.com/volcano-sh/kthena/blob/0c39f1458d26948bfd3b73416b7f81632199ce7c/python/kthena/runtime/kv_cache_manager.py#L378-L382
- the router's scoring path reads the same Redis under a 5s budget: https://github.com/volcano-sh/kthena/blob/0c39f1458d26948bfd3b73416b7f81632199ce7c/pkg/kthena-router/scheduler/plugins/kvcache_aware.go#L296-L297
- the Go GC already walks this keyspace with a cursor and a bounded batch: https://github.com/volcano-sh/kthena/blob/0c39f1458d26948bfd3b73416b7f81632199ce7c/pkg/kthena-router/scheduler/plugins/kvcache_aware.go#L371

What I have not done: measured it on a live cluster or reproduced a scoring timeout caused by a `KEYS` call. On a small keyspace `KEYS` returns quickly and nothing is visibly wrong. The argument for the change is that the blocking cost grows with the number of stored block hashes, and the project already treats `SCAN` as the correct way to walk this keyspace on the Go side.

**Special notes for your reviewer**:

The third `KEYS` at `_get_std_hash` is switched too, but that branch is currently unreachable: `remove_blocks` returns early when `pod_identifier` is empty, and it is the only caller. Changed so none are left behind rather than because it is live.

`SCAN_BATCH_SIZE` is 500. The Go GC uses 100, but that is an incremental background sweep, whereas this is a one shot cleanup where round trips matter more. Happy to align the two if you would rather they match.

#1293 touches `kv_cache_manager.py` and `test_sglang_kv_cache_handler.py` as well. Its hunks do not overlap these ones, but flagging it in case ordering matters to you.

Tests: added three for `scan_keys` covering cursor continuation, dedupe and error handling. The two existing fakes were updated from `keys` to `scan_keys`. `ruff` passes with the repo config.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
