### PR TITLE
router: relay kv_transfer_params for lmcache connector

### DIFF
--- a/pkg/apis/networking/v1alpha1/modelserver_types.go
+++ b/pkg/apis/networking/v1alpha1/modelserver_types.go
@@ -106,7 +106,7 @@ type KVConnectorType string
 const (
 	ConnectorTypeHTTP     KVConnectorType = "http"     // Passthrough without mutating prefil/decode requests
 	ConnectorTypeNIXL     KVConnectorType = "nixl"     // Indicates `NixlConnector` in vllm
-	ConnectorTypeLMCache  KVConnectorType = "lmcache"  // Indicates `LmcacheConnector` in vllm
+	ConnectorTypeLMCache  KVConnectorType = "lmcache"  // Indicates `LMCacheConnectorV1` (NIXL-based disaggregated prefill) in vllm, not the multi-process `LMCacheMPConnector`
 	ConnectorTypeMoonCake KVConnectorType = "mooncake" // Indicates `MoonCakeConnector` in vllm-ascend
 )
 

--- a/pkg/kthena-router/connectors/connectors_test.go
+++ b/pkg/kthena-router/connectors/connectors_test.go
@@ -45,6 +45,64 @@ func TestNIXLConnector(t *testing.T) {
 	}
 }
 
+func TestLMCacheConnector(t *testing.T) {
+	connector := NewLMCacheConnector()
+
+	if connector.Name() != "lmcache" {
+		t.Errorf("Expected LMCache connector name 'lmcache', got '%s'", connector.Name())
+	}
+
+	// LMCacheConnectorV1 follows vLLM's KVConnectorBase_V1 contract, so it must
+	// relay kv_transfer_params from the prefill response to the decode request
+	// the same way NIXLConnector does.
+	lmcacheConn, ok := connector.(*NIXLConnector)
+	if !ok {
+		t.Fatalf("Expected LMCache connector to reuse the NIXL kv_transfer_params relay implementation, got %T", connector)
+	}
+
+	req, _ := http.NewRequest("POST", "/v1/chat/completions", nil)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = req
+
+	reqBody := map[string]interface{}{
+		"model":      "test-model",
+		"max_tokens": 100,
+		"messages": []interface{}{
+			map[string]interface{}{
+				"role":    "user",
+				"content": "test message",
+			},
+		},
+	}
+
+	// The connector will fail due to network/connection issues, but the prefill
+	// request should still be built with kv_transfer_params before that failure.
+	if _, err := lmcacheConn.Proxy(c, reqBody, "localhost:8000", "localhost:8001", nil); err == nil {
+		t.Error("Expected LMCache connector Proxy to return error due to network/connection issues")
+	}
+
+	if lmcacheConn.prefillRequest == nil {
+		t.Fatal("Expected prefill request to be built")
+	}
+
+	prefillBody, err := parseRequestBody(lmcacheConn.prefillRequest)
+	if err != nil {
+		t.Fatalf("Failed to parse prefill request body: %v", err)
+	}
+
+	kvTransferParams, ok := prefillBody["kv_transfer_params"]
+	if !ok {
+		t.Fatal("Expected prefill request to have kv_transfer_params field")
+	}
+	params, ok := kvTransferParams.(map[string]interface{})
+	if !ok {
+		t.Fatal("Expected kv_transfer_params to be a map")
+	}
+	if doRemoteDecode, ok := params["do_remote_decode"]; !ok || doRemoteDecode != true {
+		t.Errorf("Expected do_remote_decode to be true, got %v", doRemoteDecode)
+	}
+}
+
 func TestFactory(t *testing.T) {
 	factory := NewDefaultFactory()
 
@@ -66,13 +124,13 @@ func TestFactory(t *testing.T) {
 		t.Errorf("Expected NIXL connector name 'nixl', got '%s'", nixlConnector.Name())
 	}
 
-	// Test LMCache connector (currently uses HTTP implementation)
+	// Test LMCache connector (relays kv_transfer_params like NIXL)
 	lmcacheConnector := factory.GetConnector(v1alpha1.ConnectorTypeLMCache)
 	if lmcacheConnector == nil {
 		t.Error("Expected LMCache connector to be registered")
 	}
-	if lmcacheConnector != nil && lmcacheConnector.Name() != "default" {
-		t.Errorf("Expected LMCache connector name 'default' (using HTTP implementation), got '%s'", lmcacheConnector.Name())
+	if lmcacheConnector != nil && lmcacheConnector.Name() != "lmcache" {
+		t.Errorf("Expected LMCache connector name 'lmcache', got '%s'", lmcacheConnector.Name())
 	}
 
 	// Test unknown connector type

--- a/pkg/kthena-router/connectors/factory.go
+++ b/pkg/kthena-router/connectors/factory.go
@@ -50,7 +50,7 @@ func NewDefaultFactory() *Factory {
 
 	// Register default connectors
 	factory.RegisterConnectorBuilder(v1alpha1.ConnectorTypeHTTP, NewHTTPConnector)
-	factory.RegisterConnectorBuilder(v1alpha1.ConnectorTypeLMCache, NewHTTPConnector)      // LMCache uses HTTP connector for now
+	factory.RegisterConnectorBuilder(v1alpha1.ConnectorTypeLMCache, NewLMCacheConnector)   // LMCacheConnectorV1 uses the same kv_transfer_params contract as NIXL
 	factory.RegisterConnectorBuilder(v1alpha1.ConnectorTypeMoonCake, NewMoonCakeConnector) // MoonCakeConnector in vllm-ascend
 	factory.RegisterConnectorBuilder(v1alpha1.ConnectorTypeNIXL, NewNIXLConnector)
 	factory.RegisterConnectorBuilder(ConnectorTypeSGLang, NewSGLangConnector) // SGLang disaggregated prefill-decode (internal, not user-configurable)

--- a/pkg/kthena-router/connectors/lmcache.go
+++ b/pkg/kthena-router/connectors/lmcache.go
@@ -1,0 +1,30 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package connectors
+
+// NewLMCacheConnector creates a new LMCache connector.
+// vLLM's LMCacheConnectorV1 implements the generic KVConnectorBase_V1 contract:
+// the prefill request returns kv_transfer_params, which must be forwarded on the
+// decode request for the decode side to actually reuse the KV cache produced by
+// prefill. This is the same contract NixlConnector already implements, so we
+// reuse it here instead of falling back to the plain HTTP connector, which never
+// reads the prefill response body and drops kv_transfer_params entirely.
+func NewLMCacheConnector() KVConnector {
+	return &NIXLConnector{
+		name: "lmcache",
+	}
+}

--- a/pkg/kthena-router/connectors/lmcache.go
+++ b/pkg/kthena-router/connectors/lmcache.go
@@ -16,9 +16,14 @@ limitations under the License.
 
 package connectors
 
-// NewLMCacheConnector creates a new LMCache connector.
-// vLLM's LMCacheConnectorV1 implements the generic KVConnectorBase_V1 contract:
-// the prefill request returns kv_transfer_params, which must be forwarded on the
+// NewLMCacheConnector creates a new LMCache connector for vLLM's in-process,
+// NIXL-based disaggregated prefill mode (kv_connector: LMCacheConnectorV1).
+// It is not for LMCache's multi-process mode (LMCacheMPConnector), which runs
+// KV storage as a standalone `lmcache server` and does not go through this
+// prefill/decode HTTP relay at all.
+//
+// LMCacheConnectorV1 implements the generic KVConnectorBase_V1 contract: the
+// prefill request returns kv_transfer_params, which must be forwarded on the
 // decode request for the decode side to actually reuse the KV cache produced by
 // prefill. This is the same contract NixlConnector already implements, so we
 // reuse it here instead of falling back to the plain HTTP connector, which never

--- a/pkg/kthena-router/connectors/nixl.go
+++ b/pkg/kthena-router/connectors/nixl.go
@@ -150,7 +150,7 @@ func (n *NIXLConnector) prefill(req *http.Request, prefillAddr string) (interfac
 	}
 	kvTransferParams, ok := prefillerResponse["kv_transfer_params"]
 	if !ok {
-		klog.Warning("NIXL: missing 'kv_transfer_params' in prefill response")
+		klog.Warningf("%s: missing 'kv_transfer_params' in prefill response", n.name)
 	}
 	return kvTransferParams, nil
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The connector factory registers the `lmcache` `ModelServer` connector type to the generic `HTTPConnector`:

```go
factory.RegisterConnectorBuilder(v1alpha1.ConnectorTypeLMCache, NewHTTPConnector) // LMCache uses HTTP connector for now
```

`HTTPConnector.prefill()` sends the prefill request and only checks the response status code — it never reads the response body:

```go
func (h *HTTPConnector) prefill(req *http.Request, prefillAddr string) error {
	req.URL.Host = prefillAddr
	req.URL.Scheme = "http"
	return prefillerProxy(nil, req)
}
```

vLLM's `LMCacheConnectorV1` implements the standard `KVConnectorBase_V1` contract (the same one `NixlConnector` uses): the prefill call returns `kv_transfer_params` in the response body, and the decode request must carry those params forward for the decode side to actually reuse the KV blocks produced by prefill. Because `HTTPConnector` discards the prefill response body, `kv_transfer_params` never reaches the decode request, so `LMCacheConnectorV1` deployments only get request-level prefill/decode routing — never real KV reuse.

`NixlConnector` already implements this relay correctly (parses `kv_transfer_params` from the prefill response, injects it into the decode request). This PR routes `lmcache` through that same implementation instead of `HTTPConnector`, the same way `MoonCakeConnector` already reuses it for vllm-ascend:

```go
func NewLMCacheConnector() KVConnector {
	return &NIXLConnector{
		name: "lmcache",
	}
}
```

**Which issue(s) this PR fixes**:
Fixes #1069

**Bug evidence (required for bug-related PRs)**:

From #1069, on a real 2-GPU cluster (`vLLMDisaggregated` backend, `LMCacheConnectorV1`, `kv_role: kv_producer` / `kv_consumer`):

- Generated `ModelServer` correctly resolves `kvConnector.type: lmcache`.
- Both prefill and decode pods become Ready, and a request through the router succeeds end-to-end (`200`, normal completion).
- LMCache/vLLM logs on the decode side show no cache reuse despite a successful prefill+decode round trip:
  ```
  LMCache INFO: Reqid: ..., Total tokens 30, Inference Engine computed tokens: 0, LMCache hit tokens: 0, need to load: 0
  Engine 000: ... Prefix cache hit rate: 0.0%, External prefix cache hit rate: 0.0%
  ```
- This matches the code path: `lmcache` is wired to `HTTPConnector`, which drops the prefill response body, so `kv_transfer_params` is never attached to the decode request — unlike `nixl`, which is wired to `NIXLConnector` and does forward it. This is exactly why the same environment gets real KV transfer with `nixl` but not with `lmcache`.

This change is a router-side wiring fix (route `lmcache` to the existing NIXL-style relay instead of the no-op HTTP relay); it does not change wire format or the vLLM-side connector config. Added `TestLMCacheConnector` and updated `TestFactory` in `connectors_test.go` to assert the prefill request built by the `lmcache` connector carries `kv_transfer_params`, matching the existing NIXL coverage.

**Special notes for your reviewer**:

I don't have a multi-GPU LMCache setup to reproduce the original hardware trace end-to-end, so I'd appreciate it if someone with that environment (or the original reporter) can confirm real KV reuse now shows up in the LMCache hit-rate logs after this change. Local build, `go vet`, `golangci-lint`, and the full `pkg/kthena-router/...` test suite all pass.

**Does this PR introduce a user-facing change?**:
```release-note
Fix `lmcache` `ModelServer` connector type being routed through the plain HTTP relay instead of forwarding `kv_transfer_params` from prefill to decode, so `LMCacheConnectorV1` deployments can actually reuse KV cache across prefill/decode.
```
