### PR TITLE
autoscaler: populate status, conditions, and observedGeneration for homogeneous and heterogeneous policies

### DIFF
--- a/pkg/autoscaler/controller/autoscale_controller.go
+++ b/pkg/autoscaler/controller/autoscale_controller.go
@@ -32,6 +32,7 @@ import (
 	"github.com/volcano-sh/kthena/pkg/autoscaler/util"
 	"istio.io/istio/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -44,6 +45,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	listerv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 )
 
@@ -261,6 +263,9 @@ func (ac *AutoscaleController) doOptimize(ctx context.Context, autoscalePolicy *
 		currentInstancesCount, err := ac.getTargetReplicas(&param.Target, autoscalePolicy.Namespace)
 		if err != nil {
 			klog.Errorf("failed to get current replicas, err: %v", err)
+			if statusErr := ac.updateHeterogeneousPolicyStatus(ctx, autoscalePolicy, nil, err, false); statusErr != nil {
+				klog.Warningf("failed to update heterogeneous policy status %s/%s: %v", autoscalePolicy.Namespace, autoscalePolicy.Name, statusErr)
+			}
 			return err
 		}
 		replicasMap[param.Target.TargetRef.Name] = currentInstancesCount
@@ -270,19 +275,50 @@ func (ac *AutoscaleController) doOptimize(ctx context.Context, autoscalePolicy *
 	recommendedInstances, err := optimizer.Optimize(ctx, ac.podsLister, autoscalePolicy, replicasMap)
 	if err != nil {
 		klog.Errorf("failed to do optimize, err: %v", err)
+		if statusErr := ac.updateHeterogeneousPolicyStatus(ctx, autoscalePolicy, nil, err, true); statusErr != nil {
+			klog.Warningf("failed to update heterogeneous policy status %s/%s: %v", autoscalePolicy.Namespace, autoscalePolicy.Name, statusErr)
+		}
 		return err
 	}
-	// Do update replicas
+
+	mode := "Stable"
+	if optimizer.Status != nil && optimizer.Status.IsPanicMode() {
+		mode = "Panic"
+	}
+
+	targetStatuses := make([]workload.TargetScalingStatus, 0, len(optimizer.Meta.Config.Params))
 	for _, param := range optimizer.Meta.Config.Params {
 		instancesCount, exists := recommendedInstances[param.Target.TargetRef.Name]
 		if !exists {
 			klog.Warningf("recommended instances not exists, target ref name: %s", param.Target.TargetRef.Name)
 			continue
 		}
+		current := replicasMap[param.Target.TargetRef.Name]
+		targetStatuses = append(targetStatuses, workload.TargetScalingStatus{
+			Name:            param.Target.TargetRef.Name,
+			CurrentReplicas: current,
+			DesiredReplicas: instancesCount,
+			Mode:            mode,
+		})
+	}
+
+	// Do update replicas
+	for _, param := range optimizer.Meta.Config.Params {
+		instancesCount, exists := recommendedInstances[param.Target.TargetRef.Name]
+		if !exists {
+			continue
+		}
 		if err := ac.updateTargetReplicas(ctx, &param.Target, autoscalePolicy.Namespace, instancesCount); err != nil {
 			klog.Errorf("failed to update target kind:%s name: %s replicas:%d, err: %v", param.Target.TargetRef.Kind, param.Target.TargetRef.Name, instancesCount, err)
+			if statusErr := ac.updateHeterogeneousPolicyStatus(ctx, autoscalePolicy, targetStatuses, err, true); statusErr != nil {
+				klog.Warningf("failed to update heterogeneous policy status %s/%s: %v", autoscalePolicy.Namespace, autoscalePolicy.Name, statusErr)
+			}
 			return err
 		}
+	}
+
+	if statusErr := ac.updateHeterogeneousPolicyStatus(ctx, autoscalePolicy, targetStatuses, nil, true); statusErr != nil {
+		klog.Warningf("failed to update heterogeneous policy status %s/%s: %v", autoscalePolicy.Namespace, autoscalePolicy.Name, statusErr)
 	}
 
 	return nil
@@ -301,6 +337,9 @@ func (ac *AutoscaleController) doScale(ctx context.Context, autoscalePolicy *wor
 	currentInstancesCount, err := ac.getTargetReplicas(&target, autoscalePolicy.Namespace)
 	if err != nil {
 		klog.Errorf("failed to get current replicas, err: %v", err)
+		if statusErr := ac.updateHomogeneousPolicyStatus(ctx, autoscalePolicy, 0, 0, "", err, false); statusErr != nil {
+			klog.Warningf("failed to update homogeneous policy status %s/%s: %v", autoscalePolicy.Namespace, autoscalePolicy.Name, statusErr)
+		}
 		return err
 	}
 	// Get recommended replicas
@@ -308,17 +347,33 @@ func (ac *AutoscaleController) doScale(ctx context.Context, autoscalePolicy *wor
 	recommendedInstances, err := scaler.Scale(ctx, ac.podsLister, autoscalePolicy, currentInstancesCount)
 	if err != nil {
 		klog.Errorf("failed to do homogeneous scaling for target %s, err: %v", target.TargetRef.Name, err)
+		if statusErr := ac.updateHomogeneousPolicyStatus(ctx, autoscalePolicy, currentInstancesCount, 0, "", err, true); statusErr != nil {
+			klog.Warningf("failed to update homogeneous policy status %s/%s: %v", autoscalePolicy.Namespace, autoscalePolicy.Name, statusErr)
+		}
 		return err
 	}
+	mode := "Stable"
+	if scaler.Status != nil && scaler.Status.IsPanicMode() {
+		mode = "Panic"
+	}
 	if recommendedInstances < 0 {
+		if statusErr := ac.updateHomogeneousPolicyStatus(ctx, autoscalePolicy, currentInstancesCount, currentInstancesCount, mode, nil, true); statusErr != nil {
+			klog.Warningf("failed to update homogeneous policy status %s/%s: %v", autoscalePolicy.Namespace, autoscalePolicy.Name, statusErr)
+		}
 		return nil
 	}
 	// Do update replicas
 	if err := ac.updateTargetReplicas(ctx, &target, autoscalePolicy.Namespace, recommendedInstances); err != nil {
 		klog.Errorf("failed to update target replicas %s, err: %v", target.TargetRef.Name, err)
+		if statusErr := ac.updateHomogeneousPolicyStatus(ctx, autoscalePolicy, currentInstancesCount, recommendedInstances, mode, err, true); statusErr != nil {
+			klog.Warningf("failed to update homogeneous policy status %s/%s: %v", autoscalePolicy.Namespace, autoscalePolicy.Name, statusErr)
+		}
 		return err
 	}
 	klog.InfoS("successfully update target replicas", "targetRef", target.TargetRef, "recommendedInstances", recommendedInstances)
+	if statusErr := ac.updateHomogeneousPolicyStatus(ctx, autoscalePolicy, currentInstancesCount, recommendedInstances, mode, nil, true); statusErr != nil {
+		klog.Warningf("failed to update homogeneous policy status %s/%s: %v", autoscalePolicy.Namespace, autoscalePolicy.Name, statusErr)
+	}
 	return nil
 }
 
@@ -507,89 +562,303 @@ func getRoleReplica(modelServing *workload.ModelServing, roleName string) (int, 
 	return -1, 0
 }
 
+// updateHomogeneousPolicyStatus writes status for the last homogeneous reconcile.
+func (ac *AutoscaleController) updateHomogeneousPolicyStatus(ctx context.Context, policy *workload.AutoscalingPolicy, currentReplicas int32, desiredReplicas int32, mode string, reconcileErr error, targetFound bool) error {
+	readFromAPI := false
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		var latestPolicy *workload.AutoscalingPolicy
+		var getErr error
+		if readFromAPI {
+			latestPolicy, getErr = ac.client.WorkloadV1alpha1().AutoscalingPolicies(policy.Namespace).Get(ctx, policy.Name, metav1.GetOptions{})
+		} else if ac.autoscalingPoliciesLister != nil {
+			latestPolicy, getErr = ac.autoscalingPoliciesLister.AutoscalingPolicies(policy.Namespace).Get(policy.Name)
+		} else {
+			latestPolicy, getErr = ac.client.WorkloadV1alpha1().AutoscalingPolicies(policy.Namespace).Get(ctx, policy.Name, metav1.GetOptions{})
+		}
+		if getErr != nil {
+			return getErr
+		}
+
+		policyCopy := &workload.AutoscalingPolicy{
+			TypeMeta:   latestPolicy.TypeMeta,
+			ObjectMeta: *latestPolicy.ObjectMeta.DeepCopy(),
+			Status:     *latestPolicy.Status.DeepCopy(),
+		}
+		policyCopy.Status.ObservedGeneration = latestPolicy.Generation
+		policyCopy.Status.HomogeneousStatus = nil
+		policyCopy.Status.HeterogeneousStatus = nil
+		policyCopy.Status.DisaggregatedStatus = nil
+
+		readyCondition := metav1.Condition{
+			Type:               "Ready",
+			ObservedGeneration: latestPolicy.Generation,
+			LastTransitionTime: metav1.Now(),
+		}
+		targetFoundCondition := metav1.Condition{
+			Type:               "TargetFound",
+			ObservedGeneration: latestPolicy.Generation,
+			LastTransitionTime: metav1.Now(),
+		}
+		if reconcileErr != nil {
+			readyCondition.Status = metav1.ConditionFalse
+			readyCondition.Reason = "ReconcileFailed"
+			readyCondition.Message = reconcileErr.Error()
+		} else {
+			readyCondition.Status = metav1.ConditionTrue
+			readyCondition.Reason = "Reconciled"
+			readyCondition.Message = "homogeneous autoscaling policy reconciled"
+		}
+		if targetFound {
+			targetFoundCondition.Status = metav1.ConditionTrue
+			targetFoundCondition.Reason = "TargetFound"
+			targetFoundCondition.Message = "target model serving found"
+		} else {
+			targetFoundCondition.Status = metav1.ConditionFalse
+			targetFoundCondition.Reason = "TargetInvalid"
+			if reconcileErr != nil {
+				targetFoundCondition.Message = reconcileErr.Error()
+			} else {
+				targetFoundCondition.Message = "target model serving was not found"
+			}
+		}
+		meta.SetStatusCondition(&policyCopy.Status.Conditions, readyCondition)
+		meta.SetStatusCondition(&policyCopy.Status.Conditions, targetFoundCondition)
+
+		if targetFound && reconcileErr == nil {
+			var lastScaleTime *metav1.Time
+			if latestPolicy.Status.HomogeneousStatus != nil {
+				lastScaleTime = latestPolicy.Status.HomogeneousStatus.LastScaleTime
+			}
+			if currentReplicas != desiredReplicas {
+				now := metav1.Now()
+				lastScaleTime = &now
+			}
+			policyCopy.Status.HomogeneousStatus = &workload.TargetScalingStatus{
+				CurrentReplicas: currentReplicas,
+				DesiredReplicas: desiredReplicas,
+				Mode:            mode,
+				LastScaleTime:   lastScaleTime,
+			}
+		}
+
+		if equality.Semantic.DeepEqual(latestPolicy.Status, policyCopy.Status) {
+			return nil
+		}
+		_, err := ac.client.WorkloadV1alpha1().AutoscalingPolicies(policyCopy.Namespace).UpdateStatus(ctx, policyCopy, metav1.UpdateOptions{})
+		if err != nil {
+			if apierrors.IsConflict(err) {
+				klog.V(4).Infof("AutoscalingPolicy %s/%s status update conflicted, retrying with API read: %v", policyCopy.Namespace, policyCopy.Name, err)
+				readFromAPI = true
+			}
+			return err
+		}
+		return nil
+	})
+}
+
+// updateHeterogeneousPolicyStatus writes status for the last heterogeneous reconcile.
+func (ac *AutoscaleController) updateHeterogeneousPolicyStatus(ctx context.Context, policy *workload.AutoscalingPolicy, targetsStatus []workload.TargetScalingStatus, reconcileErr error, targetFound bool) error {
+	readFromAPI := false
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		var latestPolicy *workload.AutoscalingPolicy
+		var getErr error
+		if readFromAPI {
+			latestPolicy, getErr = ac.client.WorkloadV1alpha1().AutoscalingPolicies(policy.Namespace).Get(ctx, policy.Name, metav1.GetOptions{})
+		} else if ac.autoscalingPoliciesLister != nil {
+			latestPolicy, getErr = ac.autoscalingPoliciesLister.AutoscalingPolicies(policy.Namespace).Get(policy.Name)
+		} else {
+			latestPolicy, getErr = ac.client.WorkloadV1alpha1().AutoscalingPolicies(policy.Namespace).Get(ctx, policy.Name, metav1.GetOptions{})
+		}
+		if getErr != nil {
+			return getErr
+		}
+
+		policyCopy := &workload.AutoscalingPolicy{
+			TypeMeta:   latestPolicy.TypeMeta,
+			ObjectMeta: *latestPolicy.ObjectMeta.DeepCopy(),
+			Status:     *latestPolicy.Status.DeepCopy(),
+		}
+		policyCopy.Status.ObservedGeneration = latestPolicy.Generation
+		policyCopy.Status.HomogeneousStatus = nil
+		policyCopy.Status.HeterogeneousStatus = nil
+		policyCopy.Status.DisaggregatedStatus = nil
+
+		readyCondition := metav1.Condition{
+			Type:               "Ready",
+			ObservedGeneration: latestPolicy.Generation,
+			LastTransitionTime: metav1.Now(),
+		}
+		targetFoundCondition := metav1.Condition{
+			Type:               "TargetFound",
+			ObservedGeneration: latestPolicy.Generation,
+			LastTransitionTime: metav1.Now(),
+		}
+		if reconcileErr != nil {
+			readyCondition.Status = metav1.ConditionFalse
+			readyCondition.Reason = "ReconcileFailed"
+			readyCondition.Message = reconcileErr.Error()
+		} else {
+			readyCondition.Status = metav1.ConditionTrue
+			readyCondition.Reason = "Reconciled"
+			readyCondition.Message = "heterogeneous autoscaling policy reconciled"
+		}
+		if targetFound {
+			targetFoundCondition.Status = metav1.ConditionTrue
+			targetFoundCondition.Reason = "TargetFound"
+			targetFoundCondition.Message = "target model servings found"
+		} else {
+			targetFoundCondition.Status = metav1.ConditionFalse
+			targetFoundCondition.Reason = "TargetInvalid"
+			if reconcileErr != nil {
+				targetFoundCondition.Message = reconcileErr.Error()
+			} else {
+				targetFoundCondition.Message = "target model servings were not found"
+			}
+		}
+		meta.SetStatusCondition(&policyCopy.Status.Conditions, readyCondition)
+		meta.SetStatusCondition(&policyCopy.Status.Conditions, targetFoundCondition)
+
+		if targetsStatus != nil {
+			prevLastScaleTimeByName := map[string]*metav1.Time{}
+			if latestPolicy.Status.HeterogeneousStatus != nil {
+				for _, prev := range latestPolicy.Status.HeterogeneousStatus {
+					prevLastScaleTimeByName[prev.Name] = prev.LastScaleTime
+				}
+			}
+			now := metav1.Now()
+			updatedStatuses := make([]workload.TargetScalingStatus, 0, len(targetsStatus))
+			for _, ts := range targetsStatus {
+				lastScaleTime := prevLastScaleTimeByName[ts.Name]
+				if reconcileErr == nil && ts.CurrentReplicas != ts.DesiredReplicas {
+					lastScaleTime = &now
+				}
+				ts.LastScaleTime = lastScaleTime
+				updatedStatuses = append(updatedStatuses, ts)
+			}
+			policyCopy.Status.HeterogeneousStatus = updatedStatuses
+		}
+
+		if equality.Semantic.DeepEqual(latestPolicy.Status, policyCopy.Status) {
+			return nil
+		}
+		_, err := ac.client.WorkloadV1alpha1().AutoscalingPolicies(policyCopy.Namespace).UpdateStatus(ctx, policyCopy, metav1.UpdateOptions{})
+		if err != nil {
+			if apierrors.IsConflict(err) {
+				klog.V(4).Infof("AutoscalingPolicy %s/%s status update conflicted, retrying with API read: %v", policyCopy.Namespace, policyCopy.Name, err)
+				readFromAPI = true
+			}
+			return err
+		}
+		return nil
+	})
+}
+
 // updateDisaggregatedPolicyStatus writes status for the last disaggregated
 // reconcile. Ready reports the overall reconcile result, while TargetFound only
 // reports whether the referenced ModelServing and configured roles were resolved.
 func (ac *AutoscaleController) updateDisaggregatedPolicyStatus(ctx context.Context, policy *workload.AutoscalingPolicy, result *autoscaler.DisaggregatedScaleResult, reconcileErr error, targetFound bool) error {
-	policyCopy := &workload.AutoscalingPolicy{
-		TypeMeta:   policy.TypeMeta,
-		ObjectMeta: *policy.ObjectMeta.DeepCopy(),
-		Status:     *policy.Status.DeepCopy(),
-	}
-	policyCopy.Status.ObservedGeneration = policy.Generation
-	policyCopy.Status.HomogeneousStatus = nil
-	policyCopy.Status.HeterogeneousStatus = nil
-	policyCopy.Status.DisaggregatedStatus = nil
-
-	readyCondition := metav1.Condition{
-		Type:               "Ready",
-		ObservedGeneration: policy.Generation,
-		LastTransitionTime: metav1.Now(),
-	}
-	targetFoundCondition := metav1.Condition{
-		Type:               "TargetFound",
-		ObservedGeneration: policy.Generation,
-		LastTransitionTime: metav1.Now(),
-	}
-	if reconcileErr != nil {
-		readyCondition.Status = metav1.ConditionFalse
-		readyCondition.Reason = "ReconcileFailed"
-		readyCondition.Message = reconcileErr.Error()
-	} else {
-		readyCondition.Status = metav1.ConditionTrue
-		readyCondition.Reason = "Reconciled"
-		readyCondition.Message = "disaggregated autoscaling policy reconciled"
-	}
-	if targetFound {
-		targetFoundCondition.Status = metav1.ConditionTrue
-		targetFoundCondition.Reason = "TargetFound"
-		targetFoundCondition.Message = "target model serving and roles found"
-	} else {
-		targetFoundCondition.Status = metav1.ConditionFalse
-		targetFoundCondition.Reason = "TargetInvalid"
-		if reconcileErr != nil {
-			targetFoundCondition.Message = reconcileErr.Error()
+	readFromAPI := false
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		var latestPolicy *workload.AutoscalingPolicy
+		var getErr error
+		if readFromAPI {
+			latestPolicy, getErr = ac.client.WorkloadV1alpha1().AutoscalingPolicies(policy.Namespace).Get(ctx, policy.Name, metav1.GetOptions{})
+		} else if ac.autoscalingPoliciesLister != nil {
+			latestPolicy, getErr = ac.autoscalingPoliciesLister.AutoscalingPolicies(policy.Namespace).Get(policy.Name)
 		} else {
-			targetFoundCondition.Message = "target model serving or configured roles were not found"
+			latestPolicy, getErr = ac.client.WorkloadV1alpha1().AutoscalingPolicies(policy.Namespace).Get(ctx, policy.Name, metav1.GetOptions{})
 		}
-	}
-	meta.SetStatusCondition(&policyCopy.Status.Conditions, readyCondition)
-	meta.SetStatusCondition(&policyCopy.Status.Conditions, targetFoundCondition)
+		if getErr != nil {
+			return getErr
+		}
 
-	if result != nil {
-		roleStatuses := make([]workload.TargetScalingStatus, 0, len(result.Roles))
-		prevLastScaleTimeByRole := map[string]*metav1.Time{}
-		if policy.Status.DisaggregatedStatus != nil {
-			for _, prev := range policy.Status.DisaggregatedStatus.Roles {
-				prevLastScaleTimeByRole[prev.Name] = prev.LastScaleTime
+		policyCopy := &workload.AutoscalingPolicy{
+			TypeMeta:   latestPolicy.TypeMeta,
+			ObjectMeta: *latestPolicy.ObjectMeta.DeepCopy(),
+			Status:     *latestPolicy.Status.DeepCopy(),
+		}
+		policyCopy.Status.ObservedGeneration = latestPolicy.Generation
+		policyCopy.Status.HomogeneousStatus = nil
+		policyCopy.Status.HeterogeneousStatus = nil
+		policyCopy.Status.DisaggregatedStatus = nil
+
+		readyCondition := metav1.Condition{
+			Type:               "Ready",
+			ObservedGeneration: latestPolicy.Generation,
+			LastTransitionTime: metav1.Now(),
+		}
+		targetFoundCondition := metav1.Condition{
+			Type:               "TargetFound",
+			ObservedGeneration: latestPolicy.Generation,
+			LastTransitionTime: metav1.Now(),
+		}
+		if reconcileErr != nil {
+			readyCondition.Status = metav1.ConditionFalse
+			readyCondition.Reason = "ReconcileFailed"
+			readyCondition.Message = reconcileErr.Error()
+		} else {
+			readyCondition.Status = metav1.ConditionTrue
+			readyCondition.Reason = "Reconciled"
+			readyCondition.Message = "disaggregated autoscaling policy reconciled"
+		}
+		if targetFound {
+			targetFoundCondition.Status = metav1.ConditionTrue
+			targetFoundCondition.Reason = "TargetFound"
+			targetFoundCondition.Message = "target model serving and roles found"
+		} else {
+			targetFoundCondition.Status = metav1.ConditionFalse
+			targetFoundCondition.Reason = "TargetInvalid"
+			if reconcileErr != nil {
+				targetFoundCondition.Message = reconcileErr.Error()
+			} else {
+				targetFoundCondition.Message = "target model serving or configured roles were not found"
 			}
 		}
-		now := metav1.Now()
-		for _, role := range result.Roles {
-			lastScaleTime := prevLastScaleTimeByRole[role.Name]
-			if reconcileErr == nil && role.CurrentReplicas != role.FinalReplicas {
-				lastScaleTime = &now
-			}
-			roleStatuses = append(roleStatuses, workload.TargetScalingStatus{
-				Name:            role.Name,
-				CurrentReplicas: role.CurrentReplicas,
-				DesiredReplicas: role.DesiredReplicas,
-				Mode:            role.Mode,
-				LastScaleTime:   lastScaleTime,
-			})
-		}
-		policyCopy.Status.DisaggregatedStatus = &workload.DisaggregatedScalingStatus{
-			Roles:         roleStatuses,
-			RatioStatus:   result.RatioStatus,
-			RatioAdjusted: result.RatioAdjusted,
-		}
-	}
+		meta.SetStatusCondition(&policyCopy.Status.Conditions, readyCondition)
+		meta.SetStatusCondition(&policyCopy.Status.Conditions, targetFoundCondition)
 
-	if equality.Semantic.DeepEqual(policy.Status, policyCopy.Status) {
+		if result != nil {
+			roleStatuses := make([]workload.TargetScalingStatus, 0, len(result.Roles))
+			prevLastScaleTimeByRole := map[string]*metav1.Time{}
+			if latestPolicy.Status.DisaggregatedStatus != nil {
+				for _, prev := range latestPolicy.Status.DisaggregatedStatus.Roles {
+					prevLastScaleTimeByRole[prev.Name] = prev.LastScaleTime
+				}
+			}
+			now := metav1.Now()
+			for _, role := range result.Roles {
+				lastScaleTime := prevLastScaleTimeByRole[role.Name]
+				if reconcileErr == nil && role.CurrentReplicas != role.FinalReplicas {
+					lastScaleTime = &now
+				}
+				roleStatuses = append(roleStatuses, workload.TargetScalingStatus{
+					Name:            role.Name,
+					CurrentReplicas: role.CurrentReplicas,
+					DesiredReplicas: role.DesiredReplicas,
+					Mode:            role.Mode,
+					LastScaleTime:   lastScaleTime,
+				})
+			}
+			policyCopy.Status.DisaggregatedStatus = &workload.DisaggregatedScalingStatus{
+				Roles:         roleStatuses,
+				RatioStatus:   result.RatioStatus,
+				RatioAdjusted: result.RatioAdjusted,
+			}
+		}
+
+		if equality.Semantic.DeepEqual(latestPolicy.Status, policyCopy.Status) {
+			return nil
+		}
+		_, err := ac.client.WorkloadV1alpha1().AutoscalingPolicies(policyCopy.Namespace).UpdateStatus(ctx, policyCopy, metav1.UpdateOptions{})
+		if err != nil {
+			if apierrors.IsConflict(err) {
+				klog.V(4).Infof("AutoscalingPolicy %s/%s status update conflicted, retrying with API read: %v", policyCopy.Namespace, policyCopy.Name, err)
+				readFromAPI = true
+			}
+			return err
+		}
 		return nil
-	}
-	_, err := ac.client.WorkloadV1alpha1().AutoscalingPolicies(policy.Namespace).UpdateStatus(ctx, policyCopy, metav1.UpdateOptions{})
-	return err
+	})
 }
 
 func formatAutoscalerMapKey(policyNamespace, policyName string, targetRef *corev1.ObjectReference) string {

--- a/pkg/autoscaler/controller/autoscale_controller_test.go
+++ b/pkg/autoscaler/controller/autoscale_controller_test.go
@@ -973,3 +973,262 @@ func TestPatchDoesNotMutateResourcesInFakeClient(t *testing.T) {
 		})
 	}
 }
+
+func newAutoscalingPolicyIndexer(objs ...interface{}) cache.Indexer {
+	idx := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	for _, o := range objs {
+		_ = idx.Add(o)
+	}
+	return idx
+}
+
+func TestUpdateHomogeneousPolicyStatus_Success(t *testing.T) {
+	ns := "default"
+	policyName := "policy-homo"
+	policy := &workload.AutoscalingPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       policyName,
+			Namespace:  ns,
+			Generation: 2,
+		},
+		Spec: workload.AutoscalingPolicySpec{
+			HomogeneousTarget: &workload.HomogeneousTarget{
+				Target: workload.Target{
+					TargetRef: corev1.ObjectReference{
+						Kind: workload.ModelServingKind.Kind,
+						Name: "ms-target",
+					},
+				},
+			},
+		},
+	}
+
+	client := clientfake.NewSimpleClientset(policy)
+	ac := &AutoscaleController{
+		client:                    client,
+		autoscalingPoliciesLister: workloadLister.NewAutoscalingPolicyLister(newAutoscalingPolicyIndexer(policy)),
+	}
+
+	err := ac.updateHomogeneousPolicyStatus(context.Background(), policy, 3, 5, "Stable", nil, true)
+	if err != nil {
+		t.Fatalf("updateHomogeneousPolicyStatus returned error: %v", err)
+	}
+
+	updated, err := client.WorkloadV1alpha1().AutoscalingPolicies(ns).Get(context.Background(), policyName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get updated policy: %v", err)
+	}
+
+	if updated.Status.ObservedGeneration != 2 {
+		t.Errorf("expected ObservedGeneration=2, got %d", updated.Status.ObservedGeneration)
+	}
+
+	if updated.Status.HomogeneousStatus == nil {
+		t.Fatal("expected HomogeneousStatus to be non-nil")
+	}
+	if updated.Status.HomogeneousStatus.CurrentReplicas != 3 {
+		t.Errorf("expected CurrentReplicas=3, got %d", updated.Status.HomogeneousStatus.CurrentReplicas)
+	}
+	if updated.Status.HomogeneousStatus.DesiredReplicas != 5 {
+		t.Errorf("expected DesiredReplicas=5, got %d", updated.Status.HomogeneousStatus.DesiredReplicas)
+	}
+	if updated.Status.HomogeneousStatus.Mode != "Stable" {
+		t.Errorf("expected Mode='Stable', got %s", updated.Status.HomogeneousStatus.Mode)
+	}
+	if updated.Status.HomogeneousStatus.LastScaleTime == nil {
+		t.Error("expected LastScaleTime to be set when replicas change")
+	}
+
+	// Verify conditions
+	var readyCond, targetCond *metav1.Condition
+	for i := range updated.Status.Conditions {
+		cond := &updated.Status.Conditions[i]
+		if cond.Type == "Ready" {
+			readyCond = cond
+		} else if cond.Type == "TargetFound" {
+			targetCond = cond
+		}
+	}
+
+	if readyCond == nil || readyCond.Status != metav1.ConditionTrue || readyCond.Reason != "Reconciled" {
+		t.Errorf("unexpected Ready condition: %+v", readyCond)
+	}
+	if targetCond == nil || targetCond.Status != metav1.ConditionTrue || targetCond.Reason != "TargetFound" {
+		t.Errorf("unexpected TargetFound condition: %+v", targetCond)
+	}
+}
+
+func TestUpdateHomogeneousPolicyStatus_TargetNotFound(t *testing.T) {
+	ns := "default"
+	policyName := "policy-homo-err"
+	policy := &workload.AutoscalingPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       policyName,
+			Namespace:  ns,
+			Generation: 1,
+		},
+		Spec: workload.AutoscalingPolicySpec{
+			HomogeneousTarget: &workload.HomogeneousTarget{},
+		},
+	}
+
+	client := clientfake.NewSimpleClientset(policy)
+	ac := &AutoscaleController{
+		client:                    client,
+		autoscalingPoliciesLister: workloadLister.NewAutoscalingPolicyLister(newAutoscalingPolicyIndexer(policy)),
+	}
+
+	targetErr := fmt.Errorf("modelserving ms-missing not found")
+	err := ac.updateHomogeneousPolicyStatus(context.Background(), policy, 0, 0, "", targetErr, false)
+	if err != nil {
+		t.Fatalf("updateHomogeneousPolicyStatus returned error: %v", err)
+	}
+
+	updated, err := client.WorkloadV1alpha1().AutoscalingPolicies(ns).Get(context.Background(), policyName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get updated policy: %v", err)
+	}
+
+	if updated.Status.HomogeneousStatus != nil {
+		t.Error("expected HomogeneousStatus to be nil when target is not found")
+	}
+
+	var readyCond, targetCond *metav1.Condition
+	for i := range updated.Status.Conditions {
+		cond := &updated.Status.Conditions[i]
+		if cond.Type == "Ready" {
+			readyCond = cond
+		} else if cond.Type == "TargetFound" {
+			targetCond = cond
+		}
+	}
+
+	if readyCond == nil || readyCond.Status != metav1.ConditionFalse || readyCond.Reason != "ReconcileFailed" {
+		t.Errorf("unexpected Ready condition: %+v", readyCond)
+	}
+	if targetCond == nil || targetCond.Status != metav1.ConditionFalse || targetCond.Reason != "TargetInvalid" {
+		t.Errorf("unexpected TargetFound condition: %+v", targetCond)
+	}
+}
+
+func TestUpdateHeterogeneousPolicyStatus_Success(t *testing.T) {
+	ns := "default"
+	policyName := "policy-hetero"
+	policy := &workload.AutoscalingPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       policyName,
+			Namespace:  ns,
+			Generation: 3,
+		},
+		Spec: workload.AutoscalingPolicySpec{
+			HeterogeneousTarget: &workload.HeterogeneousTarget{},
+		},
+	}
+
+	client := clientfake.NewSimpleClientset(policy)
+	ac := &AutoscaleController{
+		client:                    client,
+		autoscalingPoliciesLister: workloadLister.NewAutoscalingPolicyLister(newAutoscalingPolicyIndexer(policy)),
+	}
+
+	targetStatuses := []workload.TargetScalingStatus{
+		{Name: "ms-a", CurrentReplicas: 2, DesiredReplicas: 4, Mode: "Stable"},
+		{Name: "ms-b", CurrentReplicas: 1, DesiredReplicas: 2, Mode: "Stable"},
+	}
+
+	err := ac.updateHeterogeneousPolicyStatus(context.Background(), policy, targetStatuses, nil, true)
+	if err != nil {
+		t.Fatalf("updateHeterogeneousPolicyStatus returned error: %v", err)
+	}
+
+	updated, err := client.WorkloadV1alpha1().AutoscalingPolicies(ns).Get(context.Background(), policyName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get updated policy: %v", err)
+	}
+
+	if updated.Status.ObservedGeneration != 3 {
+		t.Errorf("expected ObservedGeneration=3, got %d", updated.Status.ObservedGeneration)
+	}
+
+	if len(updated.Status.HeterogeneousStatus) != 2 {
+		t.Fatalf("expected 2 HeterogeneousStatus entries, got %d", len(updated.Status.HeterogeneousStatus))
+	}
+
+	if updated.Status.HeterogeneousStatus[0].Name != "ms-a" || updated.Status.HeterogeneousStatus[0].DesiredReplicas != 4 {
+		t.Errorf("unexpected target 0 status: %+v", updated.Status.HeterogeneousStatus[0])
+	}
+	if updated.Status.HeterogeneousStatus[1].Name != "ms-b" || updated.Status.HeterogeneousStatus[1].DesiredReplicas != 2 {
+		t.Errorf("unexpected target 1 status: %+v", updated.Status.HeterogeneousStatus[1])
+	}
+
+	// Verify conditions
+	var readyCond, targetCond *metav1.Condition
+	for i := range updated.Status.Conditions {
+		cond := &updated.Status.Conditions[i]
+		if cond.Type == "Ready" {
+			readyCond = cond
+		} else if cond.Type == "TargetFound" {
+			targetCond = cond
+		}
+	}
+
+	if readyCond == nil || readyCond.Status != metav1.ConditionTrue || readyCond.Reason != "Reconciled" {
+		t.Errorf("unexpected Ready condition: %+v", readyCond)
+	}
+	if targetCond == nil || targetCond.Status != metav1.ConditionTrue || targetCond.Reason != "TargetFound" {
+		t.Errorf("unexpected TargetFound condition: %+v", targetCond)
+	}
+}
+
+func TestUpdateHeterogeneousPolicyStatus_TargetNotFound(t *testing.T) {
+	ns := "default"
+	policyName := "policy-hetero-err"
+	policy := &workload.AutoscalingPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       policyName,
+			Namespace:  ns,
+			Generation: 1,
+		},
+		Spec: workload.AutoscalingPolicySpec{
+			HeterogeneousTarget: &workload.HeterogeneousTarget{},
+		},
+	}
+
+	client := clientfake.NewSimpleClientset(policy)
+	ac := &AutoscaleController{
+		client:                    client,
+		autoscalingPoliciesLister: workloadLister.NewAutoscalingPolicyLister(newAutoscalingPolicyIndexer(policy)),
+	}
+
+	targetErr := fmt.Errorf("modelserving ms-missing not found")
+	err := ac.updateHeterogeneousPolicyStatus(context.Background(), policy, nil, targetErr, false)
+	if err != nil {
+		t.Fatalf("updateHeterogeneousPolicyStatus returned error: %v", err)
+	}
+
+	updated, err := client.WorkloadV1alpha1().AutoscalingPolicies(ns).Get(context.Background(), policyName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get updated policy: %v", err)
+	}
+
+	if len(updated.Status.HeterogeneousStatus) != 0 {
+		t.Error("expected HeterogeneousStatus to be empty when target is not found")
+	}
+
+	var readyCond, targetCond *metav1.Condition
+	for i := range updated.Status.Conditions {
+		cond := &updated.Status.Conditions[i]
+		if cond.Type == "Ready" {
+			readyCond = cond
+		} else if cond.Type == "TargetFound" {
+			targetCond = cond
+		}
+	}
+
+	if readyCond == nil || readyCond.Status != metav1.ConditionFalse || readyCond.Reason != "ReconcileFailed" {
+		t.Errorf("unexpected Ready condition: %+v", readyCond)
+	}
+	if targetCond == nil || targetCond.Status != metav1.ConditionFalse || targetCond.Reason != "TargetInvalid" {
+		t.Errorf("unexpected TargetFound condition: %+v", targetCond)
+	}
+}

--- a/pkg/autoscaler/controller/autoscale_controller_test.go
+++ b/pkg/autoscaler/controller/autoscale_controller_test.go
@@ -134,8 +134,6 @@ func TestNewAutoscaleControllerSyncPeriodFallback(t *testing.T) {
 func TestToleranceHigh_then_DoScale_expect_NoUpdateActions(t *testing.T) {
 	ns := "ns"
 	ms := &workload.ModelServing{ObjectMeta: metav1.ObjectMeta{Name: "ms-a", Namespace: ns}, Spec: workload.ModelServingSpec{Replicas: ptrInt32(3)}}
-	client := clientfake.NewSimpleClientset(ms)
-	msLister := workloadLister.NewModelServingLister(newModelServingIndexer(ms))
 
 	srv := httptest.NewServer(httpHandlerWithBody("load 1\n"))
 	defer srv.Close()
@@ -146,23 +144,31 @@ func TestToleranceHigh_then_DoScale_expect_NoUpdateActions(t *testing.T) {
 	target := workload.Target{TargetRef: corev1.ObjectReference{Kind: workload.ModelServingKind.Kind, Namespace: ns, Name: "ms-a"}, MetricSources: map[string]workload.MetricSource{"load": {Pod: &workload.PodMetricSource{Uri: u.Path, Port: port}}}}
 	policy := &workload.AutoscalingPolicy{ObjectMeta: metav1.ObjectMeta{Name: "ap", Namespace: ns}, Spec: workload.AutoscalingPolicySpec{TolerancePercent: 100, Metrics: []workload.AutoscalingPolicyMetric{{Name: "load", TargetValue: resource.MustParse("1")}}, Behavior: workload.AutoscalingPolicyBehavior{}, HomogeneousTarget: &workload.HomogeneousTarget{Target: target, MinReplicas: 1, MaxReplicas: 100}}}
 
+	client := clientfake.NewSimpleClientset(ms, policy)
+	msLister := workloadLister.NewModelServingLister(newModelServingIndexer(ms))
+	policyLister := workloadLister.NewAutoscalingPolicyLister(newAutoscalingPolicyIndexer(policy))
+
 	lbs := map[string]string{}
 	pods := []*corev1.Pod{readyPod(ns, "pod-a", host, lbs)}
-	ac := &AutoscaleController{client: client, modelServingLister: msLister, podsLister: fakePodLister{podsByNs: map[string][]*corev1.Pod{ns: pods}}, scalerMap: map[string]*autoscalerAutoscaler{}, optimizerMap: map[string]*autoscalerOptimizer{}}
+	ac := &AutoscaleController{client: client, modelServingLister: msLister, autoscalingPoliciesLister: policyLister, podsLister: fakePodLister{podsByNs: map[string][]*corev1.Pod{ns: pods}}, scalerMap: map[string]*autoscalerAutoscaler{}, optimizerMap: map[string]*autoscalerOptimizer{}}
 
 	if err := ac.doScale(context.Background(), policy); err != nil {
 		t.Fatalf("doScale error: %v", err)
 	}
-	if len(client.Fake.Actions()) != 0 {
-		t.Fatalf("expected no update actions with tolerance=100, got %d", len(client.Fake.Actions()))
+	msUpdates := 0
+	for _, a := range client.Fake.Actions() {
+		if (a.GetVerb() == "update" || a.GetVerb() == "patch") && a.GetResource().Resource == "modelservings" {
+			msUpdates++
+		}
+	}
+	if msUpdates != 0 {
+		t.Fatalf("expected no modelserving update actions with tolerance=100, got %d", msUpdates)
 	}
 }
 
 func TestHighLoad_then_DoScale_expect_Replicas10(t *testing.T) {
 	ns := "ns"
 	ms := &workload.ModelServing{ObjectMeta: metav1.ObjectMeta{Name: "ms-up", Namespace: ns}, Spec: workload.ModelServingSpec{Replicas: ptrInt32(1)}}
-	client := clientfake.NewSimpleClientset(ms)
-	msLister := workloadLister.NewModelServingLister(newModelServingIndexer(ms))
 
 	srv := httptest.NewServer(httpHandlerWithBody("# TYPE load gauge\nload 10\n"))
 	defer srv.Close()
@@ -173,9 +179,13 @@ func TestHighLoad_then_DoScale_expect_Replicas10(t *testing.T) {
 	target := workload.Target{TargetRef: corev1.ObjectReference{Kind: workload.ModelServingKind.Kind, Namespace: ns, Name: "ms-up"}, MetricSources: map[string]workload.MetricSource{"load": {Pod: &workload.PodMetricSource{Uri: u.Path, Port: port}}}}
 	policy := &workload.AutoscalingPolicy{ObjectMeta: metav1.ObjectMeta{Name: "ap", Namespace: ns}, Spec: workload.AutoscalingPolicySpec{TolerancePercent: 0, Metrics: []workload.AutoscalingPolicyMetric{{Name: "load", TargetValue: resource.MustParse("1")}}, HomogeneousTarget: &workload.HomogeneousTarget{Target: target, MinReplicas: 1, MaxReplicas: 10}}}
 
+	client := clientfake.NewSimpleClientset(ms, policy)
+	msLister := workloadLister.NewModelServingLister(newModelServingIndexer(ms))
+	policyLister := workloadLister.NewAutoscalingPolicyLister(newAutoscalingPolicyIndexer(policy))
+
 	lbs := map[string]string{}
 	pods := []*corev1.Pod{readyPod(ns, "pod-up", host, lbs)}
-	ac := &AutoscaleController{client: client, modelServingLister: msLister, podsLister: fakePodLister{podsByNs: map[string][]*corev1.Pod{ns: pods}}, scalerMap: map[string]*autoscalerAutoscaler{}, optimizerMap: map[string]*autoscalerOptimizer{}}
+	ac := &AutoscaleController{client: client, modelServingLister: msLister, autoscalingPoliciesLister: policyLister, podsLister: fakePodLister{podsByNs: map[string][]*corev1.Pod{ns: pods}}, scalerMap: map[string]*autoscalerAutoscaler{}, optimizerMap: map[string]*autoscalerOptimizer{}}
 
 	if err := ac.doScale(context.Background(), policy); err != nil {
 		t.Fatalf("doScale error: %v", err)
@@ -193,8 +203,6 @@ func TestTwoBackends_then_DoOptimize_expect_PatchActions(t *testing.T) {
 	ns := "ns"
 	msA := &workload.ModelServing{ObjectMeta: metav1.ObjectMeta{Name: "ms-a", Namespace: ns}, Spec: workload.ModelServingSpec{Replicas: ptrInt32(1)}}
 	msB := &workload.ModelServing{ObjectMeta: metav1.ObjectMeta{Name: "ms-b", Namespace: ns}, Spec: workload.ModelServingSpec{Replicas: ptrInt32(2)}}
-	client := clientfake.NewSimpleClientset(msA, msB)
-	msLister := workloadLister.NewModelServingLister(newModelServingIndexer(msA, msB))
 
 	srv := httptest.NewServer(httpHandlerWithBody("# TYPE load gauge\nload 10\n"))
 	defer srv.Close()
@@ -207,10 +215,14 @@ func TestTwoBackends_then_DoOptimize_expect_PatchActions(t *testing.T) {
 	var threshold int32 = 200
 	policy := &workload.AutoscalingPolicy{ObjectMeta: metav1.ObjectMeta{Name: "ap", Namespace: ns}, Spec: workload.AutoscalingPolicySpec{TolerancePercent: 0, Metrics: []workload.AutoscalingPolicyMetric{{Name: "load", TargetValue: resource.MustParse("1")}}, Behavior: workload.AutoscalingPolicyBehavior{ScaleUp: workload.AutoscalingPolicyScaleUpPolicy{PanicPolicy: workload.AutoscalingPolicyPanicPolicy{Period: metav1.Duration{Duration: (1 * time.Second)}, PanicThresholdPercent: &threshold}}}, HeterogeneousTarget: &workload.HeterogeneousTarget{Params: []workload.HeterogeneousTargetParam{paramA, paramB}, CostExpansionRatePercent: 100}}}
 
+	client := clientfake.NewSimpleClientset(msA, msB, policy)
+	msLister := workloadLister.NewModelServingLister(newModelServingIndexer(msA, msB))
+	policyLister := workloadLister.NewAutoscalingPolicyLister(newAutoscalingPolicyIndexer(policy))
+
 	lbsA := map[string]string{}
 	lbsB := map[string]string{}
 	pods := []*corev1.Pod{readyPod(ns, "pod-a", host, lbsA), readyPod(ns, "pod-b", host, lbsB)}
-	ac := &AutoscaleController{client: client, modelServingLister: msLister, podsLister: fakePodLister{podsByNs: map[string][]*corev1.Pod{ns: pods}}, scalerMap: map[string]*autoscalerAutoscaler{}, optimizerMap: map[string]*autoscalerOptimizer{}}
+	ac := &AutoscaleController{client: client, modelServingLister: msLister, autoscalingPoliciesLister: policyLister, podsLister: fakePodLister{podsByNs: map[string][]*corev1.Pod{ns: pods}}, scalerMap: map[string]*autoscalerAutoscaler{}, optimizerMap: map[string]*autoscalerOptimizer{}}
 
 	if err := ac.doOptimize(context.Background(), policy); err != nil {
 		t.Fatalf("doOptimize error: %v", err)
@@ -230,8 +242,6 @@ func TestTwoBackendsHighLoad_then_DoOptimize_expect_DistributionA5B4(t *testing.
 	ns := "ns"
 	msA := &workload.ModelServing{ObjectMeta: metav1.ObjectMeta{Name: "ms-a2", Namespace: ns}, Spec: workload.ModelServingSpec{Replicas: ptrInt32(1)}}
 	msB := &workload.ModelServing{ObjectMeta: metav1.ObjectMeta{Name: "ms-b2", Namespace: ns}, Spec: workload.ModelServingSpec{Replicas: ptrInt32(2)}}
-	client := clientfake.NewSimpleClientset(msA, msB)
-	msLister := workloadLister.NewModelServingLister(newModelServingIndexer(msA, msB))
 
 	srv := httptest.NewServer(httpHandlerWithBody("# TYPE load gauge\nload 100\n"))
 	defer srv.Close()
@@ -244,10 +254,14 @@ func TestTwoBackendsHighLoad_then_DoOptimize_expect_DistributionA5B4(t *testing.
 	var threshold int32 = 200
 	policy := &workload.AutoscalingPolicy{ObjectMeta: metav1.ObjectMeta{Name: "ap", Namespace: ns}, Spec: workload.AutoscalingPolicySpec{TolerancePercent: 0, Metrics: []workload.AutoscalingPolicyMetric{{Name: "load", TargetValue: resource.MustParse("1")}}, Behavior: workload.AutoscalingPolicyBehavior{ScaleUp: workload.AutoscalingPolicyScaleUpPolicy{PanicPolicy: workload.AutoscalingPolicyPanicPolicy{Period: metav1.Duration{Duration: (1 * time.Second)}, PanicThresholdPercent: &threshold}}}, HeterogeneousTarget: &workload.HeterogeneousTarget{Params: []workload.HeterogeneousTargetParam{paramA, paramB}, CostExpansionRatePercent: 100}}}
 
+	client := clientfake.NewSimpleClientset(msA, msB, policy)
+	msLister := workloadLister.NewModelServingLister(newModelServingIndexer(msA, msB))
+	policyLister := workloadLister.NewAutoscalingPolicyLister(newAutoscalingPolicyIndexer(policy))
+
 	lbsA := map[string]string{}
 	lbsB := map[string]string{}
 	pods := []*corev1.Pod{readyPod(ns, "pod-a2", host, lbsA), readyPod(ns, "pod-b2", host, lbsB)}
-	ac := &AutoscaleController{client: client, modelServingLister: msLister, podsLister: fakePodLister{podsByNs: map[string][]*corev1.Pod{ns: pods}}, scalerMap: map[string]*autoscalerAutoscaler{}, optimizerMap: map[string]*autoscalerOptimizer{}}
+	ac := &AutoscaleController{client: client, modelServingLister: msLister, autoscalingPoliciesLister: policyLister, podsLister: fakePodLister{podsByNs: map[string][]*corev1.Pod{ns: pods}}, scalerMap: map[string]*autoscalerAutoscaler{}, optimizerMap: map[string]*autoscalerOptimizer{}}
 
 	if err := ac.doOptimize(context.Background(), policy); err != nil {
 		t.Fatalf("doOptimize error: %v", err)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`AutoscaleController` previously only updated `AutoscalingPolicy` custom resource status for `DisaggregatedTarget` policies (via `updateDisaggregatedPolicyStatus`). For `HomogeneousTarget` and `HeterogeneousTarget` policies, `doScale` and `doOptimize` executed the replica scaling patches on `ModelServing` instances but omitted updating `.status` on the `AutoscalingPolicy` custom resource entirely.

As a result, `AutoscalingPolicy` resources using homogeneous or heterogeneous scaling targets remained with empty status blocks (`status: {}`), leaving `observedGeneration`, `conditions` (`Ready`, `TargetFound`), `homogeneousStatus`, and `heterogeneousStatus` unpopulated.

This PR adds status update helpers and integrates them into `doScale` and `doOptimize`:
- `updateHomogeneousPolicyStatus`: Writes `ObservedGeneration`, `Conditions` (`Ready`, `TargetFound`), and `HomogeneousStatus` (current/desired replicas, mode, last scale time).
- `updateHeterogeneousPolicyStatus`: Writes `ObservedGeneration`, `Conditions` (`Ready`, `TargetFound`), and `HeterogeneousStatus` (per-target current/desired replicas, mode, last scale time).
- Employs `retry.RetryOnConflict` with a fallback API read strategy to handle status update conflicts cleanly.

**Which issue(s) this PR fixes**:
Fixes #1469

**Bug evidence (required for bug-related PRs)**:

Source path inspection:
- `doScale` in `pkg/autoscaler/controller/autoscale_controller.go` scaled target replicas but had no status update call.
- `doOptimize` in `pkg/autoscaler/controller/autoscale_controller.go` scaled target replicas across heterogeneous backends but had no status update call.
- `AutoscalingPolicyStatus` API definition in `pkg/apis/workload/v1alpha1/autoscalingpolicy_types.go` explicitly defines `HomogeneousStatus` and `HeterogeneousStatus`, but no corresponding status reconciliation functions existed in `AutoscaleController`.

Reproduction:
1. Apply an `AutoscalingPolicy` with a `homogeneousTarget` or `heterogeneousTarget`.
2. Observe that `AutoscaleController` reconciles and scales target `ModelServing` instances.
3. Check `kubectl get asp <name> -o yaml` — `.status` is completely empty.

**Special notes for your reviewer**:

- Comprehensive unit tests added in `pkg/autoscaler/controller/autoscale_controller_test.go`:
  - `TestUpdateHomogeneousPolicyStatus_Success`
  - `TestUpdateHomogeneousPolicyStatus_TargetNotFound`
  - `TestUpdateHeterogeneousPolicyStatus_Success`
  - `TestUpdateHeterogeneousPolicyStatus_TargetNotFound`
- All 21 tests in `pkg/autoscaler/controller` pass cleanly.

**Does this PR introduce a user-facing change?**:
```release-note
Fix AutoscaleController to populate status, conditions, and observedGeneration for HomogeneousTarget and HeterogeneousTarget AutoscalingPolicies.
```
