### PR TITLE
router: match parentless ModelRoutes to Gateways

### DIFF
--- a/pkg/kthena-router/datastore/store.go
+++ b/pkg/kthena-router/datastore/store.go
@@ -1319,14 +1319,9 @@ func (s *store) MatchModelServer(model string, req *http.Request, gatewayKey str
 				// If ModelRoute has parentRefs but gatewayKey is empty, skip it
 				continue // Skip ModelRoute with parentRefs when gatewayKey is not specified
 			}
-		} else {
-			// If gatewayKey is specified, we only match ModelRoute with parentRefs
-			// ModelRoute without parentRefs should not match when gatewayKey is provided
-			if gatewayKey != "" {
-				continue // Skip ModelRoute without parentRefs when gatewayKey is specified
-			}
-			// If gatewayKey is empty, ModelRoute without parentRefs can match
-			// (ModelRoute without parentRefs attaches to all Gateways in the same namespace)
+		} else if gatewayKey != "" && !strings.HasPrefix(gatewayKey, mr.Namespace+"/") {
+			// ModelRoutes without parentRefs only attach to Gateways in the same namespace
+			continue
 		}
 
 		// Try to match rules

--- a/pkg/kthena-router/datastore/store_test.go
+++ b/pkg/kthena-router/datastore/store_test.go
@@ -2135,7 +2135,7 @@ func TestMatchModelServer_GatewayScoped(t *testing.T) {
 			expectedError: true,
 		},
 		{
-			name: "route without parentRefs skipped when gatewayKey is set",
+			name: "route without parentRefs matches gateway in same namespace",
 			setupStore: func() *store {
 				s := newStore()
 				s.AddOrUpdateGateway(&gatewayv1.Gateway{
@@ -2153,8 +2153,33 @@ func TestMatchModelServer_GatewayScoped(t *testing.T) {
 				})
 				return s
 			},
+			modelName:      "llama3",
+			gatewayKey:     "default/my-gateway",
+			request:        &http.Request{URL: &url.URL{Path: "/v1/chat/completions"}},
+			expectedServer: types.NamespacedName{Namespace: "default", Name: "llama3-server"},
+			expectedError:  false,
+		},
+		{
+			name: "route without parentRefs skips gateway in different namespace",
+			setupStore: func() *store {
+				s := newStore()
+				s.AddOrUpdateGateway(&gatewayv1.Gateway{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "other", Name: "my-gateway"},
+					Spec:       gatewayv1.GatewaySpec{Listeners: []gatewayv1.Listener{{Name: "http"}}},
+				})
+				s.AddOrUpdateModelRoute(&aiv1alpha1.ModelRoute{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "route-a"},
+					Spec: aiv1alpha1.ModelRouteSpec{
+						ModelName: "llama3",
+						Rules: []*aiv1alpha1.Rule{
+							{Name: "r", TargetModels: []*aiv1alpha1.TargetModel{{ModelServerName: "llama3-server", Weight: ptr(uint32(100))}}},
+						},
+					},
+				})
+				return s
+			},
 			modelName:     "llama3",
-			gatewayKey:    "default/my-gateway",
+			gatewayKey:    "other/my-gateway",
 			request:       &http.Request{URL: &url.URL{Path: "/v1/chat/completions"}},
 			expectedError: true,
 		},


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Allows a ModelRoute without parentRefs to match Gateway traffic when both are in the same namespace. This matches the documented behavior for empty parentRefs.

**Which issue(s) this PR fixes**:
Fixes #N/A

**Bug evidence (required for bug-related PRs)**:

Create a working Gateway and ModelServer, then create this ModelRoute in the same namespace:

```yaml
apiVersion: networking.serving.volcano.sh/v1alpha1
kind: ModelRoute
metadata:
  name: llama3
  namespace: default
spec:
  modelName: llama3
  rules:
  - targetModels:
    - modelServerName: llama3-server
```

Send a request through the Gateway listener:

```bash
curl -i http://<gateway-address>/v1/chat/completions \
  -H 'Content-Type: application/json' \
  -d '{"model":"llama3","messages":[{"role":"user","content":"hello"}]}'
```

Before this change, the router returns:

```text
HTTP/1.1 404 Not Found
"route not found"
```

Gateway traffic sets `gatewayKey` in the request context:
https://github.com/volcano-sh/kthena/blob/c7b49ac009e52f73bdbf74f6d85d47762ee098c2/cmd/kthena-router/app/router.go#L258

The key is passed to `MatchModelServer`:
https://github.com/volcano-sh/kthena/blob/c7b49ac009e52f73bdbf74f6d85d47762ee098c2/pkg/kthena-router/router/router.go#L404-L418

The previous logic skipped ModelRoutes without `parentRefs` whenever that key was set:
https://github.com/volcano-sh/kthena/blob/c7b49ac009e52f73bdbf74f6d85d47762ee098c2/pkg/kthena-router/datastore/store.go#L1322-L1329

This change allows the route when the Gateway and ModelRoute namespaces match.

**Special notes for your reviewer**:

AI tooling was used during analysis and preparation. I reviewed the final change and verified it with:

```text
go test ./pkg/kthena-router/datastore
go test ./pkg/kthena-router/...
```

**Does this PR introduce a user-facing change?**:

```release-note
ModelRoutes without parentRefs now match Gateway traffic from Gateways in the same namespace.
```