### PR TITLE
fix(model-booster): reject inconsistent PD kv_connector configs

### DIFF
--- a/pkg/model-booster-controller/convert/model_server.go
+++ b/pkg/model-booster-controller/convert/model_server.go
@@ -30,9 +30,10 @@ import (
 )
 
 var VLLMKvConnectorType = map[string]networking.KVConnectorType{
-	"MooncakeConnector":  networking.ConnectorTypeMoonCake,
-	"NixlConnector":      networking.ConnectorTypeNIXL,
-	"LMCacheConnectorV1": networking.ConnectorTypeLMCache,
+	"MooncakeConnector":   networking.ConnectorTypeMoonCake,
+	"MooncakeConnectorV1": networking.ConnectorTypeMoonCake,
+	"NixlConnector":       networking.ConnectorTypeNIXL,
+	"LMCacheConnectorV1":  networking.ConnectorTypeLMCache,
 }
 
 // vLLM kv_role values. "kv_both" is accepted for either prefill or decode since some
@@ -123,24 +124,49 @@ func BuildModelServer(model *workload.ModelBooster) ([]*networking.ModelServer, 
 // both workers must declare the same connector with a role compatible with their worker
 // type, otherwise this returns a descriptive error. The result never depends on the
 // order of backend.Workers.
+//
+// A backend must have at most one prefill worker and at most one decode worker: the
+// ModelWorker API scales a role via Replicas/Pods on a single entry, not by repeating
+// the worker type, so a second entry of the same type is rejected rather than silently
+// picked (which would make the result depend on worker order).
 func GetKvConnectorSpec(backend workload.ModelBackend) (*networking.KVConnectorSpec, error) {
-	var prefillConn, decodeConn *kvWorkerConnector
+	var prefillWorker, decodeWorker *workload.ModelWorker
+	prefillCount, decodeCount := 0, 0
 
-	for _, worker := range backend.Workers {
+	for i := range backend.Workers {
+		worker := &backend.Workers[i]
 		switch worker.Type {
 		case workload.ModelWorkerTypePrefill:
-			conn, err := parseKvWorkerConnector(worker)
-			if err != nil {
-				return nil, err
-			}
-			prefillConn = conn
+			prefillCount++
+			prefillWorker = worker
 		case workload.ModelWorkerTypeDecode:
-			conn, err := parseKvWorkerConnector(worker)
-			if err != nil {
-				return nil, err
-			}
-			decodeConn = conn
+			decodeCount++
+			decodeWorker = worker
 		}
+	}
+	if prefillCount > 1 {
+		return nil, fmt.Errorf("backend %s: found %d prefill workers, expected at most 1; duplicate prefill workers are not supported",
+			backend.Name, prefillCount)
+	}
+	if decodeCount > 1 {
+		return nil, fmt.Errorf("backend %s: found %d decode workers, expected at most 1; duplicate decode workers are not supported",
+			backend.Name, decodeCount)
+	}
+
+	var prefillConn, decodeConn *kvWorkerConnector
+	if prefillWorker != nil {
+		conn, err := parseKvWorkerConnector(*prefillWorker)
+		if err != nil {
+			return nil, err
+		}
+		prefillConn = conn
+	}
+	if decodeWorker != nil {
+		conn, err := parseKvWorkerConnector(*decodeWorker)
+		if err != nil {
+			return nil, err
+		}
+		decodeConn = conn
 	}
 
 	if prefillConn == nil && decodeConn == nil {

--- a/pkg/model-booster-controller/convert/model_server.go
+++ b/pkg/model-booster-controller/convert/model_server.go
@@ -18,6 +18,8 @@ package convert
 
 import (
 	"fmt"
+	"sort"
+	"strings"
 	"time"
 
 	networking "github.com/volcano-sh/kthena/pkg/apis/networking/v1alpha1"
@@ -25,13 +27,33 @@ import (
 	"github.com/volcano-sh/kthena/pkg/model-booster-controller/utils"
 	icUtils "github.com/volcano-sh/kthena/pkg/model-serving-controller/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog/v2"
 )
 
 var VLLMKvConnectorType = map[string]networking.KVConnectorType{
 	"MooncakeConnector":  networking.ConnectorTypeMoonCake,
 	"NixlConnector":      networking.ConnectorTypeNIXL,
 	"LMCacheConnectorV1": networking.ConnectorTypeLMCache,
+}
+
+// vLLM kv_role values. "kv_both" is accepted for either prefill or decode since some
+// connectors (e.g. NixlConnector) let a single worker act as both producer and consumer.
+const (
+	kvRoleProducer = "kv_producer"
+	kvRoleConsumer = "kv_consumer"
+	kvRoleBoth     = "kv_both"
+)
+
+// kvRolesByWorkerType lists the kv_role values a worker of the given type may declare.
+var kvRolesByWorkerType = map[workload.ModelWorkerType][]string{
+	workload.ModelWorkerTypePrefill: {kvRoleProducer, kvRoleBoth},
+	workload.ModelWorkerTypeDecode:  {kvRoleConsumer, kvRoleBoth},
+}
+
+// kvWorkerConnector is the parsed kv-transfer-config of a single prefill/decode worker.
+type kvWorkerConnector struct {
+	connectorName string
+	connectorType networking.KVConnectorType
+	role          string
 }
 
 // BuildModelServer creates arrays of ModelServer for the given model.
@@ -48,7 +70,7 @@ func BuildModelServer(model *workload.ModelBooster) ([]*networking.ModelServer, 
 	}
 	servedModelName := getServedModelName(model, backend)
 	pdGroup := getPdGroup(backend)
-	kvConnector, err := getKvConnectorSpec(backend)
+	kvConnector, err := GetKvConnectorSpec(backend)
 	if err != nil {
 		return nil, err
 	}
@@ -91,57 +113,131 @@ func BuildModelServer(model *workload.ModelBooster) ([]*networking.ModelServer, 
 	return modelServers, nil
 }
 
-func getKvConnectorSpec(backend workload.ModelBackend) (*networking.KVConnectorSpec, error) {
-	var connectorType *networking.KVConnectorType
-	foundConfig := false
+// GetKvConnectorSpec derives the KVConnectorSpec for a backend from its prefill/decode
+// workers' kv-transfer-config. It is exported so webhook validation can reuse the exact
+// same parsing/consistency rules instead of duplicating them.
+//
+// A backend that has no kv-transfer-config on either its prefill or decode worker is
+// valid (KV transfer is optional, e.g. PD backends that rely on another transfer
+// mechanism); this returns (nil, nil). Once either worker declares a kv_connector,
+// both workers must declare the same connector with a role compatible with their worker
+// type, otherwise this returns a descriptive error. The result never depends on the
+// order of backend.Workers.
+func GetKvConnectorSpec(backend workload.ModelBackend) (*networking.KVConnectorSpec, error) {
+	var prefillConn, decodeConn *kvWorkerConnector
+
 	for _, worker := range backend.Workers {
-		if worker.Type != workload.ModelWorkerTypePrefill && worker.Type != workload.ModelWorkerTypeDecode {
-			continue
-		}
-
-		kvTransferConfig, err := utils.TryGetField(worker.Config.Raw, "kv-transfer-config")
-		if err != nil {
-			return nil, fmt.Errorf("failed to get kv-transfer-config for worker %s: %w", worker.Type, err)
-		}
-		if kvTransferConfig == nil {
-			klog.Warningf("worker %s (backend %s) missing kv-transfer-config", worker.Type, backend.Name)
-			continue
-		}
-		kvTransferConfigStr, ok := kvTransferConfig.(string)
-		if !ok {
-			klog.Warningf("invalid kv-transfer-config type %T for worker %s", kvTransferConfig, worker.Type)
-			continue
-		}
-
-		kvTransferType, err := utils.TryGetField([]byte(kvTransferConfigStr), "kv_connector")
-		if err != nil {
-			klog.Warningf("invalid kv-transfer-config type %T for worker %s, str: %s", kvTransferConfig, worker.Type, kvTransferConfigStr)
-			return nil, fmt.Errorf("failed to get kv_connector for worker %s: %w", worker.Type, err)
-		}
-		if kvTransferType == nil {
-			klog.Warningf("worker %s (backend %s) missing kv_connector", worker.Type, backend.Name)
-			continue
-		}
-
-		if converted, ok := kvTransferType.(string); ok {
-			if ct, exists := VLLMKvConnectorType[converted]; exists {
-				connectorType = &ct
-				foundConfig = true
-			} else {
-				klog.Warningf("unknown kv_connector type %q for worker %s", converted, worker.Type)
+		switch worker.Type {
+		case workload.ModelWorkerTypePrefill:
+			conn, err := parseKvWorkerConnector(worker)
+			if err != nil {
+				return nil, err
 			}
-		} else {
-			klog.Warningf("invalid kv_connector type %T for worker %s", kvTransferType, worker.Type)
+			prefillConn = conn
+		case workload.ModelWorkerTypeDecode:
+			conn, err := parseKvWorkerConnector(worker)
+			if err != nil {
+				return nil, err
+			}
+			decodeConn = conn
 		}
 	}
 
-	if foundConfig {
-		if connectorType == nil {
-			return nil, fmt.Errorf("kv connector type found but nil")
-		}
-		return &networking.KVConnectorSpec{Type: *connectorType}, nil
+	if prefillConn == nil && decodeConn == nil {
+		return nil, nil
 	}
-	return nil, nil
+	if prefillConn == nil {
+		return nil, fmt.Errorf(
+			"backend %s: decode worker specifies kv_connector %q but the prefill worker has no kv-transfer-config; "+
+				"prefill and decode must configure the same kv connector",
+			backend.Name, decodeConn.connectorName)
+	}
+	if decodeConn == nil {
+		return nil, fmt.Errorf(
+			"backend %s: prefill worker specifies kv_connector %q but the decode worker has no kv-transfer-config; "+
+				"prefill and decode must configure the same kv connector",
+			backend.Name, prefillConn.connectorName)
+	}
+	if prefillConn.connectorType != decodeConn.connectorType {
+		return nil, fmt.Errorf(
+			"backend %s: kv_connector mismatch between prefill (%q) and decode (%q) workers; "+
+				"prefill and decode must use the same kv connector",
+			backend.Name, prefillConn.connectorName, decodeConn.connectorName)
+	}
+
+	return &networking.KVConnectorSpec{Type: prefillConn.connectorType}, nil
+}
+
+// parseKvWorkerConnector extracts and validates the kv_connector/kv_role pair from a
+// single worker's kv-transfer-config. It returns (nil, nil) when the worker has no
+// config or no kv-transfer-config field at all, since KV transfer is optional. Once
+// kv-transfer-config is present, kv_connector and kv_role must both be present, the
+// connector must be a supported type, and the role must be compatible with the
+// worker's type.
+func parseKvWorkerConnector(worker workload.ModelWorker) (*kvWorkerConnector, error) {
+	if len(worker.Config.Raw) == 0 {
+		return nil, nil
+	}
+
+	kvTransferConfig, err := utils.TryGetField(worker.Config.Raw, "kv-transfer-config")
+	if err != nil {
+		return nil, fmt.Errorf("worker %s: invalid config: %w", worker.Type, err)
+	}
+	if kvTransferConfig == nil {
+		return nil, nil
+	}
+	kvTransferConfigStr, ok := kvTransferConfig.(string)
+	if !ok {
+		return nil, fmt.Errorf("worker %s: kv-transfer-config must be a JSON string, got %T", worker.Type, kvTransferConfig)
+	}
+
+	kvConnectorField, err := utils.TryGetField([]byte(kvTransferConfigStr), "kv_connector")
+	if err != nil {
+		return nil, fmt.Errorf("worker %s: invalid kv-transfer-config: %w", worker.Type, err)
+	}
+	connectorName, ok := kvConnectorField.(string)
+	if !ok || connectorName == "" {
+		return nil, fmt.Errorf("worker %s: kv-transfer-config is set but kv_connector is missing", worker.Type)
+	}
+	connectorType, exists := VLLMKvConnectorType[connectorName]
+	if !exists {
+		return nil, fmt.Errorf("worker %s: unsupported kv_connector %q (supported: %s)",
+			worker.Type, connectorName, strings.Join(supportedKvConnectorNames(), ", "))
+	}
+
+	kvRoleField, err := utils.TryGetField([]byte(kvTransferConfigStr), "kv_role")
+	if err != nil {
+		return nil, fmt.Errorf("worker %s: invalid kv-transfer-config: %w", worker.Type, err)
+	}
+	role, ok := kvRoleField.(string)
+	if !ok || role == "" {
+		return nil, fmt.Errorf("worker %s: kv-transfer-config is set but kv_role is missing", worker.Type)
+	}
+	allowedRoles := kvRolesByWorkerType[worker.Type]
+	if !containsString(allowedRoles, role) {
+		return nil, fmt.Errorf("worker %s: invalid kv_role %q, expected one of [%s]",
+			worker.Type, role, strings.Join(allowedRoles, ", "))
+	}
+
+	return &kvWorkerConnector{connectorName: connectorName, connectorType: connectorType, role: role}, nil
+}
+
+func supportedKvConnectorNames() []string {
+	names := make([]string, 0, len(VLLMKvConnectorType))
+	for name := range VLLMKvConnectorType {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func containsString(list []string, s string) bool {
+	for _, item := range list {
+		if item == s {
+			return true
+		}
+	}
+	return false
 }
 
 func getPdGroup(backend workload.ModelBackend) *networking.PDGroup {

--- a/pkg/model-booster-controller/convert/model_server_test.go
+++ b/pkg/model-booster-controller/convert/model_server_test.go
@@ -75,6 +75,24 @@ func TestBuildModelServer(t *testing.T) {
 	}
 }
 
+func mooncakeWorker(workerType registry.ModelWorkerType, role string) registry.ModelWorker {
+	return registry.ModelWorker{
+		Type: workerType,
+		Config: apiextensionsv1.JSON{
+			Raw: []byte(`{"kv-transfer-config":"{\"kv_connector\":\"MooncakeConnector\",\"kv_role\":\"` + role + `\"}"}`),
+		},
+	}
+}
+
+func nixlWorker(workerType registry.ModelWorkerType, role string) registry.ModelWorker {
+	return registry.ModelWorker{
+		Type: workerType,
+		Config: apiextensionsv1.JSON{
+			Raw: []byte(`{"kv-transfer-config":"{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"` + role + `\"}"}`),
+		},
+	}
+}
+
 func TestGetKvConnectorSpec(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -83,28 +101,11 @@ func TestGetKvConnectorSpec(t *testing.T) {
 		expectErrMsg string
 	}{
 		{
-			name: "prefill worker with Mooncake connector",
+			name: "no workers is valid",
 			workers: []registry.ModelWorker{
-				{
-					Type: registry.ModelWorkerTypePrefill,
-					Config: apiextensionsv1.JSON{
-						Raw: []byte(`{"kv-transfer-config":"{\"kv_connector\":\"MooncakeConnector\",\"kv_role\":\"kv_producer\"}"}`),
-					},
-				},
+				{Type: registry.ModelWorkerTypeServer},
 			},
-			expected: &networking.KVConnectorSpec{Type: networking.ConnectorTypeMoonCake},
-		},
-		{
-			name: "decode worker with NIXL connector",
-			workers: []registry.ModelWorker{
-				{
-					Type: registry.ModelWorkerTypeDecode,
-					Config: apiextensionsv1.JSON{
-						Raw: []byte(`{"kv-transfer-config":"{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_consumer\"}"}`),
-					},
-				},
-			},
-			expected: &networking.KVConnectorSpec{Type: networking.ConnectorTypeNIXL},
+			expected: nil,
 		},
 		{
 			name: "server worker is ignored",
@@ -119,19 +120,93 @@ func TestGetKvConnectorSpec(t *testing.T) {
 			expected: nil,
 		},
 		{
-			name: "unknown connector type is ignored",
+			name: "PD backend with no kv-transfer-config on either worker is valid",
 			workers: []registry.ModelWorker{
-				{
-					Type: registry.ModelWorkerTypePrefill,
-					Config: apiextensionsv1.JSON{
-						Raw: []byte(`{"kv-transfer-config":"{\"kv_connector\":\"UnknownConnector\"}"}`),
-					},
-				},
+				{Type: registry.ModelWorkerTypePrefill},
+				{Type: registry.ModelWorkerTypeDecode},
 			},
 			expected: nil,
 		},
 		{
-			name: "missing connector field is ignored",
+			name: "prefill producer + decode consumer with matching NIXL connector succeeds",
+			workers: []registry.ModelWorker{
+				nixlWorker(registry.ModelWorkerTypePrefill, "kv_producer"),
+				nixlWorker(registry.ModelWorkerTypeDecode, "kv_consumer"),
+			},
+			expected: &networking.KVConnectorSpec{Type: networking.ConnectorTypeNIXL},
+		},
+		{
+			name: "matching Mooncake connector succeeds",
+			workers: []registry.ModelWorker{
+				mooncakeWorker(registry.ModelWorkerTypePrefill, "kv_producer"),
+				mooncakeWorker(registry.ModelWorkerTypeDecode, "kv_consumer"),
+			},
+			expected: &networking.KVConnectorSpec{Type: networking.ConnectorTypeMoonCake},
+		},
+		{
+			name: "kv_both role is valid for both prefill and decode",
+			workers: []registry.ModelWorker{
+				nixlWorker(registry.ModelWorkerTypePrefill, "kv_both"),
+				nixlWorker(registry.ModelWorkerTypeDecode, "kv_both"),
+			},
+			expected: &networking.KVConnectorSpec{Type: networking.ConnectorTypeNIXL},
+		},
+		{
+			name: "worker order does not change the result",
+			workers: []registry.ModelWorker{
+				nixlWorker(registry.ModelWorkerTypeDecode, "kv_consumer"),
+				nixlWorker(registry.ModelWorkerTypePrefill, "kv_producer"),
+			},
+			expected: &networking.KVConnectorSpec{Type: networking.ConnectorTypeNIXL},
+		},
+		{
+			name: "prefill NIXL + decode Mooncake mismatch is rejected",
+			workers: []registry.ModelWorker{
+				nixlWorker(registry.ModelWorkerTypePrefill, "kv_producer"),
+				mooncakeWorker(registry.ModelWorkerTypeDecode, "kv_consumer"),
+			},
+			expectErrMsg: `kv_connector mismatch between prefill ("NixlConnector") and decode ("MooncakeConnector")`,
+		},
+		{
+			name: "prefill Mooncake + decode NIXL mismatch is rejected regardless of order",
+			workers: []registry.ModelWorker{
+				mooncakeWorker(registry.ModelWorkerTypePrefill, "kv_producer"),
+				nixlWorker(registry.ModelWorkerTypeDecode, "kv_consumer"),
+			},
+			expectErrMsg: `kv_connector mismatch between prefill ("MooncakeConnector") and decode ("NixlConnector")`,
+		},
+		{
+			name: "prefill with connector but decode missing entirely is rejected",
+			workers: []registry.ModelWorker{
+				nixlWorker(registry.ModelWorkerTypePrefill, "kv_producer"),
+			},
+			expectErrMsg: "decode worker has no kv-transfer-config",
+		},
+		{
+			name: "decode with connector but prefill missing entirely is rejected",
+			workers: []registry.ModelWorker{
+				nixlWorker(registry.ModelWorkerTypeDecode, "kv_consumer"),
+			},
+			expectErrMsg: "prefill worker has no kv-transfer-config",
+		},
+		{
+			name: "prefill missing kv-transfer-config while decode has one is rejected",
+			workers: []registry.ModelWorker{
+				{Type: registry.ModelWorkerTypePrefill},
+				nixlWorker(registry.ModelWorkerTypeDecode, "kv_consumer"),
+			},
+			expectErrMsg: "prefill worker has no kv-transfer-config",
+		},
+		{
+			name: "decode missing kv-transfer-config while prefill has one is rejected",
+			workers: []registry.ModelWorker{
+				nixlWorker(registry.ModelWorkerTypePrefill, "kv_producer"),
+				{Type: registry.ModelWorkerTypeDecode},
+			},
+			expectErrMsg: "decode worker has no kv-transfer-config",
+		},
+		{
+			name: "missing kv_connector field is rejected",
 			workers: []registry.ModelWorker{
 				{
 					Type: registry.ModelWorkerTypePrefill,
@@ -139,8 +214,46 @@ func TestGetKvConnectorSpec(t *testing.T) {
 						Raw: []byte(`{"kv-transfer-config":"{\"kv_role\":\"kv_producer\"}"}`),
 					},
 				},
+				nixlWorker(registry.ModelWorkerTypeDecode, "kv_consumer"),
 			},
-			expected: nil,
+			expectErrMsg: "worker prefill: kv-transfer-config is set but kv_connector is missing",
+		},
+		{
+			name: "unknown kv_connector is rejected",
+			workers: []registry.ModelWorker{
+				{
+					Type: registry.ModelWorkerTypePrefill,
+					Config: apiextensionsv1.JSON{
+						Raw: []byte(`{"kv-transfer-config":"{\"kv_connector\":\"UnknownConnector\",\"kv_role\":\"kv_producer\"}"}`),
+					},
+				},
+				nixlWorker(registry.ModelWorkerTypeDecode, "kv_consumer"),
+			},
+			expectErrMsg: `worker prefill: unsupported kv_connector "UnknownConnector"`,
+		},
+		{
+			name: "prefill with kv_consumer role is rejected",
+			workers: []registry.ModelWorker{
+				nixlWorker(registry.ModelWorkerTypePrefill, "kv_consumer"),
+				nixlWorker(registry.ModelWorkerTypeDecode, "kv_consumer"),
+			},
+			expectErrMsg: `worker prefill: invalid kv_role "kv_consumer", expected one of [kv_producer, kv_both]`,
+		},
+		{
+			name: "decode with kv_producer role is rejected",
+			workers: []registry.ModelWorker{
+				nixlWorker(registry.ModelWorkerTypePrefill, "kv_producer"),
+				nixlWorker(registry.ModelWorkerTypeDecode, "kv_producer"),
+			},
+			expectErrMsg: `worker decode: invalid kv_role "kv_producer", expected one of [kv_consumer, kv_both]`,
+		},
+		{
+			name: "reversed roles across prefill and decode are rejected",
+			workers: []registry.ModelWorker{
+				nixlWorker(registry.ModelWorkerTypePrefill, "kv_consumer"),
+				nixlWorker(registry.ModelWorkerTypeDecode, "kv_producer"),
+			},
+			expectErrMsg: `worker prefill: invalid kv_role "kv_consumer"`,
 		},
 		{
 			name: "malformed nested kv-transfer-config returns error",
@@ -152,7 +265,7 @@ func TestGetKvConnectorSpec(t *testing.T) {
 					},
 				},
 			},
-			expectErrMsg: "failed to get kv_connector for worker prefill",
+			expectErrMsg: "worker prefill: invalid kv-transfer-config",
 		},
 		{
 			name: "malformed worker config returns error",
@@ -164,13 +277,13 @@ func TestGetKvConnectorSpec(t *testing.T) {
 					},
 				},
 			},
-			expectErrMsg: "failed to get kv-transfer-config for worker prefill",
+			expectErrMsg: "worker prefill: invalid config",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := getKvConnectorSpec(registry.ModelBackend{
+			got, err := GetKvConnectorSpec(registry.ModelBackend{
 				Name:    "test-backend",
 				Workers: tt.workers,
 			})

--- a/pkg/model-booster-controller/convert/model_server_test.go
+++ b/pkg/model-booster-controller/convert/model_server_test.go
@@ -93,6 +93,15 @@ func nixlWorker(workerType registry.ModelWorkerType, role string) registry.Model
 	}
 }
 
+func mooncakeV1Worker(workerType registry.ModelWorkerType, role string) registry.ModelWorker {
+	return registry.ModelWorker{
+		Type: workerType,
+		Config: apiextensionsv1.JSON{
+			Raw: []byte(`{"kv-transfer-config":"{\"kv_connector\":\"MooncakeConnectorV1\",\"kv_role\":\"` + role + `\"}"}`),
+		},
+	}
+}
+
 func TestGetKvConnectorSpec(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -144,6 +153,16 @@ func TestGetKvConnectorSpec(t *testing.T) {
 			expected: &networking.KVConnectorSpec{Type: networking.ConnectorTypeMoonCake},
 		},
 		{
+			// Matches the vllm-ascend connector name used by the existing
+			// examples/model-booster/prefill-decode-disaggregation.yaml ModelBooster example.
+			name: "matching MooncakeConnectorV1 connector succeeds",
+			workers: []registry.ModelWorker{
+				mooncakeV1Worker(registry.ModelWorkerTypePrefill, "kv_producer"),
+				mooncakeV1Worker(registry.ModelWorkerTypeDecode, "kv_consumer"),
+			},
+			expected: &networking.KVConnectorSpec{Type: networking.ConnectorTypeMoonCake},
+		},
+		{
 			name: "kv_both role is valid for both prefill and decode",
 			workers: []registry.ModelWorker{
 				nixlWorker(registry.ModelWorkerTypePrefill, "kv_both"),
@@ -158,6 +177,51 @@ func TestGetKvConnectorSpec(t *testing.T) {
 				nixlWorker(registry.ModelWorkerTypePrefill, "kv_producer"),
 			},
 			expected: &networking.KVConnectorSpec{Type: networking.ConnectorTypeNIXL},
+		},
+		{
+			name: "duplicate prefill workers with different connectors are rejected regardless of order",
+			workers: []registry.ModelWorker{
+				nixlWorker(registry.ModelWorkerTypePrefill, "kv_producer"),
+				mooncakeWorker(registry.ModelWorkerTypePrefill, "kv_producer"),
+				nixlWorker(registry.ModelWorkerTypeDecode, "kv_consumer"),
+			},
+			expectErrMsg: "backend test-backend: found 2 prefill workers, expected at most 1",
+		},
+		{
+			name: "duplicate prefill workers (reversed order) are rejected the same way",
+			workers: []registry.ModelWorker{
+				mooncakeWorker(registry.ModelWorkerTypePrefill, "kv_producer"),
+				nixlWorker(registry.ModelWorkerTypePrefill, "kv_producer"),
+				nixlWorker(registry.ModelWorkerTypeDecode, "kv_consumer"),
+			},
+			expectErrMsg: "backend test-backend: found 2 prefill workers, expected at most 1",
+		},
+		{
+			name: "duplicate decode workers with different connectors are rejected regardless of order",
+			workers: []registry.ModelWorker{
+				nixlWorker(registry.ModelWorkerTypePrefill, "kv_producer"),
+				nixlWorker(registry.ModelWorkerTypeDecode, "kv_consumer"),
+				mooncakeWorker(registry.ModelWorkerTypeDecode, "kv_consumer"),
+			},
+			expectErrMsg: "backend test-backend: found 2 decode workers, expected at most 1",
+		},
+		{
+			name: "duplicate decode workers (reversed order) are rejected the same way",
+			workers: []registry.ModelWorker{
+				nixlWorker(registry.ModelWorkerTypePrefill, "kv_producer"),
+				mooncakeWorker(registry.ModelWorkerTypeDecode, "kv_consumer"),
+				nixlWorker(registry.ModelWorkerTypeDecode, "kv_consumer"),
+			},
+			expectErrMsg: "backend test-backend: found 2 decode workers, expected at most 1",
+		},
+		{
+			name: "duplicate prefill workers with identical connectors are still rejected",
+			workers: []registry.ModelWorker{
+				nixlWorker(registry.ModelWorkerTypePrefill, "kv_producer"),
+				nixlWorker(registry.ModelWorkerTypePrefill, "kv_producer"),
+				nixlWorker(registry.ModelWorkerTypeDecode, "kv_consumer"),
+			},
+			expectErrMsg: "backend test-backend: found 2 prefill workers, expected at most 1",
 		},
 		{
 			name: "prefill NIXL + decode Mooncake mismatch is rejected",

--- a/pkg/model-booster-controller/webhook/model_validator.go
+++ b/pkg/model-booster-controller/webhook/model_validator.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	registryv1alpha1 "github.com/volcano-sh/kthena/pkg/apis/workload/v1alpha1"
+	"github.com/volcano-sh/kthena/pkg/model-booster-controller/convert"
 	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -82,6 +83,7 @@ func (v *ModelValidator) validateModel(model *registryv1alpha1.ModelBooster) (bo
 	allErrs = append(allErrs, validateWorkerImages(model)...)
 	allErrs = append(allErrs, validateBackendWorkerTypes(model)...)
 	allErrs = append(allErrs, validatePVCURICompatibility(model)...)
+	allErrs = append(allErrs, validateKvConnectorConfig(model)...)
 
 	if len(allErrs) > 0 {
 		// Convert field errors to a formatted multi-line error message
@@ -147,6 +149,23 @@ func validateBackendWorkerTypes(model *registryv1alpha1.ModelBooster) field.Erro
 				))
 			}
 		}
+	}
+	return allErrs
+}
+
+// validateKvConnectorConfig rejects PD backends whose prefill/decode workers specify
+// inconsistent kv-transfer-config (e.g. different kv_connector values, or a kv_role that
+// doesn't match the worker's role), reusing convert.GetKvConnectorSpec so admission uses
+// the exact same rules as the ModelServer converter.
+func validateKvConnectorConfig(model *registryv1alpha1.ModelBooster) field.ErrorList {
+	var allErrs field.ErrorList
+	backend := model.Spec.Backend
+	if _, err := convert.GetKvConnectorSpec(backend); err != nil {
+		allErrs = append(allErrs, field.Invalid(
+			field.NewPath("spec").Child("backend").Child("workers"),
+			backend.Name,
+			fmt.Sprintf("invalid kv connector configuration: %v", err),
+		))
 	}
 	return allErrs
 }

--- a/pkg/model-booster-controller/webhook/model_validator_test.go
+++ b/pkg/model-booster-controller/webhook/model_validator_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	registryv1alpha1 "github.com/volcano-sh/kthena/pkg/apis/workload/v1alpha1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -232,6 +233,168 @@ func TestValidatePVCURICompatibility(t *testing.T) {
 			if tt.expectValid {
 				assert.True(t, valid, "expected valid but got error: %s", errorMsg)
 				assert.Empty(t, errorMsg)
+			} else {
+				assert.False(t, valid)
+				assert.Contains(t, errorMsg, tt.expectMsg)
+			}
+		})
+	}
+}
+
+func nixlWorker(workerType registryv1alpha1.ModelWorkerType, role string) registryv1alpha1.ModelWorker {
+	return registryv1alpha1.ModelWorker{
+		Type: workerType,
+		Config: apiextensionsv1.JSON{
+			Raw: []byte(`{"kv-transfer-config":"{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"` + role + `\"}"}`),
+		},
+	}
+}
+
+func mooncakeWorker(workerType registryv1alpha1.ModelWorkerType, role string) registryv1alpha1.ModelWorker {
+	return registryv1alpha1.ModelWorker{
+		Type: workerType,
+		Config: apiextensionsv1.JSON{
+			Raw: []byte(`{"kv-transfer-config":"{\"kv_connector\":\"MooncakeConnector\",\"kv_role\":\"` + role + `\"}"}`),
+		},
+	}
+}
+
+func TestValidateKvConnectorConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		workers     []registryv1alpha1.ModelWorker
+		expectValid bool
+		expectMsg   string
+	}{
+		{
+			name: "prefill NIXL + decode Mooncake is rejected",
+			workers: []registryv1alpha1.ModelWorker{
+				nixlWorker(registryv1alpha1.ModelWorkerTypePrefill, "kv_producer"),
+				mooncakeWorker(registryv1alpha1.ModelWorkerTypeDecode, "kv_consumer"),
+			},
+			expectValid: false,
+			expectMsg:   "kv_connector mismatch between prefill",
+		},
+		{
+			name: "prefill Mooncake + decode NIXL is rejected",
+			workers: []registryv1alpha1.ModelWorker{
+				mooncakeWorker(registryv1alpha1.ModelWorkerTypePrefill, "kv_producer"),
+				nixlWorker(registryv1alpha1.ModelWorkerTypeDecode, "kv_consumer"),
+			},
+			expectValid: false,
+			expectMsg:   "kv_connector mismatch between prefill",
+		},
+		{
+			name: "prefill NIXL + decode NIXL succeeds",
+			workers: []registryv1alpha1.ModelWorker{
+				nixlWorker(registryv1alpha1.ModelWorkerTypePrefill, "kv_producer"),
+				nixlWorker(registryv1alpha1.ModelWorkerTypeDecode, "kv_consumer"),
+			},
+			expectValid: true,
+		},
+		{
+			name: "worker order does not change the result",
+			workers: []registryv1alpha1.ModelWorker{
+				nixlWorker(registryv1alpha1.ModelWorkerTypeDecode, "kv_consumer"),
+				nixlWorker(registryv1alpha1.ModelWorkerTypePrefill, "kv_producer"),
+			},
+			expectValid: true,
+		},
+		{
+			name: "prefill missing kv-transfer-config is rejected",
+			workers: []registryv1alpha1.ModelWorker{
+				{Type: registryv1alpha1.ModelWorkerTypePrefill},
+				nixlWorker(registryv1alpha1.ModelWorkerTypeDecode, "kv_consumer"),
+			},
+			expectValid: false,
+			expectMsg:   "prefill worker has no kv-transfer-config",
+		},
+		{
+			name: "decode missing kv-transfer-config is rejected",
+			workers: []registryv1alpha1.ModelWorker{
+				nixlWorker(registryv1alpha1.ModelWorkerTypePrefill, "kv_producer"),
+				{Type: registryv1alpha1.ModelWorkerTypeDecode},
+			},
+			expectValid: false,
+			expectMsg:   "decode worker has no kv-transfer-config",
+		},
+		{
+			name: "missing kv_connector is rejected",
+			workers: []registryv1alpha1.ModelWorker{
+				{
+					Type: registryv1alpha1.ModelWorkerTypePrefill,
+					Config: apiextensionsv1.JSON{
+						Raw: []byte(`{"kv-transfer-config":"{\"kv_role\":\"kv_producer\"}"}`),
+					},
+				},
+				nixlWorker(registryv1alpha1.ModelWorkerTypeDecode, "kv_consumer"),
+			},
+			expectValid: false,
+			expectMsg:   "kv_connector is missing",
+		},
+		{
+			name: "unknown kv_connector is rejected",
+			workers: []registryv1alpha1.ModelWorker{
+				{
+					Type: registryv1alpha1.ModelWorkerTypePrefill,
+					Config: apiextensionsv1.JSON{
+						Raw: []byte(`{"kv-transfer-config":"{\"kv_connector\":\"UnknownConnector\",\"kv_role\":\"kv_producer\"}"}`),
+					},
+				},
+				nixlWorker(registryv1alpha1.ModelWorkerTypeDecode, "kv_consumer"),
+			},
+			expectValid: false,
+			expectMsg:   "unsupported kv_connector",
+		},
+		{
+			name: "prefill with kv_consumer role is rejected",
+			workers: []registryv1alpha1.ModelWorker{
+				nixlWorker(registryv1alpha1.ModelWorkerTypePrefill, "kv_consumer"),
+				nixlWorker(registryv1alpha1.ModelWorkerTypeDecode, "kv_consumer"),
+			},
+			expectValid: false,
+			expectMsg:   "invalid kv_role",
+		},
+		{
+			name: "decode with kv_producer role is rejected",
+			workers: []registryv1alpha1.ModelWorker{
+				nixlWorker(registryv1alpha1.ModelWorkerTypePrefill, "kv_producer"),
+				nixlWorker(registryv1alpha1.ModelWorkerTypeDecode, "kv_producer"),
+			},
+			expectValid: false,
+			expectMsg:   "invalid kv_role",
+		},
+		{
+			name: "PD backend with no kv-transfer-config on either worker remains valid",
+			workers: []registryv1alpha1.ModelWorker{
+				{Type: registryv1alpha1.ModelWorkerTypePrefill},
+				{Type: registryv1alpha1.ModelWorkerTypeDecode},
+			},
+			expectValid: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := &registryv1alpha1.ModelBooster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-model",
+					Namespace: "default",
+				},
+				Spec: registryv1alpha1.ModelBoosterSpec{
+					Backend: registryv1alpha1.ModelBackend{
+						Name:     "backend1",
+						Type:     registryv1alpha1.ModelBackendTypeVLLMDisaggregated,
+						Replicas: 1,
+						Workers:  tt.workers,
+					},
+				},
+			}
+
+			valid, errorMsg := (&ModelValidator{}).validateModel(model)
+
+			if tt.expectValid {
+				assert.True(t, valid, "expected valid but got error: %s", errorMsg)
 			} else {
 				assert.False(t, valid)
 				assert.Contains(t, errorMsg, tt.expectMsg)

--- a/pkg/model-booster-controller/webhook/model_validator_test.go
+++ b/pkg/model-booster-controller/webhook/model_validator_test.go
@@ -259,6 +259,15 @@ func mooncakeWorker(workerType registryv1alpha1.ModelWorkerType, role string) re
 	}
 }
 
+func mooncakeV1Worker(workerType registryv1alpha1.ModelWorkerType, role string) registryv1alpha1.ModelWorker {
+	return registryv1alpha1.ModelWorker{
+		Type: workerType,
+		Config: apiextensionsv1.JSON{
+			Raw: []byte(`{"kv-transfer-config":"{\"kv_connector\":\"MooncakeConnectorV1\",\"kv_role\":\"` + role + `\"}"}`),
+		},
+	}
+}
+
 func TestValidateKvConnectorConfig(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -371,6 +380,36 @@ func TestValidateKvConnectorConfig(t *testing.T) {
 				{Type: registryv1alpha1.ModelWorkerTypeDecode},
 			},
 			expectValid: true,
+		},
+		{
+			// Matches the vllm-ascend connector name used by the existing
+			// examples/model-booster/prefill-decode-disaggregation.yaml ModelBooster example.
+			name: "matching MooncakeConnectorV1 succeeds",
+			workers: []registryv1alpha1.ModelWorker{
+				mooncakeV1Worker(registryv1alpha1.ModelWorkerTypePrefill, "kv_producer"),
+				mooncakeV1Worker(registryv1alpha1.ModelWorkerTypeDecode, "kv_consumer"),
+			},
+			expectValid: true,
+		},
+		{
+			name: "duplicate prefill workers are rejected regardless of order",
+			workers: []registryv1alpha1.ModelWorker{
+				nixlWorker(registryv1alpha1.ModelWorkerTypePrefill, "kv_producer"),
+				mooncakeWorker(registryv1alpha1.ModelWorkerTypePrefill, "kv_producer"),
+				nixlWorker(registryv1alpha1.ModelWorkerTypeDecode, "kv_consumer"),
+			},
+			expectValid: false,
+			expectMsg:   "found 2 prefill workers, expected at most 1",
+		},
+		{
+			name: "duplicate decode workers are rejected regardless of order",
+			workers: []registryv1alpha1.ModelWorker{
+				nixlWorker(registryv1alpha1.ModelWorkerTypePrefill, "kv_producer"),
+				mooncakeWorker(registryv1alpha1.ModelWorkerTypeDecode, "kv_consumer"),
+				nixlWorker(registryv1alpha1.ModelWorkerTypeDecode, "kv_consumer"),
+			},
+			expectValid: false,
+			expectMsg:   "found 2 decode workers, expected at most 1",
 		},
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`getKvConnectorSpec()` previously scanned prefill/decode workers and allowed the last recognized `kv_connector` to silently overwrite the previous value. As a result, inconsistent configurations such as NIXL on prefill and Mooncake on decode were accepted, and the generated ModelServer connector depended on worker ordering.

This PR makes KV connector handling deterministic and validates the configuration before workloads are started.

Specifically, this PR:

- Requires prefill and decode workers to use the same supported `kv_connector` when KV transfer is configured.
- Rejects configurations where only one side declares a connector.
- Validates that `kv_role` is compatible with the worker type.
- Supports `kv_producer` / `kv_both` for prefill and `kv_consumer` / `kv_both` for decode.
- Rejects unknown connectors instead of silently ignoring them.
- Keeps configurations where neither worker specifies `kv-transfer-config` valid.
- Adds the same validation to the ModelBooster admission webhook so invalid configurations are rejected before workloads are created.
- Keeps the converter defensive so direct conversion cannot silently accept an inconsistent configuration.
- Does not require any changes to the router because it consumes the already-resolved `ModelServer.Spec.KVConnector`.

**Which issue(s) this PR fixes**:

Fixes #1453

**Bug evidence (required for bug-related PRs)**:

The issue was reproduced at the converter level.

Given:

```yaml
workers:
  - type: prefill
    config:
      kv-transfer-config: >-
        {"kv_connector":"NixlConnector","kv_role":"kv_producer"}

  - type: decode
    config:
      kv-transfer-config: >-
        {"kv_connector":"MooncakeConnector","kv_role":"kv_consumer"}
```
The previous converter accepted the configuration and generated a ModelServer using MooncakeConnector.

Reversing the worker order caused the generated ModelServer to use NixlConnector.

The failure path was:
ModelBooster
  -> ModelBooster conversion
  -> getKvConnectorSpec()
  -> prefill connector is parsed
  -> decode connector is parsed
  -> last recognized connector overwrites the previous value
  -> generated ModelServer contains only one connector
  -> inconsistent prefill/decode configuration is silently accepted
he converter also previously logged missing/unknown connector values as warnings instead of rejecting the configuration, and did not validate kv_role.

This PR changes the behavior so the invalid configuration is rejected during ModelBooster admission/conversion instead of allowing an incompatible workload to start and potentially fail later when handling traffic.

Regression tests cover mismatched connectors, missing configuration on one side, unknown connectors, invalid/reversed roles, matching connectors, kv_both, and worker-order independence.

The issue was reproduced at the converter/webhook level. It has not been reproduced against a live Kubernetes cluster.

### Special notes for your reviewer:

getKvConnectorSpec() was made deterministic and defensive; worker order no longer affects the resulting connector.
Validation is shared between the converter and admission webhook rather than duplicating KV parsing logic.
Existing connector-less configurations remain valid when neither prefill nor decode specifies kv-transfer-config.
kv_both is intentionally supported for both prefill and decode because it is used by existing Qwen3 NIXL configurations.

No changes were made to pkg/kthena-router/router/router.go.
MooncakeConnectorV1 used by an existing example is not currently present in VLLMKvConnectorType; this is an existing compatibility gap and is now surfaced explicitly as an unsupported connector rather than silently ignored.

### Validation was performed with:
go build ./...
go vet ./pkg/model-booster-controller/...
go test ./pkg/model-booster-controller/...
go test ./pkg/kthena-router/...
gofmt -l on the changed files
The tests were run at converter/webhook level. A live Kubernetes cluster was not available for E2E validation.

### Does this PR introduce a user-facing change?:

Yes. Invalid/inconsistent ModelBooster KV connector configurations will now be rejected during admission/conversion instead of being silently accepted.

ModelBooster now validates prefill/decode KV connector consistency and rejects unsupported or role-incompatible configurations before workload creation.