### PR TITLE
fix(router): honor HTTPRoute InferencePool backend weights

### DIFF
--- a/pkg/kthena-router/router/httproute_match.go
+++ b/pkg/kthena-router/router/httproute_match.go
@@ -17,6 +17,7 @@ limitations under the License.
 package router
 
 import (
+	"math/rand"
 	"net"
 	"regexp"
 	"strings"
@@ -180,16 +181,47 @@ func compareHTTPRoutePathPrecedence(a, b httpRoutePathPrecedence) int {
 // already matched rule. Other Gateway API backend kinds are ignored because this
 // router currently forwards only through InferencePool.
 func inferencePoolFromHTTPRouteRule(route *gatewayv1.HTTPRoute, rule *gatewayv1.HTTPRouteRule) (types.NamespacedName, bool) {
-	var inferencePoolName types.NamespacedName
+	pools := make([]weightedInferencePool, 0, len(rule.BackendRefs))
+	totalWeight := 0
 	for _, backendRef := range rule.BackendRefs {
 		if backendRef.Group != nil && *backendRef.Group == inferencePoolBackendGroup &&
 			backendRef.Kind != nil && *backendRef.Kind == inferencePoolBackendKind {
-			inferencePoolName.Namespace = route.Namespace
+			weight := 1
+			if backendRef.Weight != nil {
+				weight = int(*backendRef.Weight)
+			}
+			// Gateway API defines an omitted weight as 1 and a zero weight as
+			// receiving no traffic.
+			if weight <= 0 {
+				continue
+			}
+
+			inferencePoolName := types.NamespacedName{Namespace: route.Namespace}
 			if backendRef.Namespace != nil {
 				inferencePoolName.Namespace = string(*backendRef.Namespace)
 			}
 			inferencePoolName.Name = string(backendRef.Name)
-			return inferencePoolName, true
+			pools = append(pools, weightedInferencePool{name: inferencePoolName, weight: weight})
+			totalWeight += weight
+		}
+	}
+	if totalWeight == 0 {
+		return types.NamespacedName{}, false
+	}
+
+	return selectWeightedInferencePool(pools, rand.Intn(totalWeight))
+}
+
+type weightedInferencePool struct {
+	name   types.NamespacedName
+	weight int
+}
+
+func selectWeightedInferencePool(pools []weightedInferencePool, selection int) (types.NamespacedName, bool) {
+	for _, pool := range pools {
+		selection -= pool.weight
+		if selection < 0 {
+			return pool.name, true
 		}
 	}
 	return types.NamespacedName{}, false

--- a/pkg/kthena-router/router/httproute_match_test.go
+++ b/pkg/kthena-router/router/httproute_match_test.go
@@ -273,3 +273,91 @@ func TestMatchHTTPRouteHostname(t *testing.T) {
 		})
 	}
 }
+
+func TestInferencePoolFromHTTPRouteRuleWeights(t *testing.T) {
+	group := inferencePoolBackendGroup
+	kind := inferencePoolBackendKind
+	zero := int32(0)
+	one := int32(1)
+
+	backendRef := func(name string, weight *int32) gatewayv1.HTTPBackendRef {
+		return gatewayv1.HTTPBackendRef{
+			BackendRef: gatewayv1.BackendRef{
+				BackendObjectReference: gatewayv1.BackendObjectReference{
+					Group: &group,
+					Kind:  &kind,
+					Name:  gatewayv1.ObjectName(name),
+				},
+				Weight: weight,
+			},
+		}
+	}
+
+	tests := []struct {
+		name        string
+		backendRefs []gatewayv1.HTTPBackendRef
+		expected    types.NamespacedName
+		found       bool
+	}{
+		{
+			name: "skips a zero-weight backend",
+			backendRefs: []gatewayv1.HTTPBackendRef{
+				backendRef("pool-zero", &zero),
+				backendRef("pool-live", &one),
+			},
+			expected: types.NamespacedName{Namespace: "default", Name: "pool-live"},
+			found:    true,
+		},
+		{
+			name: "uses the default weight when omitted",
+			backendRefs: []gatewayv1.HTTPBackendRef{
+				backendRef("pool-default", nil),
+			},
+			expected: types.NamespacedName{Namespace: "default", Name: "pool-default"},
+			found:    true,
+		},
+		{
+			name: "returns no backend when all weights are zero",
+			backendRefs: []gatewayv1.HTTPBackendRef{
+				backendRef("pool-zero", &zero),
+			},
+			found: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			route := &gatewayv1.HTTPRoute{ObjectMeta: v1.ObjectMeta{Namespace: "default"}}
+			rule := &gatewayv1.HTTPRouteRule{BackendRefs: tt.backendRefs}
+
+			pool, found := inferencePoolFromHTTPRouteRule(route, rule)
+			assert.Equal(t, tt.found, found)
+			assert.Equal(t, tt.expected, pool)
+		})
+	}
+}
+
+func TestSelectWeightedInferencePool(t *testing.T) {
+	pools := []weightedInferencePool{
+		{name: types.NamespacedName{Namespace: "default", Name: "pool-a"}, weight: 3},
+		{name: types.NamespacedName{Namespace: "default", Name: "pool-b"}, weight: 1},
+	}
+
+	tests := []struct {
+		name      string
+		selection int
+		expected  string
+	}{
+		{name: "first weight slot", selection: 0, expected: "pool-a"},
+		{name: "last first-pool weight slot", selection: 2, expected: "pool-a"},
+		{name: "second-pool weight slot", selection: 3, expected: "pool-b"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pool, found := selectWeightedInferencePool(pools, tt.selection)
+			assert.True(t, found)
+			assert.Equal(t, tt.expected, pool.Name)
+		})
+	}
+}

--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -448,7 +448,13 @@ func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest) error 
 		}
 
 		port = modelServer.Spec.WorkloadPort.Port
-	} else if matched, inferencePoolName := r.handleHTTPRoute(c, gatewayKey); matched {
+	} else if matched, inferencePoolName, httpRouteErr := r.handleHTTPRoute(c, gatewayKey); httpRouteErr != nil {
+		klog.Errorf("failed to select InferencePool for matched HTTPRoute: %v", httpRouteErr)
+		accesslog.SetError(c, "inference_pool_selection", httpRouteErr.Error())
+		c.AbortWithStatusJSON(http.StatusServiceUnavailable, httpRouteErr.Error())
+		c.Set("finishReason", "inference_pool_selection")
+		return httpRouteErr
+	} else if matched {
 		// If ModelRoute is not matched, try to match HTTPRoute
 
 		// Get InferencePool from store
@@ -619,13 +625,13 @@ func (r *Router) getPodsAndServer(modelServerName types.NamespacedName) ([]*data
 	return pods, modelServer, nil
 }
 
-// handleHTTPRoute handles HTTPRoute matching for non-/v1/ paths
-// Returns true if HTTPRoute was matched and request is being handled, false otherwise
-// Also returns the InferencePool NamespacedName if found
-func (r *Router) handleHTTPRoute(c *gin.Context, gatewayKey string) (bool, types.NamespacedName) {
+// handleHTTPRoute handles HTTPRoute matching for non-/v1/ paths.
+// It returns whether a route matched, the selected InferencePool, and an error
+// when a matched rule has no eligible InferencePool backend.
+func (r *Router) handleHTTPRoute(c *gin.Context, gatewayKey string) (bool, types.NamespacedName, error) {
 	matchResult, matched := r.findHTTPRouteMatch(c, gatewayKey)
 	if !matched {
-		return false, types.NamespacedName{}
+		return false, types.NamespacedName{}, nil
 	}
 
 	// Record Gateway API match into access log (gatewayKey is already "namespace/name").
@@ -639,7 +645,7 @@ func (r *Router) handleHTTPRoute(c *gin.Context, gatewayKey string) (bool, types
 
 	inferencePoolName, found := inferencePoolFromHTTPRouteRule(matchResult.route, matchResult.rule)
 	if !found {
-		return false, types.NamespacedName{}
+		return true, types.NamespacedName{}, fmt.Errorf("matched HTTPRoute %s/%s has no eligible InferencePool backend", matchResult.route.Namespace, matchResult.route.Name)
 	}
 
 	// Record InferencePool match into access log.
@@ -655,7 +661,7 @@ func (r *Router) handleHTTPRoute(c *gin.Context, gatewayKey string) (bool, types
 		}
 	}
 
-	return true, inferencePoolName
+	return true, inferencePoolName, nil
 }
 
 // applyURLRewrite applies HTTPURLRewriteFilter to the request

--- a/pkg/kthena-router/router/router_test.go
+++ b/pkg/kthena-router/router/router_test.go
@@ -288,7 +288,8 @@ func TestRouter_HandleHTTPRoute_PathPrefix(t *testing.T) {
 			c, _ := gin.CreateTestContext(w)
 			c.Request, _ = http.NewRequest(http.MethodPost, tt.path, nil)
 
-			matched, pool := router.handleHTTPRoute(c, "default/gw")
+			matched, pool, err := router.handleHTTPRoute(c, "default/gw")
+			assert.NoError(t, err)
 			assert.Equal(t, tt.expectedMatch, matched)
 			if !tt.expectedMatch {
 				return
@@ -373,7 +374,8 @@ func TestRouter_HandleHTTPRoute_UsesMatchedRuleBackend(t *testing.T) {
 	c, _ := gin.CreateTestContext(w)
 	c.Request, _ = http.NewRequest(http.MethodPost, "/b/chat", nil)
 
-	matched, pool := router.handleHTTPRoute(c, "default/gw")
+	matched, pool, err := router.handleHTTPRoute(c, "default/gw")
+	assert.NoError(t, err)
 	assert.True(t, matched)
 	assert.Equal(t, types.NamespacedName{Namespace: "default", Name: "pool-b"}, pool)
 }
@@ -450,7 +452,8 @@ func TestRouter_HandleHTTPRoute_PrefersLongestPrefix(t *testing.T) {
 	c, _ := gin.CreateTestContext(w)
 	c.Request, _ = http.NewRequest(http.MethodPost, "/chat/completions", nil)
 
-	matched, pool := router.handleHTTPRoute(c, "default/gw")
+	matched, pool, err := router.handleHTTPRoute(c, "default/gw")
+	assert.NoError(t, err)
 	assert.True(t, matched)
 	assert.Equal(t, types.NamespacedName{Namespace: "default", Name: "pool-chat"}, pool)
 	prefix, exists := c.Get("matchedPrefix")
@@ -555,7 +558,8 @@ func TestRouter_HandleHTTPRoute_UsesMatchedRuleURLRewrite(t *testing.T) {
 	c, _ := gin.CreateTestContext(w)
 	c.Request, _ = http.NewRequest(http.MethodPost, "/b/chat", nil)
 
-	matched, pool := router.handleHTTPRoute(c, "default/gw")
+	matched, pool, err := router.handleHTTPRoute(c, "default/gw")
+	assert.NoError(t, err)
 	assert.True(t, matched)
 	assert.Equal(t, types.NamespacedName{Namespace: "default", Name: "pool-b"}, pool)
 	assert.Equal(t, "/right/chat", c.Request.URL.Path)
@@ -687,7 +691,8 @@ func TestRouter_HandleHTTPRoute_HostnameMatch(t *testing.T) {
 			c.Request, _ = http.NewRequest(http.MethodPost, "/chat", nil)
 			c.Request.Host = tt.host
 
-			matched, pool := router.handleHTTPRoute(c, "default/gw")
+			matched, pool, err := router.handleHTTPRoute(c, "default/gw")
+			assert.NoError(t, err)
 			assert.Equal(t, tt.expectedMatch, matched)
 			if tt.expectedMatch {
 				assert.Equal(t, tt.expectedPool, pool)
@@ -1193,6 +1198,62 @@ func TestRouter_HandlerFunc_InferencePoolPodDiscovery(t *testing.T) {
 			)-requestsBefore)
 		})
 	}
+}
+
+func TestRouter_HandlerFunc_AllZeroHTTPRouteBackendWeights(t *testing.T) {
+	router, store, backend := setupTestRouter(t, nil)
+	defer backend.Close()
+
+	pathType := gatewayv1.PathMatchPathPrefix
+	pathValue := "/"
+	gatewayKind := gatewayv1.Kind("Gateway")
+	poolGroup := inferencePoolBackendGroup
+	poolKind := inferencePoolBackendKind
+	zero := int32(0)
+	httpRoute := &gatewayv1.HTTPRoute{
+		ObjectMeta: v1.ObjectMeta{Name: "route-all-zero", Namespace: "default"},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{{Name: "gw", Kind: &gatewayKind}},
+			},
+			Rules: []gatewayv1.HTTPRouteRule{{
+				Matches: []gatewayv1.HTTPRouteMatch{{
+					Path: &gatewayv1.HTTPPathMatch{Type: &pathType, Value: &pathValue},
+				}},
+				BackendRefs: []gatewayv1.HTTPBackendRef{{
+					BackendRef: gatewayv1.BackendRef{
+						BackendObjectReference: gatewayv1.BackendObjectReference{
+							Group: &poolGroup,
+							Kind:  &poolKind,
+							Name:  "pool-zero",
+						},
+						Weight: &zero,
+					},
+				}},
+			}},
+		},
+	}
+	assert.NoError(t, store.AddOrUpdateHTTPRoute(httpRoute))
+
+	requestsBefore := requestCounterValue(
+		t, router, metrics.UnknownModel, "/custom", "503", "inference_pool_selection",
+	)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Set(GatewayKey, "default/gw")
+	var err error
+	c.Request, err = http.NewRequest(http.MethodPost, "/custom", bytes.NewBufferString(`{"model":"inference-model","prompt":"hello"}`))
+	assert.NoError(t, err)
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	router.HandlerFunc()(c)
+
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+	assert.Contains(t, w.Body.String(), "matched HTTPRoute default/route-all-zero has no eligible InferencePool backend")
+	assert.NotContains(t, w.Body.String(), "route not found")
+	assert.Equal(t, float64(1), requestCounterValue(
+		t, router, metrics.UnknownModel, "/custom", "503", "inference_pool_selection",
+	)-requestsBefore)
 }
 
 func TestRouter_GetPodsAndServer_ModelServerDeletedDuringPodLookup(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This fixes HTTPRoute backend selection for InferencePool references.

The router previously returned the first matching InferencePool backend without reading `backendRefs[].weight`. As a result, an InferencePool with `weight: 0` could receive requests when listed first.

This change:

- Excludes zero-weight InferencePool backends.
- Treats an omitted weight as `1`.
- Selects positive-weight InferencePool backends proportionally.
- Returns no eligible backend when every InferencePool backend has zero weight.
- Adds deterministic unit tests for zero, omitted, and positive weights.

**Which issue(s) this PR fixes**:

Fixes #1468

**Bug evidence (required for bug-related PRs)**:

A local reproducer created an HTTPRoute rule with:

```yaml
backendRefs:
  - group: inference.networking.k8s.io
    kind: InferencePool
    name: pool-zero
    weight: 0
  - group: inference.networking.k8s.io
    kind: InferencePool
    name: pool-live
    weight: 1
```

Before this change, the router selected `default/pool-zero` because: https://github.com/volcano-sh/kthena/blob/0c39f1458d26948bfd3b73416b7f81632199ce7c/pkg/kthena-router/router/httproute_match.go#L182-L195 returned the first matching backend without reading its weight.

The routing path is:

```text
Client request
  -> Router.doLoadbalance
  -> Router.handleHTTPRoute
  -> inferencePoolFromHTTPRouteRule
  -> selected InferencePool
```

The expected-behavior test failed before the fix:

```text
expected: default/pool-live
actual:   default/pool-zero
```

Verification after the fix:

```bash
go test ./pkg/kthena-router/router -count=1
go test -race ./pkg/kthena-router/router -count=1
```

**Special notes for your reviewer**:

The weighted-selection boundary tests avoid randomness by checking fixed selection slots. Existing single-backend HTTPRoutes retain their behavior because an omitted weight defaults to `1`.

**Does this PR introduce a user-facing change?**:

```release-note
HTTPRoute backend weights are now honored when selecting InferencePool backends. Backends with weight 0 no longer receive requests.
```