### PR TITLE
controller: retry AutoscalingPolicy and LeaderWorkerSet status updates on conflict

### DIFF
--- a/pkg/autoscaler/controller/autoscale_controller.go
+++ b/pkg/autoscaler/controller/autoscale_controller.go
@@ -32,6 +32,7 @@ import (
 	"github.com/volcano-sh/kthena/pkg/autoscaler/util"
 	"istio.io/istio/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -512,8 +513,21 @@ func getRoleReplica(modelServing *workload.ModelServing, roleName string) (int, 
 // reconcile. Ready reports the overall reconcile result, while TargetFound only
 // reports whether the referenced ModelServing and configured roles were resolved.
 func (ac *AutoscaleController) updateDisaggregatedPolicyStatus(ctx context.Context, policy *workload.AutoscalingPolicy, result *autoscaler.DisaggregatedScaleResult, reconcileErr error, targetFound bool) error {
+	// Status updates within a single reconcile can happen back to back, and the
+	// informer cache does not always catch up between them. Read from the cache
+	// on the first attempt (cheap, and correct in the common case); if that
+	// attempt conflicts, the cache is known to be stale for this object, so
+	// subsequent attempts read directly from the API server instead of retrying
+	// against the same stale resourceVersion.
+	readFromAPI := false
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		latestPolicy, getErr := ac.autoscalingPoliciesLister.AutoscalingPolicies(policy.Namespace).Get(policy.Name)
+		var latestPolicy *workload.AutoscalingPolicy
+		var getErr error
+		if readFromAPI {
+			latestPolicy, getErr = ac.client.WorkloadV1alpha1().AutoscalingPolicies(policy.Namespace).Get(ctx, policy.Name, metav1.GetOptions{})
+		} else {
+			latestPolicy, getErr = ac.autoscalingPoliciesLister.AutoscalingPolicies(policy.Namespace).Get(policy.Name)
+		}
 		if getErr != nil {
 			return getErr
 		}
@@ -596,7 +610,14 @@ func (ac *AutoscaleController) updateDisaggregatedPolicyStatus(ctx context.Conte
 			return nil
 		}
 		_, err := ac.client.WorkloadV1alpha1().AutoscalingPolicies(policyCopy.Namespace).UpdateStatus(ctx, policyCopy, metav1.UpdateOptions{})
-		return err
+		if err != nil {
+			if apierrors.IsConflict(err) {
+				klog.V(4).Infof("AutoscalingPolicy %s/%s status update conflicted (informer cache may be stale), retrying with a fresh read from the API server: %v", policyCopy.Namespace, policyCopy.Name, err)
+				readFromAPI = true
+			}
+			return err
+		}
+		return nil
 	})
 }
 

--- a/pkg/autoscaler/controller/autoscale_controller.go
+++ b/pkg/autoscaler/controller/autoscale_controller.go
@@ -44,6 +44,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	listerv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 )
 
@@ -511,85 +512,92 @@ func getRoleReplica(modelServing *workload.ModelServing, roleName string) (int, 
 // reconcile. Ready reports the overall reconcile result, while TargetFound only
 // reports whether the referenced ModelServing and configured roles were resolved.
 func (ac *AutoscaleController) updateDisaggregatedPolicyStatus(ctx context.Context, policy *workload.AutoscalingPolicy, result *autoscaler.DisaggregatedScaleResult, reconcileErr error, targetFound bool) error {
-	policyCopy := &workload.AutoscalingPolicy{
-		TypeMeta:   policy.TypeMeta,
-		ObjectMeta: *policy.ObjectMeta.DeepCopy(),
-		Status:     *policy.Status.DeepCopy(),
-	}
-	policyCopy.Status.ObservedGeneration = policy.Generation
-	policyCopy.Status.HomogeneousStatus = nil
-	policyCopy.Status.HeterogeneousStatus = nil
-	policyCopy.Status.DisaggregatedStatus = nil
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		latestPolicy, getErr := ac.autoscalingPoliciesLister.AutoscalingPolicies(policy.Namespace).Get(policy.Name)
+		if getErr != nil {
+			return getErr
+		}
 
-	readyCondition := metav1.Condition{
-		Type:               "Ready",
-		ObservedGeneration: policy.Generation,
-		LastTransitionTime: metav1.Now(),
-	}
-	targetFoundCondition := metav1.Condition{
-		Type:               "TargetFound",
-		ObservedGeneration: policy.Generation,
-		LastTransitionTime: metav1.Now(),
-	}
-	if reconcileErr != nil {
-		readyCondition.Status = metav1.ConditionFalse
-		readyCondition.Reason = "ReconcileFailed"
-		readyCondition.Message = reconcileErr.Error()
-	} else {
-		readyCondition.Status = metav1.ConditionTrue
-		readyCondition.Reason = "Reconciled"
-		readyCondition.Message = "disaggregated autoscaling policy reconciled"
-	}
-	if targetFound {
-		targetFoundCondition.Status = metav1.ConditionTrue
-		targetFoundCondition.Reason = "TargetFound"
-		targetFoundCondition.Message = "target model serving and roles found"
-	} else {
-		targetFoundCondition.Status = metav1.ConditionFalse
-		targetFoundCondition.Reason = "TargetInvalid"
+		policyCopy := &workload.AutoscalingPolicy{
+			TypeMeta:   latestPolicy.TypeMeta,
+			ObjectMeta: *latestPolicy.ObjectMeta.DeepCopy(),
+			Status:     *latestPolicy.Status.DeepCopy(),
+		}
+		policyCopy.Status.ObservedGeneration = latestPolicy.Generation
+		policyCopy.Status.HomogeneousStatus = nil
+		policyCopy.Status.HeterogeneousStatus = nil
+		policyCopy.Status.DisaggregatedStatus = nil
+
+		readyCondition := metav1.Condition{
+			Type:               "Ready",
+			ObservedGeneration: latestPolicy.Generation,
+			LastTransitionTime: metav1.Now(),
+		}
+		targetFoundCondition := metav1.Condition{
+			Type:               "TargetFound",
+			ObservedGeneration: latestPolicy.Generation,
+			LastTransitionTime: metav1.Now(),
+		}
 		if reconcileErr != nil {
-			targetFoundCondition.Message = reconcileErr.Error()
+			readyCondition.Status = metav1.ConditionFalse
+			readyCondition.Reason = "ReconcileFailed"
+			readyCondition.Message = reconcileErr.Error()
 		} else {
-			targetFoundCondition.Message = "target model serving or configured roles were not found"
+			readyCondition.Status = metav1.ConditionTrue
+			readyCondition.Reason = "Reconciled"
+			readyCondition.Message = "disaggregated autoscaling policy reconciled"
 		}
-	}
-	meta.SetStatusCondition(&policyCopy.Status.Conditions, readyCondition)
-	meta.SetStatusCondition(&policyCopy.Status.Conditions, targetFoundCondition)
-
-	if result != nil {
-		roleStatuses := make([]workload.TargetScalingStatus, 0, len(result.Roles))
-		prevLastScaleTimeByRole := map[string]*metav1.Time{}
-		if policy.Status.DisaggregatedStatus != nil {
-			for _, prev := range policy.Status.DisaggregatedStatus.Roles {
-				prevLastScaleTimeByRole[prev.Name] = prev.LastScaleTime
+		if targetFound {
+			targetFoundCondition.Status = metav1.ConditionTrue
+			targetFoundCondition.Reason = "TargetFound"
+			targetFoundCondition.Message = "target model serving and roles found"
+		} else {
+			targetFoundCondition.Status = metav1.ConditionFalse
+			targetFoundCondition.Reason = "TargetInvalid"
+			if reconcileErr != nil {
+				targetFoundCondition.Message = reconcileErr.Error()
+			} else {
+				targetFoundCondition.Message = "target model serving or configured roles were not found"
 			}
 		}
-		now := metav1.Now()
-		for _, role := range result.Roles {
-			lastScaleTime := prevLastScaleTimeByRole[role.Name]
-			if reconcileErr == nil && role.CurrentReplicas != role.FinalReplicas {
-				lastScaleTime = &now
-			}
-			roleStatuses = append(roleStatuses, workload.TargetScalingStatus{
-				Name:            role.Name,
-				CurrentReplicas: role.CurrentReplicas,
-				DesiredReplicas: role.DesiredReplicas,
-				Mode:            role.Mode,
-				LastScaleTime:   lastScaleTime,
-			})
-		}
-		policyCopy.Status.DisaggregatedStatus = &workload.DisaggregatedScalingStatus{
-			Roles:         roleStatuses,
-			RatioStatus:   result.RatioStatus,
-			RatioAdjusted: result.RatioAdjusted,
-		}
-	}
+		meta.SetStatusCondition(&policyCopy.Status.Conditions, readyCondition)
+		meta.SetStatusCondition(&policyCopy.Status.Conditions, targetFoundCondition)
 
-	if equality.Semantic.DeepEqual(policy.Status, policyCopy.Status) {
-		return nil
-	}
-	_, err := ac.client.WorkloadV1alpha1().AutoscalingPolicies(policy.Namespace).UpdateStatus(ctx, policyCopy, metav1.UpdateOptions{})
-	return err
+		if result != nil {
+			roleStatuses := make([]workload.TargetScalingStatus, 0, len(result.Roles))
+			prevLastScaleTimeByRole := map[string]*metav1.Time{}
+			if latestPolicy.Status.DisaggregatedStatus != nil {
+				for _, prev := range latestPolicy.Status.DisaggregatedStatus.Roles {
+					prevLastScaleTimeByRole[prev.Name] = prev.LastScaleTime
+				}
+			}
+			now := metav1.Now()
+			for _, role := range result.Roles {
+				lastScaleTime := prevLastScaleTimeByRole[role.Name]
+				if reconcileErr == nil && role.CurrentReplicas != role.FinalReplicas {
+					lastScaleTime = &now
+				}
+				roleStatuses = append(roleStatuses, workload.TargetScalingStatus{
+					Name:            role.Name,
+					CurrentReplicas: role.CurrentReplicas,
+					DesiredReplicas: role.DesiredReplicas,
+					Mode:            role.Mode,
+					LastScaleTime:   lastScaleTime,
+				})
+			}
+			policyCopy.Status.DisaggregatedStatus = &workload.DisaggregatedScalingStatus{
+				Roles:         roleStatuses,
+				RatioStatus:   result.RatioStatus,
+				RatioAdjusted: result.RatioAdjusted,
+			}
+		}
+
+		if equality.Semantic.DeepEqual(latestPolicy.Status, policyCopy.Status) {
+			return nil
+		}
+		_, err := ac.client.WorkloadV1alpha1().AutoscalingPolicies(policyCopy.Namespace).UpdateStatus(ctx, policyCopy, metav1.UpdateOptions{})
+		return err
+	})
 }
 
 func formatAutoscalerMapKey(policyNamespace, policyName string, targetRef *corev1.ObjectReference) string {

--- a/pkg/autoscaler/controller/autoscale_controller_test.go
+++ b/pkg/autoscaler/controller/autoscale_controller_test.go
@@ -35,9 +35,12 @@ import (
 	"github.com/volcano-sh/kthena/pkg/autoscaler/autoscaler"
 	"github.com/volcano-sh/kthena/pkg/autoscaler/util"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	resource "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	listerv1 "k8s.io/client-go/listers/core/v1"
 	k8stesting "k8s.io/client-go/testing"
@@ -342,12 +345,13 @@ func TestDoDisaggregatedScale_RatioRaisesDecode(t *testing.T) {
 		}),
 	}
 	ac := &AutoscaleController{
-		client:                 client,
-		modelServingLister:     msLister,
-		podsLister:             fakePodLister{podsByNs: map[string][]*corev1.Pod{ns: pods}},
-		scalerMap:              map[string]*autoscalerAutoscaler{},
-		optimizerMap:           map[string]*autoscalerOptimizer{},
-		disaggregatedScalerMap: map[string]*autoscaler.DisaggregatedAutoscaler{},
+		client:                    client,
+		modelServingLister:        msLister,
+		autoscalingPoliciesLister: workloadLister.NewAutoscalingPolicyLister(newModelServingIndexer(policy.DeepCopy())),
+		podsLister:                fakePodLister{podsByNs: map[string][]*corev1.Pod{ns: pods}},
+		scalerMap:                 map[string]*autoscalerAutoscaler{},
+		optimizerMap:              map[string]*autoscalerOptimizer{},
+		disaggregatedScalerMap:    map[string]*autoscaler.DisaggregatedAutoscaler{},
 	}
 
 	if err := ac.doDisaggregatedScale(context.Background(), policy); err != nil {
@@ -536,7 +540,10 @@ func TestUpdateDisaggregatedPolicyStatus_TargetFoundIndependentFromReady(t *test
 	ns := "default"
 	policy := &workload.AutoscalingPolicy{ObjectMeta: metav1.ObjectMeta{Name: "ap", Namespace: ns, Generation: 1}}
 	fakeClient := clientfake.NewSimpleClientset(policy.DeepCopy())
-	ac := &AutoscaleController{client: fakeClient}
+	ac := &AutoscaleController{
+		client:                    fakeClient,
+		autoscalingPoliciesLister: workloadLister.NewAutoscalingPolicyLister(newModelServingIndexer(policy.DeepCopy())),
+	}
 
 	if err := ac.updateDisaggregatedPolicyStatus(context.Background(), policy, nil, fmt.Errorf("metric collection failed"), true); err != nil {
 		t.Fatalf("updateDisaggregatedPolicyStatus error: %v", err)
@@ -556,7 +563,10 @@ func TestUpdateDisaggregatedPolicyStatus_TargetFoundIndependentFromReady(t *test
 
 	policy = &workload.AutoscalingPolicy{ObjectMeta: metav1.ObjectMeta{Name: "ap-missing", Namespace: ns, Generation: 1}}
 	fakeClient = clientfake.NewSimpleClientset(policy.DeepCopy())
-	ac = &AutoscaleController{client: fakeClient}
+	ac = &AutoscaleController{
+		client:                    fakeClient,
+		autoscalingPoliciesLister: workloadLister.NewAutoscalingPolicyLister(newModelServingIndexer(policy.DeepCopy())),
+	}
 	if err := ac.updateDisaggregatedPolicyStatus(context.Background(), policy, nil, fmt.Errorf("role decode not found"), false); err != nil {
 		t.Fatalf("updateDisaggregatedPolicyStatus missing target error: %v", err)
 	}
@@ -577,6 +587,45 @@ func findPolicyCondition(conditions []metav1.Condition, conditionType string) *m
 		}
 	}
 	return nil
+}
+
+func TestUpdateDisaggregatedPolicyStatus_RetriesOnConflict(t *testing.T) {
+	ns := "default"
+	policy := &workload.AutoscalingPolicy{ObjectMeta: metav1.ObjectMeta{Name: "ap-conflict", Namespace: ns, Generation: 1}}
+	fakeClient := clientfake.NewSimpleClientset(policy.DeepCopy())
+
+	conflicts := 2
+	fakeClient.PrependReactor("update", "autoscalingpolicies", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		if action.GetSubresource() != "status" {
+			return false, nil, nil
+		}
+		if conflicts > 0 {
+			conflicts--
+			return true, nil, apierrors.NewConflict(schema.GroupResource{Group: "workload.volcano.sh", Resource: "autoscalingpolicies"}, "ap-conflict", fmt.Errorf("resourceVersion conflict"))
+		}
+		return false, nil, nil
+	})
+
+	ac := &AutoscaleController{
+		client:                    fakeClient,
+		autoscalingPoliciesLister: workloadLister.NewAutoscalingPolicyLister(newModelServingIndexer(policy.DeepCopy())),
+	}
+
+	if err := ac.updateDisaggregatedPolicyStatus(context.Background(), policy, nil, fmt.Errorf("metric collection failed"), true); err != nil {
+		t.Fatalf("expected updateDisaggregatedPolicyStatus to succeed after retrying on conflict, got: %v", err)
+	}
+	if conflicts != 0 {
+		t.Fatalf("expected all injected conflicts to be consumed, %d remaining", conflicts)
+	}
+
+	updated, err := fakeClient.WorkloadV1alpha1().AutoscalingPolicies(ns).Get(context.Background(), "ap-conflict", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get updated policy error: %v", err)
+	}
+	ready := findPolicyCondition(updated.Status.Conditions, "Ready")
+	if ready == nil || ready.Status != metav1.ConditionFalse || ready.Reason != "ReconcileFailed" {
+		t.Fatalf("expected Ready=False/ReconcileFailed after retry, got %#v", ready)
+	}
 }
 
 func TestFormatAutoscalerMapKey_IncludesNamespaceAndTarget(t *testing.T) {

--- a/pkg/model-serving-controller/controller/lws_controller.go
+++ b/pkg/model-serving-controller/controller/lws_controller.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 	lwsv1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
@@ -364,17 +365,25 @@ func (c *LWSController) constructModelServing(lws *lwsv1.LeaderWorkerSet) *workl
 }
 
 func (c *LWSController) updateLWSStatus(ctx context.Context, lws *lwsv1.LeaderWorkerSet, ms *workloadv1alpha1.ModelServing) error {
-	newStatus := lws.Status.DeepCopy()
-	newStatus.Replicas = ms.Status.Replicas
-	newStatus.ReadyReplicas = ms.Status.AvailableReplicas
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		latestLWS, getErr := c.lwsLister.LeaderWorkerSets(lws.Namespace).Get(lws.Name)
+		if getErr != nil {
+			return getErr
+		}
 
-	if !reflect.DeepEqual(lws.Status, *newStatus) {
-		lwsCopy := lws.DeepCopy()
+		newStatus := latestLWS.Status.DeepCopy()
+		newStatus.Replicas = ms.Status.Replicas
+		newStatus.ReadyReplicas = ms.Status.AvailableReplicas
+
+		if reflect.DeepEqual(latestLWS.Status, *newStatus) {
+			return nil
+		}
+
+		lwsCopy := latestLWS.DeepCopy()
 		lwsCopy.Status = *newStatus
-		_, err := c.lwsClient.LeaderworkersetV1().LeaderWorkerSets(lws.Namespace).UpdateStatus(ctx, lwsCopy, metav1.UpdateOptions{})
+		_, err := c.lwsClient.LeaderworkersetV1().LeaderWorkerSets(lwsCopy.Namespace).UpdateStatus(ctx, lwsCopy, metav1.UpdateOptions{})
 		return err
-	}
-	return nil
+	})
 }
 
 func ResourceExists(client kubernetes.Interface, groupVersion string, kind string) (bool, error) {

--- a/pkg/model-serving-controller/controller/lws_controller.go
+++ b/pkg/model-serving-controller/controller/lws_controller.go
@@ -365,8 +365,21 @@ func (c *LWSController) constructModelServing(lws *lwsv1.LeaderWorkerSet) *workl
 }
 
 func (c *LWSController) updateLWSStatus(ctx context.Context, lws *lwsv1.LeaderWorkerSet, ms *workloadv1alpha1.ModelServing) error {
+	// Status updates within a single reconcile can happen back to back, and the
+	// informer cache does not always catch up between them. Read from the cache
+	// on the first attempt (cheap, and correct in the common case); if that
+	// attempt conflicts, the cache is known to be stale for this object, so
+	// subsequent attempts read directly from the API server instead of retrying
+	// against the same stale resourceVersion.
+	readFromAPI := false
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		latestLWS, getErr := c.lwsLister.LeaderWorkerSets(lws.Namespace).Get(lws.Name)
+		var latestLWS *lwsv1.LeaderWorkerSet
+		var getErr error
+		if readFromAPI {
+			latestLWS, getErr = c.lwsClient.LeaderworkersetV1().LeaderWorkerSets(lws.Namespace).Get(ctx, lws.Name, metav1.GetOptions{})
+		} else {
+			latestLWS, getErr = c.lwsLister.LeaderWorkerSets(lws.Namespace).Get(lws.Name)
+		}
 		if getErr != nil {
 			return getErr
 		}
@@ -382,7 +395,14 @@ func (c *LWSController) updateLWSStatus(ctx context.Context, lws *lwsv1.LeaderWo
 		lwsCopy := latestLWS.DeepCopy()
 		lwsCopy.Status = *newStatus
 		_, err := c.lwsClient.LeaderworkersetV1().LeaderWorkerSets(lwsCopy.Namespace).UpdateStatus(ctx, lwsCopy, metav1.UpdateOptions{})
-		return err
+		if err != nil {
+			if errors.IsConflict(err) {
+				klog.V(4).Infof("LeaderWorkerSet %s/%s status update conflicted (informer cache may be stale), retrying with a fresh read from the API server: %v", lwsCopy.Namespace, lwsCopy.Name, err)
+				readFromAPI = true
+			}
+			return err
+		}
+		return nil
 	})
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`AutoscalingPolicy` status updates (`updateDisaggregatedPolicyStatus`) and `LeaderWorkerSet` status updates (`updateLWSStatus`) call `UpdateStatus` directly with no retry on conflict:

https://github.com/volcano-sh/kthena/blob/0c39f1458d26948bfd3b73416b7f81632199ce7c/pkg/autoscaler/controller/autoscale_controller.go#L591

https://github.com/volcano-sh/kthena/blob/0c39f1458d26948bfd3b73416b7f81632199ce7c/pkg/model-serving-controller/controller/lws_controller.go#L374

If the object's `resourceVersion` has moved on between the informer read and this `UpdateStatus` call (a concurrent status writer, or the same object being reconciled twice back to back), the call fails with a 409 Conflict and the error is just propagated up. There's no re-fetch-and-retry, so that status write is silently dropped for the reconcile and only happens on the next trigger.

Every other status-update path in the codebase (`UpdateModelServingStatus`, `updateModelBoosterStatus`, `updatePodGroupIfNeeded`) already wraps this in `retry.RetryOnConflict`. These two call sites were missed when that pattern was applied elsewhere.

This PR wraps both in `retry.RetryOnConflict`, re-fetching the latest object from the lister on each attempt and reapplying the computed status before calling `UpdateStatus`, consistent with the existing pattern.

**Which issue(s) this PR fixes**:
Fixes #1435

**Bug evidence (required for bug-related PRs)**:

Both call sites are a direct, unconditional `UpdateStatus` call with the error returned as-is:

- `pkg/autoscaler/controller/autoscale_controller.go:591` (before this change) — `updateDisaggregatedPolicyStatus` builds `policyCopy` from the `policy` object passed in by the caller (read once from the lister earlier in the reconcile), then calls `UpdateStatus` and returns whatever error comes back, with no `apierrors.IsConflict` handling.
- `pkg/model-serving-controller/controller/lws_controller.go:374` (before this change) — `updateLWSStatus` does the same: builds `lwsCopy` from the `lws` argument and returns the raw `UpdateStatus` error.

Trigger: an `AutoscalingPolicy` targeting a `DisaggregatedTarget`, or a `ModelServing` wrapped by a `LeaderWorkerSet`, gets its status patched concurrently (e.g. a scale reconcile in flight while another status writer or a second reconcile for the same object lands), so the `resourceVersion` the controller read is stale by the time `UpdateStatus` runs. The API server returns a 409 Conflict, and prior to this change that error propagated straight up — the status write for that reconcile was lost until the next trigger, with no re-fetch or retry.

Added `TestUpdateDisaggregatedPolicyStatus_RetriesOnConflict`, which injects two conflicting `UpdateStatus` responses via a reactor on the fake clientset and asserts the update ultimately succeeds and the status is applied — this test fails against the pre-change code (the conflict error is returned immediately instead of being retried).

**Special notes for your reviewer**:

Existing tests for `updateDisaggregatedPolicyStatus` constructed the controller without an `autoscalingPoliciesLister`, since the old code only used the caller-provided object. Updated those to back the lister with an indexer so the retry loop's re-fetch has something to read.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```