### PR TITLE
Feat/OpenAI batch api

### DIFF
--- a/pkg/kthena-router/batch/batches.go
+++ b/pkg/kthena-router/batch/batches.go
@@ -7,7 +7,7 @@ You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 
-    10|Unless required by applicable law or agreed to in writing, software
+Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
@@ -17,6 +17,7 @@ limitations under the License.
 package batch
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -32,12 +33,12 @@ import (
 type BatchesHandler struct {
 	files   FileStore
 	batches BatchStore
-	enqueue func(batchID string)
+	enqueue func(ctx context.Context, batchID string) error
 }
 
 // NewBatchesHandler returns a batches HTTP handler.
 // enqueue is called after a batch is created (nil-safe).
-func NewBatchesHandler(files FileStore, batches BatchStore, enqueue func(batchID string)) *BatchesHandler {
+func NewBatchesHandler(files FileStore, batches BatchStore, enqueue func(ctx context.Context, batchID string) error) *BatchesHandler {
 	return &BatchesHandler{files: files, batches: batches, enqueue: enqueue}
 }
 
@@ -149,7 +150,10 @@ func (h *BatchesHandler) create(c *gin.Context) {
 
 	klog.V(4).Infof("created batch id=%s input_file_id=%s endpoint=%s", created.ID, created.InputFileID, created.Endpoint)
 	if h.enqueue != nil {
-		h.enqueue(created.ID)
+		if err := h.enqueue(c.Request.Context(), created.ID); err != nil {
+			abortFromStoreError(c, err)
+			return
+		}
 	}
 	c.JSON(http.StatusOK, created)
 }
@@ -245,7 +249,8 @@ func (h *BatchesHandler) cancel(c *gin.Context, id string) {
 		return
 	}
 	if h.enqueue != nil {
-		h.enqueue(updated.ID)
+		// Best-effort wake of the worker; cancel is already persisted.
+		_ = h.enqueue(c.Request.Context(), updated.ID)
 	}
 	c.JSON(http.StatusOK, updated)
 }

--- a/pkg/kthena-router/batch/batches.go
+++ b/pkg/kthena-router/batch/batches.go
@@ -1,0 +1,251 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    10|Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package batch
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"k8s.io/klog/v2"
+)
+
+// BatchesHandler serves OpenAI-compatible /v1/batches endpoints.
+type BatchesHandler struct {
+	files   FileStore
+	batches BatchStore
+	enqueue func(batchID string)
+}
+
+// NewBatchesHandler returns a batches HTTP handler.
+// enqueue is called after a batch is created (nil-safe).
+func NewBatchesHandler(files FileStore, batches BatchStore, enqueue func(batchID string)) *BatchesHandler {
+	return &BatchesHandler{files: files, batches: batches, enqueue: enqueue}
+}
+
+// ServeHTTP dispatches by method and path under /v1/batches or /batches.
+func (h *BatchesHandler) ServeHTTP(c *gin.Context) {
+	if h == nil || h.files == nil || h.batches == nil {
+		abortJSON(c, http.StatusServiceUnavailable, "server_error", "batch_disabled",
+			fmt.Sprintf("batch API is disabled; set %s to enable", EnvFilesDir))
+		return
+	}
+
+	rel, ok := batchesPathSuffix(c.Request.URL.Path)
+	if !ok {
+		abortJSON(c, http.StatusNotFound, "invalid_request_error", "not_found", "not found")
+		return
+	}
+
+	switch {
+	case c.Request.Method == http.MethodPost && rel == "":
+		h.create(c)
+	case c.Request.Method == http.MethodGet && rel == "":
+		h.list(c)
+	case c.Request.Method == http.MethodPost && strings.HasSuffix(rel, CancelSuffix):
+		id := strings.TrimSuffix(rel, CancelSuffix)
+		id = strings.TrimPrefix(id, "/")
+		h.cancel(c, id)
+	case c.Request.Method == http.MethodGet && rel != "":
+		h.get(c, strings.TrimPrefix(rel, "/"))
+	default:
+		abortJSON(c, http.StatusMethodNotAllowed, "invalid_request_error", "method_not_allowed",
+			fmt.Sprintf("method %s not allowed", c.Request.Method))
+	}
+}
+
+// IsBatchesPath reports whether path is an OpenAI Batches API path.
+func IsBatchesPath(path string) bool {
+	_, ok := batchesPathSuffix(path)
+	return ok
+}
+
+func batchesPathSuffix(path string) (string, bool) {
+	switch {
+	case path == PathV1Batches || strings.HasPrefix(path, PathV1Batches+"/"):
+		return strings.TrimPrefix(path, PathV1Batches), true
+	case path == PathBatches || strings.HasPrefix(path, PathBatches+"/"):
+		return strings.TrimPrefix(path, PathBatches), true
+	default:
+		return "", false
+	}
+}
+
+func (h *BatchesHandler) create(c *gin.Context) {
+	var req CreateBatchRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		abortJSON(c, http.StatusBadRequest, "invalid_request_error", "invalid_request",
+			fmt.Sprintf("invalid request body: %v", err))
+		return
+	}
+	if req.InputFileID == "" {
+		abortFromStoreError(c, fmt.Errorf("%w: input_file_id is required", ErrInvalidInputFile))
+		return
+	}
+	if req.CompletionWindow == "" {
+		req.CompletionWindow = CompletionWindow24h
+	}
+	if req.CompletionWindow != CompletionWindow24h {
+		abortFromStoreError(c, fmt.Errorf("%w: %q", ErrInvalidWindow, req.CompletionWindow))
+		return
+	}
+	if !IsBatchEndpointAllowed(req.Endpoint) {
+		abortFromStoreError(c, fmt.Errorf("%w: %q", ErrInvalidEndpoint, req.Endpoint))
+		return
+	}
+
+	fileMeta, err := h.files.Get(c.Request.Context(), req.InputFileID)
+	if err != nil {
+		abortFromStoreError(c, fmt.Errorf("%w: %v", ErrInvalidInputFile, err))
+		return
+	}
+	if fileMeta.Purpose != PurposeBatch {
+		abortFromStoreError(c, fmt.Errorf("%w: file purpose must be %q", ErrInvalidInputFile, PurposeBatch))
+		return
+	}
+
+	now := time.Now().Unix()
+	expiresAt := now + int64(DefaultCompletionWindow.Seconds())
+	batch := &BatchObject{
+		ID:               BatchIDPrefix + uuid.New().String(),
+		Object:           ObjectBatch,
+		Endpoint:         req.Endpoint,
+		Errors:           nil,
+		InputFileID:      req.InputFileID,
+		CompletionWindow: req.CompletionWindow,
+		Status:           StatusValidating,
+		CreatedAt:        now,
+		ExpiresAt:        &expiresAt,
+		RequestCounts:    RequestCounts{},
+		Metadata:         req.Metadata,
+	}
+	if batch.Metadata == nil {
+		batch.Metadata = map[string]string{}
+	}
+
+	created, err := h.batches.Create(c.Request.Context(), batch)
+	if err != nil {
+		abortFromStoreError(c, err)
+		return
+	}
+
+	klog.V(4).Infof("created batch id=%s input_file_id=%s endpoint=%s", created.ID, created.InputFileID, created.Endpoint)
+	if h.enqueue != nil {
+		h.enqueue(created.ID)
+	}
+	c.JSON(http.StatusOK, created)
+}
+
+func (h *BatchesHandler) get(c *gin.Context, id string) {
+	if id == "" {
+		abortFromStoreError(c, ErrBatchNotFound)
+		return
+	}
+	obj, err := h.batches.Get(c.Request.Context(), id)
+	if err != nil {
+		abortFromStoreError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, obj)
+}
+
+func (h *BatchesHandler) list(c *gin.Context) {
+	opts := ListOptions{
+		Order: c.Query(QueryOrder),
+		After: c.Query(QueryAfter),
+		Limit: DefaultListLimit,
+	}
+	if raw := c.Query(QueryLimit); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err != nil || n < MinListLimit || n > MaxListLimit {
+			abortJSON(c, http.StatusBadRequest, "invalid_request_error", "invalid_limit",
+				fmt.Sprintf("limit must be between %d and %d", MinListLimit, MaxListLimit))
+			return
+		}
+		opts.Limit = n
+	}
+	if opts.Order != "" && opts.Order != OrderAsc && opts.Order != OrderDesc {
+		abortJSON(c, http.StatusBadRequest, "invalid_request_error", "invalid_order",
+			fmt.Sprintf("order must be %q or %q", OrderAsc, OrderDesc))
+		return
+	}
+
+	// Fetch one extra to compute has_more.
+	fetchLimit := opts.Limit
+	opts.Limit = fetchLimit + 1
+	items, err := h.batches.List(c.Request.Context(), opts)
+	if err != nil {
+		abortFromStoreError(c, err)
+		return
+	}
+	hasMore := len(items) > fetchLimit
+	if hasMore {
+		items = items[:fetchLimit]
+	}
+	if items == nil {
+		items = []BatchObject{}
+	}
+
+	resp := BatchList{
+		Object:  ObjectList,
+		Data:    items,
+		HasMore: hasMore,
+	}
+	if len(items) > 0 {
+		resp.FirstID = items[0].ID
+		resp.LastID = items[len(items)-1].ID
+	}
+	c.JSON(http.StatusOK, resp)
+}
+
+func (h *BatchesHandler) cancel(c *gin.Context, id string) {
+	if id == "" {
+		abortFromStoreError(c, ErrBatchNotFound)
+		return
+	}
+	obj, err := h.batches.Get(c.Request.Context(), id)
+	if err != nil {
+		abortFromStoreError(c, err)
+		return
+	}
+
+	switch obj.Status {
+	case StatusCompleted, StatusFailed, StatusExpired, StatusCancelled:
+		abortFromStoreError(c, fmt.Errorf("%w: status=%s", ErrNotCancellable, obj.Status))
+		return
+	case StatusCancelling:
+		c.JSON(http.StatusOK, obj)
+		return
+	}
+
+	now := time.Now().Unix()
+	obj.Status = StatusCancelling
+	obj.CancellingAt = &now
+	updated, err := h.batches.Update(c.Request.Context(), obj)
+	if err != nil {
+		abortFromStoreError(c, err)
+		return
+	}
+	if h.enqueue != nil {
+		h.enqueue(updated.ID)
+	}
+	c.JSON(http.StatusOK, updated)
+}

--- a/pkg/kthena-router/batch/batches_test.go
+++ b/pkg/kthena-router/batch/batches_test.go
@@ -7,7 +7,7 @@ You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 
-    10|Unless required by applicable law or agreed to in writing, software
+Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
@@ -42,7 +42,10 @@ func TestBatchesHandler_CreateGetListCancel(t *testing.T) {
 	jobs := NewMemoryBatchStore()
 
 	var enqueued []string
-	h := NewBatchesHandler(files, jobs, func(id string) { enqueued = append(enqueued, id) })
+	h := NewBatchesHandler(files, jobs, func(ctx context.Context, id string) error {
+		enqueued = append(enqueued, id)
+		return nil
+	})
 
 	line := `{"custom_id":"1","method":"POST","url":"/v1/chat/completions","body":{"model":"m","messages":[{"role":"user","content":"hi"}]}}`
 	fileObj, err := files.Create(context.Background(), "in.jsonl", PurposeBatch, strings.NewReader(line+"\n"))

--- a/pkg/kthena-router/batch/batches_test.go
+++ b/pkg/kthena-router/batch/batches_test.go
@@ -1,0 +1,123 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    10|Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package batch
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestBatchesHandler_CreateGetListCancel(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	files, err := NewLocalFileStore(Config{
+		FilesDir:     t.TempDir(),
+		MaxFileBytes: 1024 * 1024,
+		BatchTTL:     time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("NewLocalFileStore: %v", err)
+	}
+	jobs := NewMemoryBatchStore()
+
+	var enqueued []string
+	h := NewBatchesHandler(files, jobs, func(id string) { enqueued = append(enqueued, id) })
+
+	line := `{"custom_id":"1","method":"POST","url":"/v1/chat/completions","body":{"model":"m","messages":[{"role":"user","content":"hi"}]}}`
+	fileObj, err := files.Create(context.Background(), "in.jsonl", PurposeBatch, strings.NewReader(line+"\n"))
+	if err != nil {
+		t.Fatalf("Create file: %v", err)
+	}
+
+	body, _ := json.Marshal(CreateBatchRequest{
+		InputFileID:      fileObj.ID,
+		Endpoint:         EndpointChatCompletions,
+		CompletionWindow: CompletionWindow24h,
+	})
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, PathV1Batches, bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	h.ServeHTTP(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("create status=%d body=%s", w.Code, w.Body.String())
+	}
+	var created BatchObject
+	if err := json.Unmarshal(w.Body.Bytes(), &created); err != nil {
+		t.Fatalf("create json: %v", err)
+	}
+	if created.Status != StatusValidating || !strings.HasPrefix(created.ID, BatchIDPrefix) {
+		t.Fatalf("unexpected batch: %+v", created)
+	}
+	if len(enqueued) != 1 || enqueued[0] != created.ID {
+		t.Fatalf("enqueue=%v", enqueued)
+	}
+
+	w = httptest.NewRecorder()
+	c, _ = gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, PathV1Batches+"/"+created.ID, nil)
+	h.ServeHTTP(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("get status=%d", w.Code)
+	}
+
+	w = httptest.NewRecorder()
+	c, _ = gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, PathV1Batches, nil)
+	h.ServeHTTP(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("list status=%d", w.Code)
+	}
+
+	w = httptest.NewRecorder()
+	c, _ = gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, PathV1Batches+"/"+created.ID+CancelSuffix, nil)
+	h.ServeHTTP(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("cancel status=%d body=%s", w.Code, w.Body.String())
+	}
+	var cancelled BatchObject
+	_ = json.Unmarshal(w.Body.Bytes(), &cancelled)
+	if cancelled.Status != StatusCancelling {
+		t.Fatalf("status=%s", cancelled.Status)
+	}
+}
+
+func TestBatchesPathSuffix(t *testing.T) {
+	tests := []struct {
+		path   string
+		wantOK bool
+	}{
+		{PathV1Batches, true},
+		{PathV1Batches + "/batch_1", true},
+		{PathV1Batches + "/batch_1/cancel", true},
+		{PathBatches, true},
+		{"/v1/files", false},
+	}
+	for _, tt := range tests {
+		if _, ok := batchesPathSuffix(tt.path); ok != tt.wantOK {
+			t.Fatalf("path=%s ok=%v want %v", tt.path, ok, tt.wantOK)
+		}
+	}
+}

--- a/pkg/kthena-router/batch/config.go
+++ b/pkg/kthena-router/batch/config.go
@@ -7,7 +7,7 @@ You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 
-    10|Unless required by applicable law or agreed to in writing, software
+Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and

--- a/pkg/kthena-router/batch/config.go
+++ b/pkg/kthena-router/batch/config.go
@@ -7,7 +7,7 @@ You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
+    10|Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
@@ -24,27 +24,29 @@ import (
 	"k8s.io/klog/v2"
 )
 
-// Config holds runtime settings for the Files API storage backend.
-// Empty FilesDir disables the API (store is not constructed).
+// Config holds runtime settings for Files + Batches.
+// Empty FilesDir disables the APIs (stores are not constructed).
 type Config struct {
-	FilesDir     string
-	MaxFileBytes int64
-	BatchTTL     time.Duration
+	FilesDir                 string
+	MaxFileBytes             int64
+	BatchTTL                 time.Duration
+	MaxConcurrency           int
+	InteractiveBusyThreshold int64
 }
 
-// Enabled reports whether file storage is configured.
+// Enabled reports whether batch storage is configured.
 func (c Config) Enabled() bool {
 	return c.FilesDir != ""
 }
 
-// LoadConfigFromEnv reads batch file settings from the environment.
-// Missing or invalid values fall back to named defaults (same pattern as
-// fairness / access-log env parsing in the router).
+// LoadConfigFromEnv reads batch settings from the environment.
 func LoadConfigFromEnv() Config {
 	cfg := Config{
-		FilesDir:     os.Getenv(EnvFilesDir),
-		MaxFileBytes: DefaultMaxFileBytes,
-		BatchTTL:     DefaultBatchTTL,
+		FilesDir:                 os.Getenv(EnvFilesDir),
+		MaxFileBytes:             DefaultMaxFileBytes,
+		BatchTTL:                 DefaultBatchTTL,
+		MaxConcurrency:           DefaultMaxConcurrency,
+		InteractiveBusyThreshold: DefaultInteractiveBusyThreshold,
 	}
 
 	if s, ok := os.LookupEnv(EnvMaxFileBytes); ok && s != "" {
@@ -62,6 +64,24 @@ func LoadConfigFromEnv() Config {
 			klog.Warningf("Invalid %s %q, using default %v", EnvBatchTTL, s, DefaultBatchTTL)
 		} else {
 			cfg.BatchTTL = d
+		}
+	}
+
+	if s, ok := os.LookupEnv(EnvMaxConcurrency); ok && s != "" {
+		v, err := strconv.Atoi(s)
+		if err != nil || v <= 0 {
+			klog.Warningf("Invalid %s %q, using default %d", EnvMaxConcurrency, s, DefaultMaxConcurrency)
+		} else {
+			cfg.MaxConcurrency = v
+		}
+	}
+
+	if s, ok := os.LookupEnv(EnvInteractiveBusy); ok && s != "" {
+		v, err := strconv.ParseInt(s, 10, 64)
+		if err != nil || v < 0 {
+			klog.Warningf("Invalid %s %q, using default %d", EnvInteractiveBusy, s, DefaultInteractiveBusyThreshold)
+		} else {
+			cfg.InteractiveBusyThreshold = v
 		}
 	}
 

--- a/pkg/kthena-router/batch/config.go
+++ b/pkg/kthena-router/batch/config.go
@@ -1,0 +1,69 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package batch
+
+import (
+	"os"
+	"strconv"
+	"time"
+
+	"k8s.io/klog/v2"
+)
+
+// Config holds runtime settings for the Files API storage backend.
+// Empty FilesDir disables the API (store is not constructed).
+type Config struct {
+	FilesDir     string
+	MaxFileBytes int64
+	BatchTTL     time.Duration
+}
+
+// Enabled reports whether file storage is configured.
+func (c Config) Enabled() bool {
+	return c.FilesDir != ""
+}
+
+// LoadConfigFromEnv reads batch file settings from the environment.
+// Missing or invalid values fall back to named defaults (same pattern as
+// fairness / access-log env parsing in the router).
+func LoadConfigFromEnv() Config {
+	cfg := Config{
+		FilesDir:     os.Getenv(EnvFilesDir),
+		MaxFileBytes: DefaultMaxFileBytes,
+		BatchTTL:     DefaultBatchTTL,
+	}
+
+	if s, ok := os.LookupEnv(EnvMaxFileBytes); ok && s != "" {
+		v, err := strconv.ParseInt(s, 10, 64)
+		if err != nil || v <= 0 {
+			klog.Warningf("Invalid %s %q, using default %d", EnvMaxFileBytes, s, DefaultMaxFileBytes)
+		} else {
+			cfg.MaxFileBytes = v
+		}
+	}
+
+	if s, ok := os.LookupEnv(EnvBatchTTL); ok && s != "" {
+		d, err := time.ParseDuration(s)
+		if err != nil || d <= 0 {
+			klog.Warningf("Invalid %s %q, using default %v", EnvBatchTTL, s, DefaultBatchTTL)
+		} else {
+			cfg.BatchTTL = d
+		}
+	}
+
+	return cfg
+}

--- a/pkg/kthena-router/batch/constants.go
+++ b/pkg/kthena-router/batch/constants.go
@@ -7,7 +7,7 @@ You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
+    10|Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
@@ -18,29 +18,26 @@ package batch
 
 import "time"
 
-// OpenAI-compatible Files API path segments and object identifiers.
+// OpenAI-compatible Files / Batches API path segments and object identifiers.
 const (
-	// PathV1Files is the full path used when the catch-all listener sees the
-	// complete URL (gateway mode). PathFiles is used when Gin mounts under
-	// Group("/v1") and the remaining path is "/files" (default listener).
-	PathV1Files = "/v1/files"
-	PathFiles   = "/files"
+	PathV1Files   = "/v1/files"
+	PathFiles     = "/files"
+	PathV1Batches = "/v1/batches"
+	PathBatches   = "/batches"
 
-	ObjectFile = "file"
-	ObjectList = "list"
+	ObjectFile  = "file"
+	ObjectList  = "list"
+	ObjectBatch = "batch"
 
-	FileIDPrefix = "file-"
+	FileIDPrefix  = "file-"
+	BatchIDPrefix = "batch_"
 
-	// Multipart form field names for POST /v1/files.
 	FormFieldFile    = "file"
 	FormFieldPurpose = "purpose"
 
-	// Supported upload purposes for this slice. batch_output is reserved for
-	// files produced by the future batch worker (not accepted on upload).
 	PurposeBatch       = "batch"
 	PurposeBatchOutput = "batch_output"
 
-	// Query parameter names for GET /v1/files.
 	QueryPurpose = "purpose"
 	QueryLimit   = "limit"
 	QueryOrder   = "order"
@@ -50,21 +47,39 @@ const (
 	OrderDesc = "desc"
 
 	ContentSuffix = "/content"
+	CancelSuffix  = "/cancel"
+
+	StatusValidating = "validating"
+	StatusFailed     = "failed"
+	StatusInProgress = "in_progress"
+	StatusFinalizing = "finalizing"
+	StatusCompleted  = "completed"
+	StatusExpired    = "expired"
+	StatusCancelling = "cancelling"
+	StatusCancelled  = "cancelled"
+
+	CompletionWindow24h = "24h"
+
+	EndpointChatCompletions = "/v1/chat/completions"
+	EndpointCompletions     = "/v1/completions"
 )
 
-// Environment variable keys for batch file storage configuration.
 const (
-	EnvFilesDir     = "KTHENA_BATCH_FILES_DIR"
-	EnvMaxFileBytes = "KTHENA_BATCH_MAX_FILE_BYTES"
-	EnvBatchTTL     = "KTHENA_BATCH_FILE_TTL"
+	EnvFilesDir        = "KTHENA_BATCH_FILES_DIR"
+	EnvMaxFileBytes    = "KTHENA_BATCH_MAX_FILE_BYTES"
+	EnvBatchTTL        = "KTHENA_BATCH_FILE_TTL"
+	EnvMaxConcurrency  = "KTHENA_BATCH_MAX_CONCURRENCY"
+	EnvInteractiveBusy = "KTHENA_BATCH_INTERACTIVE_BUSY_THRESHOLD"
 )
 
-// Named defaults. Values mirror OpenAI Batch Files limits where applicable
-// (JSONL inputs up to 200 MiB; batch files expire after 30 days).
 const (
-	DefaultMaxFileBytes int64 = 200 * 1024 * 1024
-	DefaultBatchTTL           = 30 * 24 * time.Hour
-	DefaultListLimit          = 10000
-	MinListLimit              = 1
-	MaxListLimit              = 10000
+	DefaultMaxFileBytes             int64 = 200 * 1024 * 1024
+	DefaultBatchTTL                       = 30 * 24 * time.Hour
+	DefaultCompletionWindow               = 24 * time.Hour
+	DefaultMaxConcurrency                 = 4
+	DefaultInteractiveBusyThreshold int64 = 32
+	DefaultListLimit                      = 10000
+	MinListLimit                          = 1
+	MaxListLimit                          = 10000
+	DefaultMaxRequestsPerBatch            = 50000
 )

--- a/pkg/kthena-router/batch/constants.go
+++ b/pkg/kthena-router/batch/constants.go
@@ -1,0 +1,70 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package batch
+
+import "time"
+
+// OpenAI-compatible Files API path segments and object identifiers.
+const (
+	// PathV1Files is the full path used when the catch-all listener sees the
+	// complete URL (gateway mode). PathFiles is used when Gin mounts under
+	// Group("/v1") and the remaining path is "/files" (default listener).
+	PathV1Files = "/v1/files"
+	PathFiles   = "/files"
+
+	ObjectFile = "file"
+	ObjectList = "list"
+
+	FileIDPrefix = "file-"
+
+	// Multipart form field names for POST /v1/files.
+	FormFieldFile    = "file"
+	FormFieldPurpose = "purpose"
+
+	// Supported upload purposes for this slice. batch_output is reserved for
+	// files produced by the future batch worker (not accepted on upload).
+	PurposeBatch       = "batch"
+	PurposeBatchOutput = "batch_output"
+
+	// Query parameter names for GET /v1/files.
+	QueryPurpose = "purpose"
+	QueryLimit   = "limit"
+	QueryOrder   = "order"
+	QueryAfter   = "after"
+
+	OrderAsc  = "asc"
+	OrderDesc = "desc"
+
+	ContentSuffix = "/content"
+)
+
+// Environment variable keys for batch file storage configuration.
+const (
+	EnvFilesDir     = "KTHENA_BATCH_FILES_DIR"
+	EnvMaxFileBytes = "KTHENA_BATCH_MAX_FILE_BYTES"
+	EnvBatchTTL     = "KTHENA_BATCH_FILE_TTL"
+)
+
+// Named defaults. Values mirror OpenAI Batch Files limits where applicable
+// (JSONL inputs up to 200 MiB; batch files expire after 30 days).
+const (
+	DefaultMaxFileBytes int64 = 200 * 1024 * 1024
+	DefaultBatchTTL           = 30 * 24 * time.Hour
+	DefaultListLimit          = 10000
+	MinListLimit              = 1
+	MaxListLimit              = 10000
+)

--- a/pkg/kthena-router/batch/constants.go
+++ b/pkg/kthena-router/batch/constants.go
@@ -7,7 +7,7 @@ You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 
-    10|Unless required by applicable law or agreed to in writing, software
+Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
@@ -82,4 +82,10 @@ const (
 	MinListLimit                          = 1
 	MaxListLimit                          = 10000
 	DefaultMaxRequestsPerBatch            = 50000
+
+	DefaultWorkerQueueSize  = 256
+	DefaultScannerBufSize   = 64 * 1024
+	DefaultScannerMaxToken  = 1024 * 1024
+	DefaultBusyPollInterval = 200 * time.Millisecond
+	BatchRequestIDPrefix    = "batch_req_"
 )

--- a/pkg/kthena-router/batch/errors.go
+++ b/pkg/kthena-router/batch/errors.go
@@ -7,7 +7,7 @@ You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
+    10|Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
@@ -26,18 +26,21 @@ import (
 	"github.com/volcano-sh/kthena/pkg/kthena-router/accesslog"
 )
 
-// Sentinel errors for store and handler mapping.
 var (
-	ErrNotFound      = errors.New("file not found")
-	ErrDisabled      = errors.New("batch files API is disabled")
-	ErrInvalidPurpose = errors.New("unsupported file purpose")
-	ErrMissingFile   = errors.New("missing file upload")
-	ErrMissingPurpose = errors.New("missing purpose")
-	ErrTooLarge      = errors.New("file exceeds maximum size")
-	ErrEmptyFile     = errors.New("file is empty")
+	ErrNotFound         = errors.New("file not found")
+	ErrBatchNotFound    = errors.New("batch not found")
+	ErrDisabled         = errors.New("batch API is disabled")
+	ErrInvalidPurpose   = errors.New("unsupported file purpose")
+	ErrMissingFile      = errors.New("missing file upload")
+	ErrMissingPurpose   = errors.New("missing purpose")
+	ErrTooLarge         = errors.New("file exceeds maximum size")
+	ErrEmptyFile        = errors.New("file is empty")
+	ErrInvalidEndpoint  = errors.New("unsupported batch endpoint")
+	ErrInvalidWindow    = errors.New("unsupported completion_window")
+	ErrInvalidInputFile = errors.New("invalid input_file_id")
+	ErrNotCancellable   = errors.New("batch cannot be cancelled in its current status")
 )
 
-// abortJSON writes an OpenAI-shaped error and records it on the access log.
 func abortJSON(c *gin.Context, status int, errType, code, message string) {
 	accesslog.SetError(c, errType, message)
 	c.AbortWithStatusJSON(status, ErrorBody{
@@ -51,13 +54,14 @@ func abortJSON(c *gin.Context, status int, errType, code, message string) {
 
 func abortFromStoreError(c *gin.Context, err error) {
 	switch {
-	case errors.Is(err, ErrNotFound):
-		abortJSON(c, http.StatusNotFound, "invalid_request_error", "file_not_found", err.Error())
+	case errors.Is(err, ErrNotFound), errors.Is(err, ErrBatchNotFound):
+		abortJSON(c, http.StatusNotFound, "invalid_request_error", "not_found", err.Error())
 	case errors.Is(err, ErrDisabled):
-		abortJSON(c, http.StatusServiceUnavailable, "server_error", "files_disabled", err.Error())
-	case errors.Is(err, ErrInvalidPurpose):
-		abortJSON(c, http.StatusBadRequest, "invalid_request_error", "invalid_purpose", err.Error())
-	case errors.Is(err, ErrMissingFile), errors.Is(err, ErrMissingPurpose), errors.Is(err, ErrEmptyFile):
+		abortJSON(c, http.StatusServiceUnavailable, "server_error", "batch_disabled", err.Error())
+	case errors.Is(err, ErrInvalidPurpose), errors.Is(err, ErrInvalidEndpoint),
+		errors.Is(err, ErrInvalidWindow), errors.Is(err, ErrInvalidInputFile),
+		errors.Is(err, ErrMissingFile), errors.Is(err, ErrMissingPurpose),
+		errors.Is(err, ErrEmptyFile), errors.Is(err, ErrNotCancellable):
 		abortJSON(c, http.StatusBadRequest, "invalid_request_error", "invalid_request", err.Error())
 	case errors.Is(err, ErrTooLarge):
 		abortJSON(c, http.StatusRequestEntityTooLarge, "invalid_request_error", "file_too_large", err.Error())
@@ -69,4 +73,14 @@ func abortFromStoreError(c *gin.Context, err error) {
 // IsUploadPurposeAllowed reports whether purpose is accepted on POST /v1/files.
 func IsUploadPurposeAllowed(purpose string) bool {
 	return purpose == PurposeBatch
+}
+
+// IsStoredPurposeAllowed reports whether purpose may be persisted by FileStore.
+func IsStoredPurposeAllowed(purpose string) bool {
+	return purpose == PurposeBatch || purpose == PurposeBatchOutput
+}
+
+// IsBatchEndpointAllowed reports whether endpoint is supported by the worker.
+func IsBatchEndpointAllowed(endpoint string) bool {
+	return endpoint == EndpointChatCompletions || endpoint == EndpointCompletions
 }

--- a/pkg/kthena-router/batch/errors.go
+++ b/pkg/kthena-router/batch/errors.go
@@ -7,7 +7,7 @@ You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 
-    10|Unless required by applicable law or agreed to in writing, software
+Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
@@ -39,6 +39,7 @@ var (
 	ErrInvalidWindow    = errors.New("unsupported completion_window")
 	ErrInvalidInputFile = errors.New("invalid input_file_id")
 	ErrNotCancellable   = errors.New("batch cannot be cancelled in its current status")
+	ErrEnqueueTimeout   = errors.New("batch worker queue is full")
 )
 
 func abortJSON(c *gin.Context, status int, errType, code, message string) {
@@ -63,6 +64,8 @@ func abortFromStoreError(c *gin.Context, err error) {
 		errors.Is(err, ErrMissingFile), errors.Is(err, ErrMissingPurpose),
 		errors.Is(err, ErrEmptyFile), errors.Is(err, ErrNotCancellable):
 		abortJSON(c, http.StatusBadRequest, "invalid_request_error", "invalid_request", err.Error())
+	case errors.Is(err, ErrEnqueueTimeout):
+		abortJSON(c, http.StatusServiceUnavailable, "server_error", "queue_full", err.Error())
 	case errors.Is(err, ErrTooLarge):
 		abortJSON(c, http.StatusRequestEntityTooLarge, "invalid_request_error", "file_too_large", err.Error())
 	default:

--- a/pkg/kthena-router/batch/errors.go
+++ b/pkg/kthena-router/batch/errors.go
@@ -1,0 +1,72 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package batch
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/volcano-sh/kthena/pkg/kthena-router/accesslog"
+)
+
+// Sentinel errors for store and handler mapping.
+var (
+	ErrNotFound      = errors.New("file not found")
+	ErrDisabled      = errors.New("batch files API is disabled")
+	ErrInvalidPurpose = errors.New("unsupported file purpose")
+	ErrMissingFile   = errors.New("missing file upload")
+	ErrMissingPurpose = errors.New("missing purpose")
+	ErrTooLarge      = errors.New("file exceeds maximum size")
+	ErrEmptyFile     = errors.New("file is empty")
+)
+
+// abortJSON writes an OpenAI-shaped error and records it on the access log.
+func abortJSON(c *gin.Context, status int, errType, code, message string) {
+	accesslog.SetError(c, errType, message)
+	c.AbortWithStatusJSON(status, ErrorBody{
+		Error: ErrorDetail{
+			Message: message,
+			Type:    errType,
+			Code:    code,
+		},
+	})
+}
+
+func abortFromStoreError(c *gin.Context, err error) {
+	switch {
+	case errors.Is(err, ErrNotFound):
+		abortJSON(c, http.StatusNotFound, "invalid_request_error", "file_not_found", err.Error())
+	case errors.Is(err, ErrDisabled):
+		abortJSON(c, http.StatusServiceUnavailable, "server_error", "files_disabled", err.Error())
+	case errors.Is(err, ErrInvalidPurpose):
+		abortJSON(c, http.StatusBadRequest, "invalid_request_error", "invalid_purpose", err.Error())
+	case errors.Is(err, ErrMissingFile), errors.Is(err, ErrMissingPurpose), errors.Is(err, ErrEmptyFile):
+		abortJSON(c, http.StatusBadRequest, "invalid_request_error", "invalid_request", err.Error())
+	case errors.Is(err, ErrTooLarge):
+		abortJSON(c, http.StatusRequestEntityTooLarge, "invalid_request_error", "file_too_large", err.Error())
+	default:
+		abortJSON(c, http.StatusInternalServerError, "server_error", "internal_error", fmt.Sprintf("internal error: %v", err))
+	}
+}
+
+// IsUploadPurposeAllowed reports whether purpose is accepted on POST /v1/files.
+func IsUploadPurposeAllowed(purpose string) bool {
+	return purpose == PurposeBatch
+}

--- a/pkg/kthena-router/batch/files.go
+++ b/pkg/kthena-router/batch/files.go
@@ -31,12 +31,21 @@ import (
 // It is analogous to Router.ListModels: a dedicated control-plane handler that
 // does not enter ParseModelRequest / doLoadbalance.
 type Handler struct {
-	store FileStore
+	store        FileStore
+	maxFileBytes int64
 }
 
 // NewHandler returns a Files API handler. store may be nil (feature disabled).
 func NewHandler(store FileStore) *Handler {
-	return &Handler{store: store}
+	return NewHandlerWithLimits(store, DefaultMaxFileBytes)
+}
+
+// NewHandlerWithLimits returns a Files API handler with an explicit upload size cap.
+func NewHandlerWithLimits(store FileStore, maxFileBytes int64) *Handler {
+	if maxFileBytes <= 0 {
+		maxFileBytes = DefaultMaxFileBytes
+	}
+	return &Handler{store: store, maxFileBytes: maxFileBytes}
 }
 
 // ServeHTTP dispatches by method and path suffix under /v1/files or /files.
@@ -97,6 +106,12 @@ func filesPathSuffix(path string) (string, bool) {
 }
 
 func (h *Handler) upload(c *gin.Context) {
+	// Bound multipart parse memory/disk before reading form fields/file.
+	if err := c.Request.ParseMultipartForm(h.maxFileBytes); err != nil {
+		abortFromStoreError(c, fmt.Errorf("%w: %v", ErrTooLarge, err))
+		return
+	}
+
 	purpose := c.PostForm(FormFieldPurpose)
 	if purpose == "" {
 		abortFromStoreError(c, ErrMissingPurpose)
@@ -110,6 +125,10 @@ func (h *Handler) upload(c *gin.Context) {
 	fileHeader, err := c.FormFile(FormFieldFile)
 	if err != nil {
 		abortFromStoreError(c, ErrMissingFile)
+		return
+	}
+	if fileHeader.Size > 0 && fileHeader.Size > h.maxFileBytes {
+		abortFromStoreError(c, fmt.Errorf("%w: max %d bytes", ErrTooLarge, h.maxFileBytes))
 		return
 	}
 
@@ -194,11 +213,22 @@ func (h *Handler) content(c *gin.Context, id string) {
 	defer rc.Close()
 
 	c.Header("Content-Type", "application/octet-stream")
-	c.Header("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, obj.Filename))
+	c.Header("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, safeContentFilename(obj.Filename)))
 	c.Status(http.StatusOK)
 	if _, err := io.Copy(c.Writer, rc); err != nil {
 		klog.Errorf("failed to stream file content id=%s: %v", id, err)
 	}
+}
+
+func safeContentFilename(name string) string {
+	name = strings.ReplaceAll(name, `"`, "")
+	name = strings.ReplaceAll(name, "\r", "")
+	name = strings.ReplaceAll(name, "\n", "")
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "download"
+	}
+	return name
 }
 
 func (h *Handler) delete(c *gin.Context, id string) {

--- a/pkg/kthena-router/batch/files.go
+++ b/pkg/kthena-router/batch/files.go
@@ -1,0 +1,215 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package batch
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"k8s.io/klog/v2"
+)
+
+// Handler serves OpenAI-compatible /v1/files endpoints.
+// It is analogous to Router.ListModels: a dedicated control-plane handler that
+// does not enter ParseModelRequest / doLoadbalance.
+type Handler struct {
+	store FileStore
+}
+
+// NewHandler returns a Files API handler. store may be nil (feature disabled).
+func NewHandler(store FileStore) *Handler {
+	return &Handler{store: store}
+}
+
+// ServeHTTP dispatches by method and path suffix under /v1/files or /files.
+func (h *Handler) ServeHTTP(c *gin.Context) {
+	if h == nil || h.store == nil {
+		abortJSON(c, http.StatusServiceUnavailable, "server_error", "files_disabled",
+			fmt.Sprintf("batch files API is disabled; set %s to enable", EnvFilesDir))
+		return
+	}
+
+	rel, ok := filesPathSuffix(c.Request.URL.Path)
+	if !ok {
+		abortJSON(c, http.StatusNotFound, "invalid_request_error", "not_found", "not found")
+		return
+	}
+
+	switch {
+	case c.Request.Method == http.MethodPost && rel == "":
+		h.upload(c)
+	case c.Request.Method == http.MethodGet && rel == "":
+		h.list(c)
+	case c.Request.Method == http.MethodGet && strings.HasSuffix(rel, ContentSuffix):
+		id := strings.TrimSuffix(rel, ContentSuffix)
+		id = strings.TrimPrefix(id, "/")
+		h.content(c, id)
+	case c.Request.Method == http.MethodGet && rel != "":
+		h.get(c, strings.TrimPrefix(rel, "/"))
+	case c.Request.Method == http.MethodDelete && rel != "":
+		h.delete(c, strings.TrimPrefix(rel, "/"))
+	default:
+		abortJSON(c, http.StatusMethodNotAllowed, "invalid_request_error", "method_not_allowed",
+			fmt.Sprintf("method %s not allowed", c.Request.Method))
+	}
+}
+
+// IsFilesPath reports whether path is an OpenAI Files API path.
+func IsFilesPath(path string) bool {
+	_, ok := filesPathSuffix(path)
+	return ok
+}
+
+// filesPathSuffix returns the path after /v1/files or /files.
+// Examples:
+//
+//	"/v1/files"           -> "", true
+//	"/v1/files/file-1"    -> "/file-1", true
+//	"/files/file-1/content" -> "/file-1/content", true
+//	"/v1/chat/completions" -> "", false
+func filesPathSuffix(path string) (string, bool) {
+	switch {
+	case path == PathV1Files || strings.HasPrefix(path, PathV1Files+"/"):
+		return strings.TrimPrefix(path, PathV1Files), true
+	case path == PathFiles || strings.HasPrefix(path, PathFiles+"/"):
+		return strings.TrimPrefix(path, PathFiles), true
+	default:
+		return "", false
+	}
+}
+
+func (h *Handler) upload(c *gin.Context) {
+	purpose := c.PostForm(FormFieldPurpose)
+	if purpose == "" {
+		abortFromStoreError(c, ErrMissingPurpose)
+		return
+	}
+	if !IsUploadPurposeAllowed(purpose) {
+		abortFromStoreError(c, fmt.Errorf("%w: %q (supported: %s)", ErrInvalidPurpose, purpose, PurposeBatch))
+		return
+	}
+
+	fileHeader, err := c.FormFile(FormFieldFile)
+	if err != nil {
+		abortFromStoreError(c, ErrMissingFile)
+		return
+	}
+
+	src, err := fileHeader.Open()
+	if err != nil {
+		abortJSON(c, http.StatusBadRequest, "invalid_request_error", "invalid_request",
+			fmt.Sprintf("failed to open uploaded file: %v", err))
+		return
+	}
+	defer src.Close()
+
+	obj, err := h.store.Create(c.Request.Context(), fileHeader.Filename, purpose, src)
+	if err != nil {
+		abortFromStoreError(c, err)
+		return
+	}
+
+	klog.V(4).Infof("uploaded batch file id=%s filename=%s bytes=%d", obj.ID, obj.Filename, obj.Bytes)
+	c.JSON(http.StatusOK, obj)
+}
+
+func (h *Handler) list(c *gin.Context) {
+	opts := ListOptions{
+		Purpose: c.Query(QueryPurpose),
+		Order:   c.Query(QueryOrder),
+		After:   c.Query(QueryAfter),
+		Limit:   DefaultListLimit,
+	}
+	if raw := c.Query(QueryLimit); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err != nil || n < MinListLimit || n > MaxListLimit {
+			abortJSON(c, http.StatusBadRequest, "invalid_request_error", "invalid_limit",
+				fmt.Sprintf("limit must be between %d and %d", MinListLimit, MaxListLimit))
+			return
+		}
+		opts.Limit = n
+	}
+	if opts.Order != "" && opts.Order != OrderAsc && opts.Order != OrderDesc {
+		abortJSON(c, http.StatusBadRequest, "invalid_request_error", "invalid_order",
+			fmt.Sprintf("order must be %q or %q", OrderAsc, OrderDesc))
+		return
+	}
+
+	items, err := h.store.List(c.Request.Context(), opts)
+	if err != nil {
+		abortFromStoreError(c, err)
+		return
+	}
+	if items == nil {
+		items = []FileObject{}
+	}
+
+	c.JSON(http.StatusOK, FileList{
+		Object: ObjectList,
+		Data:   items,
+	})
+}
+
+func (h *Handler) get(c *gin.Context, id string) {
+	if id == "" {
+		abortJSON(c, http.StatusNotFound, "invalid_request_error", "file_not_found", ErrNotFound.Error())
+		return
+	}
+	obj, err := h.store.Get(c.Request.Context(), id)
+	if err != nil {
+		abortFromStoreError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, obj)
+}
+
+func (h *Handler) content(c *gin.Context, id string) {
+	if id == "" {
+		abortJSON(c, http.StatusNotFound, "invalid_request_error", "file_not_found", ErrNotFound.Error())
+		return
+	}
+	rc, obj, err := h.store.Open(c.Request.Context(), id)
+	if err != nil {
+		abortFromStoreError(c, err)
+		return
+	}
+	defer rc.Close()
+
+	c.Header("Content-Type", "application/octet-stream")
+	c.Header("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, obj.Filename))
+	c.Status(http.StatusOK)
+	if _, err := io.Copy(c.Writer, rc); err != nil {
+		klog.Errorf("failed to stream file content id=%s: %v", id, err)
+	}
+}
+
+func (h *Handler) delete(c *gin.Context, id string) {
+	if id == "" {
+		abortJSON(c, http.StatusNotFound, "invalid_request_error", "file_not_found", ErrNotFound.Error())
+		return
+	}
+	resp, err := h.store.Delete(c.Request.Context(), id)
+	if err != nil {
+		abortFromStoreError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, resp)
+}

--- a/pkg/kthena-router/batch/files_test.go
+++ b/pkg/kthena-router/batch/files_test.go
@@ -1,0 +1,159 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package batch
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestHandler_UploadListGetContentDelete(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	store, err := NewLocalFileStore(Config{
+		FilesDir:     t.TempDir(),
+		MaxFileBytes: 1024,
+		BatchTTL:     time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("NewLocalFileStore: %v", err)
+	}
+	h := NewHandler(store)
+
+	payload := `{"custom_id":"req-1","method":"POST","url":"/v1/chat/completions","body":{"model":"m"}}`
+	obj := uploadFile(t, h, "requests.jsonl", PurposeBatch, payload)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, PathV1Files, nil)
+	h.ServeHTTP(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("list status=%d body=%s", w.Code, w.Body.String())
+	}
+	var list FileList
+	if err := json.Unmarshal(w.Body.Bytes(), &list); err != nil {
+		t.Fatalf("list json: %v", err)
+	}
+	if list.Object != ObjectList || len(list.Data) != 1 || list.Data[0].ID != obj.ID {
+		t.Fatalf("unexpected list: %+v", list)
+	}
+
+	w = httptest.NewRecorder()
+	c, _ = gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, PathV1Files+"/"+obj.ID, nil)
+	h.ServeHTTP(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("get status=%d body=%s", w.Code, w.Body.String())
+	}
+
+	w = httptest.NewRecorder()
+	c, _ = gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, PathV1Files+"/"+obj.ID+ContentSuffix, nil)
+	h.ServeHTTP(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("content status=%d body=%s", w.Code, w.Body.String())
+	}
+	if w.Body.String() != payload {
+		t.Fatalf("content=%q", w.Body.String())
+	}
+
+	w = httptest.NewRecorder()
+	c, _ = gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodDelete, PathV1Files+"/"+obj.ID, nil)
+	h.ServeHTTP(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("delete status=%d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandler_RejectsUnsupportedPurposeAndDisabledStore(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	store, err := NewLocalFileStore(Config{
+		FilesDir:     t.TempDir(),
+		MaxFileBytes: 1024,
+		BatchTTL:     time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("NewLocalFileStore: %v", err)
+	}
+
+	h := NewHandler(store)
+	body, contentType := multipartBody(t, "a.jsonl", "assistants", "data")
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, PathV1Files, body)
+	c.Request.Header.Set("Content-Type", contentType)
+	h.ServeHTTP(c)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("unsupported purpose status=%d", w.Code)
+	}
+
+	disabled := NewHandler(nil)
+	w = httptest.NewRecorder()
+	c, _ = gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, PathV1Files, nil)
+	disabled.ServeHTTP(c)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("disabled status=%d", w.Code)
+	}
+}
+
+func uploadFile(t *testing.T, h *Handler, filename, purpose, content string) FileObject {
+	t.Helper()
+	body, contentType := multipartBody(t, filename, purpose, content)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, PathV1Files, body)
+	c.Request.Header.Set("Content-Type", contentType)
+	h.ServeHTTP(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("upload status=%d body=%s", w.Code, w.Body.String())
+	}
+	var obj FileObject
+	if err := json.Unmarshal(w.Body.Bytes(), &obj); err != nil {
+		t.Fatalf("upload json: %v", err)
+	}
+	return obj
+}
+
+func multipartBody(t *testing.T, filename, purpose, content string) (io.Reader, string) {
+	t.Helper()
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+	if err := w.WriteField(FormFieldPurpose, purpose); err != nil {
+		t.Fatalf("WriteField purpose: %v", err)
+	}
+	part, err := w.CreateFormFile(FormFieldFile, filename)
+	if err != nil {
+		t.Fatalf("CreateFormFile: %v", err)
+	}
+	if _, err := io.Copy(part, strings.NewReader(content)); err != nil {
+		t.Fatalf("Copy: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	return &buf, w.FormDataContentType()
+}

--- a/pkg/kthena-router/batch/list_util.go
+++ b/pkg/kthena-router/batch/list_util.go
@@ -1,0 +1,71 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package batch
+
+// normalizeListOpts applies list defaults and clamps limit/order.
+func normalizeListOpts(opts ListOptions) (limit int, order string) {
+	limit = opts.Limit
+	if limit <= 0 {
+		limit = DefaultListLimit
+	}
+	if limit < MinListLimit {
+		limit = MinListLimit
+	}
+	if limit > MaxListLimit {
+		limit = MaxListLimit
+	}
+	order = opts.Order
+	if order == "" {
+		order = OrderDesc
+	}
+	return limit, order
+}
+
+// lessCreatedAtID orders by created_at, breaking ties on id.
+func lessCreatedAtID(order string, aCreated, bCreated int64, aID, bID string) bool {
+	if order == OrderAsc {
+		if aCreated == bCreated {
+			return aID < bID
+		}
+		return aCreated < bCreated
+	}
+	if aCreated == bCreated {
+		return aID > bID
+	}
+	return aCreated > bCreated
+}
+
+// applyCursorAfter drops items up to and including the item with id == after.
+func applyCursorAfter[T any](items []T, after string, idFn func(T) string) []T {
+	if after == "" {
+		return items
+	}
+	for i, item := range items {
+		if idFn(item) == after {
+			return items[i+1:]
+		}
+	}
+	return items
+}
+
+// applyLimit truncates items to limit.
+func applyLimit[T any](items []T, limit int) []T {
+	if len(items) > limit {
+		return items[:limit]
+	}
+	return items
+}

--- a/pkg/kthena-router/batch/local_store.go
+++ b/pkg/kthena-router/batch/local_store.go
@@ -1,0 +1,260 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package batch
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"k8s.io/klog/v2"
+)
+
+// LocalFileStore keeps metadata in memory and content on disk under FilesDir.
+type LocalFileStore struct {
+	dir          string
+	maxFileBytes int64
+	batchTTL     time.Duration
+
+	mu    sync.RWMutex
+	files map[string]*storedFile
+}
+
+type storedFile struct {
+	meta     FileObject
+	diskPath string
+}
+
+// NewLocalFileStore creates the storage directory and an empty in-memory index.
+func NewLocalFileStore(cfg Config) (*LocalFileStore, error) {
+	if cfg.FilesDir == "" {
+		return nil, fmt.Errorf("%w: %s is empty", ErrDisabled, EnvFilesDir)
+	}
+	if err := os.MkdirAll(cfg.FilesDir, 0o750); err != nil {
+		return nil, fmt.Errorf("create batch files dir %q: %w", cfg.FilesDir, err)
+	}
+
+	maxBytes := cfg.MaxFileBytes
+	if maxBytes <= 0 {
+		maxBytes = DefaultMaxFileBytes
+	}
+	ttl := cfg.BatchTTL
+	if ttl <= 0 {
+		ttl = DefaultBatchTTL
+	}
+
+	klog.Infof("batch files store enabled: dir=%s maxBytes=%d ttl=%s", cfg.FilesDir, maxBytes, ttl)
+	return &LocalFileStore{
+		dir:          cfg.FilesDir,
+		maxFileBytes: maxBytes,
+		batchTTL:     ttl,
+		files:        make(map[string]*storedFile),
+	}, nil
+}
+
+func (s *LocalFileStore) Create(ctx context.Context, filename, purpose string, r io.Reader) (*FileObject, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if filename == "" {
+		filename = "upload"
+	}
+	if !IsUploadPurposeAllowed(purpose) {
+		return nil, fmt.Errorf("%w: %q", ErrInvalidPurpose, purpose)
+	}
+
+	id := FileIDPrefix + uuid.New().String()
+	diskPath := filepath.Join(s.dir, id)
+
+	f, err := os.OpenFile(diskPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o640)
+	if err != nil {
+		return nil, fmt.Errorf("create file on disk: %w", err)
+	}
+
+	limited := io.LimitReader(r, s.maxFileBytes+1)
+	n, copyErr := io.Copy(f, limited)
+	closeErr := f.Close()
+	if copyErr != nil {
+		_ = os.Remove(diskPath)
+		return nil, fmt.Errorf("write file content: %w", copyErr)
+	}
+	if closeErr != nil {
+		_ = os.Remove(diskPath)
+		return nil, fmt.Errorf("close file content: %w", closeErr)
+	}
+	if n == 0 {
+		_ = os.Remove(diskPath)
+		return nil, ErrEmptyFile
+	}
+	if n > s.maxFileBytes {
+		_ = os.Remove(diskPath)
+		return nil, fmt.Errorf("%w: max %d bytes", ErrTooLarge, s.maxFileBytes)
+	}
+
+	now := time.Now().Unix()
+	expiresAt := now + int64(s.batchTTL.Seconds())
+	meta := FileObject{
+		ID:        id,
+		Object:    ObjectFile,
+		Bytes:     n,
+		CreatedAt: now,
+		Filename:  filename,
+		Purpose:   purpose,
+		ExpiresAt: &expiresAt,
+	}
+
+	s.mu.Lock()
+	s.files[id] = &storedFile{meta: meta, diskPath: diskPath}
+	s.mu.Unlock()
+
+	out := meta
+	return &out, nil
+}
+
+func (s *LocalFileStore) Get(ctx context.Context, id string) (*FileObject, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	sf, ok := s.files[id]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	out := sf.meta
+	return &out, nil
+}
+
+func (s *LocalFileStore) List(ctx context.Context, opts ListOptions) ([]FileObject, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = DefaultListLimit
+	}
+	if limit < MinListLimit {
+		limit = MinListLimit
+	}
+	if limit > MaxListLimit {
+		limit = MaxListLimit
+	}
+
+	order := opts.Order
+	if order == "" {
+		order = OrderDesc
+	}
+
+	s.mu.RLock()
+	items := make([]FileObject, 0, len(s.files))
+	for _, sf := range s.files {
+		if opts.Purpose != "" && sf.meta.Purpose != opts.Purpose {
+			continue
+		}
+		items = append(items, sf.meta)
+	}
+	s.mu.RUnlock()
+
+	sort.Slice(items, func(i, j int) bool {
+		if order == OrderAsc {
+			if items[i].CreatedAt == items[j].CreatedAt {
+				return items[i].ID < items[j].ID
+			}
+			return items[i].CreatedAt < items[j].CreatedAt
+		}
+		if items[i].CreatedAt == items[j].CreatedAt {
+			return items[i].ID > items[j].ID
+		}
+		return items[i].CreatedAt > items[j].CreatedAt
+	})
+
+	if opts.After != "" {
+		idx := -1
+		for i, item := range items {
+			if item.ID == opts.After {
+				idx = i
+				break
+			}
+		}
+		if idx >= 0 {
+			items = items[idx+1:]
+		}
+	}
+
+	if len(items) > limit {
+		items = items[:limit]
+	}
+	return items, nil
+}
+
+func (s *LocalFileStore) Delete(ctx context.Context, id string) (*DeleteFileResponse, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	s.mu.Lock()
+	sf, ok := s.files[id]
+	if !ok {
+		s.mu.Unlock()
+		return nil, ErrNotFound
+	}
+	delete(s.files, id)
+	diskPath := sf.diskPath
+	s.mu.Unlock()
+
+	if err := os.Remove(diskPath); err != nil && !os.IsNotExist(err) {
+		klog.Warningf("failed to remove batch file %s from disk: %v", id, err)
+	}
+
+	return &DeleteFileResponse{
+		ID:      id,
+		Object:  ObjectFile,
+		Deleted: true,
+	}, nil
+}
+
+func (s *LocalFileStore) Open(ctx context.Context, id string) (io.ReadCloser, *FileObject, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, nil, err
+	}
+
+	s.mu.RLock()
+	sf, ok := s.files[id]
+	if !ok {
+		s.mu.RUnlock()
+		return nil, nil, ErrNotFound
+	}
+	meta := sf.meta
+	diskPath := sf.diskPath
+	s.mu.RUnlock()
+
+	f, err := os.Open(diskPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil, ErrNotFound
+		}
+		return nil, nil, fmt.Errorf("open file content: %w", err)
+	}
+	return f, &meta, nil
+}

--- a/pkg/kthena-router/batch/local_store.go
+++ b/pkg/kthena-router/batch/local_store.go
@@ -79,7 +79,7 @@ func (s *LocalFileStore) Create(ctx context.Context, filename, purpose string, r
 	if filename == "" {
 		filename = "upload"
 	}
-	if !IsUploadPurposeAllowed(purpose) {
+	if !IsStoredPurposeAllowed(purpose) {
 		return nil, fmt.Errorf("%w: %q", ErrInvalidPurpose, purpose)
 	}
 

--- a/pkg/kthena-router/batch/local_store.go
+++ b/pkg/kthena-router/batch/local_store.go
@@ -150,21 +150,7 @@ func (s *LocalFileStore) List(ctx context.Context, opts ListOptions) ([]FileObje
 		return nil, err
 	}
 
-	limit := opts.Limit
-	if limit <= 0 {
-		limit = DefaultListLimit
-	}
-	if limit < MinListLimit {
-		limit = MinListLimit
-	}
-	if limit > MaxListLimit {
-		limit = MaxListLimit
-	}
-
-	order := opts.Order
-	if order == "" {
-		order = OrderDesc
-	}
+	limit, order := normalizeListOpts(opts)
 
 	s.mu.RLock()
 	items := make([]FileObject, 0, len(s.files))
@@ -177,35 +163,10 @@ func (s *LocalFileStore) List(ctx context.Context, opts ListOptions) ([]FileObje
 	s.mu.RUnlock()
 
 	sort.Slice(items, func(i, j int) bool {
-		if order == OrderAsc {
-			if items[i].CreatedAt == items[j].CreatedAt {
-				return items[i].ID < items[j].ID
-			}
-			return items[i].CreatedAt < items[j].CreatedAt
-		}
-		if items[i].CreatedAt == items[j].CreatedAt {
-			return items[i].ID > items[j].ID
-		}
-		return items[i].CreatedAt > items[j].CreatedAt
+		return lessCreatedAtID(order, items[i].CreatedAt, items[j].CreatedAt, items[i].ID, items[j].ID)
 	})
-
-	if opts.After != "" {
-		idx := -1
-		for i, item := range items {
-			if item.ID == opts.After {
-				idx = i
-				break
-			}
-		}
-		if idx >= 0 {
-			items = items[idx+1:]
-		}
-	}
-
-	if len(items) > limit {
-		items = items[:limit]
-	}
-	return items, nil
+	items = applyCursorAfter(items, opts.After, func(f FileObject) string { return f.ID })
+	return applyLimit(items, limit), nil
 }
 
 func (s *LocalFileStore) Delete(ctx context.Context, id string) (*DeleteFileResponse, error) {

--- a/pkg/kthena-router/batch/local_store_test.go
+++ b/pkg/kthena-router/batch/local_store_test.go
@@ -1,0 +1,220 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package batch
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestLocalFileStore_CreateGetListDeleteContent(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewLocalFileStore(Config{
+		FilesDir:     dir,
+		MaxFileBytes: 1024,
+		BatchTTL:     time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("NewLocalFileStore: %v", err)
+	}
+
+	ctx := context.Background()
+	content := []byte(`{"custom_id":"1","method":"POST","url":"/v1/chat/completions","body":{}}`)
+	obj, err := store.Create(ctx, "requests.jsonl", PurposeBatch, bytes.NewReader(content))
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if !strings.HasPrefix(obj.ID, FileIDPrefix) {
+		t.Fatalf("unexpected id prefix: %s", obj.ID)
+	}
+	if obj.Object != ObjectFile || obj.Purpose != PurposeBatch {
+		t.Fatalf("unexpected object fields: %+v", obj)
+	}
+	if obj.Bytes != int64(len(content)) {
+		t.Fatalf("bytes=%d want %d", obj.Bytes, len(content))
+	}
+	if obj.ExpiresAt == nil {
+		t.Fatal("expected expires_at")
+	}
+
+	got, err := store.Get(ctx, obj.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.ID != obj.ID {
+		t.Fatalf("Get id=%s want %s", got.ID, obj.ID)
+	}
+
+	listed, err := store.List(ctx, ListOptions{Purpose: PurposeBatch, Limit: 10})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(listed) != 1 {
+		t.Fatalf("List len=%d want 1", len(listed))
+	}
+
+	rc, meta, err := store.Open(ctx, obj.ID)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer rc.Close()
+	body, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if !bytes.Equal(body, content) {
+		t.Fatalf("content mismatch: got %q", body)
+	}
+	if meta.Filename != "requests.jsonl" {
+		t.Fatalf("filename=%s", meta.Filename)
+	}
+
+	del, err := store.Delete(ctx, obj.ID)
+	if err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if !del.Deleted || del.ID != obj.ID {
+		t.Fatalf("unexpected delete response: %+v", del)
+	}
+
+	if _, err := store.Get(ctx, obj.ID); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Get after delete: err=%v", err)
+	}
+}
+
+func TestLocalFileStore_RejectsUnsupportedPurposeAndOversize(t *testing.T) {
+	store, err := NewLocalFileStore(Config{
+		FilesDir:     t.TempDir(),
+		MaxFileBytes: 8,
+		BatchTTL:     time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("NewLocalFileStore: %v", err)
+	}
+	ctx := context.Background()
+
+	_, err = store.Create(ctx, "a.jsonl", "assistants", strings.NewReader("hello"))
+	if !errors.Is(err, ErrInvalidPurpose) {
+		t.Fatalf("purpose err=%v want ErrInvalidPurpose", err)
+	}
+
+	_, err = store.Create(ctx, "a.jsonl", PurposeBatch, strings.NewReader("0123456789"))
+	if !errors.Is(err, ErrTooLarge) {
+		t.Fatalf("size err=%v want ErrTooLarge", err)
+	}
+
+	_, err = store.Create(ctx, "a.jsonl", PurposeBatch, strings.NewReader(""))
+	if !errors.Is(err, ErrEmptyFile) {
+		t.Fatalf("empty err=%v want ErrEmptyFile", err)
+	}
+}
+
+func TestLocalFileStore_ListPaginationAndOrder(t *testing.T) {
+	store, err := NewLocalFileStore(Config{
+		FilesDir:     t.TempDir(),
+		MaxFileBytes: 1024,
+		BatchTTL:     time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("NewLocalFileStore: %v", err)
+	}
+	ctx := context.Background()
+
+	var ids []string
+	for i := 0; i < 3; i++ {
+		obj, err := store.Create(ctx, "f.jsonl", PurposeBatch, strings.NewReader(strings.Repeat("x", i+1)))
+		if err != nil {
+			t.Fatalf("Create %d: %v", i, err)
+		}
+		ids = append(ids, obj.ID)
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	asc, err := store.List(ctx, ListOptions{Order: OrderAsc, Limit: 10})
+	if err != nil {
+		t.Fatalf("List asc: %v", err)
+	}
+	if len(asc) != 3 || asc[0].CreatedAt > asc[2].CreatedAt {
+		t.Fatalf("unexpected asc order: %+v", asc)
+	}
+
+	page, err := store.List(ctx, ListOptions{Order: OrderAsc, Limit: 1, After: asc[0].ID})
+	if err != nil {
+		t.Fatalf("List after: %v", err)
+	}
+	if len(page) != 1 || page[0].ID != asc[1].ID {
+		t.Fatalf("unexpected page: %+v", page)
+	}
+}
+
+func TestLoadConfigFromEnv_DefaultsAndOverrides(t *testing.T) {
+	t.Setenv(EnvFilesDir, "")
+	t.Setenv(EnvMaxFileBytes, "")
+	t.Setenv(EnvBatchTTL, "")
+
+	cfg := LoadConfigFromEnv()
+	if cfg.Enabled() {
+		t.Fatal("expected disabled when FilesDir empty")
+	}
+	if cfg.MaxFileBytes != DefaultMaxFileBytes {
+		t.Fatalf("MaxFileBytes=%d", cfg.MaxFileBytes)
+	}
+	if cfg.BatchTTL != DefaultBatchTTL {
+		t.Fatalf("BatchTTL=%v", cfg.BatchTTL)
+	}
+
+	t.Setenv(EnvFilesDir, "/data/batch")
+	t.Setenv(EnvMaxFileBytes, "4096")
+	t.Setenv(EnvBatchTTL, "1h")
+	cfg = LoadConfigFromEnv()
+	if !cfg.Enabled() || cfg.FilesDir != "/data/batch" {
+		t.Fatalf("unexpected cfg: %+v", cfg)
+	}
+	if cfg.MaxFileBytes != 4096 {
+		t.Fatalf("MaxFileBytes=%d", cfg.MaxFileBytes)
+	}
+	if cfg.BatchTTL != time.Hour {
+		t.Fatalf("BatchTTL=%v", cfg.BatchTTL)
+	}
+}
+
+func TestFilesPathSuffix(t *testing.T) {
+	tests := []struct {
+		path    string
+		wantRel string
+		wantOK  bool
+	}{
+		{PathV1Files, "", true},
+		{PathV1Files + "/file-1", "/file-1", true},
+		{PathV1Files + "/file-1/content", "/file-1/content", true},
+		{PathFiles, "", true},
+		{PathFiles + "/file-1", "/file-1", true},
+		{"/v1/chat/completions", "", false},
+		{"/v1/models", "", false},
+	}
+	for _, tt := range tests {
+		rel, ok := filesPathSuffix(tt.path)
+		if ok != tt.wantOK || rel != tt.wantRel {
+			t.Fatalf("path=%s got (%q,%v) want (%q,%v)", tt.path, rel, ok, tt.wantRel, tt.wantOK)
+		}
+	}
+}

--- a/pkg/kthena-router/batch/local_store_test.go
+++ b/pkg/kthena-router/batch/local_store_test.go
@@ -139,13 +139,10 @@ func TestLocalFileStore_ListPaginationAndOrder(t *testing.T) {
 	}
 	ctx := context.Background()
 
-	var ids []string
 	for i := 0; i < 3; i++ {
-		obj, err := store.Create(ctx, "f.jsonl", PurposeBatch, strings.NewReader(strings.Repeat("x", i+1)))
-		if err != nil {
+		if _, err := store.Create(ctx, "f.jsonl", PurposeBatch, strings.NewReader(strings.Repeat("x", i+1))); err != nil {
 			t.Fatalf("Create %d: %v", i, err)
 		}
-		ids = append(ids, obj.ID)
 		time.Sleep(2 * time.Millisecond)
 	}
 

--- a/pkg/kthena-router/batch/memory_batch_store.go
+++ b/pkg/kthena-router/batch/memory_batch_store.go
@@ -7,7 +7,7 @@ You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 
-    10|Unless required by applicable law or agreed to in writing, software
+Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
@@ -18,6 +18,7 @@ package batch
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"sync"
 )
@@ -38,7 +39,7 @@ func (s *MemoryBatchStore) Create(ctx context.Context, batch *BatchObject) (*Bat
 		return nil, err
 	}
 	if batch == nil || batch.ID == "" {
-		return nil, ErrInvalidInputFile
+		return nil, fmt.Errorf("%w: missing batch id", ErrBatchNotFound)
 	}
 	cp := cloneBatch(batch)
 	s.mu.Lock()
@@ -64,20 +65,7 @@ func (s *MemoryBatchStore) List(ctx context.Context, opts ListOptions) ([]BatchO
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	limit := opts.Limit
-	if limit <= 0 {
-		limit = DefaultListLimit
-	}
-	if limit < MinListLimit {
-		limit = MinListLimit
-	}
-	if limit > MaxListLimit {
-		limit = MaxListLimit
-	}
-	order := opts.Order
-	if order == "" {
-		order = OrderDesc
-	}
+	limit, order := normalizeListOpts(opts)
 
 	s.mu.RLock()
 	items := make([]BatchObject, 0, len(s.batches))
@@ -87,34 +75,10 @@ func (s *MemoryBatchStore) List(ctx context.Context, opts ListOptions) ([]BatchO
 	s.mu.RUnlock()
 
 	sort.Slice(items, func(i, j int) bool {
-		if order == OrderAsc {
-			if items[i].CreatedAt == items[j].CreatedAt {
-				return items[i].ID < items[j].ID
-			}
-			return items[i].CreatedAt < items[j].CreatedAt
-		}
-		if items[i].CreatedAt == items[j].CreatedAt {
-			return items[i].ID > items[j].ID
-		}
-		return items[i].CreatedAt > items[j].CreatedAt
+		return lessCreatedAtID(order, items[i].CreatedAt, items[j].CreatedAt, items[i].ID, items[j].ID)
 	})
-
-	if opts.After != "" {
-		idx := -1
-		for i, item := range items {
-			if item.ID == opts.After {
-				idx = i
-				break
-			}
-		}
-		if idx >= 0 {
-			items = items[idx+1:]
-		}
-	}
-	if len(items) > limit {
-		items = items[:limit]
-	}
-	return items, nil
+	items = applyCursorAfter(items, opts.After, func(b BatchObject) string { return b.ID })
+	return applyLimit(items, limit), nil
 }
 
 func (s *MemoryBatchStore) Update(ctx context.Context, batch *BatchObject) (*BatchObject, error) {
@@ -132,6 +96,20 @@ func (s *MemoryBatchStore) Update(ctx context.Context, batch *BatchObject) (*Bat
 	cp := cloneBatch(batch)
 	s.batches[cp.ID] = cp
 	return cloneBatch(cp), nil
+}
+
+func (s *MemoryBatchStore) UpdateRequestCounts(ctx context.Context, id string, counts RequestCounts) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	b, ok := s.batches[id]
+	if !ok {
+		return ErrBatchNotFound
+	}
+	b.RequestCounts = counts
+	return nil
 }
 
 func cloneBatch(in *BatchObject) *BatchObject {

--- a/pkg/kthena-router/batch/memory_batch_store.go
+++ b/pkg/kthena-router/batch/memory_batch_store.go
@@ -1,0 +1,178 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    10|Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package batch
+
+import (
+	"context"
+	"sort"
+	"sync"
+)
+
+// MemoryBatchStore keeps batch metadata in memory.
+type MemoryBatchStore struct {
+	mu      sync.RWMutex
+	batches map[string]*BatchObject
+}
+
+// NewMemoryBatchStore returns an empty in-memory BatchStore.
+func NewMemoryBatchStore() *MemoryBatchStore {
+	return &MemoryBatchStore{batches: make(map[string]*BatchObject)}
+}
+
+func (s *MemoryBatchStore) Create(ctx context.Context, batch *BatchObject) (*BatchObject, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if batch == nil || batch.ID == "" {
+		return nil, ErrInvalidInputFile
+	}
+	cp := cloneBatch(batch)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.batches[cp.ID] = cp
+	return cloneBatch(cp), nil
+}
+
+func (s *MemoryBatchStore) Get(ctx context.Context, id string) (*BatchObject, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	b, ok := s.batches[id]
+	if !ok {
+		return nil, ErrBatchNotFound
+	}
+	return cloneBatch(b), nil
+}
+
+func (s *MemoryBatchStore) List(ctx context.Context, opts ListOptions) ([]BatchObject, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = DefaultListLimit
+	}
+	if limit < MinListLimit {
+		limit = MinListLimit
+	}
+	if limit > MaxListLimit {
+		limit = MaxListLimit
+	}
+	order := opts.Order
+	if order == "" {
+		order = OrderDesc
+	}
+
+	s.mu.RLock()
+	items := make([]BatchObject, 0, len(s.batches))
+	for _, b := range s.batches {
+		items = append(items, *cloneBatch(b))
+	}
+	s.mu.RUnlock()
+
+	sort.Slice(items, func(i, j int) bool {
+		if order == OrderAsc {
+			if items[i].CreatedAt == items[j].CreatedAt {
+				return items[i].ID < items[j].ID
+			}
+			return items[i].CreatedAt < items[j].CreatedAt
+		}
+		if items[i].CreatedAt == items[j].CreatedAt {
+			return items[i].ID > items[j].ID
+		}
+		return items[i].CreatedAt > items[j].CreatedAt
+	})
+
+	if opts.After != "" {
+		idx := -1
+		for i, item := range items {
+			if item.ID == opts.After {
+				idx = i
+				break
+			}
+		}
+		if idx >= 0 {
+			items = items[idx+1:]
+		}
+	}
+	if len(items) > limit {
+		items = items[:limit]
+	}
+	return items, nil
+}
+
+func (s *MemoryBatchStore) Update(ctx context.Context, batch *BatchObject) (*BatchObject, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if batch == nil || batch.ID == "" {
+		return nil, ErrBatchNotFound
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.batches[batch.ID]; !ok {
+		return nil, ErrBatchNotFound
+	}
+	cp := cloneBatch(batch)
+	s.batches[cp.ID] = cp
+	return cloneBatch(cp), nil
+}
+
+func cloneBatch(in *BatchObject) *BatchObject {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	if in.Metadata != nil {
+		out.Metadata = make(map[string]string, len(in.Metadata))
+		for k, v := range in.Metadata {
+			out.Metadata[k] = v
+		}
+	}
+	if in.Errors != nil {
+		errs := *in.Errors
+		errs.Data = append([]BatchError(nil), in.Errors.Data...)
+		out.Errors = &errs
+	}
+	if in.OutputFileID != nil {
+		v := *in.OutputFileID
+		out.OutputFileID = &v
+	}
+	if in.ErrorFileID != nil {
+		v := *in.ErrorFileID
+		out.ErrorFileID = &v
+	}
+	out.InProgressAt = cloneInt64(in.InProgressAt)
+	out.ExpiresAt = cloneInt64(in.ExpiresAt)
+	out.FinalizingAt = cloneInt64(in.FinalizingAt)
+	out.CompletedAt = cloneInt64(in.CompletedAt)
+	out.FailedAt = cloneInt64(in.FailedAt)
+	out.ExpiredAt = cloneInt64(in.ExpiredAt)
+	out.CancellingAt = cloneInt64(in.CancellingAt)
+	out.CancelledAt = cloneInt64(in.CancelledAt)
+	return &out
+}
+
+func cloneInt64(p *int64) *int64 {
+	if p == nil {
+		return nil
+	}
+	v := *p
+	return &v
+}

--- a/pkg/kthena-router/batch/review_fixes_test.go
+++ b/pkg/kthena-router/batch/review_fixes_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    10|Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package batch
+
+import (
+	"testing"
+)
+
+func TestSafeContentFilename(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{`normal.jsonl`, `normal.jsonl`},
+		{"evil\"name\n.jsonl", "evilname.jsonl"},
+		{"  ", "download"},
+		{`"`, "download"},
+	}
+	for _, tt := range tests {
+		if got := safeContentFilename(tt.in); got != tt.want {
+			t.Fatalf("safeContentFilename(%q)=%q want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestMemoryBatchStore_UpdateRequestCountsPreservesStatus(t *testing.T) {
+	s := NewMemoryBatchStore()
+	b := &BatchObject{
+		ID:     BatchIDPrefix + "x",
+		Object: ObjectBatch,
+		Status: StatusCancelling,
+		RequestCounts: RequestCounts{
+			Total: 10,
+		},
+		Metadata: map[string]string{},
+	}
+	if _, err := s.Create(t.Context(), b); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := s.UpdateRequestCounts(t.Context(), b.ID, RequestCounts{Total: 10, Completed: 3, Failed: 1}); err != nil {
+		t.Fatalf("UpdateRequestCounts: %v", err)
+	}
+	got, err := s.Get(t.Context(), b.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Status != StatusCancelling {
+		t.Fatalf("status clobbered: %s", got.Status)
+	}
+	if got.RequestCounts.Completed != 3 || got.RequestCounts.Failed != 1 {
+		t.Fatalf("counts=%+v", got.RequestCounts)
+	}
+}

--- a/pkg/kthena-router/batch/store.go
+++ b/pkg/kthena-router/batch/store.go
@@ -1,0 +1,41 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package batch
+
+import (
+	"context"
+	"io"
+)
+
+// FileStore persists OpenAI-compatible file metadata and content.
+// Implementations must be safe for concurrent use.
+type FileStore interface {
+	Create(ctx context.Context, filename, purpose string, r io.Reader) (*FileObject, error)
+	Get(ctx context.Context, id string) (*FileObject, error)
+	List(ctx context.Context, opts ListOptions) ([]FileObject, error)
+	Delete(ctx context.Context, id string) (*DeleteFileResponse, error)
+	Open(ctx context.Context, id string) (io.ReadCloser, *FileObject, error)
+}
+
+// NewFileStoreFromConfig constructs a local file store when enabled.
+// Returns nil when FilesDir is unset so callers can treat the feature as off.
+func NewFileStoreFromConfig(cfg Config) (FileStore, error) {
+	if !cfg.Enabled() {
+		return nil, nil
+	}
+	return NewLocalFileStore(cfg)
+}

--- a/pkg/kthena-router/batch/store.go
+++ b/pkg/kthena-router/batch/store.go
@@ -7,7 +7,7 @@ You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
+    10|Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
@@ -31,6 +31,14 @@ type FileStore interface {
 	Open(ctx context.Context, id string) (io.ReadCloser, *FileObject, error)
 }
 
+// BatchStore persists OpenAI-compatible batch job metadata.
+type BatchStore interface {
+	Create(ctx context.Context, batch *BatchObject) (*BatchObject, error)
+	Get(ctx context.Context, id string) (*BatchObject, error)
+	List(ctx context.Context, opts ListOptions) ([]BatchObject, error)
+	Update(ctx context.Context, batch *BatchObject) (*BatchObject, error)
+}
+
 // NewFileStoreFromConfig constructs a local file store when enabled.
 // Returns nil when FilesDir is unset so callers can treat the feature as off.
 func NewFileStoreFromConfig(cfg Config) (FileStore, error) {
@@ -38,4 +46,9 @@ func NewFileStoreFromConfig(cfg Config) (FileStore, error) {
 		return nil, nil
 	}
 	return NewLocalFileStore(cfg)
+}
+
+// NewBatchStore constructs an in-memory batch job store.
+func NewBatchStore() BatchStore {
+	return NewMemoryBatchStore()
 }

--- a/pkg/kthena-router/batch/store.go
+++ b/pkg/kthena-router/batch/store.go
@@ -7,7 +7,7 @@ You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 
-    10|Unless required by applicable law or agreed to in writing, software
+Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
@@ -37,6 +37,8 @@ type BatchStore interface {
 	Get(ctx context.Context, id string) (*BatchObject, error)
 	List(ctx context.Context, opts ListOptions) ([]BatchObject, error)
 	Update(ctx context.Context, batch *BatchObject) (*BatchObject, error)
+	// UpdateRequestCounts patches progress counters without overwriting status/timestamps.
+	UpdateRequestCounts(ctx context.Context, id string, counts RequestCounts) error
 }
 
 // NewFileStoreFromConfig constructs a local file store when enabled.

--- a/pkg/kthena-router/batch/types.go
+++ b/pkg/kthena-router/batch/types.go
@@ -7,7 +7,7 @@ You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 
-    10|Unless required by applicable law or agreed to in writing, software
+Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and

--- a/pkg/kthena-router/batch/types.go
+++ b/pkg/kthena-router/batch/types.go
@@ -7,7 +7,7 @@ You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
+    10|Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
@@ -15,6 +15,8 @@ limitations under the License.
 */
 
 package batch
+
+import "encoding/json"
 
 // FileObject is the OpenAI-compatible file resource returned by /v1/files.
 type FileObject struct {
@@ -40,12 +42,103 @@ type DeleteFileResponse struct {
 	Deleted bool   `json:"deleted"`
 }
 
-// ListOptions controls filtering and pagination for FileStore.List.
+// ListOptions controls filtering and pagination for list APIs.
 type ListOptions struct {
 	Purpose string
 	Limit   int
 	Order   string
 	After   string
+}
+
+// CreateBatchRequest is the body for POST /v1/batches.
+type CreateBatchRequest struct {
+	InputFileID      string            `json:"input_file_id"`
+	Endpoint         string            `json:"endpoint"`
+	CompletionWindow string            `json:"completion_window"`
+	Metadata         map[string]string `json:"metadata,omitempty"`
+}
+
+// RequestCounts tracks per-batch progress (OpenAI Batch object).
+type RequestCounts struct {
+	Total     int `json:"total"`
+	Completed int `json:"completed"`
+	Failed    int `json:"failed"`
+}
+
+// BatchError is an OpenAI-shaped batch-level error entry.
+type BatchError struct {
+	Code    string `json:"code,omitempty"`
+	Message string `json:"message,omitempty"`
+	Param   string `json:"param,omitempty"`
+	Line    *int   `json:"line,omitempty"`
+}
+
+// BatchErrors wraps batch validation/runtime errors.
+type BatchErrors struct {
+	Object string       `json:"object"`
+	Data   []BatchError `json:"data"`
+}
+
+// BatchObject is the OpenAI-compatible batch resource.
+type BatchObject struct {
+	ID               string            `json:"id"`
+	Object           string            `json:"object"`
+	Endpoint         string            `json:"endpoint"`
+	Errors           *BatchErrors      `json:"errors"`
+	InputFileID      string            `json:"input_file_id"`
+	CompletionWindow string            `json:"completion_window"`
+	Status           string            `json:"status"`
+	OutputFileID     *string           `json:"output_file_id"`
+	ErrorFileID      *string           `json:"error_file_id"`
+	CreatedAt        int64             `json:"created_at"`
+	InProgressAt     *int64            `json:"in_progress_at"`
+	ExpiresAt        *int64            `json:"expires_at"`
+	FinalizingAt     *int64            `json:"finalizing_at"`
+	CompletedAt      *int64            `json:"completed_at"`
+	FailedAt         *int64            `json:"failed_at"`
+	ExpiredAt        *int64            `json:"expired_at"`
+	CancellingAt     *int64            `json:"cancelling_at"`
+	CancelledAt      *int64            `json:"cancelled_at"`
+	RequestCounts    RequestCounts     `json:"request_counts"`
+	Metadata         map[string]string `json:"metadata"`
+}
+
+// BatchList is the list envelope for GET /v1/batches.
+type BatchList struct {
+	Object  string        `json:"object"`
+	Data    []BatchObject `json:"data"`
+	FirstID string        `json:"first_id,omitempty"`
+	LastID  string        `json:"last_id,omitempty"`
+	HasMore bool          `json:"has_more"`
+}
+
+// InputLine is one JSONL request in a batch input file.
+type InputLine struct {
+	CustomID string          `json:"custom_id"`
+	Method   string          `json:"method"`
+	URL      string          `json:"url"`
+	Body     json.RawMessage `json:"body"`
+}
+
+// OutputLine is one JSONL response line in a batch output/error file.
+type OutputLine struct {
+	ID       string        `json:"id"`
+	CustomID string        `json:"custom_id"`
+	Response *LineResponse `json:"response"`
+	Error    *LineError    `json:"error"`
+}
+
+// LineResponse wraps an upstream HTTP response for a batch line.
+type LineResponse struct {
+	StatusCode int             `json:"status_code"`
+	RequestID  string          `json:"request_id,omitempty"`
+	Body       json.RawMessage `json:"body"`
+}
+
+// LineError is a per-request error in output/error JSONL.
+type LineError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
 }
 
 // ErrorBody is a small JSON error payload consistent with other router handlers.

--- a/pkg/kthena-router/batch/types.go
+++ b/pkg/kthena-router/batch/types.go
@@ -1,0 +1,61 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package batch
+
+// FileObject is the OpenAI-compatible file resource returned by /v1/files.
+type FileObject struct {
+	ID        string `json:"id"`
+	Object    string `json:"object"`
+	Bytes     int64  `json:"bytes"`
+	CreatedAt int64  `json:"created_at"`
+	Filename  string `json:"filename"`
+	Purpose   string `json:"purpose"`
+	ExpiresAt *int64 `json:"expires_at,omitempty"`
+}
+
+// FileList is the OpenAI-compatible list envelope for GET /v1/files.
+type FileList struct {
+	Object string       `json:"object"`
+	Data   []FileObject `json:"data"`
+}
+
+// DeleteFileResponse is returned by DELETE /v1/files/{id}.
+type DeleteFileResponse struct {
+	ID      string `json:"id"`
+	Object  string `json:"object"`
+	Deleted bool   `json:"deleted"`
+}
+
+// ListOptions controls filtering and pagination for FileStore.List.
+type ListOptions struct {
+	Purpose string
+	Limit   int
+	Order   string
+	After   string
+}
+
+// ErrorBody is a small JSON error payload consistent with other router handlers.
+type ErrorBody struct {
+	Error ErrorDetail `json:"error"`
+}
+
+// ErrorDetail carries a machine-readable type and human-readable message.
+type ErrorDetail struct {
+	Message string `json:"message"`
+	Type    string `json:"type"`
+	Code    string `json:"code,omitempty"`
+}

--- a/pkg/kthena-router/batch/worker.go
+++ b/pkg/kthena-router/batch/worker.go
@@ -1,0 +1,503 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    10|Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package batch
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"k8s.io/klog/v2"
+)
+
+// LineDispatcher executes one batch input line against a model endpoint.
+// Implementations typically reuse the router's load-balancing path.
+type LineDispatcher func(ctx context.Context, endpoint string, body json.RawMessage) (statusCode int, responseBody []byte, requestID string, err error)
+
+// InteractiveLoadFunc returns the current interactive active-request count.
+// Used so batch concurrency can back off under interactive pressure.
+type InteractiveLoadFunc func() int64
+
+// Worker processes batch jobs asynchronously inside the router process.
+type Worker struct {
+	files         FileStore
+	batches       BatchStore
+	dispatch      LineDispatcher
+	interactive   InteractiveLoadFunc
+	concurrency   int
+	busyThreshold int64
+
+	queue chan string
+	wg    sync.WaitGroup
+
+	mu       sync.Mutex
+	inflight map[string]struct{}
+}
+
+// WorkerConfig configures the batch worker.
+type WorkerConfig struct {
+	Concurrency              int
+	InteractiveBusyThreshold int64
+	QueueSize                int
+}
+
+// NewWorker constructs a batch worker. dispatch must be non-nil for processing.
+func NewWorker(files FileStore, batches BatchStore, dispatch LineDispatcher, interactive InteractiveLoadFunc, cfg WorkerConfig) *Worker {
+	concurrency := cfg.Concurrency
+	if concurrency <= 0 {
+		concurrency = DefaultMaxConcurrency
+	}
+	busy := cfg.InteractiveBusyThreshold
+	if busy < 0 {
+		busy = DefaultInteractiveBusyThreshold
+	}
+	qsize := cfg.QueueSize
+	if qsize <= 0 {
+		qsize = 256
+	}
+	return &Worker{
+		files:         files,
+		batches:       batches,
+		dispatch:      dispatch,
+		interactive:   interactive,
+		concurrency:   concurrency,
+		busyThreshold: busy,
+		queue:         make(chan string, qsize),
+		inflight:      make(map[string]struct{}),
+	}
+}
+
+// Enqueue schedules a batch ID for processing (non-blocking; drops if full after warn).
+func (w *Worker) Enqueue(batchID string) {
+	if w == nil || batchID == "" {
+		return
+	}
+	select {
+	case w.queue <- batchID:
+	default:
+		klog.Warningf("batch worker queue full; dropping enqueue for %s", batchID)
+	}
+}
+
+// Start runs the worker loop until ctx is cancelled, then waits for in-flight jobs.
+func (w *Worker) Start(ctx context.Context) {
+	if w == nil {
+		return
+	}
+	w.wg.Add(1)
+	go func() {
+		defer w.wg.Done()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case id := <-w.queue:
+				w.processOne(ctx, id)
+			}
+		}
+	}()
+}
+
+// Stop waits for the worker loop to exit (caller must cancel Start's context first).
+func (w *Worker) Stop() {
+	if w == nil {
+		return
+	}
+	w.wg.Wait()
+}
+
+func (w *Worker) processOne(ctx context.Context, batchID string) {
+	w.mu.Lock()
+	if _, ok := w.inflight[batchID]; ok {
+		w.mu.Unlock()
+		return
+	}
+	w.inflight[batchID] = struct{}{}
+	w.mu.Unlock()
+	defer func() {
+		w.mu.Lock()
+		delete(w.inflight, batchID)
+		w.mu.Unlock()
+	}()
+
+	batch, err := w.batches.Get(ctx, batchID)
+	if err != nil {
+		klog.Errorf("batch worker: get %s: %v", batchID, err)
+		return
+	}
+
+	switch batch.Status {
+	case StatusValidating:
+		w.runValidating(ctx, batch)
+	case StatusInProgress, StatusCancelling:
+		// Resume / continue — re-read input and process remaining is complex;
+		// for MVP re-run full processing only from validating → in_progress.
+		// If already in_progress after restart, mark failed with clear error.
+		if batch.Status == StatusInProgress && batch.RequestCounts.Completed+batch.RequestCounts.Failed == 0 {
+			w.runInProgress(ctx, batch, nil)
+			return
+		}
+		if batch.Status == StatusCancelling {
+			w.finishCancelled(ctx, batch)
+		}
+	default:
+		// Terminal or finalizing — nothing to do.
+	}
+}
+
+func (w *Worker) runValidating(ctx context.Context, batch *BatchObject) {
+	lines, verrs, err := w.readAndValidate(ctx, batch)
+	if err != nil {
+		w.failBatch(ctx, batch, "invalid_request_error", err.Error(), nil)
+		return
+	}
+	if len(verrs) > 0 {
+		w.failBatch(ctx, batch, verrs[0].Code, verrs[0].Message, verrs)
+		return
+	}
+
+	now := time.Now().Unix()
+	batch.Status = StatusInProgress
+	batch.InProgressAt = &now
+	batch.RequestCounts.Total = len(lines)
+	if _, err := w.batches.Update(ctx, batch); err != nil {
+		klog.Errorf("batch worker: update in_progress %s: %v", batch.ID, err)
+		return
+	}
+	w.runInProgress(ctx, batch, lines)
+}
+
+func (w *Worker) readAndValidate(ctx context.Context, batch *BatchObject) ([]InputLine, []BatchError, error) {
+	rc, meta, err := w.files.Open(ctx, batch.InputFileID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("open input file: %w", err)
+	}
+	defer rc.Close()
+	_ = meta
+
+	scanner := bufio.NewScanner(rc)
+	// Allow large JSONL lines (up to ~1 MiB per line by default buffer growth).
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+
+	var lines []InputLine
+	var errs []BatchError
+	seen := make(map[string]struct{})
+	lineNo := 0
+
+	for scanner.Scan() {
+		lineNo++
+		raw := strings.TrimSpace(scanner.Text())
+		if raw == "" {
+			continue
+		}
+		if len(lines) >= DefaultMaxRequestsPerBatch {
+			ln := lineNo
+			errs = append(errs, BatchError{
+				Code:    "too_many_requests",
+				Message: fmt.Sprintf("batch exceeds max %d requests", DefaultMaxRequestsPerBatch),
+				Line:    &ln,
+			})
+			break
+		}
+
+		var in InputLine
+		if err := json.Unmarshal([]byte(raw), &in); err != nil {
+			ln := lineNo
+			errs = append(errs, BatchError{Code: "invalid_json", Message: err.Error(), Line: &ln})
+			continue
+		}
+		if in.CustomID == "" {
+			ln := lineNo
+			errs = append(errs, BatchError{Code: "missing_custom_id", Message: "custom_id is required", Line: &ln})
+			continue
+		}
+		if _, dup := seen[in.CustomID]; dup {
+			ln := lineNo
+			errs = append(errs, BatchError{Code: "duplicate_custom_id", Message: in.CustomID, Line: &ln})
+			continue
+		}
+		seen[in.CustomID] = struct{}{}
+		if !strings.EqualFold(in.Method, "POST") {
+			ln := lineNo
+			errs = append(errs, BatchError{Code: "invalid_method", Message: in.Method, Line: &ln})
+			continue
+		}
+		if in.URL != batch.Endpoint {
+			ln := lineNo
+			errs = append(errs, BatchError{
+				Code:    "invalid_url",
+				Message: fmt.Sprintf("url %q does not match batch endpoint %q", in.URL, batch.Endpoint),
+				Line:    &ln,
+			})
+			continue
+		}
+		if len(in.Body) == 0 || string(in.Body) == "null" {
+			ln := lineNo
+			errs = append(errs, BatchError{Code: "missing_body", Message: "body is required", Line: &ln})
+			continue
+		}
+		lines = append(lines, in)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, nil, fmt.Errorf("read input file: %w", err)
+	}
+	if len(lines) == 0 && len(errs) == 0 {
+		return nil, []BatchError{{Code: "empty_batch", Message: "input file has no requests"}}, nil
+	}
+	return lines, errs, nil
+}
+
+func (w *Worker) runInProgress(ctx context.Context, batch *BatchObject, lines []InputLine) {
+	var err error
+	if lines == nil {
+		lines, _, err = w.readAndValidate(ctx, batch)
+		if err != nil || len(lines) == 0 {
+			w.failBatch(ctx, batch, "invalid_request_error", "failed to resume batch", nil)
+			return
+		}
+	}
+
+	sem := make(chan struct{}, w.concurrency)
+	var (
+		mu        sync.Mutex
+		outLines  []OutputLine
+		errLines  []OutputLine
+		completed int
+		failed    int
+		cancelled bool
+		expired   bool
+	)
+
+	var wg sync.WaitGroup
+	for _, line := range lines {
+		// Refresh cancel / expiry between scheduling.
+		cur, gerr := w.batches.Get(ctx, batch.ID)
+		if gerr == nil {
+			batch = cur
+		}
+		if batch.Status == StatusCancelling {
+			cancelled = true
+			break
+		}
+		if batch.ExpiresAt != nil && time.Now().Unix() > *batch.ExpiresAt {
+			expired = true
+			break
+		}
+
+		w.waitForCapacity(ctx)
+		if ctx.Err() != nil {
+			return
+		}
+
+		sem <- struct{}{}
+		wg.Add(1)
+		go func(in InputLine) {
+			defer wg.Done()
+			defer func() { <-sem }()
+
+			out := w.dispatchLine(ctx, batch.Endpoint, in)
+			mu.Lock()
+			defer mu.Unlock()
+			if out.Error != nil {
+				errLines = append(errLines, out)
+				failed++
+			} else {
+				outLines = append(outLines, out)
+				completed++
+			}
+			batch.RequestCounts.Completed = completed
+			batch.RequestCounts.Failed = failed
+			batch.RequestCounts.Total = len(lines)
+			if _, uerr := w.batches.Update(ctx, batch); uerr != nil {
+				klog.Warningf("batch worker: progress update %s: %v", batch.ID, uerr)
+			}
+		}(line)
+	}
+	wg.Wait()
+
+	// Re-read for cancel that arrived during run.
+	if cur, gerr := w.batches.Get(ctx, batch.ID); gerr == nil {
+		batch = cur
+		if batch.Status == StatusCancelling {
+			cancelled = true
+		}
+	}
+
+	batch.RequestCounts = RequestCounts{Total: len(lines), Completed: completed, Failed: failed}
+
+	if cancelled {
+		_ = w.writeResultFiles(ctx, batch, outLines, errLines)
+		w.finishCancelled(ctx, batch)
+		return
+	}
+	if expired {
+		_ = w.writeResultFiles(ctx, batch, outLines, errLines)
+		now := time.Now().Unix()
+		batch.Status = StatusExpired
+		batch.ExpiredAt = &now
+		_, _ = w.batches.Update(ctx, batch)
+		return
+	}
+
+	now := time.Now().Unix()
+	batch.Status = StatusFinalizing
+	batch.FinalizingAt = &now
+	_, _ = w.batches.Update(ctx, batch)
+
+	if err := w.writeResultFiles(ctx, batch, outLines, errLines); err != nil {
+		w.failBatch(ctx, batch, "server_error", err.Error(), nil)
+		return
+	}
+
+	now = time.Now().Unix()
+	batch.Status = StatusCompleted
+	batch.CompletedAt = &now
+	if _, err := w.batches.Update(ctx, batch); err != nil {
+		klog.Errorf("batch worker: complete %s: %v", batch.ID, err)
+	}
+}
+
+func (w *Worker) dispatchLine(ctx context.Context, endpoint string, in InputLine) OutputLine {
+	id := "batch_req_" + uuid.New().String()
+	if w.dispatch == nil {
+		return OutputLine{
+			ID:       id,
+			CustomID: in.CustomID,
+			Error:    &LineError{Code: "server_error", Message: "batch dispatcher not configured"},
+		}
+	}
+	status, body, reqID, err := w.dispatch(ctx, endpoint, in.Body)
+	if err != nil {
+		return OutputLine{
+			ID:       id,
+			CustomID: in.CustomID,
+			Error:    &LineError{Code: "server_error", Message: err.Error()},
+		}
+	}
+	if status >= 400 {
+		msg := string(body)
+		if msg == "" {
+			msg = fmt.Sprintf("upstream status %d", status)
+		}
+		raw := body
+		if !json.Valid(raw) {
+			quoted, _ := json.Marshal(string(raw))
+			raw = quoted
+		}
+		return OutputLine{
+			ID:       id,
+			CustomID: in.CustomID,
+			Response: &LineResponse{StatusCode: status, RequestID: reqID, Body: raw},
+			Error:    &LineError{Code: "upstream_error", Message: msg},
+		}
+	}
+	raw := body
+	if !json.Valid(raw) {
+		quoted, _ := json.Marshal(string(raw))
+		raw = quoted
+	}
+	return OutputLine{
+		ID:       id,
+		CustomID: in.CustomID,
+		Response: &LineResponse{StatusCode: status, RequestID: reqID, Body: raw},
+	}
+}
+
+func (w *Worker) writeResultFiles(ctx context.Context, batch *BatchObject, outLines, errLines []OutputLine) error {
+	if len(outLines) > 0 {
+		buf, err := encodeJSONL(outLines)
+		if err != nil {
+			return err
+		}
+		obj, err := w.files.Create(ctx, batch.ID+"-output.jsonl", PurposeBatchOutput, bytes.NewReader(buf))
+		if err != nil {
+			return fmt.Errorf("create output file: %w", err)
+		}
+		batch.OutputFileID = &obj.ID
+	}
+	if len(errLines) > 0 {
+		buf, err := encodeJSONL(errLines)
+		if err != nil {
+			return err
+		}
+		obj, err := w.files.Create(ctx, batch.ID+"-errors.jsonl", PurposeBatchOutput, bytes.NewReader(buf))
+		if err != nil {
+			return fmt.Errorf("create error file: %w", err)
+		}
+		batch.ErrorFileID = &obj.ID
+	}
+	_, err := w.batches.Update(ctx, batch)
+	return err
+}
+
+func encodeJSONL(lines []OutputLine) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	for _, line := range lines {
+		if err := enc.Encode(line); err != nil {
+			return nil, err
+		}
+	}
+	return buf.Bytes(), nil
+}
+
+func (w *Worker) failBatch(ctx context.Context, batch *BatchObject, code, message string, details []BatchError) {
+	now := time.Now().Unix()
+	batch.Status = StatusFailed
+	batch.FailedAt = &now
+	if len(details) == 0 {
+		details = []BatchError{{Code: code, Message: message}}
+	}
+	batch.Errors = &BatchErrors{Object: "list", Data: details}
+	if _, err := w.batches.Update(ctx, batch); err != nil {
+		klog.Errorf("batch worker: fail %s: %v", batch.ID, err)
+	}
+}
+
+func (w *Worker) finishCancelled(ctx context.Context, batch *BatchObject) {
+	now := time.Now().Unix()
+	batch.Status = StatusCancelled
+	batch.CancelledAt = &now
+	if _, err := w.batches.Update(ctx, batch); err != nil {
+		klog.Errorf("batch worker: cancel %s: %v", batch.ID, err)
+	}
+}
+
+func (w *Worker) waitForCapacity(ctx context.Context) {
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		if w.interactive == nil || w.busyThreshold <= 0 {
+			return
+		}
+		if w.interactive() < w.busyThreshold {
+			return
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(200 * time.Millisecond):
+		}
+	}
+}

--- a/pkg/kthena-router/batch/worker.go
+++ b/pkg/kthena-router/batch/worker.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -31,11 +32,9 @@ import (
 )
 
 // LineDispatcher executes one batch input line against a model endpoint.
-// Implementations typically reuse the router's load-balancing path.
 type LineDispatcher func(ctx context.Context, endpoint string, body json.RawMessage) (statusCode int, responseBody []byte, requestID string, err error)
 
 // InteractiveLoadFunc returns the current interactive active-request count.
-// Used so batch concurrency can back off under interactive pressure.
 type InteractiveLoadFunc func() int64
 
 // Worker processes batch jobs asynchronously inside the router process.
@@ -47,11 +46,12 @@ type Worker struct {
 	concurrency   int
 	busyThreshold int64
 
-	queue chan string
-	wg    sync.WaitGroup
-
-	mu       sync.Mutex
-	inflight map[string]struct{}
+	queue       chan string
+	loopWG      sync.WaitGroup
+	jobWG       sync.WaitGroup
+	mu          sync.Mutex
+	inflight    map[string]struct{}
+	activeLines atomic.Int64
 }
 
 // WorkerConfig configures the batch worker.
@@ -61,7 +61,7 @@ type WorkerConfig struct {
 	QueueSize                int
 }
 
-// NewWorker constructs a batch worker. dispatch must be non-nil for processing.
+// NewWorker constructs a batch worker.
 func NewWorker(files FileStore, batches BatchStore, dispatch LineDispatcher, interactive InteractiveLoadFunc, cfg WorkerConfig) *Worker {
 	concurrency := cfg.Concurrency
 	if concurrency <= 0 {
@@ -73,7 +73,7 @@ func NewWorker(files FileStore, batches BatchStore, dispatch LineDispatcher, int
 	}
 	qsize := cfg.QueueSize
 	if qsize <= 0 {
-		qsize = 256
+		qsize = DefaultWorkerQueueSize
 	}
 	return &Worker{
 		files:         files,
@@ -87,117 +87,123 @@ func NewWorker(files FileStore, batches BatchStore, dispatch LineDispatcher, int
 	}
 }
 
-// Enqueue schedules a batch ID for processing (non-blocking; drops if full after warn).
-func (w *Worker) Enqueue(batchID string) {
+// Enqueue schedules a batch ID for processing. Blocks until queued or ctx is done.
+func (w *Worker) Enqueue(ctx context.Context, batchID string) error {
 	if w == nil || batchID == "" {
-		return
+		return nil
 	}
 	select {
 	case w.queue <- batchID:
-	default:
-		klog.Warningf("batch worker queue full; dropping enqueue for %s", batchID)
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("%w: %v", ErrEnqueueTimeout, ctx.Err())
 	}
 }
 
-// Start runs the worker loop until ctx is cancelled, then waits for in-flight jobs.
+// Start runs the worker loop until ctx is cancelled.
 func (w *Worker) Start(ctx context.Context) {
 	if w == nil {
 		return
 	}
-	w.wg.Add(1)
+	w.loopWG.Add(1)
 	go func() {
-		defer w.wg.Done()
+		defer w.loopWG.Done()
 		for {
 			select {
 			case <-ctx.Done():
 				return
 			case id := <-w.queue:
-				w.processOne(ctx, id)
+				w.jobWG.Add(1)
+				go func(batchID string) {
+					defer w.jobWG.Done()
+					w.processOne(ctx, batchID)
+				}(id)
 			}
 		}
 	}()
 }
 
-// Stop waits for the worker loop to exit (caller must cancel Start's context first).
+// Stop waits for the loop and in-flight jobs to finish.
+// Caller must cancel the context passed to Start first.
 func (w *Worker) Stop() {
 	if w == nil {
 		return
 	}
-	w.wg.Wait()
+	w.loopWG.Wait()
+	w.jobWG.Wait()
+}
+
+func (w *Worker) tryBegin(batchID string) bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if _, ok := w.inflight[batchID]; ok {
+		return false
+	}
+	w.inflight[batchID] = struct{}{}
+	return true
+}
+
+func (w *Worker) end(batchID string) {
+	w.mu.Lock()
+	delete(w.inflight, batchID)
+	w.mu.Unlock()
 }
 
 func (w *Worker) processOne(ctx context.Context, batchID string) {
-	w.mu.Lock()
-	if _, ok := w.inflight[batchID]; ok {
-		w.mu.Unlock()
+	if !w.tryBegin(batchID) {
 		return
 	}
-	w.inflight[batchID] = struct{}{}
-	w.mu.Unlock()
-	defer func() {
-		w.mu.Lock()
-		delete(w.inflight, batchID)
-		w.mu.Unlock()
-	}()
+	defer w.end(batchID)
 
-	batch, err := w.batches.Get(ctx, batchID)
+	b, err := w.batches.Get(ctx, batchID)
 	if err != nil {
 		klog.Errorf("batch worker: get %s: %v", batchID, err)
 		return
 	}
 
-	switch batch.Status {
+	switch b.Status {
 	case StatusValidating:
-		w.runValidating(ctx, batch)
-	case StatusInProgress, StatusCancelling:
-		// Resume / continue — re-read input and process remaining is complex;
-		// for MVP re-run full processing only from validating → in_progress.
-		// If already in_progress after restart, mark failed with clear error.
-		if batch.Status == StatusInProgress && batch.RequestCounts.Completed+batch.RequestCounts.Failed == 0 {
-			w.runInProgress(ctx, batch, nil)
-			return
+		w.runValidating(ctx, b)
+	case StatusInProgress:
+		if b.RequestCounts.Completed+b.RequestCounts.Failed == 0 {
+			w.runInProgress(ctx, b, nil)
 		}
-		if batch.Status == StatusCancelling {
-			w.finishCancelled(ctx, batch)
-		}
-	default:
-		// Terminal or finalizing — nothing to do.
+	case StatusCancelling:
+		w.finishCancelled(ctx, b)
 	}
 }
 
-func (w *Worker) runValidating(ctx context.Context, batch *BatchObject) {
-	lines, verrs, err := w.readAndValidate(ctx, batch)
+func (w *Worker) runValidating(ctx context.Context, b *BatchObject) {
+	lines, verrs, err := w.readAndValidate(ctx, b)
 	if err != nil {
-		w.failBatch(ctx, batch, "invalid_request_error", err.Error(), nil)
+		w.failBatch(ctx, b, "invalid_request_error", err.Error(), nil)
 		return
 	}
 	if len(verrs) > 0 {
-		w.failBatch(ctx, batch, verrs[0].Code, verrs[0].Message, verrs)
+		w.failBatch(ctx, b, verrs[0].Code, verrs[0].Message, verrs)
 		return
 	}
 
 	now := time.Now().Unix()
-	batch.Status = StatusInProgress
-	batch.InProgressAt = &now
-	batch.RequestCounts.Total = len(lines)
-	if _, err := w.batches.Update(ctx, batch); err != nil {
-		klog.Errorf("batch worker: update in_progress %s: %v", batch.ID, err)
+	b.Status = StatusInProgress
+	b.InProgressAt = &now
+	b.RequestCounts.Total = len(lines)
+	if _, err := w.batches.Update(ctx, b); err != nil {
+		klog.Errorf("batch worker: update in_progress %s: %v", b.ID, err)
 		return
 	}
-	w.runInProgress(ctx, batch, lines)
+	w.runInProgress(ctx, b, lines)
 }
 
-func (w *Worker) readAndValidate(ctx context.Context, batch *BatchObject) ([]InputLine, []BatchError, error) {
-	rc, meta, err := w.files.Open(ctx, batch.InputFileID)
+func (w *Worker) readAndValidate(ctx context.Context, b *BatchObject) ([]InputLine, []BatchError, error) {
+	rc, _, err := w.files.Open(ctx, b.InputFileID)
 	if err != nil {
 		return nil, nil, fmt.Errorf("open input file: %w", err)
 	}
 	defer rc.Close()
-	_ = meta
 
 	scanner := bufio.NewScanner(rc)
-	// Allow large JSONL lines (up to ~1 MiB per line by default buffer growth).
-	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	scanner.Buffer(make([]byte, DefaultScannerBufSize), DefaultScannerMaxToken)
 
 	var lines []InputLine
 	var errs []BatchError
@@ -226,36 +232,11 @@ func (w *Worker) readAndValidate(ctx context.Context, batch *BatchObject) ([]Inp
 			errs = append(errs, BatchError{Code: "invalid_json", Message: err.Error(), Line: &ln})
 			continue
 		}
-		if in.CustomID == "" {
-			ln := lineNo
-			errs = append(errs, BatchError{Code: "missing_custom_id", Message: "custom_id is required", Line: &ln})
-			continue
-		}
-		if _, dup := seen[in.CustomID]; dup {
-			ln := lineNo
-			errs = append(errs, BatchError{Code: "duplicate_custom_id", Message: in.CustomID, Line: &ln})
+		if verr := validateInputLine(in, b.Endpoint, lineNo, seen); verr != nil {
+			errs = append(errs, *verr)
 			continue
 		}
 		seen[in.CustomID] = struct{}{}
-		if !strings.EqualFold(in.Method, "POST") {
-			ln := lineNo
-			errs = append(errs, BatchError{Code: "invalid_method", Message: in.Method, Line: &ln})
-			continue
-		}
-		if in.URL != batch.Endpoint {
-			ln := lineNo
-			errs = append(errs, BatchError{
-				Code:    "invalid_url",
-				Message: fmt.Sprintf("url %q does not match batch endpoint %q", in.URL, batch.Endpoint),
-				Line:    &ln,
-			})
-			continue
-		}
-		if len(in.Body) == 0 || string(in.Body) == "null" {
-			ln := lineNo
-			errs = append(errs, BatchError{Code: "missing_body", Message: "body is required", Line: &ln})
-			continue
-		}
 		lines = append(lines, in)
 	}
 	if err := scanner.Err(); err != nil {
@@ -267,46 +248,77 @@ func (w *Worker) readAndValidate(ctx context.Context, batch *BatchObject) ([]Inp
 	return lines, errs, nil
 }
 
-func (w *Worker) runInProgress(ctx context.Context, batch *BatchObject, lines []InputLine) {
-	var err error
+func validateInputLine(in InputLine, endpoint string, lineNo int, seen map[string]struct{}) *BatchError {
+	ln := lineNo
+	if in.CustomID == "" {
+		return &BatchError{Code: "missing_custom_id", Message: "custom_id is required", Line: &ln}
+	}
+	if _, dup := seen[in.CustomID]; dup {
+		return &BatchError{Code: "duplicate_custom_id", Message: in.CustomID, Line: &ln}
+	}
+	if !strings.EqualFold(in.Method, httpMethodPOST) {
+		return &BatchError{Code: "invalid_method", Message: in.Method, Line: &ln}
+	}
+	if in.URL != endpoint {
+		return &BatchError{
+			Code:    "invalid_url",
+			Message: fmt.Sprintf("url %q does not match batch endpoint %q", in.URL, endpoint),
+			Line:    &ln,
+		}
+	}
+	if len(in.Body) == 0 || string(in.Body) == "null" {
+		return &BatchError{Code: "missing_body", Message: "body is required", Line: &ln}
+	}
+	return nil
+}
+
+const httpMethodPOST = "POST"
+
+func (w *Worker) runInProgress(ctx context.Context, b *BatchObject, lines []InputLine) {
 	if lines == nil {
-		lines, _, err = w.readAndValidate(ctx, batch)
+		var err error
+		lines, _, err = w.readAndValidate(ctx, b)
 		if err != nil || len(lines) == 0 {
-			w.failBatch(ctx, batch, "invalid_request_error", "failed to resume batch", nil)
+			w.failBatch(ctx, b, "invalid_request_error", "failed to resume batch", nil)
 			return
 		}
 	}
 
+	endpoint := b.Endpoint
+	batchID := b.ID
+	total := len(lines)
+
 	sem := make(chan struct{}, w.concurrency)
 	var (
-		mu        sync.Mutex
-		outLines  []OutputLine
-		errLines  []OutputLine
-		completed int
-		failed    int
-		cancelled bool
-		expired   bool
+		mu          sync.Mutex
+		outLines    []OutputLine
+		errLines    []OutputLine
+		completed   int
+		failed      int
+		cancelled   bool
+		expired     bool
+		interrupted bool
+		processed   = make(map[string]struct{}, total)
 	)
 
 	var wg sync.WaitGroup
 	for _, line := range lines {
-		// Refresh cancel / expiry between scheduling.
-		cur, gerr := w.batches.Get(ctx, batch.ID)
+		cur, gerr := w.batches.Get(ctx, batchID)
 		if gerr == nil {
-			batch = cur
-		}
-		if batch.Status == StatusCancelling {
-			cancelled = true
-			break
-		}
-		if batch.ExpiresAt != nil && time.Now().Unix() > *batch.ExpiresAt {
-			expired = true
-			break
+			if cur.Status == StatusCancelling {
+				cancelled = true
+				break
+			}
+			if cur.ExpiresAt != nil && time.Now().Unix() > *cur.ExpiresAt {
+				expired = true
+				break
+			}
 		}
 
 		w.waitForCapacity(ctx)
 		if ctx.Err() != nil {
-			return
+			interrupted = true
+			break
 		}
 
 		sem <- struct{}{}
@@ -315,9 +327,10 @@ func (w *Worker) runInProgress(ctx context.Context, batch *BatchObject, lines []
 			defer wg.Done()
 			defer func() { <-sem }()
 
-			out := w.dispatchLine(ctx, batch.Endpoint, in)
+			out := w.dispatchLine(ctx, endpoint, in)
+
 			mu.Lock()
-			defer mu.Unlock()
+			processed[in.CustomID] = struct{}{}
 			if out.Error != nil {
 				errLines = append(errLines, out)
 				failed++
@@ -325,128 +338,158 @@ func (w *Worker) runInProgress(ctx context.Context, batch *BatchObject, lines []
 				outLines = append(outLines, out)
 				completed++
 			}
-			batch.RequestCounts.Completed = completed
-			batch.RequestCounts.Failed = failed
-			batch.RequestCounts.Total = len(lines)
-			if _, uerr := w.batches.Update(ctx, batch); uerr != nil {
-				klog.Warningf("batch worker: progress update %s: %v", batch.ID, uerr)
+			counts := RequestCounts{Total: total, Completed: completed, Failed: failed}
+			mu.Unlock()
+
+			if err := w.batches.UpdateRequestCounts(ctx, batchID, counts); err != nil {
+				klog.Warningf("batch worker: progress update %s: %v", batchID, err)
 			}
 		}(line)
 	}
 	wg.Wait()
 
-	// Re-read for cancel that arrived during run.
-	if cur, gerr := w.batches.Get(ctx, batch.ID); gerr == nil {
-		batch = cur
-		if batch.Status == StatusCancelling {
-			cancelled = true
+	cur, err := w.batches.Get(ctx, batchID)
+	if err != nil {
+		klog.Errorf("batch worker: reload %s: %v", batchID, err)
+		return
+	}
+	if cur.Status == StatusCancelling {
+		cancelled = true
+	}
+
+	// Lines never started because of cancel/expiry/interrupt.
+	for _, in := range lines {
+		if _, ok := processed[in.CustomID]; ok {
+			continue
 		}
+		code := "batch_cancelled"
+		msg := "This request was not executed because the batch was cancelled."
+		if expired {
+			code = "batch_expired"
+			msg = "This request could not be executed before the completion window expired."
+		} else if interrupted {
+			code = "batch_interrupted"
+			msg = "This request was not executed because the batch worker was interrupted."
+		} else if !cancelled {
+			continue
+		}
+		errLines = append(errLines, OutputLine{
+			ID:       BatchRequestIDPrefix + uuid.New().String(),
+			CustomID: in.CustomID,
+			Error:    &LineError{Code: code, Message: msg},
+		})
+		failed++
 	}
 
-	batch.RequestCounts = RequestCounts{Total: len(lines), Completed: completed, Failed: failed}
+	cur.RequestCounts = RequestCounts{Total: total, Completed: completed, Failed: failed}
 
-	if cancelled {
-		_ = w.writeResultFiles(ctx, batch, outLines, errLines)
-		w.finishCancelled(ctx, batch)
-		return
-	}
-	if expired {
-		_ = w.writeResultFiles(ctx, batch, outLines, errLines)
+	switch {
+	case cancelled:
+		_ = w.writeResultFiles(ctx, cur, outLines, errLines)
+		w.finishCancelled(ctx, cur)
+	case expired:
+		_ = w.writeResultFiles(ctx, cur, outLines, errLines)
 		now := time.Now().Unix()
-		batch.Status = StatusExpired
-		batch.ExpiredAt = &now
-		_, _ = w.batches.Update(ctx, batch)
-		return
-	}
-
-	now := time.Now().Unix()
-	batch.Status = StatusFinalizing
-	batch.FinalizingAt = &now
-	_, _ = w.batches.Update(ctx, batch)
-
-	if err := w.writeResultFiles(ctx, batch, outLines, errLines); err != nil {
-		w.failBatch(ctx, batch, "server_error", err.Error(), nil)
-		return
-	}
-
-	now = time.Now().Unix()
-	batch.Status = StatusCompleted
-	batch.CompletedAt = &now
-	if _, err := w.batches.Update(ctx, batch); err != nil {
-		klog.Errorf("batch worker: complete %s: %v", batch.ID, err)
+		cur.Status = StatusExpired
+		cur.ExpiredAt = &now
+		if _, err := w.batches.Update(ctx, cur); err != nil {
+			klog.Errorf("batch worker: expire %s: %v", batchID, err)
+		}
+	case interrupted:
+		_ = w.writeResultFiles(ctx, cur, outLines, errLines)
+		w.failBatch(ctx, cur, "server_error", "batch worker interrupted", nil)
+	default:
+		now := time.Now().Unix()
+		cur.Status = StatusFinalizing
+		cur.FinalizingAt = &now
+		if _, err := w.batches.Update(ctx, cur); err != nil {
+			klog.Errorf("batch worker: finalizing %s: %v", batchID, err)
+			return
+		}
+		if err := w.writeResultFiles(ctx, cur, outLines, errLines); err != nil {
+			w.failBatch(ctx, cur, "server_error", err.Error(), nil)
+			return
+		}
+		now = time.Now().Unix()
+		cur.Status = StatusCompleted
+		cur.CompletedAt = &now
+		if _, err := w.batches.Update(ctx, cur); err != nil {
+			klog.Errorf("batch worker: complete %s: %v", batchID, err)
+		}
 	}
 }
 
 func (w *Worker) dispatchLine(ctx context.Context, endpoint string, in InputLine) OutputLine {
-	id := "batch_req_" + uuid.New().String()
+	id := BatchRequestIDPrefix + uuid.New().String()
+	w.activeLines.Add(1)
+	defer w.activeLines.Add(-1)
+
 	if w.dispatch == nil {
 		return OutputLine{
-			ID:       id,
-			CustomID: in.CustomID,
-			Error:    &LineError{Code: "server_error", Message: "batch dispatcher not configured"},
+			ID: id, CustomID: in.CustomID,
+			Error: &LineError{Code: "server_error", Message: "batch dispatcher not configured"},
 		}
 	}
+
 	status, body, reqID, err := w.dispatch(ctx, endpoint, in.Body)
 	if err != nil {
 		return OutputLine{
-			ID:       id,
-			CustomID: in.CustomID,
-			Error:    &LineError{Code: "server_error", Message: err.Error()},
+			ID: id, CustomID: in.CustomID,
+			Error: &LineError{Code: "server_error", Message: err.Error()},
 		}
+	}
+
+	raw := asJSONBody(body)
+	line := OutputLine{
+		ID:       id,
+		CustomID: in.CustomID,
+		Response: &LineResponse{StatusCode: status, RequestID: reqID, Body: raw},
 	}
 	if status >= 400 {
 		msg := string(body)
 		if msg == "" {
 			msg = fmt.Sprintf("upstream status %d", status)
 		}
-		raw := body
-		if !json.Valid(raw) {
-			quoted, _ := json.Marshal(string(raw))
-			raw = quoted
-		}
-		return OutputLine{
-			ID:       id,
-			CustomID: in.CustomID,
-			Response: &LineResponse{StatusCode: status, RequestID: reqID, Body: raw},
-			Error:    &LineError{Code: "upstream_error", Message: msg},
-		}
+		line.Error = &LineError{Code: "upstream_error", Message: msg}
 	}
-	raw := body
-	if !json.Valid(raw) {
-		quoted, _ := json.Marshal(string(raw))
-		raw = quoted
-	}
-	return OutputLine{
-		ID:       id,
-		CustomID: in.CustomID,
-		Response: &LineResponse{StatusCode: status, RequestID: reqID, Body: raw},
-	}
+	return line
 }
 
-func (w *Worker) writeResultFiles(ctx context.Context, batch *BatchObject, outLines, errLines []OutputLine) error {
+func asJSONBody(body []byte) json.RawMessage {
+	if json.Valid(body) {
+		return body
+	}
+	quoted, err := json.Marshal(string(body))
+	if err != nil {
+		return json.RawMessage(`""`)
+	}
+	return quoted
+}
+
+func (w *Worker) writeResultFiles(ctx context.Context, b *BatchObject, outLines, errLines []OutputLine) error {
 	if len(outLines) > 0 {
 		buf, err := encodeJSONL(outLines)
 		if err != nil {
 			return err
 		}
-		obj, err := w.files.Create(ctx, batch.ID+"-output.jsonl", PurposeBatchOutput, bytes.NewReader(buf))
+		obj, err := w.files.Create(ctx, b.ID+"-output.jsonl", PurposeBatchOutput, bytes.NewReader(buf))
 		if err != nil {
 			return fmt.Errorf("create output file: %w", err)
 		}
-		batch.OutputFileID = &obj.ID
+		b.OutputFileID = &obj.ID
 	}
 	if len(errLines) > 0 {
 		buf, err := encodeJSONL(errLines)
 		if err != nil {
 			return err
 		}
-		obj, err := w.files.Create(ctx, batch.ID+"-errors.jsonl", PurposeBatchOutput, bytes.NewReader(buf))
+		obj, err := w.files.Create(ctx, b.ID+"-errors.jsonl", PurposeBatchOutput, bytes.NewReader(buf))
 		if err != nil {
 			return fmt.Errorf("create error file: %w", err)
 		}
-		batch.ErrorFileID = &obj.ID
+		b.ErrorFileID = &obj.ID
 	}
-	_, err := w.batches.Update(ctx, batch)
+	_, err := w.batches.Update(ctx, b)
 	return err
 }
 
@@ -461,25 +504,25 @@ func encodeJSONL(lines []OutputLine) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func (w *Worker) failBatch(ctx context.Context, batch *BatchObject, code, message string, details []BatchError) {
+func (w *Worker) failBatch(ctx context.Context, b *BatchObject, code, message string, details []BatchError) {
 	now := time.Now().Unix()
-	batch.Status = StatusFailed
-	batch.FailedAt = &now
+	b.Status = StatusFailed
+	b.FailedAt = &now
 	if len(details) == 0 {
 		details = []BatchError{{Code: code, Message: message}}
 	}
-	batch.Errors = &BatchErrors{Object: "list", Data: details}
-	if _, err := w.batches.Update(ctx, batch); err != nil {
-		klog.Errorf("batch worker: fail %s: %v", batch.ID, err)
+	b.Errors = &BatchErrors{Object: ObjectList, Data: details}
+	if _, err := w.batches.Update(ctx, b); err != nil {
+		klog.Errorf("batch worker: fail %s: %v", b.ID, err)
 	}
 }
 
-func (w *Worker) finishCancelled(ctx context.Context, batch *BatchObject) {
+func (w *Worker) finishCancelled(ctx context.Context, b *BatchObject) {
 	now := time.Now().Unix()
-	batch.Status = StatusCancelled
-	batch.CancelledAt = &now
-	if _, err := w.batches.Update(ctx, batch); err != nil {
-		klog.Errorf("batch worker: cancel %s: %v", batch.ID, err)
+	b.Status = StatusCancelled
+	b.CancelledAt = &now
+	if _, err := w.batches.Update(ctx, b); err != nil {
+		klog.Errorf("batch worker: cancel %s: %v", b.ID, err)
 	}
 }
 
@@ -488,16 +531,21 @@ func (w *Worker) waitForCapacity(ctx context.Context) {
 		if ctx.Err() != nil {
 			return
 		}
-		if w.interactive == nil || w.busyThreshold <= 0 {
+		if w.busyThreshold <= 0 {
 			return
 		}
-		if w.interactive() < w.busyThreshold {
+		var interactive int64
+		if w.interactive != nil {
+			interactive = w.interactive()
+		}
+		load := interactive + w.activeLines.Load()
+		if load < w.busyThreshold {
 			return
 		}
 		select {
 		case <-ctx.Done():
 			return
-		case <-time.After(200 * time.Millisecond):
+		case <-time.After(DefaultBusyPollInterval):
 		}
 	}
 }

--- a/pkg/kthena-router/batch/worker_test.go
+++ b/pkg/kthena-router/batch/worker_test.go
@@ -1,0 +1,155 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    10|Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package batch
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestWorker_CompletesBatch(t *testing.T) {
+	files, err := NewLocalFileStore(Config{
+		FilesDir:     t.TempDir(),
+		MaxFileBytes: 1024 * 1024,
+		BatchTTL:     time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	jobs := NewMemoryBatchStore()
+
+	dispatch := func(ctx context.Context, endpoint string, body json.RawMessage) (int, []byte, string, error) {
+		resp := map[string]interface{}{
+			"id":      "chatcmpl-1",
+			"object":  "chat.completion",
+			"choices": []map[string]interface{}{{"message": map[string]string{"role": "assistant", "content": "ok"}}},
+		}
+		b, _ := json.Marshal(resp)
+		return 200, b, "req-1", nil
+	}
+
+	w := NewWorker(files, jobs, dispatch, func() int64 { return 0 }, WorkerConfig{Concurrency: 2})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	w.Start(ctx)
+	defer func() {
+		cancel()
+		w.Stop()
+	}()
+
+	line := `{"custom_id":"req-a","method":"POST","url":"/v1/chat/completions","body":{"model":"m","messages":[{"role":"user","content":"hi"}]}}`
+	fileObj, err := files.Create(context.Background(), "in.jsonl", PurposeBatch, strings.NewReader(line+"\n"))
+	if err != nil {
+		t.Fatalf("file: %v", err)
+	}
+	now := time.Now().Unix()
+	expires := now + 3600
+	batch := &BatchObject{
+		ID:               BatchIDPrefix + "test1",
+		Object:           ObjectBatch,
+		Endpoint:         EndpointChatCompletions,
+		InputFileID:      fileObj.ID,
+		CompletionWindow: CompletionWindow24h,
+		Status:           StatusValidating,
+		CreatedAt:        now,
+		ExpiresAt:        &expires,
+		Metadata:         map[string]string{},
+	}
+	if _, err := jobs.Create(context.Background(), batch); err != nil {
+		t.Fatalf("create batch: %v", err)
+	}
+
+	w.Enqueue(batch.ID)
+
+	deadline := time.Now().Add(5 * time.Second)
+	var got *BatchObject
+	for time.Now().Before(deadline) {
+		got, err = jobs.Get(context.Background(), batch.ID)
+		if err != nil {
+			t.Fatalf("get: %v", err)
+		}
+		if got.Status == StatusCompleted {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if got.Status != StatusCompleted {
+		t.Fatalf("status=%s counts=%+v errors=%+v", got.Status, got.RequestCounts, got.Errors)
+	}
+	if got.OutputFileID == nil {
+		t.Fatal("expected output_file_id")
+	}
+	if got.RequestCounts.Completed != 1 || got.RequestCounts.Total != 1 {
+		t.Fatalf("counts=%+v", got.RequestCounts)
+	}
+}
+
+func TestWorker_FailsInvalidJSONL(t *testing.T) {
+	files, err := NewLocalFileStore(Config{
+		FilesDir:     t.TempDir(),
+		MaxFileBytes: 1024 * 1024,
+		BatchTTL:     time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	jobs := NewMemoryBatchStore()
+	w := NewWorker(files, jobs, nil, nil, WorkerConfig{Concurrency: 1})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	w.Start(ctx)
+	defer func() {
+		cancel()
+		w.Stop()
+	}()
+
+	fileObj, err := files.Create(context.Background(), "bad.jsonl", PurposeBatch, strings.NewReader("not-json\n"))
+	if err != nil {
+		t.Fatalf("file: %v", err)
+	}
+	now := time.Now().Unix()
+	expires := now + 3600
+	batch := &BatchObject{
+		ID:               BatchIDPrefix + "bad",
+		Object:           ObjectBatch,
+		Endpoint:         EndpointChatCompletions,
+		InputFileID:      fileObj.ID,
+		CompletionWindow: CompletionWindow24h,
+		Status:           StatusValidating,
+		CreatedAt:        now,
+		ExpiresAt:        &expires,
+		Metadata:         map[string]string{},
+	}
+	_, _ = jobs.Create(context.Background(), batch)
+	w.Enqueue(batch.ID)
+
+	deadline := time.Now().Add(5 * time.Second)
+	var got *BatchObject
+	for time.Now().Before(deadline) {
+		got, _ = jobs.Get(context.Background(), batch.ID)
+		if got.Status == StatusFailed {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if got.Status != StatusFailed {
+		t.Fatalf("status=%s", got.Status)
+	}
+}

--- a/pkg/kthena-router/batch/worker_test.go
+++ b/pkg/kthena-router/batch/worker_test.go
@@ -7,7 +7,7 @@ You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 
-    10|Unless required by applicable law or agreed to in writing, software
+Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
@@ -76,7 +76,7 @@ func TestWorker_CompletesBatch(t *testing.T) {
 		t.Fatalf("create batch: %v", err)
 	}
 
-	w.Enqueue(batch.ID)
+	w.Enqueue(context.Background(), batch.ID)
 
 	deadline := time.Now().Add(5 * time.Second)
 	var got *BatchObject
@@ -138,7 +138,7 @@ func TestWorker_FailsInvalidJSONL(t *testing.T) {
 		Metadata:         map[string]string{},
 	}
 	_, _ = jobs.Create(context.Background(), batch)
-	w.Enqueue(batch.ID)
+	w.Enqueue(context.Background(), batch.ID)
 
 	deadline := time.Now().Add(5 * time.Second)
 	var got *BatchObject

--- a/pkg/kthena-router/router/batch_dispatch.go
+++ b/pkg/kthena-router/router/batch_dispatch.go
@@ -1,0 +1,91 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    10|Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package router
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/volcano-sh/kthena/pkg/kthena-router/metrics"
+	"github.com/volcano-sh/kthena/pkg/kthena-router/utils"
+)
+
+// ExecuteBatchLine runs one batch JSONL body through the router's load-balancing
+// path (same scheduling/proxy as interactive traffic) and captures the response.
+// It intentionally skips fairness/session queues so batch has its own concurrency.
+func (r *Router) ExecuteBatchLine(ctx context.Context, endpoint string, body json.RawMessage) (int, []byte, string, error) {
+	if endpoint == "" {
+		return 0, nil, "", fmt.Errorf("endpoint is required")
+	}
+	if len(body) == 0 {
+		return 0, nil, "", fmt.Errorf("body is required")
+	}
+
+	var modelRequest ModelRequest
+	if err := json.Unmarshal(body, &modelRequest); err != nil {
+		return http.StatusBadRequest, nil, "", fmt.Errorf("invalid body: %w", err)
+	}
+	modelName, ok := modelRequest["model"].(string)
+	if !ok || modelName == "" {
+		return http.StatusBadRequest, nil, "", fmt.Errorf("model not found in body")
+	}
+
+	// Force non-streaming for batch capture.
+	modelRequest["stream"] = false
+	rewritten, err := json.Marshal(modelRequest)
+	if err != nil {
+		return 0, nil, "", err
+	}
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(rewritten))
+	if err != nil {
+		return 0, nil, "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	requestID := uuid.New().String()
+	req.Header.Set("x-request-id", requestID)
+	c.Request = req
+
+	prompt, err := utils.ParsePrompt(modelRequest)
+	if err != nil {
+		return http.StatusBadRequest, nil, requestID, fmt.Errorf("prompt not found")
+	}
+	c.Set(PromptKey, prompt)
+	c.Set("model", modelName)
+	c.Set("metricsRecorder", metrics.NewRequestMetricsRecorder(r.metrics, modelName, endpoint))
+
+	if err := r.doLoadbalance(c, modelRequest); err != nil {
+		if w.Code == 0 || w.Code == http.StatusOK {
+			return http.StatusInternalServerError, w.Body.Bytes(), requestID, err
+		}
+		return w.Code, w.Body.Bytes(), requestID, nil
+	}
+	status := w.Code
+	if status == 0 {
+		status = http.StatusOK
+	}
+	return status, w.Body.Bytes(), requestID, nil
+}

--- a/pkg/kthena-router/router/batch_dispatch.go
+++ b/pkg/kthena-router/router/batch_dispatch.go
@@ -7,7 +7,7 @@ You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 
-    10|Unless required by applicable law or agreed to in writing, software
+Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
@@ -51,15 +51,15 @@ func (r *Router) ExecuteBatchLine(ctx context.Context, endpoint string, body jso
 		return http.StatusBadRequest, nil, "", fmt.Errorf("model not found in body")
 	}
 
-	// Force non-streaming for batch capture.
+	// Force non-streaming so responses can be captured as a single body.
 	modelRequest["stream"] = false
 	rewritten, err := json.Marshal(modelRequest)
 	if err != nil {
 		return 0, nil, "", err
 	}
 
-	w := httptest.NewRecorder()
-	c, _ := gin.CreateTestContext(w)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(rewritten))
 	if err != nil {
 		return 0, nil, "", err
@@ -78,14 +78,14 @@ func (r *Router) ExecuteBatchLine(ctx context.Context, endpoint string, body jso
 	c.Set("metricsRecorder", metrics.NewRequestMetricsRecorder(r.metrics, modelName, endpoint))
 
 	if err := r.doLoadbalance(c, modelRequest); err != nil {
-		if w.Code == 0 || w.Code == http.StatusOK {
-			return http.StatusInternalServerError, w.Body.Bytes(), requestID, err
+		if recorder.Code == 0 || recorder.Code == http.StatusOK {
+			return http.StatusInternalServerError, recorder.Body.Bytes(), requestID, err
 		}
-		return w.Code, w.Body.Bytes(), requestID, nil
+		return recorder.Code, recorder.Body.Bytes(), requestID, nil
 	}
-	status := w.Code
+	status := recorder.Code
 	if status == 0 {
 		status = http.StatusOK
 	}
-	return status, w.Body.Bytes(), requestID, nil
+	return status, recorder.Body.Bytes(), requestID, nil
 }

--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -40,6 +40,7 @@ import (
 
 	"github.com/volcano-sh/kthena/pkg/apis/networking/v1alpha1"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/accesslog"
+	"github.com/volcano-sh/kthena/pkg/kthena-router/batch"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/common"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/connectors"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/datastore"
@@ -102,6 +103,9 @@ type Router struct {
 
 	// KV Connector management
 	connectorFactory *connectors.Factory
+
+	// OpenAI-compatible Files API (batch control plane). Nil store disables it.
+	filesHandler *batch.Handler
 
 	// Priority queue configuration
 	queueTimeout     time.Duration
@@ -191,6 +195,11 @@ func NewRouter(store datastore.Store, routerConfigPath string) *Router {
 		klog.Fatalf("failed to create access logger: %v", err)
 	}
 
+	filesHandler, err := newFilesHandlerFromEnv()
+	if err != nil {
+		klog.Fatalf("failed to initialize batch files store: %v", err)
+	}
+
 	return &Router{
 		store:            store,
 		scheduler:        scheduler.NewScheduler(store, routerConfig),
@@ -200,12 +209,25 @@ func NewRouter(store datastore.Store, routerConfigPath string) *Router {
 		metrics:          metricsInstance,
 		tokenizer:        tokenizerInstance,
 		connectorFactory: connectors.NewDefaultFactory(),
+		filesHandler:     filesHandler,
 		queueTimeout:     parseQueueTimeout(),
 		tokenWeight:      parseEnvFloat("FAIRNESS_PRIORITY_TOKEN_WEIGHT", 1.0),
 		requestNumWeight: parseEnvFloat("FAIRNESS_PRIORITY_REQUEST_NUM_WEIGHT", 0.0),
 
 		sessionBoostTimeout: parseSessionBoostTimeout(),
 	}
+}
+
+// newFilesHandlerFromEnv builds the OpenAI Files API handler from env config.
+// When KTHENA_BATCH_FILES_DIR is unset the handler is still created but serves
+// 503 until storage is configured (mirrors optional feature flags elsewhere).
+func newFilesHandlerFromEnv() (*batch.Handler, error) {
+	cfg := batch.LoadConfigFromEnv()
+	store, err := batch.NewFileStoreFromConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return batch.NewHandler(store), nil
 }
 
 const defaultQueueTimeout = 60 * time.Second
@@ -273,6 +295,13 @@ func (r *Router) HandlerFunc() gin.HandlerFunc {
 		if c.Request.Method == http.MethodGet &&
 			(c.Request.URL.Path == "/v1/models" || c.Request.URL.Path == "/models") {
 			r.ListModels(c)
+			return
+		}
+
+		// Handle /v1/files (OpenAI-compatible Files API for batch jobs).
+		// Must run before ParseModelRequest: uploads are multipart and have no "model" field.
+		if batch.IsFilesPath(c.Request.URL.Path) {
+			r.HandleFiles(c)
 			return
 		}
 
@@ -888,6 +917,22 @@ func (r *Router) ListModels(c *gin.Context) {
 		Object: "list",
 		Data:   data,
 	})
+}
+
+// HandleFiles implements the OpenAI-compatible /v1/files endpoints.
+// Like ListModels, this is control-plane traffic and never enters doLoadbalance.
+func (r *Router) HandleFiles(c *gin.Context) {
+	if r.filesHandler == nil {
+		c.AbortWithStatusJSON(http.StatusServiceUnavailable, batch.ErrorBody{
+			Error: batch.ErrorDetail{
+				Message: fmt.Sprintf("batch files API is disabled; set %s to enable", batch.EnvFilesDir),
+				Type:    "server_error",
+				Code:    "files_disabled",
+			},
+		})
+		return
+	}
+	r.filesHandler.ServeHTTP(c)
 }
 
 func (r *Router) Auth() gin.HandlerFunc {

--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -255,7 +255,7 @@ func initBatchWithRouter(r *Router) (*batch.Handler, *batch.BatchesHandler, *bat
 	batchesHandler := batch.NewBatchesHandler(fileStore, jobStore, worker.Enqueue)
 	ctx, cancel := context.WithCancel(context.Background())
 	worker.Start(ctx)
-	return batch.NewHandler(fileStore), batchesHandler, worker, cancel, nil
+	return batch.NewHandlerWithLimits(fileStore, cfg.MaxFileBytes), batchesHandler, worker, cancel, nil
 }
 
 const defaultQueueTimeout = 60 * time.Second

--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -104,8 +104,11 @@ type Router struct {
 	// KV Connector management
 	connectorFactory *connectors.Factory
 
-	// OpenAI-compatible Files API (batch control plane). Nil store disables it.
-	filesHandler *batch.Handler
+	// OpenAI-compatible Files + Batches APIs (control plane + worker).
+	filesHandler   *batch.Handler
+	batchesHandler *batch.BatchesHandler
+	batchWorker    *batch.Worker
+	batchCancel    context.CancelFunc
 
 	// Priority queue configuration
 	queueTimeout     time.Duration
@@ -195,12 +198,7 @@ func NewRouter(store datastore.Store, routerConfigPath string) *Router {
 		klog.Fatalf("failed to create access logger: %v", err)
 	}
 
-	filesHandler, err := newFilesHandlerFromEnv()
-	if err != nil {
-		klog.Fatalf("failed to initialize batch files store: %v", err)
-	}
-
-	return &Router{
+	r := &Router{
 		store:            store,
 		scheduler:        scheduler.NewScheduler(store, routerConfig),
 		authenticator:    auth.NewJWTAuthenticator(routerConfig),
@@ -209,25 +207,55 @@ func NewRouter(store datastore.Store, routerConfigPath string) *Router {
 		metrics:          metricsInstance,
 		tokenizer:        tokenizerInstance,
 		connectorFactory: connectors.NewDefaultFactory(),
-		filesHandler:     filesHandler,
 		queueTimeout:     parseQueueTimeout(),
 		tokenWeight:      parseEnvFloat("FAIRNESS_PRIORITY_TOKEN_WEIGHT", 1.0),
 		requestNumWeight: parseEnvFloat("FAIRNESS_PRIORITY_REQUEST_NUM_WEIGHT", 0.0),
 
 		sessionBoostTimeout: parseSessionBoostTimeout(),
 	}
+
+	filesHandler, batchesHandler, batchWorker, batchCancel, err := initBatchWithRouter(r)
+	if err != nil {
+		klog.Fatalf("failed to initialize batch subsystem: %v", err)
+	}
+	r.filesHandler = filesHandler
+	r.batchesHandler = batchesHandler
+	r.batchWorker = batchWorker
+	r.batchCancel = batchCancel
+
+	return r
 }
 
-// newFilesHandlerFromEnv builds the OpenAI Files API handler from env config.
-// When KTHENA_BATCH_FILES_DIR is unset the handler is still created but serves
-// 503 until storage is configured (mirrors optional feature flags elsewhere).
-func newFilesHandlerFromEnv() (*batch.Handler, error) {
-	cfg := batch.LoadConfigFromEnv()
-	store, err := batch.NewFileStoreFromConfig(cfg)
-	if err != nil {
-		return nil, err
+// Close stops the batch worker if running.
+func (r *Router) Close() {
+	if r.batchCancel != nil {
+		r.batchCancel()
+		r.batchCancel = nil
 	}
-	return batch.NewHandler(store), nil
+	if r.batchWorker != nil {
+		r.batchWorker.Stop()
+	}
+}
+
+func initBatchWithRouter(r *Router) (*batch.Handler, *batch.BatchesHandler, *batch.Worker, context.CancelFunc, error) {
+	cfg := batch.LoadConfigFromEnv()
+	fileStore, err := batch.NewFileStoreFromConfig(cfg)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+	if fileStore == nil {
+		return batch.NewHandler(nil), batch.NewBatchesHandler(nil, nil, nil), nil, nil, nil
+	}
+
+	jobStore := batch.NewBatchStore()
+	worker := batch.NewWorker(fileStore, jobStore, r.ExecuteBatchLine, r.ActiveRequestCount, batch.WorkerConfig{
+		Concurrency:              cfg.MaxConcurrency,
+		InteractiveBusyThreshold: cfg.InteractiveBusyThreshold,
+	})
+	batchesHandler := batch.NewBatchesHandler(fileStore, jobStore, worker.Enqueue)
+	ctx, cancel := context.WithCancel(context.Background())
+	worker.Start(ctx)
+	return batch.NewHandler(fileStore), batchesHandler, worker, cancel, nil
 }
 
 const defaultQueueTimeout = 60 * time.Second
@@ -302,6 +330,12 @@ func (r *Router) HandlerFunc() gin.HandlerFunc {
 		// Must run before ParseModelRequest: uploads are multipart and have no "model" field.
 		if batch.IsFilesPath(c.Request.URL.Path) {
 			r.HandleFiles(c)
+			return
+		}
+
+		// Handle /v1/batches (OpenAI-compatible Batches API).
+		if batch.IsBatchesPath(c.Request.URL.Path) {
+			r.HandleBatches(c)
 			return
 		}
 
@@ -933,6 +967,21 @@ func (r *Router) HandleFiles(c *gin.Context) {
 		return
 	}
 	r.filesHandler.ServeHTTP(c)
+}
+
+// HandleBatches implements the OpenAI-compatible /v1/batches endpoints.
+func (r *Router) HandleBatches(c *gin.Context) {
+	if r.batchesHandler == nil {
+		c.AbortWithStatusJSON(http.StatusServiceUnavailable, batch.ErrorBody{
+			Error: batch.ErrorDetail{
+				Message: fmt.Sprintf("batch API is disabled; set %s to enable", batch.EnvFilesDir),
+				Type:    "server_error",
+				Code:    "batch_disabled",
+			},
+		})
+		return
+	}
+	r.batchesHandler.ServeHTTP(c)
 }
 
 func (r *Router) Auth() gin.HandlerFunc {

--- a/pkg/kthena-router/router/router_test.go
+++ b/pkg/kthena-router/router/router_test.go
@@ -23,6 +23,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -48,6 +49,7 @@ import (
 
 	aiv1alpha1 "github.com/volcano-sh/kthena/pkg/apis/networking/v1alpha1"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/accesslog"
+	"github.com/volcano-sh/kthena/pkg/kthena-router/batch"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/common"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/connectors"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/datastore"
@@ -1651,6 +1653,81 @@ func TestRouter_HandlerFunc_ListModels_Empty(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "list", resp.Object)
 	assert.Empty(t, resp.Data)
+}
+
+func TestRouter_HandlerFunc_Files_UploadAndGet(t *testing.T) {
+	router, _, backend := setupTestRouter(t, nil)
+	defer backend.Close()
+
+	store, err := batch.NewLocalFileStore(batch.Config{
+		FilesDir:     t.TempDir(),
+		MaxFileBytes: batch.DefaultMaxFileBytes,
+		BatchTTL:     time.Hour,
+	})
+	assert.NoError(t, err)
+	router.filesHandler = batch.NewHandler(store)
+
+	payload := `{"custom_id":"1","method":"POST","url":"/v1/chat/completions","body":{"model":"m"}}`
+	var body bytes.Buffer
+	mw := multipart.NewWriter(&body)
+	assert.NoError(t, mw.WriteField(batch.FormFieldPurpose, batch.PurposeBatch))
+	part, err := mw.CreateFormFile(batch.FormFieldFile, "requests.jsonl")
+	assert.NoError(t, err)
+	_, err = io.Copy(part, strings.NewReader(payload))
+	assert.NoError(t, err)
+	assert.NoError(t, mw.Close())
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request, _ = http.NewRequest(http.MethodPost, batch.PathV1Files, &body)
+	c.Request.Header.Set("Content-Type", mw.FormDataContentType())
+
+	router.HandlerFunc()(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var uploaded batch.FileObject
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &uploaded))
+	assert.Equal(t, batch.ObjectFile, uploaded.Object)
+	assert.Equal(t, batch.PurposeBatch, uploaded.Purpose)
+	assert.True(t, strings.HasPrefix(uploaded.ID, batch.FileIDPrefix))
+
+	w = httptest.NewRecorder()
+	c, _ = gin.CreateTestContext(w)
+	c.Request, _ = http.NewRequest(http.MethodGet, batch.PathV1Files+"/"+uploaded.ID, nil)
+	router.HandlerFunc()(c)
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestRouter_HandlerFunc_Files_DisabledWithoutStore(t *testing.T) {
+	router, _, backend := setupTestRouter(t, nil)
+	defer backend.Close()
+	router.filesHandler = batch.NewHandler(nil)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request, _ = http.NewRequest(http.MethodGet, batch.PathV1Files, nil)
+	router.HandlerFunc()(c)
+
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+}
+
+func TestRouter_HandlerFunc_Files_DoesNotRequireModelField(t *testing.T) {
+	// Proves Files early-return never reaches ParseModelRequest (which requires "model").
+	router, _, backend := setupTestRouter(t, nil)
+	defer backend.Close()
+	store, err := batch.NewLocalFileStore(batch.Config{
+		FilesDir:     t.TempDir(),
+		MaxFileBytes: 1024,
+		BatchTTL:     time.Hour,
+	})
+	assert.NoError(t, err)
+	router.filesHandler = batch.NewHandler(store)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request, _ = http.NewRequest(http.MethodGet, batch.PathV1Files, nil)
+	router.HandlerFunc()(c)
+	assert.Equal(t, http.StatusOK, w.Code)
 }
 
 // Helper function to parse boolean (same logic as strconv.ParseBool but simpler for test)


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Adds OpenAI-compatible `/v1/batches` API and an in-router async worker so batch jobs can run through the same load-balancing path as interactive traffic, while staying isolated from it.

**Which issue(s) this PR fixes**:
Fixes #1291 
**Bug evidence (required for bug-related PRs)**:
N/A

**Special notes for your reviewer**:


**Does this PR introduce a user-facing change?**:

```release-note
Add OpenAI-compatible /v1/batches API and in-router async worker in kthena-router (create/get/list/cancel), reusing router load-balancing with isolation from interactive traffic.
