### PR TITLE
helm: document replicas values

### DIFF
--- a/charts/kthena/values.yaml
+++ b/charts/kthena/values.yaml
@@ -2,6 +2,8 @@ workload:
   # -- Enable the workload subchart.
   enabled: true
   controllerManager:
+    # -- Number of Controller Manager instances to run.
+    replicas: 1
     image:
       # -- Image repository for the Controller Manager.
       repository: ghcr.io/volcano-sh/kthena-controller-manager
@@ -39,6 +41,8 @@ networking:
   kthenaRouter:
     # -- Enable Kthena Router.
     enabled: true
+    # -- Number of Kthena Router instances to run.
+    replicas: 1
     # -- Container port for Kthena Router.
     port: 8080
     # -- Debug server port for Kthena Router (localhost only).

--- a/docs/kthena/docs/reference/helm-chart-values.md
+++ b/docs/kthena/docs/reference/helm-chart-values.md
@@ -32,6 +32,7 @@ A Helm chart for deploying Kthena
 | networking.kthenaRouter.image.repository | string | `"ghcr.io/volcano-sh/kthena-router"` | Image repository for Kthena Router. |
 | networking.kthenaRouter.image.tag | string | `"latest"` | Image tag for Kthena Router. |
 | networking.kthenaRouter.port | int | `8080` | Container port for Kthena Router. |
+| networking.kthenaRouter.replicas | int | `1` | Number of Kthena Router instances to run. |
 | networking.kthenaRouter.sessionBoost.enabled | bool | `false` | Enable session-boost scheduling. Mutually exclusive with fairness. |
 | networking.kthenaRouter.sessionBoost.gracePeriod | string | `"0s"` | Wait time after a request completes for a same-session follow-up.<br/> Disabled by default (`0s`). |
 | networking.kthenaRouter.sessionBoost.header | string | `"X-Session-ID"` | HTTP header used to identify conversation sessions. |
@@ -55,6 +56,7 @@ A Helm chart for deploying Kthena
 | workload.controllerManager.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy for the Controller Manager. |
 | workload.controllerManager.image.repository | string | `"ghcr.io/volcano-sh/kthena-controller-manager"` | Image repository for the Controller Manager. |
 | workload.controllerManager.image.tag | string | `"latest"` | Image tag for the Controller Manager. |
+| workload.controllerManager.replicas | int | `1` | Number of Controller Manager instances to run. |
 | workload.controllerManager.runtimeImage.repository | string | `"ghcr.io/volcano-sh/runtime"` | Image repository for the Runtime. |
 | workload.controllerManager.runtimeImage.tag | string | `"latest"` | Image tag for the Runtime. |
 | workload.controllerManager.webhook.enabled | bool | `true` | Enable webhook for the Controller Manager. |


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

`kthenaRouter.replicas` and `controllerManager.replicas` are read by the deployment templates, but neither key exists in the parent chart's `values.yaml`, so neither appears in the generated Helm values reference. Every other tunable on those two components is there, so there is no way to discover from the docs that either component can be scaled.

The two keys live only in the subcharts, where their comments use a plain `#` rather than the `# --` marker helm-docs picks up:

- `charts/kthena/charts/networking/values.yaml` line 3, consumed at `charts/kthena/charts/networking/templates/kthena-router/component/deployment.yaml` line 10
- `charts/kthena/charts/workload/values.yaml` line 10, consumed at `charts/kthena/charts/workload/templates/kthena-controller-manager/component/deployment.yaml` line 10

This adds both keys to the parent `values.yaml` with `# --` comments and regenerates the reference. Defaults stay at `1`, matching the subcharts, so rendered output is unchanged.

**Which issue(s) this PR fixes**:

N/A

**Bug evidence (required for bug-related PRs)**:

N/A, this is a documentation gap rather than a bug. Setting the values already works today: `charts/kthena/values.schema.json` covers only the `global` block and sets no `additionalProperties: false`, so `--set networking.kthenaRouter.replicas=3` is accepted on current main. The keys are simply undiscoverable from the published reference.

**Special notes for your reviewer**:

The reference doc was regenerated with helm-docs v1.14.2, the version pinned in the Makefile, and the resulting diff is only the two new rows.

`webhook.replicas` at `charts/kthena/charts/networking/values.yaml` line 103 has the same plain-comment style but no template consumes it, so it looks like dead config. Left alone here rather than mixed into this change, happy to follow up separately if you want it removed.

#1397 touches the same files, including the generated reference. It adds scheduling keys rather than replicas so there is no overlap in scope, but whichever lands second will need a regenerate.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
