### PR TITLE
perf: initialize tiktoken BPE encoding once via sync.OnceValues

### DIFF
--- a/pkg/kthena-router/filters/tokenizer/tiktoken.go
+++ b/pkg/kthena-router/filters/tokenizer/tiktoken.go
@@ -17,19 +17,26 @@ limitations under the License.
 package tokenizer
 
 import (
+	"fmt"
+	"sync"
+
 	"github.com/pkoukk/tiktoken-go"
 	tiktokenloader "github.com/pkoukk/tiktoken-go-loader"
 )
 
 const encodingName = "cl100k_base"
 
+var getBPE = sync.OnceValues(func() (*tiktoken.Tiktoken, error) {
+	tiktoken.SetBpeLoader(tiktokenloader.NewOfflineLoader())
+	return tiktoken.GetEncoding(encodingName)
+})
+
 type TickToken struct{}
 
 func (t *TickToken) CalculateTokenNum(prompt string) (int, error) {
-	tiktoken.SetBpeLoader(tiktokenloader.NewOfflineLoader())
-	encoding, err := tiktoken.GetEncoding(encodingName)
+	encoding, err := getBPE()
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("failed to initialize BPE encoding: %w", err)
 	}
 	return len(encoding.Encode(prompt, nil, nil)), nil
 }

--- a/pkg/kthena-router/filters/tokenizer/tokenizer_test.go
+++ b/pkg/kthena-router/filters/tokenizer/tokenizer_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package tokenizer
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -135,5 +136,28 @@ func TestTickToken(t *testing.T) {
 				assert.LessOrEqual(t, got, tt.wantMax)
 			}
 		})
+	}
+}
+
+func TestTickToken_ConcurrentSafety(t *testing.T) {
+	tokenizer := &TickToken{}
+	const goroutines = 50
+	var wg sync.WaitGroup
+	results := make([]int, goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			count, err := tokenizer.CalculateTokenNum("hello world")
+			require.NoError(t, err)
+			results[idx] = count
+		}(i)
+	}
+	wg.Wait()
+
+	for i := range results {
+		assert.Equal(t, results[0], results[i],
+			"goroutine %d returned different token count", i)
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

In `TickToken.CalculateTokenNum()`, `tiktoken.SetBpeLoader()` and `tiktoken.GetEncoding()` were called on every request. `SetBpeLoader()` writes a package-level global in tiktoken-go with no synchronization — confirmed data race under concurrent callers (see issue #1448). `GetEncoding()` re-parses the BPE vocabulary file from disk on every call — redundant I/O at request rate. Both now initialize exactly once via `sync.OnceValues`. No changes to `TickToken` struct or callers.

**Which issue(s) this PR fixes**:

Fixes #1448

**Bug evidence (required for bug-related PRs)**:

Race detector confirmed with 100 concurrent goroutines on original code. Full output in issue #1448. After fix: 60 tests, zero race warnings across 3 runs with `-race` flag.

**Special notes for your reviewer**:

`TestTickToken_ConcurrentSafety` spawns 50 goroutines calling `CalculateTokenNum` concurrently and asserts consistent results. Passes `go test -race` cleanly. This PR was prepared with the assistance of an AI coding tool. I have reviewed every line, verified compilation, passed lint, and all tests pass.

**Does this PR introduce a user-facing change?**:

```release-note
Fix: tiktoken BPE encoding is now initialized once at startup instead of on every token count request, eliminating a data race and redundant disk I/O under concurrent load.
```