### PR TITLE
test: wait for generated ModelBooster pods to terminate in TestModelCR

### DIFF
--- a/test/e2e/controller-manager/model_booster_test.go
+++ b/test/e2e/controller-manager/model_booster_test.go
@@ -18,6 +18,7 @@ package controller_manager
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"testing"
 	"time"
@@ -55,7 +56,41 @@ func TestModelCR(t *testing.T) {
 	require.NoError(t, err, "Failed to create Model CR")
 	require.NotNil(t, createdModel)
 	t.Cleanup(func() {
-		cleanupModelBoosterAndWaitForPods(t, kthenaClient, kubeClient, model)
+		cleanupCtx := context.Background()
+		if err := kthenaClient.WorkloadV1alpha1().ModelBoosters(testNamespace).Delete(cleanupCtx, model.Name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			t.Logf("cleanup: failed to delete ModelBooster %s: %v", model.Name, err)
+		}
+
+		// Deleting the CR only removes the CR objects; the generated vLLM Pod has a long
+		// terminationGracePeriodSeconds and can still be Terminating for a while afterwards.
+		// Best-effort wait for it to disappear so the next test doesn't contend for node
+		// resources with a Pod that is still shutting down. This runs as part of cleanup (not
+		// as a trailing test-body assertion) so it is attempted even if an earlier assertion in
+		// this test already failed, and it uses assert.Eventually (not require.Eventually) so a
+		// slow-terminating Pod is logged rather than treated as a fatal failure of TestModelCR.
+		backendResourceName := mbutils.GetBackendResourceName(model.Name, model.Spec.Backend.Name)
+		podLabelSelector := modelServingLabelSelector(backendResourceName)
+		assert.Eventually(t, func() bool {
+			pods, err := kubeClient.CoreV1().Pods(testNamespace).List(cleanupCtx, metav1.ListOptions{
+				LabelSelector: podLabelSelector,
+			})
+			if err != nil {
+				t.Logf("cleanup: failed to list pods for %s: %v", backendResourceName, err)
+				return false
+			}
+			if len(pods.Items) > 0 {
+				remaining := make([]string, 0, len(pods.Items))
+				for _, pod := range pods.Items {
+					deletionState := "not-set"
+					if pod.DeletionTimestamp != nil {
+						deletionState = pod.DeletionTimestamp.Format(time.RFC3339)
+					}
+					remaining = append(remaining, fmt.Sprintf("%s(phase=%s,deletionTimestamp=%s)", pod.Name, pod.Status.Phase, deletionState))
+				}
+				t.Logf("cleanup: waiting for %d generated pod(s) to terminate: %v", len(pods.Items), remaining)
+			}
+			return len(pods.Items) == 0
+		}, 6*time.Minute, 5*time.Second, "cleanup: generated workload Pods for %s were not terminated", backendResourceName)
 	})
 	t.Logf("Created Model CR: %s/%s", createdModel.Namespace, createdModel.Name)
 
@@ -168,30 +203,6 @@ func TestModelCR(t *testing.T) {
 		list, err := kthenaClient.NetworkingV1alpha1().ModelRoutes(testNamespace).List(ctx, listOpts)
 		return err == nil && len(list.Items) == 0
 	}, 2*time.Minute, 5*time.Second, "Orphan ModelRoutes should be garbage-collected")
-
-	// Deleting the CR only removes the CR objects; the generated vLLM Pod has a long
-	// terminationGracePeriodSeconds and can still be Terminating for a while afterwards.
-	// Wait for it to fully disappear so the next test doesn't contend for node resources
-	// with a Pod that is still shutting down.
-	t.Log("Verifying generated workload Pods have terminated")
-	podLabelSelector := modelServingLabelSelector(expectedChildName)
-	require.Eventually(t, func() bool {
-		pods, err := kubeClient.CoreV1().Pods(testNamespace).List(ctx, metav1.ListOptions{
-			LabelSelector: podLabelSelector,
-		})
-		if err != nil {
-			t.Logf("Failed to list pods for %s: %v", expectedChildName, err)
-			return false
-		}
-		if len(pods.Items) > 0 {
-			names := make([]string, 0, len(pods.Items))
-			for _, pod := range pods.Items {
-				names = append(names, pod.Name)
-			}
-			t.Logf("Waiting for %d generated pod(s) to terminate: %v", len(pods.Items), names)
-		}
-		return len(pods.Items) == 0
-	}, 6*time.Minute, 5*time.Second, "Generated workload Pods for %s were not terminated", expectedChildName)
 }
 
 // TestModelCRDisaggregated verifies that a vLLMDisaggregated ModelBooster is

--- a/test/e2e/controller-manager/model_booster_test.go
+++ b/test/e2e/controller-manager/model_booster_test.go
@@ -168,6 +168,30 @@ func TestModelCR(t *testing.T) {
 		list, err := kthenaClient.NetworkingV1alpha1().ModelRoutes(testNamespace).List(ctx, listOpts)
 		return err == nil && len(list.Items) == 0
 	}, 2*time.Minute, 5*time.Second, "Orphan ModelRoutes should be garbage-collected")
+
+	// Deleting the CR only removes the CR objects; the generated vLLM Pod has a long
+	// terminationGracePeriodSeconds and can still be Terminating for a while afterwards.
+	// Wait for it to fully disappear so the next test doesn't contend for node resources
+	// with a Pod that is still shutting down.
+	t.Log("Verifying generated workload Pods have terminated")
+	podLabelSelector := modelServingLabelSelector(expectedChildName)
+	require.Eventually(t, func() bool {
+		pods, err := kubeClient.CoreV1().Pods(testNamespace).List(ctx, metav1.ListOptions{
+			LabelSelector: podLabelSelector,
+		})
+		if err != nil {
+			t.Logf("Failed to list pods for %s: %v", expectedChildName, err)
+			return false
+		}
+		if len(pods.Items) > 0 {
+			names := make([]string, 0, len(pods.Items))
+			for _, pod := range pods.Items {
+				names = append(names, pod.Name)
+			}
+			t.Logf("Waiting for %d generated pod(s) to terminate: %v", len(pods.Items), names)
+		}
+		return len(pods.Items) == 0
+	}, 6*time.Minute, 5*time.Second, "Generated workload Pods for %s were not terminated", expectedChildName)
 }
 
 // TestModelCRDisaggregated verifies that a vLLMDisaggregated ModelBooster is


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`TestModelCR` previously waited only for the generated ModelServing, ModelServer, and ModelRoute resources to disappear after deleting the ModelBooster.

The underlying vLLM Pod can remain in `Terminating` state because the generated workload uses `terminationGracePeriodSeconds: 300`. As a result, `TestModelCR` could finish while the old Pod was still consuming node resources.

A subsequent ModelBooster E2E test could then create another resource-intensive vLLM Pod on the same single-node Kind cluster. The new Pod could remain `Pending` until the previous Pod finished terminating, causing unnecessary delays or E2E timeouts.

This PR updates `TestModelCR` cleanup to also wait for Pods associated with the generated ModelServing to terminate before the test completes.

The existing `modelserving.volcano.sh/name` label and `modelServingLabelSelector` helper are reused, consistent with the existing E2E test patterns. No production controller behaviour or workload configuration is changed.

**Which issue(s) this PR fixes**:

Fixes #1443

**Bug evidence (required for bug-related PRs)**:

The failure occurs through the following E2E workload lifecycle:

1. `TestModelCR` deletes a ModelBooster.
2. The generated ModelServing, ModelServer, and ModelRoute resources are garbage-collected.
3. The test observes those resources have disappeared and previously completes cleanup.
4. The generated vLLM Pod can still be in `Terminating` state.
5. The vLLM workload has `terminationGracePeriodSeconds: 300`, allowing the Pod to remain terminating for up to five minutes.
6. A subsequent ModelBooster E2E test creates another resource-intensive vLLM Pod on the same Kind node.
7. The previous Pod can continue consuming node resources while terminating, causing the new Pod to remain `Pending` until the old Pod exits.

The fix waits for Pods matching the generated ModelServing's existing `modelserving.volcano.sh/name` label to disappear before `TestModelCR` returns.

This synchronises the E2E test lifecycle with the actual workload termination rather than relying only on deletion of the generated custom resources.

**Special notes for your reviewer**:

- This change is limited to E2E test cleanup.
- No production controller logic is modified.
- No changes are made to `terminationGracePeriodSeconds`.
- No image, image-pull policy, or timeout changes are introduced elsewhere.
- The existing `modelServingLabelSelector` helper is reused rather than introducing a new label or selector.
- The Pod wait uses a 6-minute timeout with a 5-second polling interval to cover the configured 300-second termination grace period plus a small margin.
- Remaining Pod names are logged while waiting to make CI failures easier to diagnose.
- Validation performed:
  - `go build ./test/e2e/controller-manager/...`
  - `go vet ./test/e2e/controller-manager/...`
  - `gofmt` check on the changed file
  - `golangci-lint` on `./test/e2e/controller-manager/...`
- The full E2E test requires a running Kubernetes/Kind environment and could not be executed in the local environment.

**Does this PR introduce a user-facing change?**:

NONE

```release-note
NONE
```