### PR TITLE
Fix heterogeneous autoscaler target identity across namespaces

### DIFF
--- a/pkg/autoscaler/autoscaler/optimizer.go
+++ b/pkg/autoscaler/autoscaler/optimizer.go
@@ -23,6 +23,7 @@ import (
 
 	workload "github.com/volcano-sh/kthena/pkg/apis/workload/v1alpha1"
 	"github.com/volcano-sh/kthena/pkg/autoscaler/algorithm"
+	corev1 "k8s.io/api/core/v1"
 	listerv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/klog/v2"
 )
@@ -44,22 +45,33 @@ type OptimizerMeta struct {
 }
 
 type ReplicaBlock struct {
-	name     string
-	index    int32
-	replicas int32
-	cost     int64
+	targetKey string
+	index     int32
+	replicas  int32
+	cost      int64
+}
+
+// HeterogeneousTargetKey returns a namespace-qualified key for a
+// heterogeneous autoscaling target. An empty target namespace refers to the
+// namespace of the AutoscalingPolicy.
+func HeterogeneousTargetKey(targetRef corev1.ObjectReference, policyNamespace string) string {
+	namespace := targetRef.Namespace
+	if namespace == "" {
+		namespace = policyNamespace
+	}
+	return namespace + "/" + targetRef.Name
 }
 
 func (meta *OptimizerMeta) RestoreReplicasOfEachBackend(replicas int32) map[string]int32 {
 	replicasMap := make(map[string]int32, len(meta.Config.Params))
 	for _, param := range meta.Config.Params {
-		replicasMap[param.Target.TargetRef.Name] = param.MinReplicas
+		replicasMap[HeterogeneousTargetKey(param.Target.TargetRef, meta.Scope.Namespace)] = param.MinReplicas
 	}
 	replicas = min(max(replicas, meta.MinReplicas), meta.MaxReplicas)
 	replicas -= meta.MinReplicas
 	for _, block := range meta.ScalingOrder {
 		slot := min(replicas, block.replicas)
-		replicasMap[block.name] += slot
+		replicasMap[block.targetKey] += slot
 		replicas -= slot
 		if replicas <= 0 {
 			break
@@ -78,6 +90,7 @@ func NewOptimizerMeta(policy *workload.AutoscalingPolicy) *OptimizerMeta {
 	maxReplicas := int32(0)
 	var scalingOrder []*ReplicaBlock
 	for index, param := range policy.Spec.HeterogeneousTarget.Params {
+		targetKey := HeterogeneousTargetKey(param.Target.TargetRef, policy.Namespace)
 		minReplicas += param.MinReplicas
 		maxReplicas += param.MaxReplicas
 		replicas := param.MaxReplicas - param.MinReplicas
@@ -86,10 +99,10 @@ func NewOptimizerMeta(policy *workload.AutoscalingPolicy) *OptimizerMeta {
 		}
 		if costExpansionRatePercent == 100 {
 			scalingOrder = append(scalingOrder, &ReplicaBlock{
-				index:    int32(index),
-				name:     param.Target.TargetRef.Name,
-				replicas: replicas,
-				cost:     int64(param.Cost),
+				index:     int32(index),
+				targetKey: targetKey,
+				replicas:  replicas,
+				cost:      int64(param.Cost),
 			})
 			continue
 		}
@@ -97,10 +110,10 @@ func NewOptimizerMeta(policy *workload.AutoscalingPolicy) *OptimizerMeta {
 		for replicas > 0 {
 			currentLen := min(replicas, max(int32(packageLen), 1))
 			scalingOrder = append(scalingOrder, &ReplicaBlock{
-				name:     param.Target.TargetRef.Name,
-				index:    int32(index),
-				replicas: currentLen,
-				cost:     int64(param.Cost) * int64(currentLen),
+				targetKey: targetKey,
+				index:     int32(index),
+				replicas:  currentLen,
+				cost:      int64(param.Cost) * int64(currentLen),
 			})
 			replicas -= currentLen
 			packageLen = packageLen * float64(costExpansionRatePercent) / 100
@@ -128,7 +141,8 @@ func NewOptimizer(autoscalePolicy *workload.AutoscalingPolicy) *Optimizer {
 	metricTargets := GetMetricTargets(autoscalePolicy)
 	collectors := make(map[string]*MetricCollector)
 	for _, param := range autoscalePolicy.Spec.HeterogeneousTarget.Params {
-		collectors[param.Target.TargetRef.Name] = NewMetricCollector(&param.Target, autoscalePolicy, metricTargets)
+		targetKey := HeterogeneousTargetKey(param.Target.TargetRef, autoscalePolicy.Namespace)
+		collectors[targetKey] = NewMetricCollector(&param.Target, autoscalePolicy, metricTargets)
 	}
 
 	meta := NewOptimizerMeta(autoscalePolicy)
@@ -157,13 +171,14 @@ func (optimizer *Optimizer) Optimize(ctx context.Context, podLister listerv1.Pod
 	instancesCountSum := int32(0)
 	// Update all model serving instances' metrics
 	for _, param := range optimizer.Meta.Config.Params {
-		collector, exists := optimizer.Collectors[param.Target.TargetRef.Name]
+		targetKey := HeterogeneousTargetKey(param.Target.TargetRef, autoscalePolicy.Namespace)
+		collector, exists := optimizer.Collectors[targetKey]
 		if !exists {
-			klog.Warningf("collector for target %s not exists", param.Target.TargetRef.Name)
+			klog.Warningf("collector for target %s not exists", targetKey)
 			continue
 		}
 
-		backendReplicas := currentInstancesCounts[param.Target.TargetRef.Name]
+		backendReplicas := currentInstancesCounts[targetKey]
 		instancesCountSum += backendReplicas
 		currentUnreadyInstancesCount, currentReadyInstancesMetrics, currentExternalMetrics, err := collector.UpdateMetrics(ctx, podLister, param.Target.MetricSources)
 		if err != nil {

--- a/pkg/autoscaler/autoscaler/optimizer_test.go
+++ b/pkg/autoscaler/autoscaler/optimizer_test.go
@@ -198,6 +198,63 @@ func makeParam(name string, cost, minReplicas, maxReplicas int32) workload.Heter
 	}
 }
 
+func TestHeterogeneousTargetKey(t *testing.T) {
+	tests := []struct {
+		name            string
+		targetRef       corev1.ObjectReference
+		policyNamespace string
+		want            string
+	}{
+		{
+			name:            "uses explicit target namespace",
+			targetRef:       corev1.ObjectReference{Namespace: "team-a", Name: "llama"},
+			policyNamespace: "policy-ns",
+			want:            "team-a/llama",
+		},
+		{
+			name:            "uses policy namespace when target namespace is empty",
+			targetRef:       corev1.ObjectReference{Name: "llama"},
+			policyNamespace: "policy-ns",
+			want:            "policy-ns/llama",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, HeterogeneousTargetKey(tt.targetRef, tt.policyNamespace))
+		})
+	}
+}
+
+func TestHeterogeneousTargetsWithSameNameAcrossNamespaces(t *testing.T) {
+	policy := makePolicy("uid-same-name", "policy-ns", 100, []workload.HeterogeneousTargetParam{
+		{
+			Target: workload.Target{
+				TargetRef: corev1.ObjectReference{Namespace: "team-a", Name: "llama"},
+			},
+			Cost:        100,
+			MinReplicas: 1,
+			MaxReplicas: 3,
+		},
+		{
+			Target: workload.Target{
+				TargetRef: corev1.ObjectReference{Namespace: "team-b", Name: "llama"},
+			},
+			Cost:        60,
+			MinReplicas: 2,
+			MaxReplicas: 5,
+		},
+	})
+
+	optimizer := NewOptimizer(policy)
+
+	// Names are unique only within a namespace. The optimizer must preserve
+	// one metric collector for each separately addressable ModelServing target.
+	require.Len(t, optimizer.Collectors, 2)
+	assert.Contains(t, optimizer.Collectors, "team-a/llama")
+	assert.Contains(t, optimizer.Collectors, "team-b/llama")
+}
+
 func TestNewOptimizerMeta(t *testing.T) {
 	t.Run("nil when HeterogeneousTarget unset", func(t *testing.T) {
 		policy := &workload.AutoscalingPolicy{
@@ -285,8 +342,8 @@ func TestRestoreReplicasOfEachBackend(t *testing.T) {
 			rate:     100,
 			replicas: 5,
 			want: map[string]int32{
-				"a100": 3,
-				"h100": 2,
+				"ns/a100": 3,
+				"ns/h100": 2,
 			},
 		},
 		{
@@ -297,7 +354,7 @@ func TestRestoreReplicasOfEachBackend(t *testing.T) {
 			rate:     100,
 			replicas: 0,
 			want: map[string]int32{
-				"h100": 2,
+				"ns/h100": 2,
 			},
 		},
 		{
@@ -308,7 +365,7 @@ func TestRestoreReplicasOfEachBackend(t *testing.T) {
 			rate:     100,
 			replicas: 999,
 			want: map[string]int32{
-				"h100": 3,
+				"ns/h100": 3,
 			},
 		},
 		{
@@ -319,7 +376,30 @@ func TestRestoreReplicasOfEachBackend(t *testing.T) {
 			rate:     100,
 			replicas: 4,
 			want: map[string]int32{
-				"h100": 4,
+				"ns/h100": 4,
+			},
+		},
+		{
+			name: "same target name in different namespaces remains distinct",
+			params: []workload.HeterogeneousTargetParam{
+				{
+					Target:      workload.Target{TargetRef: corev1.ObjectReference{Namespace: "team-a", Name: "llama"}},
+					Cost:        100,
+					MinReplicas: 1,
+					MaxReplicas: 3,
+				},
+				{
+					Target:      workload.Target{TargetRef: corev1.ObjectReference{Namespace: "team-b", Name: "llama"}},
+					Cost:        60,
+					MinReplicas: 2,
+					MaxReplicas: 5,
+				},
+			},
+			rate:     100,
+			replicas: 8,
+			want: map[string]int32{
+				"team-a/llama": 3,
+				"team-b/llama": 5,
 			},
 		},
 	}
@@ -330,9 +410,7 @@ func TestRestoreReplicasOfEachBackend(t *testing.T) {
 			meta := NewOptimizerMeta(policy)
 			require.NotNil(t, meta)
 			got := meta.RestoreReplicasOfEachBackend(tt.replicas)
-			for backend, wantCount := range tt.want {
-				assert.Equal(t, wantCount, got[backend], "backend %q", backend)
-			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/pkg/autoscaler/controller/autoscale_controller.go
+++ b/pkg/autoscaler/controller/autoscale_controller.go
@@ -263,7 +263,8 @@ func (ac *AutoscaleController) doOptimize(ctx context.Context, autoscalePolicy *
 			klog.Errorf("failed to get current replicas, err: %v", err)
 			return err
 		}
-		replicasMap[param.Target.TargetRef.Name] = currentInstancesCount
+		targetKey := autoscaler.HeterogeneousTargetKey(param.Target.TargetRef, autoscalePolicy.Namespace)
+		replicasMap[targetKey] = currentInstancesCount
 	}
 
 	// Get recommended replicas
@@ -274,9 +275,10 @@ func (ac *AutoscaleController) doOptimize(ctx context.Context, autoscalePolicy *
 	}
 	// Do update replicas
 	for _, param := range optimizer.Meta.Config.Params {
-		instancesCount, exists := recommendedInstances[param.Target.TargetRef.Name]
+		targetKey := autoscaler.HeterogeneousTargetKey(param.Target.TargetRef, autoscalePolicy.Namespace)
+		instancesCount, exists := recommendedInstances[targetKey]
 		if !exists {
-			klog.Warningf("recommended instances not exists, target ref name: %s", param.Target.TargetRef.Name)
+			klog.Warningf("recommended instances not exists, target: %s", targetKey)
 			continue
 		}
 		if err := ac.updateTargetReplicas(ctx, &param.Target, autoscalePolicy.Namespace, instancesCount); err != nil {

--- a/pkg/autoscaler/controller/autoscale_controller_test.go
+++ b/pkg/autoscaler/controller/autoscale_controller_test.go
@@ -265,6 +265,100 @@ func TestTwoBackendsHighLoad_then_DoOptimize_expect_DistributionA5B4(t *testing.
 	}
 }
 
+func TestHeterogeneousSameNameTargetsAcrossNamespaces(t *testing.T) {
+	const (
+		policyNamespace = "policy-ns"
+		teamANamespace  = "team-a"
+		teamBNamespace  = "team-b"
+		modelName       = "llama"
+	)
+
+	msA := &workload.ModelServing{
+		ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: teamANamespace},
+		Spec:       workload.ModelServingSpec{Replicas: ptrInt32(1)},
+	}
+	msB := &workload.ModelServing{
+		ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: teamBNamespace},
+		Spec:       workload.ModelServingSpec{Replicas: ptrInt32(2)},
+	}
+	client := clientfake.NewSimpleClientset(msA, msB)
+	msLister := workloadLister.NewModelServingLister(newModelServingIndexer(msA, msB))
+
+	srv := httptest.NewServer(httpHandlerWithBody("# TYPE load gauge\nload 100\n"))
+	defer srv.Close()
+	u, _ := url.Parse(srv.URL)
+	host, portStr, _ := net.SplitHostPort(u.Host)
+	port := toInt32(portStr)
+
+	newTarget := func(namespace string) workload.Target {
+		return workload.Target{
+			TargetRef: corev1.ObjectReference{
+				Kind:      workload.ModelServingKind.Kind,
+				Namespace: namespace,
+				Name:      modelName,
+			},
+			MetricSources: map[string]workload.MetricSource{
+				"load": {Pod: &workload.PodMetricSource{Uri: u.Path, Port: port}},
+			},
+		}
+	}
+
+	panicThreshold := int32(200)
+	policy := &workload.AutoscalingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "same-name-targets", Namespace: policyNamespace},
+		Spec: workload.AutoscalingPolicySpec{
+			TolerancePercent: 0,
+			Metrics: []workload.AutoscalingPolicyMetric{
+				{Name: "load", TargetValue: resource.MustParse("1")},
+			},
+			Behavior: workload.AutoscalingPolicyBehavior{
+				ScaleUp: workload.AutoscalingPolicyScaleUpPolicy{
+					PanicPolicy: workload.AutoscalingPolicyPanicPolicy{
+						Period:                metav1.Duration{Duration: time.Second},
+						PanicThresholdPercent: &panicThreshold,
+					},
+				},
+			},
+			HeterogeneousTarget: &workload.HeterogeneousTarget{
+				CostExpansionRatePercent: 100,
+				Params: []workload.HeterogeneousTargetParam{
+					{Target: newTarget(teamANamespace), Cost: 100, MinReplicas: 1, MaxReplicas: 3},
+					{Target: newTarget(teamBNamespace), Cost: 60, MinReplicas: 2, MaxReplicas: 5},
+				},
+			},
+		},
+	}
+
+	ac := &AutoscaleController{
+		client:             client,
+		modelServingLister: msLister,
+		podsLister: fakePodLister{podsByNs: map[string][]*corev1.Pod{
+			teamANamespace: {readyPod(teamANamespace, "llama-a", host, nil)},
+			teamBNamespace: {readyPod(teamBNamespace, "llama-b", host, nil)},
+		}},
+		optimizerMap: map[string]*autoscalerOptimizer{},
+	}
+
+	if err := ac.schedule(context.Background(), policy); err != nil {
+		t.Fatalf("schedule error: %v", err)
+	}
+
+	updatedA, err := client.WorkloadV1alpha1().ModelServings(teamANamespace).Get(context.Background(), modelName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get updated team-a target: %v", err)
+	}
+	updatedB, err := client.WorkloadV1alpha1().ModelServings(teamBNamespace).Get(context.Background(), modelName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get updated team-b target: %v", err)
+	}
+
+	// A total recommendation of eight replicas should respect each target's
+	// independent bounds: team-a/llama=3 and team-b/llama=5.
+	if *updatedA.Spec.Replicas != 3 || *updatedB.Spec.Replicas != 5 {
+		t.Fatalf("expected team-a/llama=3 and team-b/llama=5, got team-a/llama=%d and team-b/llama=%d", *updatedA.Spec.Replicas, *updatedB.Spec.Replicas)
+	}
+}
+
 func httpHandlerWithBody(body string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.Write([]byte(body)) })
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fixes incorrect scaling when one heterogeneous `AutoscalingPolicy` targets `ModelServing` resources with the same name in different namespaces.

The heterogeneous optimizer and controller previously used only `targetRef.name` as the map key for metric collectors, current replica counts, replica allocation, and recommended replica updates. As a result, `team-a/llama` and `team-b/llama` overwrote each other.

This PR uses a resolved `namespace/name` key, falling back to the `AutoscalingPolicy` namespace when `targetRef.namespace` is empty.

**Which issue(s) this PR fixes**:
Fixes #1438

**Bug evidence (required for bug-related PRs)**:

A valid heterogeneous policy can reference:

```text
team-a/llama: current=1, min=1, max=3, cost=100
team-b/llama: current=2, min=2, max=5, cost=60
```

Both targets report high load. The expected total recommendation of 8 must respect each target’s independent bounds:

```text
team-a/llama=3
team-b/llama=5
```

Before this change, the controller-level reproduction executed the normal autoscaling path:

```text
AutoscaleController.schedule
→ doOptimize
→ Optimizer.Optimize
→ RestoreReplicasOfEachBackend
→ updateTargetReplicas
```

It observed both targets patched to the same invalid value:

```text
expected team-a/llama=3 and team-b/llama=5,
got team-a/llama=7 and team-b/llama=7
```

The pre-fix collision occurs where maps use only `TargetRef.Name`.

This PR keeps each target distinct through the complete path with a canonical `namespace/name` key.

**Special notes for your reviewer**:

`MetricCollector` already resolves `targetRef.namespace` correctly. This change aligns heterogeneous optimizer and controller map identity with that existing behavior.

Regression coverage includes:

- Explicit target namespaces.
- Empty target namespace fallback to the policy namespace.
- Same-named targets in different namespaces.
- Controller reconciliation that independently patches `team-a/llama` and `team-b/llama`.

Tested with:

```text
go test ./pkg/autoscaler/...
```

**Does this PR introduce a user-facing change?**:

```release-note
Fix heterogeneous autoscaling for ModelServing targets with the same name in different namespaces.
```