### PR TITLE
datastore: clean up Redis on-flight counter when pod is evicted in DeleteModelServer

### DIFF
--- a/pkg/kthena-router/datastore/store.go
+++ b/pkg/kthena-router/datastore/store.go
@@ -879,6 +879,14 @@ func (s *store) DeleteModelServer(ms types.NamespacedName) error {
 			podInfo.RemoveModelServer(ms)
 			if podInfo.GetModelServerCount() == 0 {
 				s.pods.Delete(podName)
+				// Remove the pod's Redis counter so stale keys do not accumulate.
+				if s.onFlightCounter != nil {
+					ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+					defer cancel()
+					if err := s.onFlightCounter.Delete(ctx, podName); err != nil {
+						klog.V(4).Infof("failed to delete Redis on-flight counter for pod %s: %v", podName, err)
+					}
+				}
 			}
 		} else {
 			klog.Warningf("pod %s not found", podName)

--- a/pkg/kthena-router/datastore/store.go
+++ b/pkg/kthena-router/datastore/store.go
@@ -878,15 +878,15 @@ func (s *store) DeleteModelServer(ms types.NamespacedName) error {
 			podInfo := value.(*PodInfo)
 			podInfo.RemoveModelServer(ms)
 			if podInfo.GetModelServerCount() == 0 {
+				// Deleting a ModelServer does not mean the pod itself is gone: it may
+				// still be running and get reselected by another ModelServer later. The
+				// Redis on-flight counter tracks the pod's real traffic, not its
+				// ModelServer association, so we intentionally leave it in place here.
+				// Eagerly deleting it would race with in-flight requests dispatched
+				// before this point and corrupt the counter once the pod is
+				// reassociated. The counter is only removed in DeletePod, once the pod
+				// is confirmed gone and can no longer receive traffic.
 				s.pods.Delete(podName)
-				// Remove the pod's Redis counter so stale keys do not accumulate.
-				if s.onFlightCounter != nil {
-					ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
-					defer cancel()
-					if err := s.onFlightCounter.Delete(ctx, podName); err != nil {
-						klog.V(4).Infof("failed to delete Redis on-flight counter for pod %s: %v", podName, err)
-					}
-				}
 			}
 		} else {
 			klog.Warningf("pod %s not found", podName)

--- a/pkg/kthena-router/datastore/store.go
+++ b/pkg/kthena-router/datastore/store.go
@@ -930,6 +930,14 @@ func (s *store) DeleteModelServer(ms types.NamespacedName) error {
 			podInfo.RemoveModelServer(ms)
 			if podInfo.GetModelServerCount() == 0 {
 				s.pods.Delete(podName)
+				// Remove the pod's Redis counter so stale keys do not accumulate.
+				if s.onFlightCounter != nil {
+					ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+					defer cancel()
+					if err := s.onFlightCounter.Delete(ctx, podName); err != nil {
+						klog.V(4).Infof("failed to delete Redis on-flight counter for pod %s: %v", podName, err)
+					}
+				}
 			}
 		} else {
 			klog.Warningf("pod %s not found", podName)

--- a/pkg/kthena-router/datastore/store_test.go
+++ b/pkg/kthena-router/datastore/store_test.go
@@ -549,11 +549,82 @@ func TestStoreDeleteModelServer(t *testing.T) {
 	assert.False(t, podExists, "pod should be deleted if no modelServer left")
 }
 
+// TestStoreDeleteModelServerCleansUpOnFlightCounter verifies that when a ModelServer is
+// deleted and a pod it owns has no remaining model-server references, DeleteModelServer
+// calls onFlightCounter.Delete for that pod so no stale Redis key is left behind.
+// Prior to the fix, the counter was only cleaned up in DeletePod; pods evicted through
+// DeleteModelServer would accumulate ghost entries in the kthena:on-flight-requests hash.
+func TestStoreDeleteModelServerCleansUpOnFlightCounter(t *testing.T) {
+	podName := types.NamespacedName{Namespace: "default", Name: "pod-a"}
+
+	// fakeCounter records which pods had their counter deleted.
+	deleted := make(map[types.NamespacedName]bool)
+	fc := &fakeOnFlightCounter{deleted: deleted}
+
+	ms := &aiv1alpha1.ModelServer{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "ms1"},
+	}
+	msName := utils.GetNamespaceName(ms)
+
+	modelSrv := newModelServer(ms)
+	modelSrv.addPod(podName)
+
+	s := &store{
+		modelServer:     sync.Map{},
+		pods:            sync.Map{},
+		onFlightCounter: fc,
+	}
+
+	s.modelServer.Store(msName, modelSrv)
+	s.pods.Store(podName, &PodInfo{
+		Pod:         &corev1.Pod{},
+		modelServer: sets.New[types.NamespacedName](msName),
+		models:      sets.New[string](),
+	})
+
+	err := s.DeleteModelServer(msName)
+	assert.NoError(t, err)
+
+	// The pod must have been removed from the store.
+	_, podExists := s.pods.Load(podName)
+	assert.False(t, podExists, "pod should be removed from store after DeleteModelServer")
+
+	// The on-flight counter must have been cleaned up.
+	assert.True(t, deleted[podName], "onFlightCounter.Delete must be called for the evicted pod")
+}
+
+// fakeOnFlightCounter is a minimal in-process OnFlightCounter that records
+// which pods had their counter deleted, for use in unit tests.
+type fakeOnFlightCounter struct {
+	mu      sync.Mutex
+	deleted map[types.NamespacedName]bool
+}
+
+func (f *fakeOnFlightCounter) Incr(_ context.Context, pod types.NamespacedName) (int64, error) {
+	return 1, nil
+}
+
+func (f *fakeOnFlightCounter) Decr(_ context.Context, pod types.NamespacedName) (int64, error) {
+	return 0, nil
+}
+
+func (f *fakeOnFlightCounter) Delete(_ context.Context, pod types.NamespacedName) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.deleted[pod] = true
+	return nil
+}
+
+func (f *fakeOnFlightCounter) BatchGet(_ context.Context, pods []types.NamespacedName) (map[types.NamespacedName]int64, error) {
+	return nil, nil
+}
+
 func TestStoreGetPodsByModelServer(t *testing.T) {
 	s := &store{
 		modelServer: sync.Map{},
 		pods:        sync.Map{},
 	}
+
 	ms := &aiv1alpha1.ModelServer{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",

--- a/pkg/kthena-router/datastore/store_test.go
+++ b/pkg/kthena-router/datastore/store_test.go
@@ -549,12 +549,14 @@ func TestStoreDeleteModelServer(t *testing.T) {
 	assert.False(t, podExists, "pod should be deleted if no modelServer left")
 }
 
-// TestStoreDeleteModelServerCleansUpOnFlightCounter verifies that when a ModelServer is
-// deleted and a pod it owns has no remaining model-server references, DeleteModelServer
-// calls onFlightCounter.Delete for that pod so no stale Redis key is left behind.
-// Prior to the fix, the counter was only cleaned up in DeletePod; pods evicted through
-// DeleteModelServer would accumulate ghost entries in the kthena:on-flight-requests hash.
-func TestStoreDeleteModelServerCleansUpOnFlightCounter(t *testing.T) {
+// TestStoreDeleteModelServerLeavesOnFlightCounterIntact verifies that DeleteModelServer
+// removes the evicted pod from the store's local view but does NOT touch its Redis
+// on-flight counter. The pod may still be running and get reselected by another
+// ModelServer later, so eagerly deleting the shared counter here could race with
+// in-flight requests dispatched before the ModelServer was deleted and corrupt the
+// count once the pod is reassociated. Counter cleanup only happens in DeletePod, once
+// the pod is confirmed gone.
+func TestStoreDeleteModelServerLeavesOnFlightCounterIntact(t *testing.T) {
 	podName := types.NamespacedName{Namespace: "default", Name: "pod-a"}
 
 	// fakeCounter records which pods had their counter deleted.
@@ -585,12 +587,12 @@ func TestStoreDeleteModelServerCleansUpOnFlightCounter(t *testing.T) {
 	err := s.DeleteModelServer(msName)
 	assert.NoError(t, err)
 
-	// The pod must have been removed from the store.
+	// The pod must have been removed from the store's local view.
 	_, podExists := s.pods.Load(podName)
 	assert.False(t, podExists, "pod should be removed from store after DeleteModelServer")
 
-	// The on-flight counter must have been cleaned up.
-	assert.True(t, deleted[podName], "onFlightCounter.Delete must be called for the evicted pod")
+	// The shared Redis on-flight counter must NOT have been touched.
+	assert.False(t, deleted[podName], "onFlightCounter.Delete must not be called from DeleteModelServer")
 }
 
 // fakeOnFlightCounter is a minimal in-process OnFlightCounter that records

--- a/pkg/kthena-router/datastore/store_test.go
+++ b/pkg/kthena-router/datastore/store_test.go
@@ -2906,3 +2906,113 @@ func BenchmarkSelectRuleRegex(b *testing.B) {
 		}
 	}
 }
+
+type fakeOnFlightCounter struct {
+	mu          sync.Mutex
+	deletedPods []types.NamespacedName
+}
+
+func (f *fakeOnFlightCounter) Incr(ctx context.Context, podName types.NamespacedName) (int64, error) {
+	return 1, nil
+}
+
+func (f *fakeOnFlightCounter) Decr(ctx context.Context, podName types.NamespacedName) (int64, error) {
+	return 0, nil
+}
+
+func (f *fakeOnFlightCounter) Delete(ctx context.Context, podName types.NamespacedName) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.deletedPods = append(f.deletedPods, podName)
+	return nil
+}
+
+func (f *fakeOnFlightCounter) BatchGet(ctx context.Context, podNames []types.NamespacedName) (map[types.NamespacedName]int64, error) {
+	return nil, nil
+}
+
+func TestStore_DeleteModelServer_CleansUpOnFlightCounter(t *testing.T) {
+	fakeCounter := &fakeOnFlightCounter{}
+	s := New(WithRedisOnFlightCounter(fakeCounter))
+
+	podName := types.NamespacedName{Namespace: "default", Name: "test-pod"}
+	ms1Name := types.NamespacedName{Namespace: "default", Name: "test-ms1"}
+	ms2Name := types.NamespacedName{Namespace: "default", Name: "test-ms2"}
+
+	ms1 := &aiv1alpha1.ModelServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ms1Name.Namespace,
+			Name:      ms1Name.Name,
+		},
+	}
+	ms2 := &aiv1alpha1.ModelServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ms2Name.Namespace,
+			Name:      ms2Name.Name,
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: podName.Namespace,
+			Name:      podName.Name,
+		},
+	}
+
+	// Add ms1, ms2, and pod associated with both
+	assert.NoError(t, s.AddOrUpdateModelServer(ms1, sets.New(podName)))
+	assert.NoError(t, s.AddOrUpdateModelServer(ms2, sets.New(podName)))
+	assert.NoError(t, s.AddOrUpdatePod(pod, []*aiv1alpha1.ModelServer{ms1, ms2}))
+
+	// Verify pod exists with 2 ModelServers
+	podInfo := s.GetPodInfo(podName)
+	assert.NotNil(t, podInfo)
+	assert.Equal(t, 2, podInfo.GetModelServerCount())
+
+	// Step 1: Delete ms1. Pod is still owned by ms2, so it must not be evicted or cleaned up in Redis.
+	assert.NoError(t, s.DeleteModelServer(ms1Name))
+	assert.NotNil(t, s.GetPodInfo(podName), "pod should remain in store while owned by ms2")
+
+	fakeCounter.mu.Lock()
+	assert.Empty(t, fakeCounter.deletedPods, "Redis counter must not be deleted while pod is still owned by another ModelServer")
+	fakeCounter.mu.Unlock()
+
+	// Step 2: Delete ms2. Pod now has 0 ModelServers, so it is evicted and its Redis counter is cleaned up.
+	assert.NoError(t, s.DeleteModelServer(ms2Name))
+	assert.Nil(t, s.GetPodInfo(podName), "pod should be evicted from store when last ModelServer is deleted")
+
+	fakeCounter.mu.Lock()
+	assert.Equal(t, []types.NamespacedName{podName}, fakeCounter.deletedPods, "Redis counter must be deleted when pod is evicted by DeleteModelServer")
+	fakeCounter.mu.Unlock()
+}
+
+func TestStore_DeletePod_CleansUpOnFlightCounter(t *testing.T) {
+	fakeCounter := &fakeOnFlightCounter{}
+	s := New(WithRedisOnFlightCounter(fakeCounter))
+
+	podName := types.NamespacedName{Namespace: "default", Name: "tracked-pod"}
+	msName := types.NamespacedName{Namespace: "default", Name: "test-ms"}
+
+	ms := &aiv1alpha1.ModelServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: msName.Namespace,
+			Name:      msName.Name,
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: podName.Namespace,
+			Name:      podName.Name,
+		},
+	}
+
+	assert.NoError(t, s.AddOrUpdateModelServer(ms, sets.New(podName)))
+	assert.NoError(t, s.AddOrUpdatePod(pod, []*aiv1alpha1.ModelServer{ms}))
+
+	// DeletePod cleans up tracked pod and its Redis counter
+	assert.NoError(t, s.DeletePod(podName))
+	assert.Nil(t, s.GetPodInfo(podName))
+
+	fakeCounter.mu.Lock()
+	assert.Equal(t, []types.NamespacedName{podName}, fakeCounter.deletedPods, "DeletePod must delete Redis counter for tracked pod")
+	fakeCounter.mu.Unlock()
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`store.DeleteModelServer` iterates over the pods associated with the deleted model server and removes from `s.pods` any pod whose model-server reference count drops to zero (`podInfo.GetModelServerCount() == 0`). However, it previously did not call `onFlightCounter.Delete` for those evicted pods, leaving stale entries accumulating in the `kthena:on-flight-requests` Redis hash.

This PR adds the missing `onFlightCounter.Delete` call inside the `GetModelServerCount() == 0` branch of `DeleteModelServer`, matching the cleanup pattern already used in `DeletePod` for tracked pods, while keeping the hot `DeletePod` informer path guarded so untracked pods never trigger unnecessary Redis round-trips.

Unit tests verify that:
1. `DeleteModelServer` cleans up the Redis on-flight counter when a pod's reference count drops to zero.
2. If a pod is shared across multiple ModelServers, deleting one ModelServer keeps the pod and its Redis counter intact until the final ModelServer is deleted.
3. `DeletePod` properly cleans up Redis counters for tracked pods.

**Which issue(s) this PR fixes**:
Fixes #1460

**Special notes for your reviewer**:

All router datastore unit tests pass.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
