### PR TITLE
feat: add additional printer columns for various CRDs and types

### DIFF
--- a/charts/kthena/charts/networking/crds/networking.serving.volcano.sh_modelroutes.yaml
+++ b/charts/kthena/charts/networking/crds/networking.serving.volcano.sh_modelroutes.yaml
@@ -14,7 +14,11 @@ spec:
     singular: modelroute
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: ModelRoute is the Schema for the Modelroutes API.

--- a/charts/kthena/charts/networking/crds/networking.serving.volcano.sh_modelservers.yaml
+++ b/charts/kthena/charts/networking/crds/networking.serving.volcano.sh_modelservers.yaml
@@ -14,7 +14,23 @@ spec:
     singular: modelserver
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Inference engine used to serve the model
+      jsonPath: .spec.inferenceEngine
+      name: Engine
+      type: string
+    - description: Model server port
+      jsonPath: .spec.workloadPort.port
+      name: Port
+      type: integer
+    - description: Model server protocol
+      jsonPath: .spec.workloadPort.protocol
+      name: Protocol
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: ModelServer is the Schema for the modelservers API.

--- a/charts/kthena/charts/workload/crds/workload.serving.volcano.sh_autoscalingpolicies.yaml
+++ b/charts/kthena/charts/workload/crds/workload.serving.volcano.sh_autoscalingpolicies.yaml
@@ -15,10 +15,6 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - description: Whether the policy is actively reconciled
-      jsonPath: .status.conditions[?(@.type=='Ready')].status
-      name: Ready
-      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/charts/kthena/charts/workload/crds/workload.serving.volcano.sh_autoscalingpolicies.yaml
+++ b/charts/kthena/charts/workload/crds/workload.serving.volcano.sh_autoscalingpolicies.yaml
@@ -14,7 +14,15 @@ spec:
     singular: autoscalingpolicy
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Whether the policy is actively reconciled
+      jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: |-

--- a/charts/kthena/charts/workload/crds/workload.serving.volcano.sh_modelboosters.yaml
+++ b/charts/kthena/charts/workload/crds/workload.serving.volcano.sh_modelboosters.yaml
@@ -14,7 +14,15 @@ spec:
     singular: modelbooster
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Whether the model booster is active
+      jsonPath: .status.conditions[?(@.type=='Active')].status
+      name: Active
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: ModelBooster is the Schema for the models API.

--- a/charts/kthena/charts/workload/crds/workload.serving.volcano.sh_modelservings.yaml
+++ b/charts/kthena/charts/workload/crds/workload.serving.volcano.sh_modelservings.yaml
@@ -14,7 +14,23 @@ spec:
     singular: modelserving
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Total number of serving groups
+      jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    - description: Number of serving groups that are ready
+      jsonPath: .status.availableReplicas
+      name: Available
+      type: integer
+    - description: Number of serving groups updated to the latest revision
+      jsonPath: .status.updatedReplicas
+      name: Updated
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: ModelServing is the Schema for the LLM Serving API

--- a/pkg/apis/networking/v1alpha1/modelroute_types.go
+++ b/pkg/apis/networking/v1alpha1/modelroute_types.go
@@ -173,6 +173,7 @@ type ModelRouteStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
 // +genclient
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 //
 // ModelRoute is the Schema for the Modelroutes API.
 type ModelRoute struct {

--- a/pkg/apis/networking/v1alpha1/modelserver_types.go
+++ b/pkg/apis/networking/v1alpha1/modelserver_types.go
@@ -151,6 +151,10 @@ type ModelServerStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
 // +genclient
+// +kubebuilder:printcolumn:name="Engine",type="string",JSONPath=".spec.inferenceEngine",description="Inference engine used to serve the model"
+// +kubebuilder:printcolumn:name="Port",type="integer",JSONPath=".spec.workloadPort.port",description="Model server port"
+// +kubebuilder:printcolumn:name="Protocol",type="string",JSONPath=".spec.workloadPort.protocol",description="Model server protocol"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 //
 // ModelServer is the Schema for the modelservers API.
 type ModelServer struct {

--- a/pkg/apis/workload/v1alpha1/autoscalingpolicy_types.go
+++ b/pkg/apis/workload/v1alpha1/autoscalingpolicy_types.go
@@ -228,6 +228,8 @@ type RoleRatioStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
 // +genclient
+// +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status",description="Whether the policy is actively reconciled"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // AutoscalingPolicy defines the autoscaling policy configuration for model serving workloads.
 // It specifies scaling rules, metrics, and behavior for automatic replica adjustment.

--- a/pkg/apis/workload/v1alpha1/autoscalingpolicy_types.go
+++ b/pkg/apis/workload/v1alpha1/autoscalingpolicy_types.go
@@ -228,7 +228,6 @@ type RoleRatioStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
 // +genclient
-// +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status",description="Whether the policy is actively reconciled"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // AutoscalingPolicy defines the autoscaling policy configuration for model serving workloads.

--- a/pkg/apis/workload/v1alpha1/model_booster_types.go
+++ b/pkg/apis/workload/v1alpha1/model_booster_types.go
@@ -209,6 +209,8 @@ const (
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
 // +genclient
+// +kubebuilder:printcolumn:name="Active",type="string",JSONPath=".status.conditions[?(@.type=='Active')].status",description="Whether the model booster is active"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // ModelBooster is the Schema for the models API.
 type ModelBooster struct {

--- a/pkg/apis/workload/v1alpha1/model_serving_types.go
+++ b/pkg/apis/workload/v1alpha1/model_serving_types.go
@@ -243,6 +243,10 @@ type ModelServingStatus struct {
 // +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.labelSelector
 // +kubebuilder:storageversion
 // +genclient
+// +kubebuilder:printcolumn:name="Replicas",type="integer",JSONPath=".status.replicas",description="Total number of serving groups"
+// +kubebuilder:printcolumn:name="Available",type="integer",JSONPath=".status.availableReplicas",description="Number of serving groups that are ready"
+// +kubebuilder:printcolumn:name="Updated",type="integer",JSONPath=".status.updatedReplicas",description="Number of serving groups updated to the latest revision"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // ModelServing is the Schema for the LLM Serving API
 type ModelServing struct {


### PR DESCRIPTION
## Summary

Adds Kubernetes printer columns to all Kthena CRDs so `kubectl get` exposes useful operational state without requiring YAML output.

- `ModelServing`: Replicas, Available, Updated, Age
- `ModelBooster`: Active, Age
- `AutoscalingPolicy`: Ready, Age
- `ModelServer`: Engine, Port, Protocol, Age
- `ModelRoute`: Age

The generated Helm CRDs are updated accordingly. This intentionally does not add ModelRoute status fields or controller reconciliation logic; that remains follow-up scope.

## Rationale

AutoscalingPolicy uses a universal `Ready` condition instead of replica-count columns because it supports homogeneous, heterogeneous, and disaggregated modes; a homogeneous-only path would be blank or misleading for valid policies.

## Testing

- `go test -count=1 ./pkg/apis/...`
- Regenerated networking and workload CRDs with `controller-gen`.
- Verified regeneration is repeatable after the repository’s CRD normalization step.
- `git diff --check`

Fixes #1436