### PR TITLE
helm: drop unused webhook values

### DIFF
--- a/charts/kthena/charts/networking/values.yaml
+++ b/charts/kthena/charts/networking/values.yaml
@@ -96,26 +96,3 @@ kthenaRouter:
   # kubeAPIBurst is the burst to use while talking with kubernetes apiserver
   # If 0 or not specified, uses default value (10)
   kubeAPIBurst: 0
-
-webhook:
-  enabled: true
-  # replicas is the number of router-webhook instances to run.
-  replicas: 1
-  image:
-    # repository is the container image repository for the router-webhook.
-    repository: ghcr.io/volcano-sh/kthena-router-webhook
-    # tag is the container image tag for the router-webhook.
-    # node: edit by CI. No need to modify manually
-    tag: latest
-    # pullPolicy is the image pull policy for the router-webhook.
-    pullPolicy: IfNotPresent
-    # args are the command line arguments for the router-webhook.
-    args: ["--port=8443"]
-  # resource defines the resource limits and requests for the router-webhook.
-  resource:
-    limits:
-      cpu: 100m
-      memory: 128Mi
-    requests:
-      cpu: 100m
-      memory: 128Mi


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Removes the top level `webhook:` block from the networking subchart values. It configured a separate `kthena-router-webhook` workload, with `enabled`, `replicas`, image repository, tag, pullPolicy and args, plus CPU and memory limits and requests, but no template read any of it.

Per @LiZhenCheng9527 in #1441, this is left over from when the webhook was a separate component and can be deleted now. The webhook is served in process by the router, configured through `kthenaRouter.webhook.*`, which this PR leaves untouched.

**Which issue(s) this PR fixes**:
Fixes #1441

**Bug evidence (required for bug-related PRs)**:

N/A for a cleanup, but the checks behind it:

- `grep -rn "Values\.webhook" charts/` returns nothing across all three charts, both before and after this change
- the parent chart's `networking:` block defines only `enabled` and `kthenaRouter`, so nothing was feeding values into it either
- `ghcr.io/volcano-sh/kthena-router-webhook` is not built anywhere in the repo, in no Dockerfile, Makefile target or workflow
- `helm-docs` output is byte identical before and after, since the parent chart never surfaced these keys, so `docs/kthena/docs/reference/helm-chart-values.md` needs no regeneration and is not touched here
- the remaining file parses, and `kthenaRouter.webhook` is intact with `port: 8443`

`global.webhook.caBundle` is a different key and is in use. It is unaffected.

**Special notes for your reviewer**:

Deletion only, no renames or moves, and the trailing blank line before the block goes with it so the file ends on `kubeAPIBurst`.

Anyone who had set these keys sees no behaviour change, since they did nothing before. Helm ignores values that no template consumes, so leftover entries in a user's own values file will not error after this either.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
