### PR TITLE
feat(router): add OpenAI-compatible /v1/files API

### DIFF
--- a/charts/kthena/charts/networking/templates/kthena-router/component/deployment.yaml
+++ b/charts/kthena/charts/networking/templates/kthena-router/component/deployment.yaml
@@ -125,6 +125,21 @@ spec:
             - name: ACCESS_LOG_OUTPUT
               value: {{ .Values.kthenaRouter.accessLog.output | quote }}
 
+            {{- with .Values.kthenaRouter.batchFiles }}
+            {{- if .enabled }}
+            - name: KTHENA_BATCH_FILES_DIR
+              value: {{ .mountPath | quote }}
+            {{- if .maxFileBytes }}
+            - name: KTHENA_BATCH_MAX_FILE_BYTES
+              value: {{ .maxFileBytes | quote }}
+            {{- end }}
+            {{- if .ttl }}
+            - name: KTHENA_BATCH_FILE_TTL
+              value: {{ .ttl | quote }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
+
             - name: DRAIN_TIMEOUT
               value: {{ .Values.kthenaRouter.drainTimeout | quote }}
           resources: {{- toYaml .Values.kthenaRouter.resource | nindent 12 }}
@@ -160,6 +175,10 @@ spec:
             mountPath: /etc/tls
             readOnly: true
           {{- end }}
+          {{- if .Values.kthenaRouter.batchFiles.enabled }}
+          - name: batch-files
+            mountPath: {{ .Values.kthenaRouter.batchFiles.mountPath }}
+          {{- end }}
       volumes:
         - name: scheduler-config
           configMap:
@@ -174,6 +193,10 @@ spec:
           secret:
             secretName: {{ .Values.kthenaRouter.webhook.tls.secretName }}
             optional: true
+        {{- end }}
+        {{- if .Values.kthenaRouter.batchFiles.enabled }}
+        - name: batch-files
+          emptyDir: {}
         {{- end }}
       serviceAccountName: kthena-router
       terminationGracePeriodSeconds: {{ .Values.kthenaRouter.terminationGracePeriodSeconds }}

--- a/charts/kthena/charts/networking/values.yaml
+++ b/charts/kthena/charts/networking/values.yaml
@@ -83,6 +83,17 @@ kthenaRouter:
     format: "text"
     # output specifies where to write logs: "stdout", "stderr", or file path (default: stdout)
     output: "stdout"
+  # batchFiles configures the OpenAI-compatible /v1/files API used by Batch workloads.
+  # Local-disk metadata is process-local: prefer replicas: 1 until a shared FileStore backend lands.
+  batchFiles:
+    # enabled mounts storage and sets KTHENA_BATCH_FILES_DIR on the router.
+    enabled: false
+    # mountPath is the container path used as KTHENA_BATCH_FILES_DIR.
+    mountPath: /var/lib/kthena/batch-files
+    # maxFileBytes is optional; when empty the router default (200MiB) is used.
+    maxFileBytes: ""
+    # ttl is optional Go duration (e.g. "720h"); when empty the router default (30d) is used.
+    ttl: ""
   # gatewayAPI configuration
   gatewayAPI:
     # enabled controls whether Gateway API related features are enabled

--- a/charts/kthena/values.yaml
+++ b/charts/kthena/values.yaml
@@ -107,6 +107,17 @@ networking:
       # rejected with HTTP 504. Defaults to `30s`; set a non-positive duration<br/>
       # (e.g. `0s`) to disable it (bounded only by client disconnect).
       timeout: "30s"
+    # batchFiles configures the OpenAI-compatible /v1/files API for Batch workloads.
+    # Local metadata is process-local; prefer a single router replica until shared storage lands.
+    batchFiles:
+      # -- Enable batch files storage mount and set KTHENA_BATCH_FILES_DIR.
+      enabled: false
+      # -- Container path used as KTHENA_BATCH_FILES_DIR.
+      mountPath: /var/lib/kthena/batch-files
+      # -- Optional max upload size in bytes; empty uses router default (200MiB).
+      maxFileBytes: ""
+      # -- Optional TTL Go duration (e.g. "720h"); empty uses router default (30d).
+      ttl: ""
     gatewayAPI:
       # -- Enable Gateway API related features.
       enabled: false

--- a/docs/kthena/docs/reference/helm-chart-values.md
+++ b/docs/kthena/docs/reference/helm-chart-values.md
@@ -18,6 +18,10 @@ A Helm chart for deploying Kthena
 | global.certManagementMode | string | `"auto"` | Certificate Management Mode.<br/>  Three mutually exclusive options for managing TLS certificates:<br/>  - `auto`: Webhook servers generate self-signed certificates automatically.<br/>  - `cert-manager`: Use cert-manager to generate and manage certificates (requires cert-manager installation).<br/>  - `manual`: Provide your own certificates via caBundle. |
 | global.webhook.caBundle | string | `""` | CA bundle for webhook server certificates (base64-encoded).<br/> This is ONLY required when `certManagementMode` is set to "manual".<br/> You can generate it with: `cat /path/to/your/ca.crt | base64 | tr -d '\n'`<br/> |
 | networking.enabled | bool | `true` | Enable the networking subchart. |
+| networking.kthenaRouter.batchFiles.enabled | bool | `false` | Enable batch files storage mount and set KTHENA_BATCH_FILES_DIR. |
+| networking.kthenaRouter.batchFiles.maxFileBytes | string | `""` | Optional max upload size in bytes; empty uses router default (200MiB). |
+| networking.kthenaRouter.batchFiles.mountPath | string | `"/var/lib/kthena/batch-files"` | Container path used as KTHENA_BATCH_FILES_DIR. |
+| networking.kthenaRouter.batchFiles.ttl | string | `""` | Optional TTL Go duration (e.g. "720h"); empty uses router default (30d). |
 | networking.kthenaRouter.debugPort | int | `15000` | Debug server port for Kthena Router (localhost only). |
 | networking.kthenaRouter.drainTimeout | string | `"5m"` | This should be less than terminationGracePeriodSeconds. |
 | networking.kthenaRouter.enabled | bool | `true` | Enable Kthena Router. |

--- a/pkg/kthena-router/batch/config.go
+++ b/pkg/kthena-router/batch/config.go
@@ -1,0 +1,69 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package batch
+
+import (
+	"os"
+	"strconv"
+	"time"
+
+	"k8s.io/klog/v2"
+)
+
+// Config holds runtime settings for the Files API storage backend.
+// Empty FilesDir disables the API (store is not constructed).
+type Config struct {
+	FilesDir     string
+	MaxFileBytes int64
+	BatchTTL     time.Duration
+}
+
+// Enabled reports whether file storage is configured.
+func (c Config) Enabled() bool {
+	return c.FilesDir != ""
+}
+
+// LoadConfigFromEnv reads batch file settings from the environment.
+// Missing or invalid values fall back to named defaults (same pattern as
+// fairness / access-log env parsing in the router).
+func LoadConfigFromEnv() Config {
+	cfg := Config{
+		FilesDir:     os.Getenv(EnvFilesDir),
+		MaxFileBytes: DefaultMaxFileBytes,
+		BatchTTL:     DefaultBatchTTL,
+	}
+
+	if s, ok := os.LookupEnv(EnvMaxFileBytes); ok && s != "" {
+		v, err := strconv.ParseInt(s, 10, 64)
+		if err != nil || v <= 0 {
+			klog.Warningf("Invalid %s %q, using default %d", EnvMaxFileBytes, s, DefaultMaxFileBytes)
+		} else {
+			cfg.MaxFileBytes = v
+		}
+	}
+
+	if s, ok := os.LookupEnv(EnvBatchTTL); ok && s != "" {
+		d, err := time.ParseDuration(s)
+		if err != nil || d <= 0 {
+			klog.Warningf("Invalid %s %q, using default %v", EnvBatchTTL, s, DefaultBatchTTL)
+		} else {
+			cfg.BatchTTL = d
+		}
+	}
+
+	return cfg
+}

--- a/pkg/kthena-router/batch/constants.go
+++ b/pkg/kthena-router/batch/constants.go
@@ -1,0 +1,70 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package batch
+
+import "time"
+
+// OpenAI-compatible Files API path segments and object identifiers.
+const (
+	// PathV1Files is the full path used when the catch-all listener sees the
+	// complete URL (gateway mode). PathFiles is used when Gin mounts under
+	// Group("/v1") and the remaining path is "/files" (default listener).
+	PathV1Files = "/v1/files"
+	PathFiles   = "/files"
+
+	ObjectFile = "file"
+	ObjectList = "list"
+
+	FileIDPrefix = "file-"
+
+	// Multipart form field names for POST /v1/files.
+	FormFieldFile    = "file"
+	FormFieldPurpose = "purpose"
+
+	// Supported upload purposes for this slice. batch_output is reserved for
+	// files produced by the future batch worker (not accepted on upload).
+	PurposeBatch       = "batch"
+	PurposeBatchOutput = "batch_output"
+
+	// Query parameter names for GET /v1/files.
+	QueryPurpose = "purpose"
+	QueryLimit   = "limit"
+	QueryOrder   = "order"
+	QueryAfter   = "after"
+
+	OrderAsc  = "asc"
+	OrderDesc = "desc"
+
+	ContentSuffix = "/content"
+)
+
+// Environment variable keys for batch file storage configuration.
+const (
+	EnvFilesDir     = "KTHENA_BATCH_FILES_DIR"
+	EnvMaxFileBytes = "KTHENA_BATCH_MAX_FILE_BYTES"
+	EnvBatchTTL     = "KTHENA_BATCH_FILE_TTL"
+)
+
+// Named defaults. Values mirror OpenAI Batch Files limits where applicable
+// (JSONL inputs up to 200 MiB; batch files expire after 30 days).
+const (
+	DefaultMaxFileBytes int64 = 200 * 1024 * 1024
+	DefaultBatchTTL           = 30 * 24 * time.Hour
+	DefaultListLimit          = 10000
+	MinListLimit              = 1
+	MaxListLimit              = 10000
+)

--- a/pkg/kthena-router/batch/errors.go
+++ b/pkg/kthena-router/batch/errors.go
@@ -28,13 +28,13 @@ import (
 
 // Sentinel errors for store and handler mapping.
 var (
-	ErrNotFound      = errors.New("file not found")
-	ErrDisabled      = errors.New("batch files API is disabled")
+	ErrNotFound       = errors.New("file not found")
+	ErrDisabled       = errors.New("batch files API is disabled")
 	ErrInvalidPurpose = errors.New("unsupported file purpose")
-	ErrMissingFile   = errors.New("missing file upload")
+	ErrMissingFile    = errors.New("missing file upload")
 	ErrMissingPurpose = errors.New("missing purpose")
-	ErrTooLarge      = errors.New("file exceeds maximum size")
-	ErrEmptyFile     = errors.New("file is empty")
+	ErrTooLarge       = errors.New("file exceeds maximum size")
+	ErrEmptyFile      = errors.New("file is empty")
 )
 
 // abortJSON writes an OpenAI-shaped error and records it on the access log.

--- a/pkg/kthena-router/batch/errors.go
+++ b/pkg/kthena-router/batch/errors.go
@@ -1,0 +1,72 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package batch
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/volcano-sh/kthena/pkg/kthena-router/accesslog"
+)
+
+// Sentinel errors for store and handler mapping.
+var (
+	ErrNotFound      = errors.New("file not found")
+	ErrDisabled      = errors.New("batch files API is disabled")
+	ErrInvalidPurpose = errors.New("unsupported file purpose")
+	ErrMissingFile   = errors.New("missing file upload")
+	ErrMissingPurpose = errors.New("missing purpose")
+	ErrTooLarge      = errors.New("file exceeds maximum size")
+	ErrEmptyFile     = errors.New("file is empty")
+)
+
+// abortJSON writes an OpenAI-shaped error and records it on the access log.
+func abortJSON(c *gin.Context, status int, errType, code, message string) {
+	accesslog.SetError(c, errType, message)
+	c.AbortWithStatusJSON(status, ErrorBody{
+		Error: ErrorDetail{
+			Message: message,
+			Type:    errType,
+			Code:    code,
+		},
+	})
+}
+
+func abortFromStoreError(c *gin.Context, err error) {
+	switch {
+	case errors.Is(err, ErrNotFound):
+		abortJSON(c, http.StatusNotFound, "invalid_request_error", "file_not_found", err.Error())
+	case errors.Is(err, ErrDisabled):
+		abortJSON(c, http.StatusServiceUnavailable, "server_error", "files_disabled", err.Error())
+	case errors.Is(err, ErrInvalidPurpose):
+		abortJSON(c, http.StatusBadRequest, "invalid_request_error", "invalid_purpose", err.Error())
+	case errors.Is(err, ErrMissingFile), errors.Is(err, ErrMissingPurpose), errors.Is(err, ErrEmptyFile):
+		abortJSON(c, http.StatusBadRequest, "invalid_request_error", "invalid_request", err.Error())
+	case errors.Is(err, ErrTooLarge):
+		abortJSON(c, http.StatusRequestEntityTooLarge, "invalid_request_error", "file_too_large", err.Error())
+	default:
+		abortJSON(c, http.StatusInternalServerError, "server_error", "internal_error", fmt.Sprintf("internal error: %v", err))
+	}
+}
+
+// IsUploadPurposeAllowed reports whether purpose is accepted on POST /v1/files.
+func IsUploadPurposeAllowed(purpose string) bool {
+	return purpose == PurposeBatch
+}

--- a/pkg/kthena-router/batch/files.go
+++ b/pkg/kthena-router/batch/files.go
@@ -1,0 +1,215 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package batch
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"k8s.io/klog/v2"
+)
+
+// Handler serves OpenAI-compatible /v1/files endpoints.
+// It is analogous to Router.ListModels: a dedicated control-plane handler that
+// does not enter ParseModelRequest / doLoadbalance.
+type Handler struct {
+	store FileStore
+}
+
+// NewHandler returns a Files API handler. store may be nil (feature disabled).
+func NewHandler(store FileStore) *Handler {
+	return &Handler{store: store}
+}
+
+// ServeHTTP dispatches by method and path suffix under /v1/files or /files.
+func (h *Handler) ServeHTTP(c *gin.Context) {
+	if h == nil || h.store == nil {
+		abortJSON(c, http.StatusServiceUnavailable, "server_error", "files_disabled",
+			fmt.Sprintf("batch files API is disabled; set %s to enable", EnvFilesDir))
+		return
+	}
+
+	rel, ok := filesPathSuffix(c.Request.URL.Path)
+	if !ok {
+		abortJSON(c, http.StatusNotFound, "invalid_request_error", "not_found", "not found")
+		return
+	}
+
+	switch {
+	case c.Request.Method == http.MethodPost && rel == "":
+		h.upload(c)
+	case c.Request.Method == http.MethodGet && rel == "":
+		h.list(c)
+	case c.Request.Method == http.MethodGet && strings.HasSuffix(rel, ContentSuffix):
+		id := strings.TrimSuffix(rel, ContentSuffix)
+		id = strings.TrimPrefix(id, "/")
+		h.content(c, id)
+	case c.Request.Method == http.MethodGet && rel != "":
+		h.get(c, strings.TrimPrefix(rel, "/"))
+	case c.Request.Method == http.MethodDelete && rel != "":
+		h.delete(c, strings.TrimPrefix(rel, "/"))
+	default:
+		abortJSON(c, http.StatusMethodNotAllowed, "invalid_request_error", "method_not_allowed",
+			fmt.Sprintf("method %s not allowed", c.Request.Method))
+	}
+}
+
+// IsFilesPath reports whether path is an OpenAI Files API path.
+func IsFilesPath(path string) bool {
+	_, ok := filesPathSuffix(path)
+	return ok
+}
+
+// filesPathSuffix returns the path after /v1/files or /files.
+// Examples:
+//
+//	"/v1/files"           -> "", true
+//	"/v1/files/file-1"    -> "/file-1", true
+//	"/files/file-1/content" -> "/file-1/content", true
+//	"/v1/chat/completions" -> "", false
+func filesPathSuffix(path string) (string, bool) {
+	switch {
+	case path == PathV1Files || strings.HasPrefix(path, PathV1Files+"/"):
+		return strings.TrimPrefix(path, PathV1Files), true
+	case path == PathFiles || strings.HasPrefix(path, PathFiles+"/"):
+		return strings.TrimPrefix(path, PathFiles), true
+	default:
+		return "", false
+	}
+}
+
+func (h *Handler) upload(c *gin.Context) {
+	purpose := c.PostForm(FormFieldPurpose)
+	if purpose == "" {
+		abortFromStoreError(c, ErrMissingPurpose)
+		return
+	}
+	if !IsUploadPurposeAllowed(purpose) {
+		abortFromStoreError(c, fmt.Errorf("%w: %q (supported: %s)", ErrInvalidPurpose, purpose, PurposeBatch))
+		return
+	}
+
+	fileHeader, err := c.FormFile(FormFieldFile)
+	if err != nil {
+		abortFromStoreError(c, ErrMissingFile)
+		return
+	}
+
+	src, err := fileHeader.Open()
+	if err != nil {
+		abortJSON(c, http.StatusBadRequest, "invalid_request_error", "invalid_request",
+			fmt.Sprintf("failed to open uploaded file: %v", err))
+		return
+	}
+	defer src.Close()
+
+	obj, err := h.store.Create(c.Request.Context(), fileHeader.Filename, purpose, src)
+	if err != nil {
+		abortFromStoreError(c, err)
+		return
+	}
+
+	klog.V(4).Infof("uploaded batch file id=%s filename=%s bytes=%d", obj.ID, obj.Filename, obj.Bytes)
+	c.JSON(http.StatusOK, obj)
+}
+
+func (h *Handler) list(c *gin.Context) {
+	opts := ListOptions{
+		Purpose: c.Query(QueryPurpose),
+		Order:   c.Query(QueryOrder),
+		After:   c.Query(QueryAfter),
+		Limit:   DefaultListLimit,
+	}
+	if raw := c.Query(QueryLimit); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err != nil || n < MinListLimit || n > MaxListLimit {
+			abortJSON(c, http.StatusBadRequest, "invalid_request_error", "invalid_limit",
+				fmt.Sprintf("limit must be between %d and %d", MinListLimit, MaxListLimit))
+			return
+		}
+		opts.Limit = n
+	}
+	if opts.Order != "" && opts.Order != OrderAsc && opts.Order != OrderDesc {
+		abortJSON(c, http.StatusBadRequest, "invalid_request_error", "invalid_order",
+			fmt.Sprintf("order must be %q or %q", OrderAsc, OrderDesc))
+		return
+	}
+
+	items, err := h.store.List(c.Request.Context(), opts)
+	if err != nil {
+		abortFromStoreError(c, err)
+		return
+	}
+	if items == nil {
+		items = []FileObject{}
+	}
+
+	c.JSON(http.StatusOK, FileList{
+		Object: ObjectList,
+		Data:   items,
+	})
+}
+
+func (h *Handler) get(c *gin.Context, id string) {
+	if id == "" {
+		abortJSON(c, http.StatusNotFound, "invalid_request_error", "file_not_found", ErrNotFound.Error())
+		return
+	}
+	obj, err := h.store.Get(c.Request.Context(), id)
+	if err != nil {
+		abortFromStoreError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, obj)
+}
+
+func (h *Handler) content(c *gin.Context, id string) {
+	if id == "" {
+		abortJSON(c, http.StatusNotFound, "invalid_request_error", "file_not_found", ErrNotFound.Error())
+		return
+	}
+	rc, obj, err := h.store.Open(c.Request.Context(), id)
+	if err != nil {
+		abortFromStoreError(c, err)
+		return
+	}
+	defer rc.Close()
+
+	c.Header("Content-Type", "application/octet-stream")
+	c.Header("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, obj.Filename))
+	c.Status(http.StatusOK)
+	if _, err := io.Copy(c.Writer, rc); err != nil {
+		klog.Errorf("failed to stream file content id=%s: %v", id, err)
+	}
+}
+
+func (h *Handler) delete(c *gin.Context, id string) {
+	if id == "" {
+		abortJSON(c, http.StatusNotFound, "invalid_request_error", "file_not_found", ErrNotFound.Error())
+		return
+	}
+	resp, err := h.store.Delete(c.Request.Context(), id)
+	if err != nil {
+		abortFromStoreError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, resp)
+}

--- a/pkg/kthena-router/batch/files_test.go
+++ b/pkg/kthena-router/batch/files_test.go
@@ -1,0 +1,159 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package batch
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestHandler_UploadListGetContentDelete(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	store, err := NewLocalFileStore(Config{
+		FilesDir:     t.TempDir(),
+		MaxFileBytes: 1024,
+		BatchTTL:     time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("NewLocalFileStore: %v", err)
+	}
+	h := NewHandler(store)
+
+	payload := `{"custom_id":"req-1","method":"POST","url":"/v1/chat/completions","body":{"model":"m"}}`
+	obj := uploadFile(t, h, "requests.jsonl", PurposeBatch, payload)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, PathV1Files, nil)
+	h.ServeHTTP(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("list status=%d body=%s", w.Code, w.Body.String())
+	}
+	var list FileList
+	if err := json.Unmarshal(w.Body.Bytes(), &list); err != nil {
+		t.Fatalf("list json: %v", err)
+	}
+	if list.Object != ObjectList || len(list.Data) != 1 || list.Data[0].ID != obj.ID {
+		t.Fatalf("unexpected list: %+v", list)
+	}
+
+	w = httptest.NewRecorder()
+	c, _ = gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, PathV1Files+"/"+obj.ID, nil)
+	h.ServeHTTP(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("get status=%d body=%s", w.Code, w.Body.String())
+	}
+
+	w = httptest.NewRecorder()
+	c, _ = gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, PathV1Files+"/"+obj.ID+ContentSuffix, nil)
+	h.ServeHTTP(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("content status=%d body=%s", w.Code, w.Body.String())
+	}
+	if w.Body.String() != payload {
+		t.Fatalf("content=%q", w.Body.String())
+	}
+
+	w = httptest.NewRecorder()
+	c, _ = gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodDelete, PathV1Files+"/"+obj.ID, nil)
+	h.ServeHTTP(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("delete status=%d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandler_RejectsUnsupportedPurposeAndDisabledStore(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	store, err := NewLocalFileStore(Config{
+		FilesDir:     t.TempDir(),
+		MaxFileBytes: 1024,
+		BatchTTL:     time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("NewLocalFileStore: %v", err)
+	}
+
+	h := NewHandler(store)
+	body, contentType := multipartBody(t, "a.jsonl", "assistants", "data")
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, PathV1Files, body)
+	c.Request.Header.Set("Content-Type", contentType)
+	h.ServeHTTP(c)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("unsupported purpose status=%d", w.Code)
+	}
+
+	disabled := NewHandler(nil)
+	w = httptest.NewRecorder()
+	c, _ = gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, PathV1Files, nil)
+	disabled.ServeHTTP(c)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("disabled status=%d", w.Code)
+	}
+}
+
+func uploadFile(t *testing.T, h *Handler, filename, purpose, content string) FileObject {
+	t.Helper()
+	body, contentType := multipartBody(t, filename, purpose, content)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, PathV1Files, body)
+	c.Request.Header.Set("Content-Type", contentType)
+	h.ServeHTTP(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("upload status=%d body=%s", w.Code, w.Body.String())
+	}
+	var obj FileObject
+	if err := json.Unmarshal(w.Body.Bytes(), &obj); err != nil {
+		t.Fatalf("upload json: %v", err)
+	}
+	return obj
+}
+
+func multipartBody(t *testing.T, filename, purpose, content string) (io.Reader, string) {
+	t.Helper()
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+	if err := w.WriteField(FormFieldPurpose, purpose); err != nil {
+		t.Fatalf("WriteField purpose: %v", err)
+	}
+	part, err := w.CreateFormFile(FormFieldFile, filename)
+	if err != nil {
+		t.Fatalf("CreateFormFile: %v", err)
+	}
+	if _, err := io.Copy(part, strings.NewReader(content)); err != nil {
+		t.Fatalf("Copy: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	return &buf, w.FormDataContentType()
+}

--- a/pkg/kthena-router/batch/local_store.go
+++ b/pkg/kthena-router/batch/local_store.go
@@ -1,0 +1,260 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package batch
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"k8s.io/klog/v2"
+)
+
+// LocalFileStore keeps metadata in memory and content on disk under FilesDir.
+type LocalFileStore struct {
+	dir          string
+	maxFileBytes int64
+	batchTTL     time.Duration
+
+	mu    sync.RWMutex
+	files map[string]*storedFile
+}
+
+type storedFile struct {
+	meta     FileObject
+	diskPath string
+}
+
+// NewLocalFileStore creates the storage directory and an empty in-memory index.
+func NewLocalFileStore(cfg Config) (*LocalFileStore, error) {
+	if cfg.FilesDir == "" {
+		return nil, fmt.Errorf("%w: %s is empty", ErrDisabled, EnvFilesDir)
+	}
+	if err := os.MkdirAll(cfg.FilesDir, 0o750); err != nil {
+		return nil, fmt.Errorf("create batch files dir %q: %w", cfg.FilesDir, err)
+	}
+
+	maxBytes := cfg.MaxFileBytes
+	if maxBytes <= 0 {
+		maxBytes = DefaultMaxFileBytes
+	}
+	ttl := cfg.BatchTTL
+	if ttl <= 0 {
+		ttl = DefaultBatchTTL
+	}
+
+	klog.Infof("batch files store enabled: dir=%s maxBytes=%d ttl=%s", cfg.FilesDir, maxBytes, ttl)
+	return &LocalFileStore{
+		dir:          cfg.FilesDir,
+		maxFileBytes: maxBytes,
+		batchTTL:     ttl,
+		files:        make(map[string]*storedFile),
+	}, nil
+}
+
+func (s *LocalFileStore) Create(ctx context.Context, filename, purpose string, r io.Reader) (*FileObject, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if filename == "" {
+		filename = "upload"
+	}
+	if !IsUploadPurposeAllowed(purpose) {
+		return nil, fmt.Errorf("%w: %q", ErrInvalidPurpose, purpose)
+	}
+
+	id := FileIDPrefix + uuid.New().String()
+	diskPath := filepath.Join(s.dir, id)
+
+	f, err := os.OpenFile(diskPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o640)
+	if err != nil {
+		return nil, fmt.Errorf("create file on disk: %w", err)
+	}
+
+	limited := io.LimitReader(r, s.maxFileBytes+1)
+	n, copyErr := io.Copy(f, limited)
+	closeErr := f.Close()
+	if copyErr != nil {
+		_ = os.Remove(diskPath)
+		return nil, fmt.Errorf("write file content: %w", copyErr)
+	}
+	if closeErr != nil {
+		_ = os.Remove(diskPath)
+		return nil, fmt.Errorf("close file content: %w", closeErr)
+	}
+	if n == 0 {
+		_ = os.Remove(diskPath)
+		return nil, ErrEmptyFile
+	}
+	if n > s.maxFileBytes {
+		_ = os.Remove(diskPath)
+		return nil, fmt.Errorf("%w: max %d bytes", ErrTooLarge, s.maxFileBytes)
+	}
+
+	now := time.Now().Unix()
+	expiresAt := now + int64(s.batchTTL.Seconds())
+	meta := FileObject{
+		ID:        id,
+		Object:    ObjectFile,
+		Bytes:     n,
+		CreatedAt: now,
+		Filename:  filename,
+		Purpose:   purpose,
+		ExpiresAt: &expiresAt,
+	}
+
+	s.mu.Lock()
+	s.files[id] = &storedFile{meta: meta, diskPath: diskPath}
+	s.mu.Unlock()
+
+	out := meta
+	return &out, nil
+}
+
+func (s *LocalFileStore) Get(ctx context.Context, id string) (*FileObject, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	sf, ok := s.files[id]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	out := sf.meta
+	return &out, nil
+}
+
+func (s *LocalFileStore) List(ctx context.Context, opts ListOptions) ([]FileObject, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = DefaultListLimit
+	}
+	if limit < MinListLimit {
+		limit = MinListLimit
+	}
+	if limit > MaxListLimit {
+		limit = MaxListLimit
+	}
+
+	order := opts.Order
+	if order == "" {
+		order = OrderDesc
+	}
+
+	s.mu.RLock()
+	items := make([]FileObject, 0, len(s.files))
+	for _, sf := range s.files {
+		if opts.Purpose != "" && sf.meta.Purpose != opts.Purpose {
+			continue
+		}
+		items = append(items, sf.meta)
+	}
+	s.mu.RUnlock()
+
+	sort.Slice(items, func(i, j int) bool {
+		if order == OrderAsc {
+			if items[i].CreatedAt == items[j].CreatedAt {
+				return items[i].ID < items[j].ID
+			}
+			return items[i].CreatedAt < items[j].CreatedAt
+		}
+		if items[i].CreatedAt == items[j].CreatedAt {
+			return items[i].ID > items[j].ID
+		}
+		return items[i].CreatedAt > items[j].CreatedAt
+	})
+
+	if opts.After != "" {
+		idx := -1
+		for i, item := range items {
+			if item.ID == opts.After {
+				idx = i
+				break
+			}
+		}
+		if idx >= 0 {
+			items = items[idx+1:]
+		}
+	}
+
+	if len(items) > limit {
+		items = items[:limit]
+	}
+	return items, nil
+}
+
+func (s *LocalFileStore) Delete(ctx context.Context, id string) (*DeleteFileResponse, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	s.mu.Lock()
+	sf, ok := s.files[id]
+	if !ok {
+		s.mu.Unlock()
+		return nil, ErrNotFound
+	}
+	delete(s.files, id)
+	diskPath := sf.diskPath
+	s.mu.Unlock()
+
+	if err := os.Remove(diskPath); err != nil && !os.IsNotExist(err) {
+		klog.Warningf("failed to remove batch file %s from disk: %v", id, err)
+	}
+
+	return &DeleteFileResponse{
+		ID:      id,
+		Object:  ObjectFile,
+		Deleted: true,
+	}, nil
+}
+
+func (s *LocalFileStore) Open(ctx context.Context, id string) (io.ReadCloser, *FileObject, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, nil, err
+	}
+
+	s.mu.RLock()
+	sf, ok := s.files[id]
+	if !ok {
+		s.mu.RUnlock()
+		return nil, nil, ErrNotFound
+	}
+	meta := sf.meta
+	diskPath := sf.diskPath
+	s.mu.RUnlock()
+
+	f, err := os.Open(diskPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil, ErrNotFound
+		}
+		return nil, nil, fmt.Errorf("open file content: %w", err)
+	}
+	return f, &meta, nil
+}

--- a/pkg/kthena-router/batch/local_store.go
+++ b/pkg/kthena-router/batch/local_store.go
@@ -135,10 +135,14 @@ func (s *LocalFileStore) Get(ctx context.Context, id string) (*FileObject, error
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	sf, ok := s.files[id]
 	if !ok {
+		return nil, ErrNotFound
+	}
+	if isExpired(sf.meta, time.Now().Unix()) {
+		s.purgeLocked(id, sf)
 		return nil, ErrNotFound
 	}
 	out := sf.meta
@@ -166,15 +170,20 @@ func (s *LocalFileStore) List(ctx context.Context, opts ListOptions) ([]FileObje
 		order = OrderDesc
 	}
 
-	s.mu.RLock()
+	now := time.Now().Unix()
+	s.mu.Lock()
 	items := make([]FileObject, 0, len(s.files))
-	for _, sf := range s.files {
+	for id, sf := range s.files {
+		if isExpired(sf.meta, now) {
+			s.purgeLocked(id, sf)
+			continue
+		}
 		if opts.Purpose != "" && sf.meta.Purpose != opts.Purpose {
 			continue
 		}
 		items = append(items, sf.meta)
 	}
-	s.mu.RUnlock()
+	s.mu.Unlock()
 
 	sort.Slice(items, func(i, j int) bool {
 		if order == OrderAsc {
@@ -239,15 +248,20 @@ func (s *LocalFileStore) Open(ctx context.Context, id string) (io.ReadCloser, *F
 		return nil, nil, err
 	}
 
-	s.mu.RLock()
+	s.mu.Lock()
 	sf, ok := s.files[id]
 	if !ok {
-		s.mu.RUnlock()
+		s.mu.Unlock()
+		return nil, nil, ErrNotFound
+	}
+	if isExpired(sf.meta, time.Now().Unix()) {
+		s.purgeLocked(id, sf)
+		s.mu.Unlock()
 		return nil, nil, ErrNotFound
 	}
 	meta := sf.meta
 	diskPath := sf.diskPath
-	s.mu.RUnlock()
+	s.mu.Unlock()
 
 	f, err := os.Open(diskPath)
 	if err != nil {
@@ -257,4 +271,20 @@ func (s *LocalFileStore) Open(ctx context.Context, id string) (io.ReadCloser, *F
 		return nil, nil, fmt.Errorf("open file content: %w", err)
 	}
 	return f, &meta, nil
+}
+
+func isExpired(meta FileObject, now int64) bool {
+	return meta.ExpiresAt != nil && *meta.ExpiresAt <= now
+}
+
+// purgeLocked removes metadata and best-effort deletes the on-disk blob.
+// Caller must hold s.mu for writing.
+func (s *LocalFileStore) purgeLocked(id string, sf *storedFile) {
+	delete(s.files, id)
+	if sf == nil {
+		return
+	}
+	if err := os.Remove(sf.diskPath); err != nil && !os.IsNotExist(err) {
+		klog.Warningf("failed to purge expired batch file %s from disk: %v", id, err)
+	}
 }

--- a/pkg/kthena-router/batch/local_store_test.go
+++ b/pkg/kthena-router/batch/local_store_test.go
@@ -163,6 +163,37 @@ func TestLocalFileStore_ListPaginationAndOrder(t *testing.T) {
 	}
 }
 
+func TestLocalFileStore_ExpiresAtEnforced(t *testing.T) {
+	store, err := NewLocalFileStore(Config{
+		FilesDir:     t.TempDir(),
+		MaxFileBytes: 1024,
+		BatchTTL:     time.Millisecond, // expire almost immediately
+	})
+	if err != nil {
+		t.Fatalf("NewLocalFileStore: %v", err)
+	}
+	ctx := context.Background()
+	obj, err := store.Create(ctx, "f.jsonl", PurposeBatch, strings.NewReader("hello"))
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	time.Sleep(5 * time.Millisecond)
+
+	if _, err := store.Get(ctx, obj.ID); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Get after expiry: err=%v want ErrNotFound", err)
+	}
+	listed, err := store.List(ctx, ListOptions{Limit: 10})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(listed) != 0 {
+		t.Fatalf("List after expiry len=%d want 0", len(listed))
+	}
+	if _, _, err := store.Open(ctx, obj.ID); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Open after expiry: err=%v want ErrNotFound", err)
+	}
+}
+
 func TestLoadConfigFromEnv_DefaultsAndOverrides(t *testing.T) {
 	t.Setenv(EnvFilesDir, "")
 	t.Setenv(EnvMaxFileBytes, "")

--- a/pkg/kthena-router/batch/local_store_test.go
+++ b/pkg/kthena-router/batch/local_store_test.go
@@ -1,0 +1,220 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package batch
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestLocalFileStore_CreateGetListDeleteContent(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewLocalFileStore(Config{
+		FilesDir:     dir,
+		MaxFileBytes: 1024,
+		BatchTTL:     time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("NewLocalFileStore: %v", err)
+	}
+
+	ctx := context.Background()
+	content := []byte(`{"custom_id":"1","method":"POST","url":"/v1/chat/completions","body":{}}`)
+	obj, err := store.Create(ctx, "requests.jsonl", PurposeBatch, bytes.NewReader(content))
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if !strings.HasPrefix(obj.ID, FileIDPrefix) {
+		t.Fatalf("unexpected id prefix: %s", obj.ID)
+	}
+	if obj.Object != ObjectFile || obj.Purpose != PurposeBatch {
+		t.Fatalf("unexpected object fields: %+v", obj)
+	}
+	if obj.Bytes != int64(len(content)) {
+		t.Fatalf("bytes=%d want %d", obj.Bytes, len(content))
+	}
+	if obj.ExpiresAt == nil {
+		t.Fatal("expected expires_at")
+	}
+
+	got, err := store.Get(ctx, obj.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.ID != obj.ID {
+		t.Fatalf("Get id=%s want %s", got.ID, obj.ID)
+	}
+
+	listed, err := store.List(ctx, ListOptions{Purpose: PurposeBatch, Limit: 10})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(listed) != 1 {
+		t.Fatalf("List len=%d want 1", len(listed))
+	}
+
+	rc, meta, err := store.Open(ctx, obj.ID)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer rc.Close()
+	body, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if !bytes.Equal(body, content) {
+		t.Fatalf("content mismatch: got %q", body)
+	}
+	if meta.Filename != "requests.jsonl" {
+		t.Fatalf("filename=%s", meta.Filename)
+	}
+
+	del, err := store.Delete(ctx, obj.ID)
+	if err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if !del.Deleted || del.ID != obj.ID {
+		t.Fatalf("unexpected delete response: %+v", del)
+	}
+
+	if _, err := store.Get(ctx, obj.ID); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Get after delete: err=%v", err)
+	}
+}
+
+func TestLocalFileStore_RejectsUnsupportedPurposeAndOversize(t *testing.T) {
+	store, err := NewLocalFileStore(Config{
+		FilesDir:     t.TempDir(),
+		MaxFileBytes: 8,
+		BatchTTL:     time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("NewLocalFileStore: %v", err)
+	}
+	ctx := context.Background()
+
+	_, err = store.Create(ctx, "a.jsonl", "assistants", strings.NewReader("hello"))
+	if !errors.Is(err, ErrInvalidPurpose) {
+		t.Fatalf("purpose err=%v want ErrInvalidPurpose", err)
+	}
+
+	_, err = store.Create(ctx, "a.jsonl", PurposeBatch, strings.NewReader("0123456789"))
+	if !errors.Is(err, ErrTooLarge) {
+		t.Fatalf("size err=%v want ErrTooLarge", err)
+	}
+
+	_, err = store.Create(ctx, "a.jsonl", PurposeBatch, strings.NewReader(""))
+	if !errors.Is(err, ErrEmptyFile) {
+		t.Fatalf("empty err=%v want ErrEmptyFile", err)
+	}
+}
+
+func TestLocalFileStore_ListPaginationAndOrder(t *testing.T) {
+	store, err := NewLocalFileStore(Config{
+		FilesDir:     t.TempDir(),
+		MaxFileBytes: 1024,
+		BatchTTL:     time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("NewLocalFileStore: %v", err)
+	}
+	ctx := context.Background()
+
+	var ids []string
+	for i := 0; i < 3; i++ {
+		obj, err := store.Create(ctx, "f.jsonl", PurposeBatch, strings.NewReader(strings.Repeat("x", i+1)))
+		if err != nil {
+			t.Fatalf("Create %d: %v", i, err)
+		}
+		ids = append(ids, obj.ID)
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	asc, err := store.List(ctx, ListOptions{Order: OrderAsc, Limit: 10})
+	if err != nil {
+		t.Fatalf("List asc: %v", err)
+	}
+	if len(asc) != 3 || asc[0].CreatedAt > asc[2].CreatedAt {
+		t.Fatalf("unexpected asc order: %+v", asc)
+	}
+
+	page, err := store.List(ctx, ListOptions{Order: OrderAsc, Limit: 1, After: asc[0].ID})
+	if err != nil {
+		t.Fatalf("List after: %v", err)
+	}
+	if len(page) != 1 || page[0].ID != asc[1].ID {
+		t.Fatalf("unexpected page: %+v", page)
+	}
+}
+
+func TestLoadConfigFromEnv_DefaultsAndOverrides(t *testing.T) {
+	t.Setenv(EnvFilesDir, "")
+	t.Setenv(EnvMaxFileBytes, "")
+	t.Setenv(EnvBatchTTL, "")
+
+	cfg := LoadConfigFromEnv()
+	if cfg.Enabled() {
+		t.Fatal("expected disabled when FilesDir empty")
+	}
+	if cfg.MaxFileBytes != DefaultMaxFileBytes {
+		t.Fatalf("MaxFileBytes=%d", cfg.MaxFileBytes)
+	}
+	if cfg.BatchTTL != DefaultBatchTTL {
+		t.Fatalf("BatchTTL=%v", cfg.BatchTTL)
+	}
+
+	t.Setenv(EnvFilesDir, "/data/batch")
+	t.Setenv(EnvMaxFileBytes, "4096")
+	t.Setenv(EnvBatchTTL, "1h")
+	cfg = LoadConfigFromEnv()
+	if !cfg.Enabled() || cfg.FilesDir != "/data/batch" {
+		t.Fatalf("unexpected cfg: %+v", cfg)
+	}
+	if cfg.MaxFileBytes != 4096 {
+		t.Fatalf("MaxFileBytes=%d", cfg.MaxFileBytes)
+	}
+	if cfg.BatchTTL != time.Hour {
+		t.Fatalf("BatchTTL=%v", cfg.BatchTTL)
+	}
+}
+
+func TestFilesPathSuffix(t *testing.T) {
+	tests := []struct {
+		path    string
+		wantRel string
+		wantOK  bool
+	}{
+		{PathV1Files, "", true},
+		{PathV1Files + "/file-1", "/file-1", true},
+		{PathV1Files + "/file-1/content", "/file-1/content", true},
+		{PathFiles, "", true},
+		{PathFiles + "/file-1", "/file-1", true},
+		{"/v1/chat/completions", "", false},
+		{"/v1/models", "", false},
+	}
+	for _, tt := range tests {
+		rel, ok := filesPathSuffix(tt.path)
+		if ok != tt.wantOK || rel != tt.wantRel {
+			t.Fatalf("path=%s got (%q,%v) want (%q,%v)", tt.path, rel, ok, tt.wantRel, tt.wantOK)
+		}
+	}
+}

--- a/pkg/kthena-router/batch/local_store_test.go
+++ b/pkg/kthena-router/batch/local_store_test.go
@@ -139,13 +139,10 @@ func TestLocalFileStore_ListPaginationAndOrder(t *testing.T) {
 	}
 	ctx := context.Background()
 
-	var ids []string
 	for i := 0; i < 3; i++ {
-		obj, err := store.Create(ctx, "f.jsonl", PurposeBatch, strings.NewReader(strings.Repeat("x", i+1)))
-		if err != nil {
+		if _, err := store.Create(ctx, "f.jsonl", PurposeBatch, strings.NewReader(strings.Repeat("x", i+1))); err != nil {
 			t.Fatalf("Create %d: %v", i, err)
 		}
-		ids = append(ids, obj.ID)
 		time.Sleep(2 * time.Millisecond)
 	}
 

--- a/pkg/kthena-router/batch/store.go
+++ b/pkg/kthena-router/batch/store.go
@@ -1,0 +1,41 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package batch
+
+import (
+	"context"
+	"io"
+)
+
+// FileStore persists OpenAI-compatible file metadata and content.
+// Implementations must be safe for concurrent use.
+type FileStore interface {
+	Create(ctx context.Context, filename, purpose string, r io.Reader) (*FileObject, error)
+	Get(ctx context.Context, id string) (*FileObject, error)
+	List(ctx context.Context, opts ListOptions) ([]FileObject, error)
+	Delete(ctx context.Context, id string) (*DeleteFileResponse, error)
+	Open(ctx context.Context, id string) (io.ReadCloser, *FileObject, error)
+}
+
+// NewFileStoreFromConfig constructs a local file store when enabled.
+// Returns nil when FilesDir is unset so callers can treat the feature as off.
+func NewFileStoreFromConfig(cfg Config) (FileStore, error) {
+	if !cfg.Enabled() {
+		return nil, nil
+	}
+	return NewLocalFileStore(cfg)
+}

--- a/pkg/kthena-router/batch/types.go
+++ b/pkg/kthena-router/batch/types.go
@@ -1,0 +1,61 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package batch
+
+// FileObject is the OpenAI-compatible file resource returned by /v1/files.
+type FileObject struct {
+	ID        string `json:"id"`
+	Object    string `json:"object"`
+	Bytes     int64  `json:"bytes"`
+	CreatedAt int64  `json:"created_at"`
+	Filename  string `json:"filename"`
+	Purpose   string `json:"purpose"`
+	ExpiresAt *int64 `json:"expires_at,omitempty"`
+}
+
+// FileList is the OpenAI-compatible list envelope for GET /v1/files.
+type FileList struct {
+	Object string       `json:"object"`
+	Data   []FileObject `json:"data"`
+}
+
+// DeleteFileResponse is returned by DELETE /v1/files/{id}.
+type DeleteFileResponse struct {
+	ID      string `json:"id"`
+	Object  string `json:"object"`
+	Deleted bool   `json:"deleted"`
+}
+
+// ListOptions controls filtering and pagination for FileStore.List.
+type ListOptions struct {
+	Purpose string
+	Limit   int
+	Order   string
+	After   string
+}
+
+// ErrorBody is a small JSON error payload consistent with other router handlers.
+type ErrorBody struct {
+	Error ErrorDetail `json:"error"`
+}
+
+// ErrorDetail carries a machine-readable type and human-readable message.
+type ErrorDetail struct {
+	Message string `json:"message"`
+	Type    string `json:"type"`
+	Code    string `json:"code,omitempty"`
+}

--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -40,6 +40,7 @@ import (
 
 	"github.com/volcano-sh/kthena/pkg/apis/networking/v1alpha1"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/accesslog"
+	"github.com/volcano-sh/kthena/pkg/kthena-router/batch"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/common"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/connectors"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/datastore"
@@ -102,6 +103,9 @@ type Router struct {
 
 	// KV Connector management
 	connectorFactory *connectors.Factory
+
+	// OpenAI-compatible Files API (batch control plane). Nil store disables it.
+	filesHandler *batch.Handler
 
 	// Priority queue configuration
 	queueTimeout     time.Duration
@@ -191,6 +195,11 @@ func NewRouter(store datastore.Store, routerConfigPath string) *Router {
 		klog.Fatalf("failed to create access logger: %v", err)
 	}
 
+	filesHandler, err := newFilesHandlerFromEnv()
+	if err != nil {
+		klog.Fatalf("failed to initialize batch files store: %v", err)
+	}
+
 	return &Router{
 		store:            store,
 		scheduler:        scheduler.NewScheduler(store, routerConfig),
@@ -200,12 +209,25 @@ func NewRouter(store datastore.Store, routerConfigPath string) *Router {
 		metrics:          metricsInstance,
 		tokenizer:        tokenizerInstance,
 		connectorFactory: connectors.NewDefaultFactory(),
+		filesHandler:     filesHandler,
 		queueTimeout:     parseQueueTimeout(),
 		tokenWeight:      parseEnvFloat("FAIRNESS_PRIORITY_TOKEN_WEIGHT", 1.0),
 		requestNumWeight: parseEnvFloat("FAIRNESS_PRIORITY_REQUEST_NUM_WEIGHT", 0.0),
 
 		sessionBoostTimeout: parseSessionBoostTimeout(),
 	}
+}
+
+// newFilesHandlerFromEnv builds the OpenAI Files API handler from env config.
+// When KTHENA_BATCH_FILES_DIR is unset the handler is still created but serves
+// 503 until storage is configured (mirrors optional feature flags elsewhere).
+func newFilesHandlerFromEnv() (*batch.Handler, error) {
+	cfg := batch.LoadConfigFromEnv()
+	store, err := batch.NewFileStoreFromConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return batch.NewHandler(store), nil
 }
 
 const defaultQueueTimeout = 60 * time.Second
@@ -273,6 +295,13 @@ func (r *Router) HandlerFunc() gin.HandlerFunc {
 		if c.Request.Method == http.MethodGet &&
 			(c.Request.URL.Path == "/v1/models" || c.Request.URL.Path == "/models") {
 			r.ListModels(c)
+			return
+		}
+
+		// Handle /v1/files (OpenAI-compatible Files API for batch jobs).
+		// Must run before ParseModelRequest: uploads are multipart and have no "model" field.
+		if batch.IsFilesPath(c.Request.URL.Path) {
+			r.HandleFiles(c)
 			return
 		}
 
@@ -888,6 +917,22 @@ func (r *Router) ListModels(c *gin.Context) {
 		Object: "list",
 		Data:   data,
 	})
+}
+
+// HandleFiles implements the OpenAI-compatible /v1/files endpoints.
+// Like ListModels, this is control-plane traffic and never enters doLoadbalance.
+func (r *Router) HandleFiles(c *gin.Context) {
+	if r.filesHandler == nil {
+		c.AbortWithStatusJSON(http.StatusServiceUnavailable, batch.ErrorBody{
+			Error: batch.ErrorDetail{
+				Message: fmt.Sprintf("batch files API is disabled; set %s to enable", batch.EnvFilesDir),
+				Type:    "server_error",
+				Code:    "files_disabled",
+			},
+		})
+		return
+	}
+	r.filesHandler.ServeHTTP(c)
 }
 
 func (r *Router) Auth() gin.HandlerFunc {

--- a/pkg/kthena-router/router/router_test.go
+++ b/pkg/kthena-router/router/router_test.go
@@ -23,6 +23,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -48,6 +49,7 @@ import (
 
 	aiv1alpha1 "github.com/volcano-sh/kthena/pkg/apis/networking/v1alpha1"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/accesslog"
+	"github.com/volcano-sh/kthena/pkg/kthena-router/batch"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/common"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/connectors"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/datastore"
@@ -1651,6 +1653,81 @@ func TestRouter_HandlerFunc_ListModels_Empty(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "list", resp.Object)
 	assert.Empty(t, resp.Data)
+}
+
+func TestRouter_HandlerFunc_Files_UploadAndGet(t *testing.T) {
+	router, _, backend := setupTestRouter(t, nil)
+	defer backend.Close()
+
+	store, err := batch.NewLocalFileStore(batch.Config{
+		FilesDir:     t.TempDir(),
+		MaxFileBytes: batch.DefaultMaxFileBytes,
+		BatchTTL:     time.Hour,
+	})
+	assert.NoError(t, err)
+	router.filesHandler = batch.NewHandler(store)
+
+	payload := `{"custom_id":"1","method":"POST","url":"/v1/chat/completions","body":{"model":"m"}}`
+	var body bytes.Buffer
+	mw := multipart.NewWriter(&body)
+	assert.NoError(t, mw.WriteField(batch.FormFieldPurpose, batch.PurposeBatch))
+	part, err := mw.CreateFormFile(batch.FormFieldFile, "requests.jsonl")
+	assert.NoError(t, err)
+	_, err = io.Copy(part, strings.NewReader(payload))
+	assert.NoError(t, err)
+	assert.NoError(t, mw.Close())
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request, _ = http.NewRequest(http.MethodPost, batch.PathV1Files, &body)
+	c.Request.Header.Set("Content-Type", mw.FormDataContentType())
+
+	router.HandlerFunc()(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var uploaded batch.FileObject
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &uploaded))
+	assert.Equal(t, batch.ObjectFile, uploaded.Object)
+	assert.Equal(t, batch.PurposeBatch, uploaded.Purpose)
+	assert.True(t, strings.HasPrefix(uploaded.ID, batch.FileIDPrefix))
+
+	w = httptest.NewRecorder()
+	c, _ = gin.CreateTestContext(w)
+	c.Request, _ = http.NewRequest(http.MethodGet, batch.PathV1Files+"/"+uploaded.ID, nil)
+	router.HandlerFunc()(c)
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestRouter_HandlerFunc_Files_DisabledWithoutStore(t *testing.T) {
+	router, _, backend := setupTestRouter(t, nil)
+	defer backend.Close()
+	router.filesHandler = batch.NewHandler(nil)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request, _ = http.NewRequest(http.MethodGet, batch.PathV1Files, nil)
+	router.HandlerFunc()(c)
+
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+}
+
+func TestRouter_HandlerFunc_Files_DoesNotRequireModelField(t *testing.T) {
+	// Proves Files early-return never reaches ParseModelRequest (which requires "model").
+	router, _, backend := setupTestRouter(t, nil)
+	defer backend.Close()
+	store, err := batch.NewLocalFileStore(batch.Config{
+		FilesDir:     t.TempDir(),
+		MaxFileBytes: 1024,
+		BatchTTL:     time.Hour,
+	})
+	assert.NoError(t, err)
+	router.filesHandler = batch.NewHandler(store)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request, _ = http.NewRequest(http.MethodGet, batch.PathV1Files, nil)
+	router.HandlerFunc()(c)
+	assert.Equal(t, http.StatusOK, w.Code)
 }
 
 // Helper function to parse boolean (same logic as strconv.ParseBool but simpler for test)


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Adds OpenAI-compatible `/v1/files` support in `kthena-router` as the foundation for Batch API workloads.

- Upload / list / get / content / delete for files with `purpose=batch`
- Local filesystem store behind a pluggable `FileStore` interface
- Wired early in the router handler path (same pattern as `/v1/models`), before model request parsing
- Enabled when `KTHENA_BATCH_FILES_DIR` is set; optional `KTHENA_BATCH_MAX_FILE_BYTES` (default 200MiB) and `KTHENA_BATCH_FILE_TTL` (default 30d)

This unlocks offline batch input/output file management inside the router (no separate service) and prepares for the follow-up `/v1/batches` + worker PR.

**Which issue(s) this PR fixes**:
Fixes #

**Bug evidence (required for bug-related PRs)**:
N/A

**Special notes for your reviewer**:

- Feature is opt-in via `KTHENA_BATCH_FILES_DIR`; with it unset, `/v1/files` is not enabled
- Storage is local-disk only in this PR (S3/SQL deferred)
- Upload limited to `purpose=batch`
- Unit tests cover store + HTTP handlers + router routing
- Follow-up PR: `/v1/batches` API and in-router async worker

**Does this PR introduce a user-facing change?**:

```release-note
Add OpenAI-compatible /v1/files API in kthena-router for batch file upload, list, get, content, and delete (enabled via KTHENA_BATCH_FILES_DIR).