### PR TITLE
controller: validate PD KV connector configuration

### DIFF
--- a/pkg/model-booster-controller/convert/model_server.go
+++ b/pkg/model-booster-controller/convert/model_server.go
@@ -25,7 +25,6 @@ import (
 	"github.com/volcano-sh/kthena/pkg/model-booster-controller/utils"
 	icUtils "github.com/volcano-sh/kthena/pkg/model-serving-controller/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog/v2"
 )
 
 var VLLMKvConnectorType = map[string]networking.KVConnectorType{
@@ -33,6 +32,11 @@ var VLLMKvConnectorType = map[string]networking.KVConnectorType{
 	"NixlConnector":      networking.ConnectorTypeNIXL,
 	"LMCacheConnectorV1": networking.ConnectorTypeLMCache,
 }
+
+const (
+	vLLMKVRoleProducer = "kv_producer"
+	vLLMKVRoleConsumer = "kv_consumer"
+)
 
 // BuildModelServer creates arrays of ModelServer for the given model.
 // Each model backend will create one model server.
@@ -92,56 +96,99 @@ func BuildModelServer(model *workload.ModelBooster) ([]*networking.ModelServer, 
 }
 
 func getKvConnectorSpec(backend workload.ModelBackend) (*networking.KVConnectorSpec, error) {
-	var connectorType *networking.KVConnectorType
+	var connectorType networking.KVConnectorType
+	var connectorName string
 	foundConfig := false
+	var workersMissingConfig []workload.ModelWorkerType
+
 	for _, worker := range backend.Workers {
 		if worker.Type != workload.ModelWorkerTypePrefill && worker.Type != workload.ModelWorkerTypeDecode {
 			continue
 		}
 
+		if len(worker.Config.Raw) == 0 {
+			workersMissingConfig = append(workersMissingConfig, worker.Type)
+			continue
+		}
 		kvTransferConfig, err := utils.TryGetField(worker.Config.Raw, "kv-transfer-config")
 		if err != nil {
 			return nil, fmt.Errorf("failed to get kv-transfer-config for worker %s: %w", worker.Type, err)
 		}
 		if kvTransferConfig == nil {
-			klog.Warningf("worker %s (backend %s) missing kv-transfer-config", worker.Type, backend.Name)
+			workersMissingConfig = append(workersMissingConfig, worker.Type)
 			continue
 		}
 		kvTransferConfigStr, ok := kvTransferConfig.(string)
 		if !ok {
-			klog.Warningf("invalid kv-transfer-config type %T for worker %s", kvTransferConfig, worker.Type)
-			continue
+			return nil, fmt.Errorf("kv-transfer-config for worker %s must be a string, got %T", worker.Type, kvTransferConfig)
 		}
 
 		kvTransferType, err := utils.TryGetField([]byte(kvTransferConfigStr), "kv_connector")
 		if err != nil {
-			klog.Warningf("invalid kv-transfer-config type %T for worker %s, str: %s", kvTransferConfig, worker.Type, kvTransferConfigStr)
 			return nil, fmt.Errorf("failed to get kv_connector for worker %s: %w", worker.Type, err)
 		}
 		if kvTransferType == nil {
-			klog.Warningf("worker %s (backend %s) missing kv_connector", worker.Type, backend.Name)
-			continue
+			return nil, fmt.Errorf("worker %s missing kv_connector", worker.Type)
 		}
 
-		if converted, ok := kvTransferType.(string); ok {
-			if ct, exists := VLLMKvConnectorType[converted]; exists {
-				connectorType = &ct
-				foundConfig = true
-			} else {
-				klog.Warningf("unknown kv_connector type %q for worker %s", converted, worker.Type)
-			}
-		} else {
-			klog.Warningf("invalid kv_connector type %T for worker %s", kvTransferType, worker.Type)
+		converted, ok := kvTransferType.(string)
+		if !ok || converted == "" {
+			return nil, fmt.Errorf("kv_connector for worker %s must be a non-empty string, got %T", worker.Type, kvTransferType)
 		}
+		currentConnectorType, exists := VLLMKvConnectorType[converted]
+		if !exists {
+			return nil, fmt.Errorf("unknown kv_connector type %q for worker %s", converted, worker.Type)
+		}
+
+		kvRole, err := utils.TryGetField([]byte(kvTransferConfigStr), "kv_role")
+		if err != nil {
+			return nil, fmt.Errorf("failed to get kv_role for worker %s: %w", worker.Type, err)
+		}
+		if kvRole == nil {
+			return nil, fmt.Errorf("worker %s missing kv_role", worker.Type)
+		}
+		kvRoleStr, ok := kvRole.(string)
+		if !ok {
+			return nil, fmt.Errorf("kv_role for worker %s must be a string, got %T", worker.Type, kvRole)
+		}
+		expectedRole := vLLMKVRoleProducer
+		if worker.Type == workload.ModelWorkerTypeDecode {
+			expectedRole = vLLMKVRoleConsumer
+		}
+		if kvRoleStr != expectedRole {
+			return nil, fmt.Errorf("worker %s kv_role must be %q, got %q", worker.Type, expectedRole, kvRoleStr)
+		}
+
+		if foundConfig && converted != connectorName {
+			return nil, fmt.Errorf(
+				"workers must use the same kv_connector: got %q and %q",
+				connectorName,
+				converted,
+			)
+		}
+		connectorName = converted
+		connectorType = currentConnectorType
+		foundConfig = true
 	}
 
-	if foundConfig {
-		if connectorType == nil {
-			return nil, fmt.Errorf("kv connector type found but nil")
-		}
-		return &networking.KVConnectorSpec{Type: *connectorType}, nil
+	if !foundConfig {
+		return nil, nil
 	}
-	return nil, nil
+	if len(workersMissingConfig) > 0 {
+		return nil, fmt.Errorf(
+			"worker %s missing kv-transfer-config while another PD worker configures kv_connector %q",
+			workersMissingConfig[0],
+			connectorName,
+		)
+	}
+
+	return &networking.KVConnectorSpec{Type: connectorType}, nil
+}
+
+// ValidateKVConnectorConfig validates the connector and role contract shared by PD workers.
+func ValidateKVConnectorConfig(backend workload.ModelBackend) error {
+	_, err := getKvConnectorSpec(backend)
+	return err
 }
 
 func getPdGroup(backend workload.ModelBackend) *networking.PDGroup {

--- a/pkg/model-booster-controller/convert/model_server_test.go
+++ b/pkg/model-booster-controller/convert/model_server_test.go
@@ -119,19 +119,88 @@ func TestGetKvConnectorSpec(t *testing.T) {
 			expected: nil,
 		},
 		{
-			name: "unknown connector type is ignored",
+			name: "PD workers with matching connectors and roles",
 			workers: []registry.ModelWorker{
 				{
 					Type: registry.ModelWorkerTypePrefill,
 					Config: apiextensionsv1.JSON{
-						Raw: []byte(`{"kv-transfer-config":"{\"kv_connector\":\"UnknownConnector\"}"}`),
+						Raw: []byte(`{"kv-transfer-config":"{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_producer\"}"}`),
 					},
 				},
+				{
+					Type: registry.ModelWorkerTypeDecode,
+					Config: apiextensionsv1.JSON{
+						Raw: []byte(`{"kv-transfer-config":"{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_consumer\"}"}`),
+					},
+				},
+			},
+			expected: &networking.KVConnectorSpec{Type: networking.ConnectorTypeNIXL},
+		},
+		{
+			name: "PD workers without connector configuration are allowed",
+			workers: []registry.ModelWorker{
+				{Type: registry.ModelWorkerTypePrefill},
+				{Type: registry.ModelWorkerTypeDecode},
 			},
 			expected: nil,
 		},
 		{
-			name: "missing connector field is ignored",
+			name: "mismatched connector types return error",
+			workers: []registry.ModelWorker{
+				{
+					Type: registry.ModelWorkerTypePrefill,
+					Config: apiextensionsv1.JSON{
+						Raw: []byte(`{"kv-transfer-config":"{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_producer\"}"}`),
+					},
+				},
+				{
+					Type: registry.ModelWorkerTypeDecode,
+					Config: apiextensionsv1.JSON{
+						Raw: []byte(`{"kv-transfer-config":"{\"kv_connector\":\"MooncakeConnector\",\"kv_role\":\"kv_consumer\"}"}`),
+					},
+				},
+			},
+			expectErrMsg: `workers must use the same kv_connector: got "NixlConnector" and "MooncakeConnector"`,
+		},
+		{
+			name: "connector missing from decode worker returns error",
+			workers: []registry.ModelWorker{
+				{
+					Type: registry.ModelWorkerTypePrefill,
+					Config: apiextensionsv1.JSON{
+						Raw: []byte(`{"kv-transfer-config":"{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_producer\"}"}`),
+					},
+				},
+				{Type: registry.ModelWorkerTypeDecode},
+			},
+			expectErrMsg: `worker decode missing kv-transfer-config while another PD worker configures kv_connector "NixlConnector"`,
+		},
+		{
+			name: "reversed prefill role returns error",
+			workers: []registry.ModelWorker{
+				{
+					Type: registry.ModelWorkerTypePrefill,
+					Config: apiextensionsv1.JSON{
+						Raw: []byte(`{"kv-transfer-config":"{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_consumer\"}"}`),
+					},
+				},
+			},
+			expectErrMsg: `worker prefill kv_role must be "kv_producer", got "kv_consumer"`,
+		},
+		{
+			name: "unknown connector type returns error",
+			workers: []registry.ModelWorker{
+				{
+					Type: registry.ModelWorkerTypePrefill,
+					Config: apiextensionsv1.JSON{
+						Raw: []byte(`{"kv-transfer-config":"{\"kv_connector\":\"UnknownConnector\",\"kv_role\":\"kv_producer\"}"}`),
+					},
+				},
+			},
+			expectErrMsg: `unknown kv_connector type "UnknownConnector" for worker prefill`,
+		},
+		{
+			name: "missing connector field returns error",
 			workers: []registry.ModelWorker{
 				{
 					Type: registry.ModelWorkerTypePrefill,
@@ -140,7 +209,19 @@ func TestGetKvConnectorSpec(t *testing.T) {
 					},
 				},
 			},
-			expected: nil,
+			expectErrMsg: "worker prefill missing kv_connector",
+		},
+		{
+			name: "missing role field returns error",
+			workers: []registry.ModelWorker{
+				{
+					Type: registry.ModelWorkerTypePrefill,
+					Config: apiextensionsv1.JSON{
+						Raw: []byte(`{"kv-transfer-config":"{\"kv_connector\":\"NixlConnector\"}"}`),
+					},
+				},
+			},
+			expectErrMsg: "worker prefill missing kv_role",
 		},
 		{
 			name: "malformed nested kv-transfer-config returns error",

--- a/pkg/model-booster-controller/convert/model_serving.go
+++ b/pkg/model-booster-controller/convert/model_serving.go
@@ -62,6 +62,9 @@ func BuildModelServing(model *workload.ModelBooster) (*workload.ModelServing, er
 	case workload.ModelBackendTypeVLLM:
 		serving, err = buildVllmModelServing(model)
 	case workload.ModelBackendTypeVLLMDisaggregated:
+		if err := ValidateKVConnectorConfig(*backend); err != nil {
+			return nil, err
+		}
 		serving, err = buildVllmDisaggregatedModelServing(model)
 	default:
 		return nil, fmt.Errorf("not support model backend type: %s", backend.Type)

--- a/pkg/model-booster-controller/convert/model_serving_test.go
+++ b/pkg/model-booster-controller/convert/model_serving_test.go
@@ -389,6 +389,24 @@ func TestBuildModelServingVLLMPreStopHandlesUnavailableMetrics(t *testing.T) {
 	assert.NotContains(t, script, "$ERR")
 }
 
+func TestBuildModelServingRejectsMismatchedKVConnectors(t *testing.T) {
+	model := loadYaml[workload.ModelBooster](t, "testdata/input/pd-disaggregated-model-mooncake.yaml")
+	for i := range model.Spec.Backend.Workers {
+		if model.Spec.Backend.Workers[i].Type == workload.ModelWorkerTypeDecode {
+			model.Spec.Backend.Workers[i].Config.Raw = []byte(strings.ReplaceAll(
+				string(model.Spec.Backend.Workers[i].Config.Raw),
+				"MooncakeConnector",
+				"NixlConnector",
+			))
+		}
+	}
+
+	serving, err := BuildModelServing(model)
+
+	assert.Nil(t, serving)
+	assert.ErrorContains(t, err, `workers must use the same kv_connector`)
+}
+
 func TestBuildModelServingSkipEngineDependencyInstall(t *testing.T) {
 	tests := []struct {
 		name              string

--- a/pkg/model-booster-controller/webhook/model_validator.go
+++ b/pkg/model-booster-controller/webhook/model_validator.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	registryv1alpha1 "github.com/volcano-sh/kthena/pkg/apis/workload/v1alpha1"
+	"github.com/volcano-sh/kthena/pkg/model-booster-controller/convert"
 	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -81,6 +82,7 @@ func (v *ModelValidator) validateModel(model *registryv1alpha1.ModelBooster) (bo
 	allErrs = append(allErrs, validateBackendReplicaBounds(model)...)
 	allErrs = append(allErrs, validateWorkerImages(model)...)
 	allErrs = append(allErrs, validateBackendWorkerTypes(model)...)
+	allErrs = append(allErrs, validateKVConnectorConfig(model)...)
 	allErrs = append(allErrs, validatePVCURICompatibility(model)...)
 
 	if len(allErrs) > 0 {
@@ -149,6 +151,21 @@ func validateBackendWorkerTypes(model *registryv1alpha1.ModelBooster) field.Erro
 		}
 	}
 	return allErrs
+}
+
+func validateKVConnectorConfig(model *registryv1alpha1.ModelBooster) field.ErrorList {
+	backend := model.Spec.Backend
+	if backend.Type != registryv1alpha1.ModelBackendTypeVLLMDisaggregated {
+		return nil
+	}
+	if err := convert.ValidateKVConnectorConfig(backend); err != nil {
+		return field.ErrorList{field.Invalid(
+			field.NewPath("spec").Child("backend").Child("workers"),
+			"kv-transfer-config",
+			err.Error(),
+		)}
+	}
+	return nil
 }
 
 func validateBackendReplicaBounds(model *registryv1alpha1.ModelBooster) field.ErrorList {

--- a/pkg/model-booster-controller/webhook/model_validator_test.go
+++ b/pkg/model-booster-controller/webhook/model_validator_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	registryv1alpha1 "github.com/volcano-sh/kthena/pkg/apis/workload/v1alpha1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -111,6 +112,107 @@ func TestValidateModel_NoErrors(t *testing.T) {
 	// Should be valid with no errors
 	assert.True(t, valid)
 	assert.Empty(t, errorMsg)
+}
+
+func TestValidateKVConnectorConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		workers     []registryv1alpha1.ModelWorker
+		expectValid bool
+		expectMsg   string
+	}{
+		{
+			name: "matching connectors and roles are valid",
+			workers: []registryv1alpha1.ModelWorker{
+				{
+					Type: registryv1alpha1.ModelWorkerTypePrefill,
+					Config: apiextensionsv1.JSON{
+						Raw: []byte(`{"kv-transfer-config":"{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_producer\"}"}`),
+					},
+				},
+				{
+					Type: registryv1alpha1.ModelWorkerTypeDecode,
+					Config: apiextensionsv1.JSON{
+						Raw: []byte(`{"kv-transfer-config":"{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_consumer\"}"}`),
+					},
+				},
+			},
+			expectValid: true,
+		},
+		{
+			name: "mismatched connectors are rejected",
+			workers: []registryv1alpha1.ModelWorker{
+				{
+					Type: registryv1alpha1.ModelWorkerTypePrefill,
+					Config: apiextensionsv1.JSON{
+						Raw: []byte(`{"kv-transfer-config":"{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_producer\"}"}`),
+					},
+				},
+				{
+					Type: registryv1alpha1.ModelWorkerTypeDecode,
+					Config: apiextensionsv1.JSON{
+						Raw: []byte(`{"kv-transfer-config":"{\"kv_connector\":\"MooncakeConnector\",\"kv_role\":\"kv_consumer\"}"}`),
+					},
+				},
+			},
+			expectMsg: `workers must use the same kv_connector`,
+		},
+		{
+			name: "missing decode connector is rejected",
+			workers: []registryv1alpha1.ModelWorker{
+				{
+					Type: registryv1alpha1.ModelWorkerTypePrefill,
+					Config: apiextensionsv1.JSON{
+						Raw: []byte(`{"kv-transfer-config":"{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_producer\"}"}`),
+					},
+				},
+				{Type: registryv1alpha1.ModelWorkerTypeDecode},
+			},
+			expectMsg: "worker decode missing kv-transfer-config",
+		},
+		{
+			name: "reversed role is rejected",
+			workers: []registryv1alpha1.ModelWorker{
+				{
+					Type: registryv1alpha1.ModelWorkerTypePrefill,
+					Config: apiextensionsv1.JSON{
+						Raw: []byte(`{"kv-transfer-config":"{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_consumer\"}"}`),
+					},
+				},
+				{
+					Type: registryv1alpha1.ModelWorkerTypeDecode,
+					Config: apiextensionsv1.JSON{
+						Raw: []byte(`{"kv-transfer-config":"{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_consumer\"}"}`),
+					},
+				},
+			},
+			expectMsg: `worker prefill kv_role must be "kv_producer"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := &registryv1alpha1.ModelBooster{
+				Spec: registryv1alpha1.ModelBoosterSpec{
+					Backend: registryv1alpha1.ModelBackend{
+						Name:    "test-backend",
+						Type:    registryv1alpha1.ModelBackendTypeVLLMDisaggregated,
+						Workers: tt.workers,
+					},
+				},
+			}
+
+			valid, errorMsg := (&ModelValidator{}).validateModel(model)
+
+			if tt.expectValid {
+				assert.True(t, valid, "expected valid but got error: %s", errorMsg)
+				assert.Empty(t, errorMsg)
+			} else {
+				assert.False(t, valid)
+				assert.Contains(t, errorMsg, tt.expectMsg)
+			}
+		})
+	}
 }
 
 func TestValidatePVCURICompatibility(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Reject invalid vLLM PD KV-transfer configurations before workloads start.

Previously, `getKvConnectorSpec` scanned prefill and decode workers and overwrote one connector variable for every recognized value. Mismatched configurations therefore succeeded and the last worker's connector silently became the connector for the whole PD group.

This PR:

- requires configured prefill and decode workers to use the same supported `kv_connector`;
- requires prefill to use `kv_producer` and decode to use `kv_consumer`;
- rejects missing, unknown, malformed, and role-incompatible partial configurations;
- preserves existing configurations where neither PD worker enables KV transfer;
- applies the shared validation during admission and before both ModelServing and ModelServer conversion paths can create inconsistent resources.

**Which issue(s) this PR fixes**:

Fixes #1453

**Bug evidence (required for bug-related PRs)**:

A `vLLMDisaggregated` ModelBooster with prefill using `NixlConnector` and decode using `MooncakeConnector` previously converted successfully. The generated ModelServer recorded `mooncake`; reversing worker order recorded `nixl`, demonstrating that the last recognized connector won.

The production controller creates ModelServing before ModelServer, so validating only while building ModelServer could still allow an invalid workload to start. The admission check now rejects the resource first, and `BuildModelServing` repeats the same validation as a fallback if admission is bypassed.

Validation:

```text
go test ./pkg/model-booster-controller/convert ./pkg/model-booster-controller/webhook -count=1
go test ./pkg/model-booster-controller/... -count=1
go vet ./pkg/model-booster-controller/...
golangci-lint run --new-from-rev=origin/main
go test $(go list ./... | grep -v /e2e | grep -v /client-go) -count=1
```

All commands pass. The unscoped Windows lint invocation reports pre-existing CRLF/gofmt findings across unmodified files; lint restricted to this PR's changes passes.

**Special notes for your reviewer**:

Both workers omitting `kv-transfer-config` remains valid for backward compatibility. Once any PD worker configures a connector, every PD worker must provide a valid, consistent connector and the role expected for its worker type.

This change was developed with AI assistance and reviewed and validated before submission.

**Does this PR introduce a user-facing change?**:

```release-note
ModelBooster admission now rejects inconsistent, missing, unknown, or role-incompatible vLLM PD KV connector configurations before workloads start.
```
