### PR TITLE
fix: propagate ModelBooster engine port

### DIFF
--- a/pkg/model-booster-controller/convert/model_server.go
+++ b/pkg/model-booster-controller/convert/model_server.go
@@ -69,6 +69,10 @@ func BuildModelServer(model *workload.ModelBooster) ([]*networking.ModelServer, 
 	default:
 		return nil, fmt.Errorf("not support %s backend yet, please use vLLM backend", backend.Type)
 	}
+	enginePort, err := utils.GetEnginePort(&backend)
+	if err != nil {
+		return nil, err
+	}
 	servedModelName := getServedModelName(model, backend)
 	pdGroup := getPdGroup(backend)
 	kvConnector, err := GetKvConnectorSpec(backend)
@@ -97,7 +101,7 @@ func BuildModelServer(model *workload.ModelBooster) ([]*networking.ModelServer, 
 				PDGroup: pdGroup,
 			},
 			WorkloadPort: networking.WorkloadPort{
-				Port: 8000, // todo: get port from config
+				Port: enginePort,
 			},
 			TrafficPolicy: &networking.TrafficPolicy{
 				Retry: &networking.Retry{

--- a/pkg/model-booster-controller/convert/model_server_test.go
+++ b/pkg/model-booster-controller/convert/model_server_test.go
@@ -75,6 +75,16 @@ func TestBuildModelServer(t *testing.T) {
 	}
 }
 
+func TestBuildModelServerCustomPort(t *testing.T) {
+	model := loadYaml[registry.ModelBooster](t, "testdata/input/model.yaml")
+	model.Spec.Backend.Workers[0].Config.Raw = []byte(`{"port":9000}`)
+
+	servers, err := BuildModelServer(model)
+
+	assert.NoError(t, err)
+	assert.Equal(t, int32(9000), servers[0].Spec.WorkloadPort.Port)
+}
+
 func mooncakeWorker(workerType registry.ModelWorkerType, role string) registry.ModelWorker {
 	return registry.ModelWorker{
 		Type: workerType,

--- a/pkg/model-booster-controller/convert/model_serving.go
+++ b/pkg/model-booster-controller/convert/model_serving.go
@@ -82,6 +82,10 @@ func buildVllmDisaggregatedModelServing(model *workload.ModelBooster) (*workload
 	if workersMap[workload.ModelWorkerTypeDecode] == nil {
 		return nil, fmt.Errorf("decode worker not found in backend")
 	}
+	enginePort, err := utils.GetEnginePort(backend)
+	if err != nil {
+		return nil, err
+	}
 	cacheVolume, err := buildCacheVolume(backend)
 	if err != nil {
 		return nil, err
@@ -188,8 +192,9 @@ func buildVllmDisaggregatedModelServing(model *workload.ModelBooster) (*workload
 		},
 		"MODEL_SERVING_RUNTIME_IMAGE":        config.Config.RuntimeImage(),
 		"MODEL_SERVING_RUNTIME_PORT":         env.GetEnvValueOrDefault[int32](backend, env.RuntimePort, 8100),
-		"MODEL_SERVING_RUNTIME_URL":          env.GetEnvValueOrDefault[string](backend, env.RuntimeUrl, "http://localhost:8000"),
+		"MODEL_SERVING_RUNTIME_URL":          env.GetEnvValueOrDefault[string](backend, env.RuntimeUrl, fmt.Sprintf("http://localhost:%d", enginePort)),
 		"MODEL_SERVING_RUNTIME_METRICS_PATH": env.GetEnvValueOrDefault[string](backend, env.RuntimeMetricsPath, "/metrics"),
+		"ENGINE_PORT":                        enginePort,
 		"ENGINE_PREFILL_ENV":                 prefillEngineEnv,
 		"ENGINE_DECODE_ENV":                  decodeEngineEnv,
 		"MODEL_SERVING_RUNTIME_ENGINE":       strings.ToLower(string(backend.Type)),
@@ -216,6 +221,10 @@ func buildVllmModelServing(model *workload.ModelBooster) (*workload.ModelServing
 	workersMap := mapWorkers(backend.Workers)
 	if workersMap[workload.ModelWorkerTypeServer] == nil {
 		return nil, fmt.Errorf("server worker not found in backend: %s", backend.Name)
+	}
+	enginePort, err := utils.GetEnginePort(backend)
+	if err != nil {
+		return nil, err
 	}
 	cacheVolume, err := buildCacheVolume(backend)
 	if err != nil {
@@ -316,10 +325,11 @@ func buildVllmModelServing(model *workload.ModelBooster) (*workload.ModelServing
 		"MODEL_DOWNLOAD_ENVFROM":             backend.EnvFrom,
 		"MODEL_SERVING_RUNTIME_IMAGE":        config.Config.RuntimeImage(),
 		"MODEL_SERVING_RUNTIME_PORT":         env.GetEnvValueOrDefault[int32](backend, env.RuntimePort, 8100),
-		"MODEL_SERVING_RUNTIME_URL":          env.GetEnvValueOrDefault[string](backend, env.RuntimeUrl, "http://localhost:8000"),
+		"MODEL_SERVING_RUNTIME_URL":          env.GetEnvValueOrDefault[string](backend, env.RuntimeUrl, fmt.Sprintf("http://localhost:%d", enginePort)),
 		"MODEL_SERVING_RUNTIME_METRICS_PATH": env.GetEnvValueOrDefault[string](backend, env.RuntimeMetricsPath, "/metrics"),
 		"MODEL_SERVING_RUNTIME_ENGINE":       strings.ToLower(string(backend.Type)),
 		"MODEL_SERVING_RUNTIME_POD":          "$(POD_NAME).$(NAMESPACE)",
+		"ENGINE_PORT":                        enginePort,
 		"ENGINE_SERVER_RESOURCES":            workersMap[workload.ModelWorkerTypeServer].Resources,
 		"ENGINE_SERVER_IMAGE":                workersMap[workload.ModelWorkerTypeServer].Image,
 		"ENGINE_SERVER_COMMAND":              commands,

--- a/pkg/model-booster-controller/convert/model_serving_test.go
+++ b/pkg/model-booster-controller/convert/model_serving_test.go
@@ -389,6 +389,67 @@ func TestBuildModelServingVLLMPreStopHandlesUnavailableMetrics(t *testing.T) {
 	assert.NotContains(t, script, "$ERR")
 }
 
+func TestBuildModelServingCustomEnginePort(t *testing.T) {
+	t.Run("aggregated", func(t *testing.T) {
+		model := loadYaml[workload.ModelBooster](t, "testdata/input/model.yaml")
+		model.Spec.Backend.Workers[0].Config.Raw = []byte(`{"port":9000}`)
+
+		serving, err := BuildModelServing(model)
+		require.NoError(t, err)
+
+		var runtime, engine *corev1.Container
+		for i := range serving.Spec.Template.Roles[0].EntryTemplate.Spec.Containers {
+			container := &serving.Spec.Template.Roles[0].EntryTemplate.Spec.Containers[i]
+			switch container.Name {
+			case "runtime":
+				runtime = container
+			case "engine":
+				engine = container
+			}
+		}
+		require.NotNil(t, runtime)
+		require.NotNil(t, engine)
+		assert.Contains(t, runtime.Args, "http://localhost:9000")
+		assert.Contains(t, strings.Join(engine.Command, " "), "--port 9000")
+		assert.Equal(t, int32(9000), engine.ReadinessProbe.HTTPGet.Port.IntVal)
+		assert.Contains(t, engine.Lifecycle.PreStop.Exec.Command[2], "http://localhost:9000/metrics")
+	})
+
+	t.Run("disaggregated", func(t *testing.T) {
+		model := loadYaml[workload.ModelBooster](t, "testdata/input/pd-disaggregated-model-npu.yaml")
+		for i := range model.Spec.Backend.Workers {
+			worker := &model.Spec.Backend.Workers[i]
+			if worker.Type == workload.ModelWorkerTypePrefill || worker.Type == workload.ModelWorkerTypeDecode {
+				worker.Config.Raw = []byte(`{"port":9000}`)
+			}
+		}
+
+		serving, err := BuildModelServing(model)
+		require.NoError(t, err)
+
+		for i := range serving.Spec.Template.Roles {
+			var runtime, engine *corev1.Container
+			for j := range serving.Spec.Template.Roles[i].EntryTemplate.Spec.Containers {
+				container := &serving.Spec.Template.Roles[i].EntryTemplate.Spec.Containers[j]
+				switch container.Name {
+				case "runtime":
+					runtime = container
+				case "vllm":
+					engine = container
+				}
+			}
+			require.NotNil(t, runtime)
+			require.NotNil(t, engine)
+			assert.Contains(t, runtime.Args, "http://localhost:9000")
+			assert.Contains(t, engine.Command, "--port")
+			assert.Contains(t, engine.Command, "9000")
+			assert.Equal(t, int32(9000), engine.Ports[0].ContainerPort)
+			assert.Equal(t, int32(9000), engine.ReadinessProbe.HTTPGet.Port.IntVal)
+			assert.Equal(t, int32(9000), engine.LivenessProbe.HTTPGet.Port.IntVal)
+		}
+	})
+}
+
 func TestBuildModelServingSkipEngineDependencyInstall(t *testing.T) {
 	tests := []struct {
 		name              string

--- a/pkg/model-booster-controller/convert/templates/vllm-pd.yaml
+++ b/pkg/model-booster-controller/convert/templates/vllm-pd.yaml
@@ -42,7 +42,7 @@ spec:
               - name: vllm
                 image: ${ENGINE_PREFILL_IMAGE}
                 ports:
-                  - containerPort: 8000
+                  - containerPort: ${ENGINE_PORT}
                 env: ${ENGINE_PREFILL_ENV}
                 command: ${ENGINE_PREFILL_COMMAND}
                 imagePullPolicy: IfNotPresent
@@ -53,14 +53,14 @@ spec:
                   failureThreshold: 3
                   httpGet:
                     path: /health
-                    port: 8000
+                    port: ${ENGINE_PORT}
                 livenessProbe:
                   initialDelaySeconds: 180
                   periodSeconds: 5
                   failureThreshold: 3
                   httpGet:
                     path: /health
-                    port: 8000
+                    port: ${ENGINE_PORT}
                 volumeMounts: ${VOLUME_MOUNTS}
             volumes: ${VOLUMES}
         workerReplicas: 0
@@ -99,7 +99,7 @@ spec:
               - name: vllm
                 image: ${ENGINE_DECODE_IMAGE}
                 ports:
-                  - containerPort: 8000
+                  - containerPort: ${ENGINE_PORT}
                 env: ${ENGINE_DECODE_ENV}
                 command: ${ENGINE_DECODE_COMMAND}
                 imagePullPolicy: IfNotPresent
@@ -110,14 +110,14 @@ spec:
                   failureThreshold: 3
                   httpGet:
                     path: /health
-                    port: 8000
+                    port: ${ENGINE_PORT}
                 livenessProbe:
                   initialDelaySeconds: 180
                   periodSeconds: 5
                   failureThreshold: 3
                   httpGet:
                     path: /health
-                    port: 8000
+                    port: ${ENGINE_PORT}
                 volumeMounts: ${VOLUME_MOUNTS}
             volumes: ${VOLUMES}
         workerReplicas: 0

--- a/pkg/model-booster-controller/convert/templates/vllm.yaml
+++ b/pkg/model-booster-controller/convert/templates/vllm.yaml
@@ -64,7 +64,7 @@ spec:
                   failureThreshold: 3
                   httpGet:
                     path: /health
-                    port: 8000
+                    port: ${ENGINE_PORT}
                     scheme: HTTP
                   initialDelaySeconds: 180
                   periodSeconds: 5
@@ -78,7 +78,7 @@ spec:
                         - -c
                         - |
                           while true; do
-                            METRICS=$(curl -s --max-time 2 http://localhost:8000/metrics)
+                            METRICS=$(curl -s --max-time 2 http://localhost:${ENGINE_PORT}/metrics)
                             RUNNING=$(echo "$METRICS" | grep 'vllm:num_requests_running' | grep -v '#' | awk '{print $2}' || true)
                             WAITING=$(echo "$METRICS" | grep 'vllm:num_requests_waiting' | grep -v '#' | awk '{print $2}' || true)
                             if [ -z "$RUNNING" ]; then

--- a/pkg/model-booster-controller/utils/common.go
+++ b/pkg/model-booster-controller/utils/common.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strconv"
 
 	workloadv1alpha1 "github.com/volcano-sh/kthena/pkg/apis/workload/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
@@ -42,6 +43,73 @@ func TryGetField(config []byte, key string) (any, error) {
 		return nil, nil
 	}
 	return configMap[key], nil
+}
+
+// EnginePortError identifies the worker and value that failed port validation.
+type EnginePortError struct {
+	WorkerIndex int
+	BadValue    any
+	Err         error
+}
+
+func (e *EnginePortError) Error() string {
+	return e.Err.Error()
+}
+
+func (e *EnginePortError) Unwrap() error {
+	return e.Err
+}
+
+// GetEnginePort returns the port shared by all serving workers in a backend.
+func GetEnginePort(backend *workloadv1alpha1.ModelBackend) (int32, error) {
+	const defaultPort int32 = 8000
+
+	var enginePort int32
+	for i, worker := range backend.Workers {
+		if worker.Type != workloadv1alpha1.ModelWorkerTypeServer &&
+			worker.Type != workloadv1alpha1.ModelWorkerTypePrefill &&
+			worker.Type != workloadv1alpha1.ModelWorkerTypeDecode {
+			continue
+		}
+
+		workerPort := defaultPort
+		if len(worker.Config.Raw) > 0 {
+			var config map[string]interface{}
+			if err := json.Unmarshal(worker.Config.Raw, &config); err != nil {
+				return 0, &EnginePortError{
+					WorkerIndex: i,
+					BadValue:    nil,
+					Err:         fmt.Errorf("failed to get port for worker %s: %w", worker.Type, err),
+				}
+			}
+			if portValue, exists := config["port"]; exists {
+				port := fmt.Sprint(portValue)
+				parsedPort, err := strconv.ParseInt(port, 10, 32)
+				if err != nil || parsedPort < 1 || parsedPort > 65535 {
+					return 0, &EnginePortError{
+						WorkerIndex: i,
+						BadValue:    portValue,
+						Err:         fmt.Errorf("invalid port %q for worker %s", port, worker.Type),
+					}
+				}
+				workerPort = int32(parsedPort)
+			}
+		}
+
+		if enginePort != 0 && enginePort != workerPort {
+			return 0, &EnginePortError{
+				WorkerIndex: i,
+				BadValue:    workerPort,
+				Err:         fmt.Errorf("workers use different engine ports: %d and %d", enginePort, workerPort),
+			}
+		}
+		enginePort = workerPort
+	}
+
+	if enginePort == 0 {
+		return defaultPort, nil
+	}
+	return enginePort, nil
 }
 
 func GetDeviceNum(worker *workloadv1alpha1.ModelWorker) int64 {

--- a/pkg/model-booster-controller/utils/common_test.go
+++ b/pkg/model-booster-controller/utils/common_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	workloadv1alpha1 "github.com/volcano-sh/kthena/pkg/apis/workload/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -90,6 +91,82 @@ func TestTryGetField(t *testing.T) {
 				assert.NoError(t, err)
 				assert.Equal(t, tt.expected, result)
 			}
+		})
+	}
+}
+
+func TestGetEnginePort(t *testing.T) {
+	tests := []struct {
+		name         string
+		workers      []workloadv1alpha1.ModelWorker
+		expected     int32
+		expectErrMsg string
+	}{
+		{
+			name: "default port",
+			workers: []workloadv1alpha1.ModelWorker{{
+				Type: workloadv1alpha1.ModelWorkerTypeServer,
+			}},
+			expected: 8000,
+		},
+		{
+			name: "numeric port",
+			workers: []workloadv1alpha1.ModelWorker{{
+				Type: workloadv1alpha1.ModelWorkerTypeServer,
+				Config: apiextensionsv1.JSON{
+					Raw: []byte(`{"port":9000}`),
+				},
+			}},
+			expected: 9000,
+		},
+		{
+			name: "string port",
+			workers: []workloadv1alpha1.ModelWorker{{
+				Type: workloadv1alpha1.ModelWorkerTypeServer,
+				Config: apiextensionsv1.JSON{
+					Raw: []byte(`{"port":"9000"}`),
+				},
+			}},
+			expected: 9000,
+		},
+		{
+			name: "null port",
+			workers: []workloadv1alpha1.ModelWorker{{
+				Type: workloadv1alpha1.ModelWorkerTypeServer,
+				Config: apiextensionsv1.JSON{
+					Raw: []byte(`{"port":null}`),
+				},
+			}},
+			expectErrMsg: `invalid port "<nil>"`,
+		},
+		{
+			name: "different PD ports",
+			workers: []workloadv1alpha1.ModelWorker{
+				{
+					Type: workloadv1alpha1.ModelWorkerTypePrefill,
+					Config: apiextensionsv1.JSON{
+						Raw: []byte(`{"port":9000}`),
+					},
+				},
+				{
+					Type: workloadv1alpha1.ModelWorkerTypeDecode,
+				},
+			},
+			expectErrMsg: "workers use different engine ports",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetEnginePort(&workloadv1alpha1.ModelBackend{Workers: tt.workers})
+			if tt.expectErrMsg != "" {
+				if assert.Error(t, err) {
+					assert.Contains(t, err.Error(), tt.expectErrMsg)
+				}
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, got)
 		})
 	}
 }

--- a/pkg/model-booster-controller/webhook/model_validator.go
+++ b/pkg/model-booster-controller/webhook/model_validator.go
@@ -24,6 +24,7 @@ import (
 
 	registryv1alpha1 "github.com/volcano-sh/kthena/pkg/apis/workload/v1alpha1"
 	"github.com/volcano-sh/kthena/pkg/model-booster-controller/convert"
+	"github.com/volcano-sh/kthena/pkg/model-booster-controller/utils"
 	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -82,6 +83,7 @@ func (v *ModelValidator) validateModel(model *registryv1alpha1.ModelBooster) (bo
 	allErrs = append(allErrs, validateBackendReplicaBounds(model)...)
 	allErrs = append(allErrs, validateWorkerImages(model)...)
 	allErrs = append(allErrs, validateBackendWorkerTypes(model)...)
+	allErrs = append(allErrs, validateEnginePorts(model)...)
 	allErrs = append(allErrs, validatePVCURICompatibility(model)...)
 	allErrs = append(allErrs, validateKvConnectorConfig(model)...)
 
@@ -168,6 +170,31 @@ func validateKvConnectorConfig(model *registryv1alpha1.ModelBooster) field.Error
 		))
 	}
 	return allErrs
+}
+
+func validateEnginePorts(model *registryv1alpha1.ModelBooster) field.ErrorList {
+	backend := &model.Spec.Backend
+	if backend.Type != registryv1alpha1.ModelBackendTypeVLLM &&
+		backend.Type != registryv1alpha1.ModelBackendTypeVLLMDisaggregated {
+		return nil
+	}
+
+	if _, err := utils.GetEnginePort(backend); err != nil {
+		portPath := field.NewPath("spec").Child("backend").Child("workers")
+		var badValue any
+		if portErr, ok := err.(*utils.EnginePortError); ok {
+			portPath = portPath.Index(portErr.WorkerIndex).Child("config").Child("port")
+			badValue = portErr.BadValue
+		}
+		return field.ErrorList{
+			field.Invalid(
+				portPath,
+				badValue,
+				err.Error(),
+			),
+		}
+	}
+	return nil
 }
 
 func validateBackendReplicaBounds(model *registryv1alpha1.ModelBooster) field.ErrorList {

--- a/pkg/model-booster-controller/webhook/model_validator_test.go
+++ b/pkg/model-booster-controller/webhook/model_validator_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package webhook
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -112,6 +113,82 @@ func TestValidateModel_NoErrors(t *testing.T) {
 	// Should be valid with no errors
 	assert.True(t, valid)
 	assert.Empty(t, errorMsg)
+}
+
+func TestValidateEnginePorts(t *testing.T) {
+	tests := []struct {
+		name            string
+		ports           []string
+		expectErrMsg    string
+		expectErrorPath string
+	}{
+		{
+			name:  "matching numeric ports",
+			ports: []string{"9000", "9000"},
+		},
+		{
+			name:  "matching string ports",
+			ports: []string{`"9000"`, `"9000"`},
+		},
+		{
+			name:            "null port",
+			ports:           []string{"null", "8000"},
+			expectErrMsg:    "invalid port",
+			expectErrorPath: "spec.backend.workers[0].config.port",
+		},
+		{
+			name:            "different ports",
+			ports:           []string{"9000", "8000"},
+			expectErrMsg:    "workers use different engine ports",
+			expectErrorPath: "spec.backend.workers[1].config.port",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := &registryv1alpha1.ModelBooster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-model",
+					Namespace: "default",
+				},
+				Spec: registryv1alpha1.ModelBoosterSpec{
+					Backend: registryv1alpha1.ModelBackend{
+						Name:     "backend1",
+						Type:     registryv1alpha1.ModelBackendTypeVLLMDisaggregated,
+						Replicas: 1,
+						Workers: []registryv1alpha1.ModelWorker{
+							{
+								Type:  registryv1alpha1.ModelWorkerTypePrefill,
+								Pods:  1,
+								Image: "test-image:latest",
+								Config: apiextensionsv1.JSON{
+									Raw: []byte(fmt.Sprintf(`{"port":%s}`, tt.ports[0])),
+								},
+							},
+							{
+								Type:  registryv1alpha1.ModelWorkerTypeDecode,
+								Pods:  1,
+								Image: "test-image:latest",
+								Config: apiextensionsv1.JSON{
+									Raw: []byte(fmt.Sprintf(`{"port":%s}`, tt.ports[1])),
+								},
+							},
+						},
+					},
+				},
+			}
+
+			valid, errorMsg := (&ModelValidator{}).validateModel(model)
+			if tt.expectErrMsg == "" {
+				assert.True(t, valid, "expected valid but got error: %s", errorMsg)
+				return
+			}
+			assert.False(t, valid)
+			assert.Contains(t, errorMsg, tt.expectErrMsg)
+			assert.Contains(t, errorMsg, tt.expectErrorPath)
+			assert.NotContains(t, errorMsg, "test-image:latest")
+		})
+	}
 }
 
 func TestValidatePVCURICompatibility(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Uses `workers[].config.port` consistently when generating ModelServer, runtime configuration, health probes, and lifecycle checks. Port 8000 remains the default.

PD workers with different ports are rejected because ModelServer exposes a single workload port.

**Which issue(s) this PR fixes**:

Fixes #1434

**Bug evidence (required for bug-related PRs)**:

Using a ModelBooster with:

```yaml
workers:
  - type: server
    config:
      port: 9000
```

starts vLLM with `--port 9000`, but the generated ModelServer and probes previously used 8000:

```text
configured vLLM port: 9000; generated ModelServer port: 8000
```

This can also be checked with:

```bash
kubectl get modelserver -n <namespace> -o yaml
kubectl get modelserving -n <namespace> -o yaml
```

The controller production path uses the affected converters:

https://github.com/volcano-sh/kthena/blob/e9b98f0402fbdcebe7a6d156ab3e86ef308fc7e9/pkg/model-booster-controller/controller/model_server_handler.go#L37

https://github.com/volcano-sh/kthena/blob/e9b98f0402fbdcebe7a6d156ab3e86ef308fc7e9/pkg/model-booster-controller/controller/model_serving_handler.go#L38

The hardcoded ModelServer port was here:

https://github.com/volcano-sh/kthena/blob/e9b98f0402fbdcebe7a6d156ab3e86ef308fc7e9/pkg/model-booster-controller/convert/model_server.go#L76-L78

**Special notes for your reviewer**:

Both aggregated and PD vLLM paths are covered. Existing configurations without `port` keep using 8000.

**Does this PR introduce a user-facing change?**:

```release-note
ModelBooster now uses the configured vLLM engine port when generating ModelServer and workload probes.
```