### PR TITLE
router: skip KV cache ownership written before a pod restart

### DIFF
--- a/pkg/kthena-router/scheduler/plugins/kvcache_aware.go
+++ b/pkg/kthena-router/scheduler/plugins/kvcache_aware.go
@@ -42,6 +42,7 @@ import (
 	"github.com/volcano-sh/kthena/pkg/kthena-router/scheduler/framework"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/scheduler/plugins/tokenization"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/utils"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/yaml"
@@ -241,7 +242,7 @@ func (t *KVCacheAware) Score(ctx *framework.Context, pods []*datastore.PodInfo) 
 	}
 
 	redisStart := time.Now()
-	blockToPods, err := t.queryRedisForBlocks(blockHashes, ctx.Model)
+	blockToPods, err := t.queryRedisForBlocks(blockHashes, ctx.Model, recentlyReadyOwners(pods, time.Now()))
 	redisDuration := time.Since(redisStart)
 	if err != nil {
 		if ctx.MetricsRecorder != nil {
@@ -292,8 +293,10 @@ func (t *KVCacheAware) Score(ctx *framework.Context, pods []*datastore.PodInfo) 
 }
 
 // queryRedisForBlocks queries Redis to find which pods have cached the given token block hashes
-// Returns a map from block hash to list of pod names that have cached that block
-func (t *KVCacheAware) queryRedisForBlocks(blockHashes []uint64, modelName string) (map[uint64][]string, error) {
+// Returns a map from block hash to list of pod names that have cached that block.
+// ownerReadySince holds the Ready time of recently restarted candidates; when non-empty the
+// write timestamps are fetched too, to drop ownership recorded before a pod's current start.
+func (t *KVCacheAware) queryRedisForBlocks(blockHashes []uint64, modelName string, ownerReadySince map[string]int64) (map[uint64][]string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -307,15 +310,27 @@ func (t *KVCacheAware) queryRedisForBlocks(blockHashes []uint64, modelName strin
 	klog.V(2).Infof("KVCacheAware.queryRedis: querying %d block hashes for model=%q", len(blockHashes), modelName)
 
 	pipe := t.redisClient.Pipeline()
-	cmds := make([]*redis.StringSliceCmd, len(blockHashes))
 	keys := make([]string, len(blockHashes))
+	// Only one of these is populated, depending on whether write timestamps are needed.
+	needTimestamps := len(ownerReadySince) > 0
+	var fieldCmds []*redis.StringSliceCmd
+	var entryCmds []*redis.MapStringStringCmd
+	if needTimestamps {
+		entryCmds = make([]*redis.MapStringStringCmd, len(blockHashes))
+	} else {
+		fieldCmds = make([]*redis.StringSliceCmd, len(blockHashes))
+	}
 
 	// Build pipeline commands for batch Redis query
 	for i, hash := range blockHashes {
 		block := KVCacheAwareBlock{ModelName: modelName, ChunkHash: hash}
 		key := block.String(t.keyPrefix)
 		keys[i] = key
-		cmds[i] = pipe.HKeys(ctx, key)
+		if needTimestamps {
+			entryCmds[i] = pipe.HGetAll(ctx, key)
+		} else {
+			fieldCmds[i] = pipe.HKeys(ctx, key)
+		}
 	}
 
 	if len(keys) > 0 {
@@ -329,9 +344,22 @@ func (t *KVCacheAware) queryRedisForBlocks(blockHashes []uint64, modelName strin
 	}
 
 	// Process results and extract pod names
-	for i, cmd := range cmds {
-		pods, err := cmd.Result()
-		if err != nil || len(pods) == 0 {
+	for i := range blockHashes {
+		var pods []string
+		if needTimestamps {
+			entries, err := entryCmds[i].Result()
+			if err != nil || len(entries) == 0 {
+				continue
+			}
+			pods = freshOwners(entries, ownerReadySince)
+		} else {
+			owners, err := fieldCmds[i].Result()
+			if err != nil || len(owners) == 0 {
+				continue
+			}
+			pods = owners
+		}
+		if len(pods) == 0 {
 			continue
 		}
 
@@ -411,6 +439,60 @@ func (t *KVCacheAware) deleteStaleFields(staleFields map[string][]string) {
 	if _, err := pipe.Exec(ctx); err != nil {
 		klog.V(4).Infof("KVCacheAware.gcStaleFields: failed to delete stale fields: %v", err)
 	}
+}
+
+// podReadySinceUnix reports when the pod's Ready condition last became true, or 0 if it is
+// not Ready. Callers treat 0 as unknown and skip the staleness check for that pod.
+func podReadySinceUnix(pod *corev1.Pod) int64 {
+	if pod == nil {
+		return 0
+	}
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
+			return cond.LastTransitionTime.Unix()
+		}
+	}
+	return 0
+}
+
+// recentlyReadyOwners maps candidate pod names to their Ready time, limited to pods that
+// became Ready within the GC freshness window. Older pods cannot hold ownership predating
+// their current start since gcStaleFields already aged it out, so the map stays empty in
+// steady state and the query keeps using HKeys.
+func recentlyReadyOwners(pods []*datastore.PodInfo, now time.Time) map[string]int64 {
+	cutoff := now.Add(-kvCacheFieldFreshDuration).Unix()
+	var owners map[string]int64
+	for _, p := range pods {
+		readySince := podReadySinceUnix(p.GetPod())
+		if readySince <= cutoff {
+			continue
+		}
+		if owners == nil {
+			owners = make(map[string]int64, len(pods))
+		}
+		owners[p.GetPodNamespacedName().Name] = readySince
+	}
+	return owners
+}
+
+// freshOwners drops ownership written before the owning pod's current Ready time. Owners not
+// in ownerReadySince are kept; they have not restarted recently, or Score filters them out.
+func freshOwners(entries map[string]string, ownerReadySince map[string]int64) []string {
+	owners := make([]string, 0, len(entries))
+	for owner, writtenAt := range entries {
+		readySince, tracked := ownerReadySince[extractPodNameFromIdentifier(owner)]
+		if tracked {
+			written, err := strconv.ParseInt(writtenAt, 10, 64)
+			// An unparsable timestamp proves nothing, so keep it and leave it to gcStaleFields.
+			if err == nil && written < readySince {
+				klog.V(4).Infof("KVCacheAware.queryRedis: dropping ownership by %s written at %d, pod ready since %d",
+					owner, written, readySince)
+				continue
+			}
+		}
+		owners = append(owners, owner)
+	}
+	return owners
 }
 
 func extractPodNameFromIdentifier(podIdentifier string) string {

--- a/pkg/kthena-router/scheduler/plugins/kvcache_aware.go
+++ b/pkg/kthena-router/scheduler/plugins/kvcache_aware.go
@@ -242,7 +242,7 @@ func (t *KVCacheAware) Score(ctx *framework.Context, pods []*datastore.PodInfo) 
 	}
 
 	redisStart := time.Now()
-	blockToPods, err := t.queryRedisForBlocks(blockHashes, ctx.Model, recentlyReadyOwners(pods, time.Now()))
+	blockToPods, err := t.queryRedisForBlocks(blockHashes, ctx.Model, ownerStartTimes(pods))
 	redisDuration := time.Since(redisStart)
 	if err != nil {
 		if ctx.MetricsRecorder != nil {
@@ -294,9 +294,8 @@ func (t *KVCacheAware) Score(ctx *framework.Context, pods []*datastore.PodInfo) 
 
 // queryRedisForBlocks queries Redis to find which pods have cached the given token block hashes
 // Returns a map from block hash to list of pod names that have cached that block.
-// ownerReadySince holds the Ready time of recently restarted candidates; when non-empty the
-// write timestamps are fetched too, to drop ownership recorded before a pod's current start.
-func (t *KVCacheAware) queryRedisForBlocks(blockHashes []uint64, modelName string, ownerReadySince map[string]int64) (map[uint64][]string, error) {
+// ownerStartedAt carries each candidate's container start time, used to drop stale ownership.
+func (t *KVCacheAware) queryRedisForBlocks(blockHashes []uint64, modelName string, ownerStartedAt map[string]int64) (map[uint64][]string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -311,26 +310,15 @@ func (t *KVCacheAware) queryRedisForBlocks(blockHashes []uint64, modelName strin
 
 	pipe := t.redisClient.Pipeline()
 	keys := make([]string, len(blockHashes))
-	// Only one of these is populated, depending on whether write timestamps are needed.
-	needTimestamps := len(ownerReadySince) > 0
-	var fieldCmds []*redis.StringSliceCmd
-	var entryCmds []*redis.MapStringStringCmd
-	if needTimestamps {
-		entryCmds = make([]*redis.MapStringStringCmd, len(blockHashes))
-	} else {
-		fieldCmds = make([]*redis.StringSliceCmd, len(blockHashes))
-	}
+	cmds := make([]*redis.MapStringStringCmd, len(blockHashes))
 
-	// Build pipeline commands for batch Redis query
+	// Build pipeline commands for batch Redis query. Values are read alongside the owners so
+	// ownership predating a restart can be dropped.
 	for i, hash := range blockHashes {
 		block := KVCacheAwareBlock{ModelName: modelName, ChunkHash: hash}
 		key := block.String(t.keyPrefix)
 		keys[i] = key
-		if needTimestamps {
-			entryCmds[i] = pipe.HGetAll(ctx, key)
-		} else {
-			fieldCmds[i] = pipe.HKeys(ctx, key)
-		}
+		cmds[i] = pipe.HGetAll(ctx, key)
 	}
 
 	if len(keys) > 0 {
@@ -344,21 +332,12 @@ func (t *KVCacheAware) queryRedisForBlocks(blockHashes []uint64, modelName strin
 	}
 
 	// Process results and extract pod names
-	for i := range blockHashes {
-		var pods []string
-		if needTimestamps {
-			entries, err := entryCmds[i].Result()
-			if err != nil || len(entries) == 0 {
-				continue
-			}
-			pods = freshOwners(entries, ownerReadySince)
-		} else {
-			owners, err := fieldCmds[i].Result()
-			if err != nil || len(owners) == 0 {
-				continue
-			}
-			pods = owners
+	for i, cmd := range cmds {
+		entries, err := cmd.Result()
+		if err != nil || len(entries) == 0 {
+			continue
 		}
+		pods := freshOwners(entries, ownerStartedAt)
 		if len(pods) == 0 {
 			continue
 		}
@@ -441,52 +420,48 @@ func (t *KVCacheAware) deleteStaleFields(staleFields map[string][]string) {
 	}
 }
 
-// podReadySinceUnix reports when the pod's Ready condition last became true, or 0 if it is
-// not Ready. Callers treat 0 as unknown and skip the staleness check for that pod.
-func podReadySinceUnix(pod *corev1.Pod) int64 {
+// podLastContainerStartUnix reports when the pod's containers last started, or 0 if none are
+// running. Readiness is not used: it also flips on a probe failure, which leaves the cache intact.
+func podLastContainerStartUnix(pod *corev1.Pod) int64 {
 	if pod == nil {
 		return 0
 	}
-	for _, cond := range pod.Status.Conditions {
-		if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
-			return cond.LastTransitionTime.Unix()
-		}
-	}
-	return 0
-}
-
-// recentlyReadyOwners maps candidate pod names to their Ready time, limited to pods that
-// became Ready within the GC freshness window. Older pods cannot hold ownership predating
-// their current start since gcStaleFields already aged it out, so the map stays empty in
-// steady state and the query keeps using HKeys.
-func recentlyReadyOwners(pods []*datastore.PodInfo, now time.Time) map[string]int64 {
-	cutoff := now.Add(-kvCacheFieldFreshDuration).Unix()
-	var owners map[string]int64
-	for _, p := range pods {
-		readySince := podReadySinceUnix(p.GetPod())
-		if readySince <= cutoff {
+	var newest int64
+	for _, cs := range pod.Status.ContainerStatuses {
+		if cs.State.Running == nil {
 			continue
 		}
-		if owners == nil {
-			owners = make(map[string]int64, len(pods))
+		if started := cs.State.Running.StartedAt.Unix(); started > newest {
+			newest = started
 		}
-		owners[p.GetPodNamespacedName().Name] = readySince
+	}
+	return newest
+}
+
+// ownerStartTimes maps each candidate's cache-owner identifier to its container start time.
+// Keyed on the full name.namespace form so pods sharing a name across namespaces stay distinct.
+func ownerStartTimes(pods []*datastore.PodInfo) map[string]int64 {
+	owners := make(map[string]int64, len(pods))
+	for _, p := range pods {
+		if started := podLastContainerStartUnix(p.GetPod()); started > 0 {
+			owners[podCacheOwnerIdentifier(p)] = started
+		}
 	}
 	return owners
 }
 
-// freshOwners drops ownership written before the owning pod's current Ready time. Owners not
-// in ownerReadySince are kept; they have not restarted recently, or Score filters them out.
-func freshOwners(entries map[string]string, ownerReadySince map[string]int64) []string {
+// freshOwners drops ownership written before the owning pod's containers last started.
+// Owners absent from ownerStartedAt are kept; Score filters non-candidates out by identifier.
+func freshOwners(entries map[string]string, ownerStartedAt map[string]int64) []string {
 	owners := make([]string, 0, len(entries))
 	for owner, writtenAt := range entries {
-		readySince, tracked := ownerReadySince[extractPodNameFromIdentifier(owner)]
+		startedAt, tracked := ownerStartedAt[owner]
 		if tracked {
 			written, err := strconv.ParseInt(writtenAt, 10, 64)
 			// An unparsable timestamp proves nothing, so keep it and leave it to gcStaleFields.
-			if err == nil && written < readySince {
-				klog.V(4).Infof("KVCacheAware.queryRedis: dropping ownership by %s written at %d, pod ready since %d",
-					owner, written, readySince)
+			if err == nil && written < startedAt {
+				klog.V(4).Infof("KVCacheAware.queryRedis: dropping ownership by %s written at %d, containers started at %d",
+					owner, written, startedAt)
 				continue
 			}
 		}

--- a/pkg/kthena-router/scheduler/plugins/kvcache_aware.go
+++ b/pkg/kthena-router/scheduler/plugins/kvcache_aware.go
@@ -459,7 +459,9 @@ func freshOwners(entries map[string]string, ownerStartedAt map[string]int64) []s
 		if tracked {
 			written, err := strconv.ParseInt(writtenAt, 10, 64)
 			// An unparsable timestamp proves nothing, so keep it and leave it to gcStaleFields.
-			if err == nil && written < startedAt {
+			// Both sides are second-truncated, so a same-second write is dropped: it may have
+			// preceded the restart, and keeping it would route to a cache that is gone.
+			if err == nil && written <= startedAt {
 				klog.V(4).Infof("KVCacheAware.queryRedis: dropping ownership by %s written at %d, containers started at %d",
 					owner, written, startedAt)
 				continue

--- a/pkg/kthena-router/scheduler/plugins/kvcache_aware.go
+++ b/pkg/kthena-router/scheduler/plugins/kvcache_aware.go
@@ -293,7 +293,7 @@ func (t *KVCacheAware) Score(ctx *framework.Context, pods []*datastore.PodInfo) 
 }
 
 // queryRedisForBlocks queries Redis to find which pods have cached the given token block hashes
-// Returns a map from block hash to list of pod names that have cached that block.
+// Returns a map from block hash to the pod.namespace owner identifiers that have cached it.
 // ownerStartedAt carries each candidate's container start time, used to drop stale ownership.
 func (t *KVCacheAware) queryRedisForBlocks(blockHashes []uint64, modelName string, ownerStartedAt map[string]int64) (map[uint64][]string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -309,8 +309,8 @@ func (t *KVCacheAware) queryRedisForBlocks(blockHashes []uint64, modelName strin
 	klog.V(2).Infof("KVCacheAware.queryRedis: querying %d block hashes for model=%q", len(blockHashes), modelName)
 
 	pipe := t.redisClient.Pipeline()
-	keys := make([]string, len(blockHashes))
 	cmds := make([]*redis.MapStringStringCmd, len(blockHashes))
+	keys := make([]string, len(blockHashes))
 
 	// Build pipeline commands for batch Redis query. Values are read alongside the owners so
 	// ownership predating a restart can be dropped.
@@ -458,7 +458,8 @@ func freshOwners(entries map[string]string, ownerStartedAt map[string]int64) []s
 		startedAt, tracked := ownerStartedAt[owner]
 		if tracked {
 			written, err := strconv.ParseInt(writtenAt, 10, 64)
-			// An unparsable timestamp proves nothing, so keep it and leave it to gcStaleFields.
+			// An unparsable timestamp is kept: gcStaleFields skips it too, and a future
+			// higher-precision format would otherwise drop every owner at once.
 			// Both sides are second-truncated, so a same-second write is dropped: it may have
 			// preceded the restart, and keeping it would route to a cache that is gone.
 			if err == nil && written <= startedAt {

--- a/pkg/kthena-router/scheduler/plugins/kvcache_aware_test.go
+++ b/pkg/kthena-router/scheduler/plugins/kvcache_aware_test.go
@@ -2413,27 +2413,28 @@ func TestKVCacheAware_CandidateFilteringRestrictsLongestMatch(t *testing.T) {
 	}
 }
 
-func readyPod(name string, ready bool, readySince time.Time) *datastore.PodInfo {
-	status := v1.ConditionFalse
-	if ready {
-		status = v1.ConditionTrue
+// startedPod builds a candidate whose containers report the given start times. A nil entry
+// stands for a container that is not running.
+func startedPod(name, namespace string, starts ...*time.Time) *datastore.PodInfo {
+	statuses := make([]v1.ContainerStatus, 0, len(starts))
+	for _, at := range starts {
+		cs := v1.ContainerStatus{}
+		if at != nil {
+			cs.State.Running = &v1.ContainerStateRunning{StartedAt: metav1.NewTime(*at)}
+		}
+		statuses = append(statuses, cs)
 	}
 	return &datastore.PodInfo{
 		Pod: &v1.Pod{
-			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "test-namespace"},
-			Status: v1.PodStatus{
-				Conditions: []v1.PodCondition{{
-					Type:               v1.PodReady,
-					Status:             status,
-					LastTransitionTime: metav1.NewTime(readySince),
-				}},
-			},
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+			Status:     v1.PodStatus{ContainerStatuses: statuses},
 		},
 	}
 }
 
-func TestPodReadySinceUnix(t *testing.T) {
-	readySince := time.Now().Add(-time.Hour).Truncate(time.Second)
+func TestPodLastContainerStartUnix(t *testing.T) {
+	older := time.Now().Add(-2 * time.Hour).Truncate(time.Second)
+	newer := time.Now().Add(-time.Minute).Truncate(time.Second)
 
 	tests := []struct {
 		name string
@@ -2441,115 +2442,128 @@ func TestPodReadySinceUnix(t *testing.T) {
 		want int64
 	}{
 		{name: "nil pod", pod: nil, want: 0},
-		{name: "no conditions", pod: &v1.Pod{}, want: 0},
-		{name: "ready", pod: readyPod("p", true, readySince).Pod, want: readySince.Unix()},
-		{name: "not ready", pod: readyPod("p", false, readySince).Pod, want: 0},
+		{name: "no container statuses", pod: &v1.Pod{}, want: 0},
+		{
+			name: "single running container",
+			pod:  startedPod("p", "ns", &older).Pod,
+			want: older.Unix(),
+		},
+		{
+			// A sidecar restart moves this forward even though the engine did not restart.
+			name: "newest start across containers wins",
+			pod:  startedPod("p", "ns", &older, &newer).Pod,
+			want: newer.Unix(),
+		},
+		{
+			name: "container that is not running is ignored",
+			pod:  startedPod("p", "ns", &older, nil).Pod,
+			want: older.Unix(),
+		},
+		{
+			name: "no running container",
+			pod:  startedPod("p", "ns", nil).Pod,
+			want: 0,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := podReadySinceUnix(tt.pod); got != tt.want {
-				t.Errorf("podReadySinceUnix() = %d, want %d", got, tt.want)
+			if got := podLastContainerStartUnix(tt.pod); got != tt.want {
+				t.Errorf("podLastContainerStartUnix() = %d, want %d", got, tt.want)
 			}
 		})
 	}
 }
 
-func TestRecentlyReadyOwners(t *testing.T) {
-	now := time.Now()
-	justRestarted := now.Add(-time.Minute).Truncate(time.Second)
-	longRunning := now.Add(-2 * kvCacheFieldFreshDuration).Truncate(time.Second)
+// Readiness flaps without a restart must not be mistaken for one, otherwise ownership that is
+// still valid gets discarded and a warm pod is treated as cold.
+func TestPodLastContainerStartUnixIgnoresReadinessFlap(t *testing.T) {
+	started := time.Now().Add(-time.Hour).Truncate(time.Second)
+	flapped := time.Now().Add(-time.Minute)
 
-	tests := []struct {
-		name string
-		pods []*datastore.PodInfo
-		want map[string]int64
-	}{
-		{
-			name: "steady state pods are omitted so timestamps are not fetched",
-			pods: []*datastore.PodInfo{readyPod("old", true, longRunning)},
-			want: nil,
-		},
-		{
-			name: "recently ready pod is tracked",
-			pods: []*datastore.PodInfo{readyPod("fresh", true, justRestarted)},
-			want: map[string]int64{"fresh": justRestarted.Unix()},
-		},
-		{
-			name: "not ready pod is omitted",
-			pods: []*datastore.PodInfo{readyPod("down", false, justRestarted)},
-			want: nil,
-		},
-		{
-			name: "only the recently ready pod is tracked",
-			pods: []*datastore.PodInfo{
-				readyPod("old", true, longRunning),
-				readyPod("fresh", true, justRestarted),
-			},
-			want: map[string]int64{"fresh": justRestarted.Unix()},
-		},
+	pod := startedPod("p", "ns", &started).Pod
+	pod.Status.Conditions = []v1.PodCondition{{
+		Type:               v1.PodReady,
+		Status:             v1.ConditionTrue,
+		LastTransitionTime: metav1.NewTime(flapped),
+	}}
+
+	if got := podLastContainerStartUnix(pod); got != started.Unix() {
+		t.Errorf("readiness transition leaked into the restart signal: got %d, want %d", got, started.Unix())
 	}
+}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := recentlyReadyOwners(tt.pods, now)
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("recentlyReadyOwners() = %v, want %v", got, tt.want)
-			}
-		})
+func TestOwnerStartTimes(t *testing.T) {
+	at := time.Now().Add(-time.Minute).Truncate(time.Second)
+	other := time.Now().Add(-time.Hour).Truncate(time.Second)
+
+	// The same pod name in two namespaces must stay distinct.
+	got := ownerStartTimes([]*datastore.PodInfo{
+		startedPod("pod-1", "ns-a", &at),
+		startedPod("pod-1", "ns-b", &other),
+		startedPod("pod-2", "ns-a", nil),
+	})
+
+	want := map[string]int64{
+		"pod-1.ns-a": at.Unix(),
+		"pod-1.ns-b": other.Unix(),
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ownerStartTimes() = %v, want %v", got, want)
 	}
 }
 
 func TestFreshOwners(t *testing.T) {
-	const readySince = int64(1000)
+	const startedAt = int64(1000)
 
 	tests := []struct {
-		name            string
-		entries         map[string]string
-		ownerReadySince map[string]int64
-		want            []string
+		name           string
+		entries        map[string]string
+		ownerStartedAt map[string]int64
+		want           []string
 	}{
 		{
-			name:            "ownership written before the restart is dropped",
-			entries:         map[string]string{"pod-1.default": "999"},
-			ownerReadySince: map[string]int64{"pod-1": readySince},
-			want:            []string{},
+			name:           "ownership written before the restart is dropped",
+			entries:        map[string]string{"pod-1.default": "999"},
+			ownerStartedAt: map[string]int64{"pod-1.default": startedAt},
+			want:           []string{},
 		},
 		{
-			name:            "ownership written after the restart is kept",
-			entries:         map[string]string{"pod-1.default": "1001"},
-			ownerReadySince: map[string]int64{"pod-1": readySince},
-			want:            []string{"pod-1.default"},
+			name:           "ownership written after the restart is kept",
+			entries:        map[string]string{"pod-1.default": "1001"},
+			ownerStartedAt: map[string]int64{"pod-1.default": startedAt},
+			want:           []string{"pod-1.default"},
 		},
 		{
-			name:            "ownership written exactly at the restart is kept",
-			entries:         map[string]string{"pod-1.default": "1000"},
-			ownerReadySince: map[string]int64{"pod-1": readySince},
-			want:            []string{"pod-1.default"},
+			name:           "ownership written exactly at the restart is kept",
+			entries:        map[string]string{"pod-1.default": "1000"},
+			ownerStartedAt: map[string]int64{"pod-1.default": startedAt},
+			want:           []string{"pod-1.default"},
 		},
 		{
-			name:            "untracked owner is kept",
-			entries:         map[string]string{"pod-2.default": "1"},
-			ownerReadySince: map[string]int64{"pod-1": readySince},
-			want:            []string{"pod-2.default"},
+			name:           "untracked owner is kept",
+			entries:        map[string]string{"pod-2.default": "1"},
+			ownerStartedAt: map[string]int64{"pod-1.default": startedAt},
+			want:           []string{"pod-2.default"},
 		},
 		{
-			name:            "unparsable timestamp is kept",
-			entries:         map[string]string{"pod-1.default": "not-a-number"},
-			ownerReadySince: map[string]int64{"pod-1": readySince},
-			want:            []string{"pod-1.default"},
+			name:           "unparsable timestamp is kept",
+			entries:        map[string]string{"pod-1.default": "not-a-number"},
+			ownerStartedAt: map[string]int64{"pod-1.default": startedAt},
+			want:           []string{"pod-1.default"},
 		},
 		{
-			name:            "bare pod name identifier is matched",
-			entries:         map[string]string{"pod-1": "999"},
-			ownerReadySince: map[string]int64{"pod-1": readySince},
-			want:            []string{},
+			// Identical names in different namespaces must not share a start time.
+			name:           "same name in another namespace is unaffected",
+			entries:        map[string]string{"pod-1.other": "999"},
+			ownerStartedAt: map[string]int64{"pod-1.default": startedAt},
+			want:           []string{"pod-1.other"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := freshOwners(tt.entries, tt.ownerReadySince)
+			got := freshOwners(tt.entries, tt.ownerStartedAt)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("freshOwners() = %v, want %v", got, tt.want)
 			}
@@ -2557,9 +2571,9 @@ func TestFreshOwners(t *testing.T) {
 	}
 }
 
-// A pod that restarts keeps its name and returns Ready, so candidate filtering in Score cannot
-// drop it and its ownership is too recent for gcStaleFields. Only the write timestamp separates
-// the pod that still holds the blocks from the one that lost them on restart.
+// A restarted pod keeps its name and comes back Ready, so candidate filtering cannot drop it
+// and its ownership is too recent for gcStaleFields. Only the write timestamp separates the
+// pod that still holds the blocks from the one that lost them.
 func TestKVCacheAware_QueryRedisForBlocks_DropsOwnershipFromBeforeRestart(t *testing.T) {
 	mr, err := miniredis.Run()
 	if err != nil {
@@ -2579,6 +2593,7 @@ func TestKVCacheAware_QueryRedisForBlocks_DropsOwnershipFromBeforeRestart(t *tes
 	now := time.Now()
 	writtenAt := now.Add(-10 * time.Minute)
 	restartedAt := now.Add(-5 * time.Minute)
+	longRunning := now.Add(-24 * time.Hour)
 
 	if err := client.HSet(ctx, key,
 		"restarted.default", fmt.Sprintf("%d", writtenAt.Unix()),
@@ -2587,10 +2602,10 @@ func TestKVCacheAware_QueryRedisForBlocks_DropsOwnershipFromBeforeRestart(t *tes
 		t.Fatalf("failed to seed redis: %v", err)
 	}
 
-	owners := recentlyReadyOwners([]*datastore.PodInfo{
-		readyPod("restarted", true, restartedAt),
-		readyPod("stable", true, now.Add(-2*kvCacheFieldFreshDuration)),
-	}, now)
+	owners := ownerStartTimes([]*datastore.PodInfo{
+		startedPod("restarted", "default", &restartedAt),
+		startedPod("stable", "default", &longRunning),
+	})
 
 	result, err := plugin.queryRedisForBlocks([]uint64{hash}, "qwen", owners)
 	if err != nil {
@@ -2599,5 +2614,44 @@ func TestKVCacheAware_QueryRedisForBlocks_DropsOwnershipFromBeforeRestart(t *tes
 
 	if want := []string{"stable.default"}; !reflect.DeepEqual(result[hash], want) {
 		t.Errorf("queryRedisForBlocks() = %v, want %v", result[hash], want)
+	}
+}
+
+// The restart happened well beyond the GC freshness window, so no timing shortcut can be used
+// to skip the check: gcStaleFields scans a bounded slice of the keyspace per tick and may not
+// have reached this entry yet.
+func TestKVCacheAware_QueryRedisForBlocks_DropsOldOwnershipAfterLongAgoRestart(t *testing.T) {
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("failed to start miniredis: %v", err)
+	}
+	defer mr.Close()
+
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer client.Close()
+
+	plugin := &KVCacheAware{keyPrefix: kvCacheKeyPrefix, redisClient: client}
+
+	ctx := context.Background()
+	hash := uint64(333)
+	key := KVCacheAwareBlock{ModelName: "qwen", ChunkHash: hash}.String(kvCacheKeyPrefix)
+
+	now := time.Now()
+	writtenAt := now.Add(-40 * 24 * time.Hour)
+	restartedAt := now.Add(-30 * 24 * time.Hour)
+
+	if err := client.HSet(ctx, key, "restarted.default", fmt.Sprintf("%d", writtenAt.Unix())).Err(); err != nil {
+		t.Fatalf("failed to seed redis: %v", err)
+	}
+
+	owners := ownerStartTimes([]*datastore.PodInfo{startedPod("restarted", "default", &restartedAt)})
+
+	result, err := plugin.queryRedisForBlocks([]uint64{hash}, "qwen", owners)
+	if err != nil {
+		t.Fatalf("queryRedisForBlocks returned error: %v", err)
+	}
+
+	if len(result[hash]) != 0 {
+		t.Errorf("stale ownership survived a long-ago restart: got %v, want none", result[hash])
 	}
 }

--- a/pkg/kthena-router/scheduler/plugins/kvcache_aware_test.go
+++ b/pkg/kthena-router/scheduler/plugins/kvcache_aware_test.go
@@ -434,7 +434,7 @@ func TestKVCacheAware_QueryRedisForBlocks_ReturnsRedisOwners(t *testing.T) {
 		t.Fatalf("failed to seed redis: %v", err)
 	}
 
-	result, err := plugin.queryRedisForBlocks([]uint64{hash}, "qwen")
+	result, err := plugin.queryRedisForBlocks([]uint64{hash}, "qwen", nil)
 	if err != nil {
 		t.Fatalf("queryRedisForBlocks returned error: %v", err)
 	}
@@ -475,7 +475,7 @@ func TestKVCacheAware_QueryRedisForBlocks_KeepsNamespacedOwners(t *testing.T) {
 		t.Fatalf("failed to seed redis: %v", err)
 	}
 
-	result, err := plugin.queryRedisForBlocks([]uint64{hash}, "qwen")
+	result, err := plugin.queryRedisForBlocks([]uint64{hash}, "qwen", nil)
 	if err != nil {
 		t.Fatalf("queryRedisForBlocks returned error: %v", err)
 	}
@@ -2410,5 +2410,194 @@ func TestKVCacheAware_CandidateFilteringRestrictsLongestMatch(t *testing.T) {
 	}
 	if _, candidateLongest := plugin.calculatePodScores(blockHashes, candidateScoped); candidateLongest != 2 {
 		t.Errorf("candidate-restricted longestMatch = %d, want 2 (pod1 holds only the first 2 blocks)", candidateLongest)
+	}
+}
+
+func readyPod(name string, ready bool, readySince time.Time) *datastore.PodInfo {
+	status := v1.ConditionFalse
+	if ready {
+		status = v1.ConditionTrue
+	}
+	return &datastore.PodInfo{
+		Pod: &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "test-namespace"},
+			Status: v1.PodStatus{
+				Conditions: []v1.PodCondition{{
+					Type:               v1.PodReady,
+					Status:             status,
+					LastTransitionTime: metav1.NewTime(readySince),
+				}},
+			},
+		},
+	}
+}
+
+func TestPodReadySinceUnix(t *testing.T) {
+	readySince := time.Now().Add(-time.Hour).Truncate(time.Second)
+
+	tests := []struct {
+		name string
+		pod  *v1.Pod
+		want int64
+	}{
+		{name: "nil pod", pod: nil, want: 0},
+		{name: "no conditions", pod: &v1.Pod{}, want: 0},
+		{name: "ready", pod: readyPod("p", true, readySince).Pod, want: readySince.Unix()},
+		{name: "not ready", pod: readyPod("p", false, readySince).Pod, want: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := podReadySinceUnix(tt.pod); got != tt.want {
+				t.Errorf("podReadySinceUnix() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRecentlyReadyOwners(t *testing.T) {
+	now := time.Now()
+	justRestarted := now.Add(-time.Minute).Truncate(time.Second)
+	longRunning := now.Add(-2 * kvCacheFieldFreshDuration).Truncate(time.Second)
+
+	tests := []struct {
+		name string
+		pods []*datastore.PodInfo
+		want map[string]int64
+	}{
+		{
+			name: "steady state pods are omitted so timestamps are not fetched",
+			pods: []*datastore.PodInfo{readyPod("old", true, longRunning)},
+			want: nil,
+		},
+		{
+			name: "recently ready pod is tracked",
+			pods: []*datastore.PodInfo{readyPod("fresh", true, justRestarted)},
+			want: map[string]int64{"fresh": justRestarted.Unix()},
+		},
+		{
+			name: "not ready pod is omitted",
+			pods: []*datastore.PodInfo{readyPod("down", false, justRestarted)},
+			want: nil,
+		},
+		{
+			name: "only the recently ready pod is tracked",
+			pods: []*datastore.PodInfo{
+				readyPod("old", true, longRunning),
+				readyPod("fresh", true, justRestarted),
+			},
+			want: map[string]int64{"fresh": justRestarted.Unix()},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := recentlyReadyOwners(tt.pods, now)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("recentlyReadyOwners() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFreshOwners(t *testing.T) {
+	const readySince = int64(1000)
+
+	tests := []struct {
+		name            string
+		entries         map[string]string
+		ownerReadySince map[string]int64
+		want            []string
+	}{
+		{
+			name:            "ownership written before the restart is dropped",
+			entries:         map[string]string{"pod-1.default": "999"},
+			ownerReadySince: map[string]int64{"pod-1": readySince},
+			want:            []string{},
+		},
+		{
+			name:            "ownership written after the restart is kept",
+			entries:         map[string]string{"pod-1.default": "1001"},
+			ownerReadySince: map[string]int64{"pod-1": readySince},
+			want:            []string{"pod-1.default"},
+		},
+		{
+			name:            "ownership written exactly at the restart is kept",
+			entries:         map[string]string{"pod-1.default": "1000"},
+			ownerReadySince: map[string]int64{"pod-1": readySince},
+			want:            []string{"pod-1.default"},
+		},
+		{
+			name:            "untracked owner is kept",
+			entries:         map[string]string{"pod-2.default": "1"},
+			ownerReadySince: map[string]int64{"pod-1": readySince},
+			want:            []string{"pod-2.default"},
+		},
+		{
+			name:            "unparsable timestamp is kept",
+			entries:         map[string]string{"pod-1.default": "not-a-number"},
+			ownerReadySince: map[string]int64{"pod-1": readySince},
+			want:            []string{"pod-1.default"},
+		},
+		{
+			name:            "bare pod name identifier is matched",
+			entries:         map[string]string{"pod-1": "999"},
+			ownerReadySince: map[string]int64{"pod-1": readySince},
+			want:            []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := freshOwners(tt.entries, tt.ownerReadySince)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("freshOwners() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// A pod that restarts keeps its name and returns Ready, so candidate filtering in Score cannot
+// drop it and its ownership is too recent for gcStaleFields. Only the write timestamp separates
+// the pod that still holds the blocks from the one that lost them on restart.
+func TestKVCacheAware_QueryRedisForBlocks_DropsOwnershipFromBeforeRestart(t *testing.T) {
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("failed to start miniredis: %v", err)
+	}
+	defer mr.Close()
+
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer client.Close()
+
+	plugin := &KVCacheAware{keyPrefix: kvCacheKeyPrefix, redisClient: client}
+
+	ctx := context.Background()
+	hash := uint64(222)
+	key := KVCacheAwareBlock{ModelName: "qwen", ChunkHash: hash}.String(kvCacheKeyPrefix)
+
+	now := time.Now()
+	writtenAt := now.Add(-10 * time.Minute)
+	restartedAt := now.Add(-5 * time.Minute)
+
+	if err := client.HSet(ctx, key,
+		"restarted.default", fmt.Sprintf("%d", writtenAt.Unix()),
+		"stable.default", fmt.Sprintf("%d", writtenAt.Unix()),
+	).Err(); err != nil {
+		t.Fatalf("failed to seed redis: %v", err)
+	}
+
+	owners := recentlyReadyOwners([]*datastore.PodInfo{
+		readyPod("restarted", true, restartedAt),
+		readyPod("stable", true, now.Add(-2*kvCacheFieldFreshDuration)),
+	}, now)
+
+	result, err := plugin.queryRedisForBlocks([]uint64{hash}, "qwen", owners)
+	if err != nil {
+		t.Fatalf("queryRedisForBlocks returned error: %v", err)
+	}
+
+	if want := []string{"stable.default"}; !reflect.DeepEqual(result[hash], want) {
+		t.Errorf("queryRedisForBlocks() = %v, want %v", result[hash], want)
 	}
 }

--- a/pkg/kthena-router/scheduler/plugins/kvcache_aware_test.go
+++ b/pkg/kthena-router/scheduler/plugins/kvcache_aware_test.go
@@ -2535,10 +2535,12 @@ func TestFreshOwners(t *testing.T) {
 			want:           []string{"pod-1.default"},
 		},
 		{
-			name:           "ownership written exactly at the restart is kept",
+			// Both timestamps are second-truncated, so a write in the restart's own second may
+			// have preceded it. Dropping costs a cache miss; keeping can route to a lost cache.
+			name:           "ownership written in the restart's second is dropped",
 			entries:        map[string]string{"pod-1.default": "1000"},
 			ownerStartedAt: map[string]int64{"pod-1.default": startedAt},
-			want:           []string{"pod-1.default"},
+			want:           []string{},
 		},
 		{
 			name:           "untracked owner is kept",


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

A pod that restarts keeps its name and comes back Ready, so nothing drops its KV cache ownership: candidate filtering keeps it because it is a live pod, and `gcStaleFields` skips it because the write timestamps are recent. The scorer then treats a pod with an empty cache as a warm one.

This compares the stored write time against the start time of the pod's current containers and drops ownership recorded before it. The Redis hash value is already a write timestamp, so nothing new is stored.

**Which issue(s) this PR fixes**:
Fixes #1428

**Bug evidence (required for bug-related PRs)**:

Reasoning and source permalinks are in #1428. In short, on current main:

- ownership is written with `hset(matrix_block_key, pod_identifier, timestamp)` and has no TTL
- every agent side removal path is driven by engine published zmq events, and there is no cleanup on agent startup or shutdown
- `Score` filters owners against the live candidate set, which is what makes the deleted pod case safe, but a restarted pod is in that set
- `gcStaleFields` only removes fields older than the freshness window, and it scans a bounded slice of the keyspace per tick, so an eligible entry is not necessarily visited soon after it becomes eligible

What I have not done is reproduce it on a cluster. The tests exercise the path but are not a live repro.

@acsoto reviewed #1428 and confirmed it looked like a real issue.

**Special notes for your reviewer**:

Revised after @kube-gopher's review. Each point is in its own thread, in short:

- the restart signal is the container's `State.Running.StartedAt`, not the Ready condition, which also moves on a probe failure while the cache stays intact
- owners are keyed on the full `name.namespace` identifier, which is what candidate filtering has keyed on since #1422
- the skip for pods older than the freshness window is gone, it assumed the GC had already visited those entries
- a write in the restart's own second is dropped, since both sides truncate to seconds

Timestamps are now always fetched. That looks like the right trade: #1100 puts the Redis round trip at roughly 0.6ms against 25 to 115ms for the tokenization that precedes it.

One open point. The start time is the newest across all of the pod's containers rather than the engine's, because the engine container cannot be identified reliably: matching by port needs `containerPort`, which is optional and absent from `examples/model-serving/gpu-kvcache-aware.yaml`, where vLLM takes `--port "8000"` on the command line.

Newest is the only safe choice without that, since taking the oldest would miss an engine restart whenever a sidecar has been running longer. The cost lands on a runtime agent restart, and that one does not heal: the subscriber is a plain `zmq.SUB` socket with no replay or startup resync, so blocks the engine still holds are never re-announced, and `startedAt` only moves forward. Routing stays correct, the pod just loses the locality it had.

Pushing the signal into the runtime agent removes this, since it can report the engine's own start time and its restart becomes a no-op. Happy to do that, or to plumb `WorkloadPort` onto `PodInfo`, if you would prefer either.

`queryRedisForBlocks` takes an extra parameter for the per-owner start times.

**Does this PR introduce a user-facing change?**:

```release-note
Fixed kvcache-aware routing treating a restarted pod as still holding its previous KV cache blocks.
```
