### PR TITLE
test(e2e): ensure generated workloads are fully cleaned up

### DIFF
--- a/test/e2e/controller-manager/model_booster_test.go
+++ b/test/e2e/controller-manager/model_booster_test.go
@@ -235,6 +235,14 @@ func TestModelCRDisaggregated(t *testing.T) {
 	}, 2*time.Minute, 2*time.Second, "Disaggregated ModelServer should be garbage-collected")
 }
 
+// modelBoosterPodCleanupTimeout bounds how long cleanup waits for a ModelBooster's generated Pods to
+// disappear. The vLLM backend template (pkg/model-booster-controller/convert/templates/vllm.yaml) sets
+// terminationGracePeriodSeconds: 300 on the leader pod, and observed CI behavior shows it uses the full
+// grace period rather than exiting early on SIGTERM. The timeout below leaves headroom above that 300s
+// floor for the owner-reference GC cascade (ModelBooster -> ModelServing -> Pod) and kubelet reap latency
+// on top of it.
+const modelBoosterPodCleanupTimeout = 8 * time.Minute
+
 // cleanupModelBoosterAndWaitForPods deletes a ModelBooster and waits for both the CR and the Pods
 // generated for its backend to be fully removed before returning. Deleting the CR (or waiting only for
 // its removal) is not enough: the ModelBooster's generated ModelServing is garbage-collected
@@ -258,7 +266,7 @@ func cleanupModelBoosterAndWaitForPods(t *testing.T, kthenaClient *clientset.Cli
 	}, 2*time.Minute, 5*time.Second, "cleanup: ModelBooster %s was not deleted", model.Name)
 
 	backendResourceName := mbutils.GetBackendResourceName(model.Name, model.Spec.Backend.Name)
-	waitForPodsGone(t, cleanupCtx, kubeClient, modelServingLabelSelector(backendResourceName), 3*time.Minute)
+	waitForPodsGone(t, cleanupCtx, kubeClient, modelServingLabelSelector(backendResourceName), modelBoosterPodCleanupTimeout)
 }
 
 // assertModelBoosterChildrenSelfHeal verifies that deleting child resources triggers controller recreation.

--- a/test/e2e/controller-manager/model_booster_test.go
+++ b/test/e2e/controller-manager/model_booster_test.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
 )
 
 const (
@@ -44,7 +45,7 @@ const (
 // validates self-healing of deleted child resources, updates the CR,
 // and verifies cascading deletion.
 func TestModelCR(t *testing.T) {
-	ctx, kthenaClient, _ := setupControllerManagerE2ETest(t)
+	ctx, kthenaClient, kubeClient := setupControllerManagerE2ETest(t)
 
 	// Load the ModelBooster CR from YAML fixture
 	model := utils.LoadYAMLFromFile[workload.ModelBooster](filepath.Join(testDataDir, "ModelBooster-vllm.yaml"))
@@ -54,9 +55,7 @@ func TestModelCR(t *testing.T) {
 	require.NoError(t, err, "Failed to create Model CR")
 	require.NotNil(t, createdModel)
 	t.Cleanup(func() {
-		if err := kthenaClient.WorkloadV1alpha1().ModelBoosters(testNamespace).Delete(context.Background(), model.Name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
-			t.Logf("cleanup: failed to delete ModelBooster %s: %v", model.Name, err)
-		}
+		cleanupModelBoosterAndWaitForPods(t, kthenaClient, kubeClient, model)
 	})
 	t.Logf("Created Model CR: %s/%s", createdModel.Namespace, createdModel.Name)
 
@@ -174,7 +173,7 @@ func TestModelCR(t *testing.T) {
 // TestModelCRDisaggregated verifies that a vLLMDisaggregated ModelBooster is
 // reconciled into the split prefill/decode ModelServing shape.
 func TestModelCRDisaggregated(t *testing.T) {
-	ctx, kthenaClient, _ := setupControllerManagerE2ETest(t)
+	ctx, kthenaClient, kubeClient := setupControllerManagerE2ETest(t)
 
 	model := utils.LoadYAMLFromFile[workload.ModelBooster](filepath.Join(testDataDir, "ModelBooster-vllm-disaggregated.yaml"))
 	model.Namespace = testNamespace
@@ -183,9 +182,7 @@ func TestModelCRDisaggregated(t *testing.T) {
 	require.NoError(t, err, "Failed to create disaggregated ModelBooster")
 	require.NotNil(t, createdModel)
 	t.Cleanup(func() {
-		if err := kthenaClient.WorkloadV1alpha1().ModelBoosters(testNamespace).Delete(context.Background(), model.Name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
-			t.Logf("cleanup: failed to delete ModelBooster %s: %v", model.Name, err)
-		}
+		cleanupModelBoosterAndWaitForPods(t, kthenaClient, kubeClient, model)
 	})
 
 	expectedChildName := mbutils.GetBackendResourceName(model.Name, model.Spec.Backend.Name)
@@ -236,6 +233,32 @@ func TestModelCRDisaggregated(t *testing.T) {
 		list, err := kthenaClient.NetworkingV1alpha1().ModelServers(testNamespace).List(ctx, listOpts)
 		return err == nil && len(list.Items) == 0
 	}, 2*time.Minute, 2*time.Second, "Disaggregated ModelServer should be garbage-collected")
+}
+
+// cleanupModelBoosterAndWaitForPods deletes a ModelBooster and waits for both the CR and the Pods
+// generated for its backend to be fully removed before returning. Deleting the CR (or waiting only for
+// its removal) is not enough: the ModelBooster's generated ModelServing is garbage-collected
+// asynchronously, and its Pods can still be Terminating afterwards. Since the controller-manager E2E
+// suite runs sequentially against one shared namespace, a leftover Terminating pod from a heavy backend
+// (e.g. the real vLLM image used by ModelBooster-vllm.yaml) can bleed resource pressure into the next
+// test. The wait is scoped via the deterministic backend resource name so it never depends on, or
+// blocks on, pods belonging to other tests.
+func cleanupModelBoosterAndWaitForPods(t *testing.T, kthenaClient *clientset.Clientset, kubeClient *kubernetes.Clientset, model *workload.ModelBooster) {
+	t.Helper()
+	cleanupCtx := context.Background()
+
+	if err := kthenaClient.WorkloadV1alpha1().ModelBoosters(testNamespace).Delete(cleanupCtx, model.Name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+		t.Logf("cleanup: failed to delete ModelBooster %s: %v", model.Name, err)
+		return
+	}
+
+	require.Eventually(t, func() bool {
+		_, err := kthenaClient.WorkloadV1alpha1().ModelBoosters(testNamespace).Get(cleanupCtx, model.Name, metav1.GetOptions{})
+		return apierrors.IsNotFound(err)
+	}, 2*time.Minute, 5*time.Second, "cleanup: ModelBooster %s was not deleted", model.Name)
+
+	backendResourceName := mbutils.GetBackendResourceName(model.Name, model.Spec.Backend.Name)
+	waitForPodsGone(t, cleanupCtx, kubeClient, modelServingLabelSelector(backendResourceName), 3*time.Minute)
 }
 
 // assertModelBoosterChildrenSelfHeal verifies that deleting child resources triggers controller recreation.

--- a/test/e2e/controller-manager/model_serving_test.go
+++ b/test/e2e/controller-manager/model_serving_test.go
@@ -132,15 +132,7 @@ func TestModelServingLifecycle(t *testing.T) {
 	}, 2*time.Minute, 5*time.Second, "ModelServing was not deleted")
 
 	// Verify that associated pods are cleaned up
-	require.Eventually(t, func() bool {
-		pods, err := kubeClient.CoreV1().Pods(testNamespace).List(ctx, metav1.ListOptions{
-			LabelSelector: labelSelector,
-		})
-		if err != nil {
-			return false
-		}
-		return len(pods.Items) == 0
-	}, 2*time.Minute, 5*time.Second, "Pods were not cleaned up after ModelServing deletion")
+	waitForPodsGone(t, ctx, kubeClient, labelSelector, 2*time.Minute)
 
 	t.Log("Phase 3 passed: ModelServing deleted and pods cleaned up")
 	t.Log("ModelServing lifecycle test passed successfully")
@@ -1252,15 +1244,7 @@ func TestLWSAPIBasic(t *testing.T) {
 
 	// Wait for all pods to be deleted
 	t.Log("Waiting for all pods to be deleted")
-	require.Eventually(t, func() bool {
-		podList, err := kubeClient.CoreV1().Pods(testNamespace).List(ctx, metav1.ListOptions{
-			LabelSelector: labelSelector,
-		})
-		if err != nil {
-			return false
-		}
-		return len(podList.Items) == 0
-	}, 2*time.Minute, 2*time.Second, "Pods were not deleted after LWS deletion")
+	waitForPodsGone(t, ctx, kubeClient, labelSelector, 2*time.Minute)
 
 	t.Log("LWS API basic test passed successfully")
 }

--- a/test/e2e/controller-manager/test_suite_test.go
+++ b/test/e2e/controller-manager/test_suite_test.go
@@ -106,6 +106,33 @@ func setupControllerManagerE2ETest(t *testing.T) (context.Context, *clientset.Cl
 	return ctx, kthenaClient, kubeClient
 }
 
+// waitForPodsGone waits until no Pods matching labelSelector remain in the shared test namespace.
+// The controller-manager E2E suite runs all tests sequentially against one shared namespace, so
+// labelSelector must scope the wait to the resource under cleanup (e.g. a specific ModelServing or
+// ModelBooster instance) rather than the namespace as a whole - an unscoped wait could be satisfied
+// by, or block on, pods belonging to an unrelated test.
+func waitForPodsGone(t *testing.T, ctx context.Context, kubeClient *kubernetes.Clientset, labelSelector string, timeout time.Duration) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		pods, err := kubeClient.CoreV1().Pods(testNamespace).List(ctx, metav1.ListOptions{
+			LabelSelector: labelSelector,
+		})
+		if err != nil {
+			t.Logf("waitForPodsGone: failed to list pods (selector=%q): %v", labelSelector, err)
+			return false
+		}
+		if len(pods.Items) == 0 {
+			return true
+		}
+		remaining := make([]string, 0, len(pods.Items))
+		for _, pod := range pods.Items {
+			remaining = append(remaining, fmt.Sprintf("%s(phase=%s,deleting=%t)", pod.Name, pod.Status.Phase, pod.DeletionTimestamp != nil))
+		}
+		t.Logf("waitForPodsGone: %d pod(s) still present (selector=%q): %v", len(pods.Items), labelSelector, remaining)
+		return false
+	}, timeout, 5*time.Second, "pods matching selector %q were not cleaned up within %s", labelSelector, timeout)
+}
+
 func waitForWebhookReady(t *testing.T, ctx context.Context, kthenaClient *clientset.Clientset, namespace string) {
 	t.Helper()
 	t.Log("Waiting for webhook server to accept requests")


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR fixes a controller-manager E2E cleanup race where ModelBooster tests could finish while Pods generated by the deleted ModelBooster were still terminating.

The controller-manager E2E suite runs tests sequentially against a shared namespace. `TestModelCR` and `TestModelCRDisaggregated` previously deleted the ModelBooster and waited for the generated Custom Resources to disappear, but did not wait for the corresponding Pods to terminate.

This is particularly relevant for the ModelBooster vLLM workload, which uses a long termination grace period. A previous Pod can therefore remain in `Terminating` state after the test cleanup has completed and continue consuming node resources. A subsequent test can then create another resource-intensive workload and experience Pending/Active wait delays.

This PR:

- Adds a shared `waitForPodsGone` helper for bounded, label-scoped Pod cleanup.
- Logs the remaining Pod names, phases, and deletion state while waiting.
- Updates the ModelBooster cleanup path to wait for Pods belonging to the specific generated backend resource.
- Uses the existing `modelserving.volcano.sh/name` label to scope the wait to the current test's workload.
- Reuses the same helper in `TestModelServingLifecycle` and `TestLWSAPIBasic`, replacing their duplicated inline Pod-wait logic.
- Does not change production controller behaviour, Pod termination settings, image configuration, or CI-wide timeouts.

The Pod selector is scoped to the specific workload, so cleanup does not wait on unrelated Pods in the shared namespace.

**Which issue(s) this PR fixes**:

Fixes #1447

**Bug evidence (required for bug-related PRs)**:

The generated ModelBooster vLLM workload specifies:

```yaml
terminationGracePeriodSeconds: 300
```
### Relevant source:

pkg/model-booster-controller/convert/templates/vllm.yaml

The affected E2E cleanup path is in:

test/e2e/controller-manager/model_booster_test.go

The cleanup previously waited for generated ModelServing/ModelServer/ModelRoute resources to disappear without establishing that the corresponding generated Pods had terminated.

The existing TestModelServingLifecycle and TestLWSAPIBasic cleanup paths already wait for Pods using the modelserving.volcano.sh/name label. This provides an existing repository pattern for treating Pod termination as a separate cleanup condition.

The affected lifecycle is:

TestModelCR
  -> delete ModelBooster
  -> generated ModelServing/ModelServer/ModelRoute disappear
  -> test cleanup completes
  -> generated vLLM Pod can still be Terminating
  -> next E2E test starts
  -> another vLLM workload is created
  -> previous Pod may still consume node resources
  -> new Pod can remain Pending
  -> Active/Ready wait can be delayed or time out

The issue is specific to the controller-manager E2E lifecycle and does not indicate incorrect production controller behaviour.

### Special notes for your reviewer:

The Pod wait is bounded and label-scoped; it does not perform a namespace-wide wait.
The ModelBooster cleanup uses the deterministic backend resource name to identify only Pods belonging to that test's workload.
The helper is also used to deduplicate existing Pod cleanup logic in TestModelServingLifecycle and TestLWSAPIBasic.
No production controller code is changed.
No terminationGracePeriodSeconds, image pull policy, model configuration, or CI job timeout is changed.
If Pods fail to terminate within the bounded timeout, the test now reports the remaining Pod names/phases instead of allowing the lifecycle leak to affect a later test.
Full E2E execution requires a live Kind/Kubernetes environment; compile, formatting, vet, and lint checks can be run independently.

Does this PR introduce a user-facing change?:

NONE

