### PR TITLE
fix: scope kthena-controller-manager and kthena-router Secrets RBAC to least privilege

### DIFF
--- a/charts/kthena/charts/networking/templates/kthena-router/rbac/cluster-role.yaml
+++ b/charts/kthena/charts/networking/templates/kthena-router/rbac/cluster-role.yaml
@@ -34,15 +34,6 @@ rules:
       - list
       - watch
   - apiGroups:
-      - ""
-    resources:
-      - secrets
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-  - apiGroups:
       - admissionregistration.k8s.io
     resources:
       - validatingwebhookconfigurations

--- a/charts/kthena/charts/networking/templates/kthena-router/rbac/role-binding.yaml
+++ b/charts/kthena/charts/networking/templates/kthena-router/rbac/role-binding.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kthena-router
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: kthena-router-role-binding
+    {{- include "kthena.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kthena-router
+subjects:
+  - kind: ServiceAccount
+    name: kthena-router
+    namespace: {{ .Release.Namespace }}

--- a/charts/kthena/charts/networking/templates/kthena-router/rbac/role.yaml
+++ b/charts/kthena/charts/networking/templates/kthena-router/rbac/role.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kthena-router
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: kthena-router
+    {{- include "kthena.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    resourceNames:
+      - {{ .Values.kthenaRouter.webhook.tls.secretName }}
+    verbs:
+      - get

--- a/charts/kthena/charts/workload/templates/kthena-controller-manager/rbac/cluster-role.yaml
+++ b/charts/kthena/charts/workload/templates/kthena-controller-manager/rbac/cluster-role.yaml
@@ -83,14 +83,6 @@ rules:
       - create
       - update
   - apiGroups:
-      - ""
-    resources:
-      - configmaps
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
       - workload.serving.volcano.sh
     resources:
       - modelboosters
@@ -122,15 +114,6 @@ rules:
     verbs:
       - create
       - delete
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - secrets
-    verbs:
-      - create
       - get
       - list
       - watch

--- a/charts/kthena/charts/workload/templates/kthena-controller-manager/rbac/role-binding.yaml
+++ b/charts/kthena/charts/workload/templates/kthena-controller-manager/rbac/role-binding.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kthena-controller-manager
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: kthena-controller-manager
+    {{- include "kthena.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kthena-controller-manager
+subjects:
+  - kind: ServiceAccount
+    name: kthena-controller-manager
+    namespace: {{ .Release.Namespace }}

--- a/charts/kthena/charts/workload/templates/kthena-controller-manager/rbac/role.yaml
+++ b/charts/kthena/charts/workload/templates/kthena-controller-manager/rbac/role.yaml
@@ -1,0 +1,31 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kthena-controller-manager
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: kthena-controller-manager
+    {{- include "kthena.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    resourceNames:
+      - {{ .Values.controllerManager.webhook.tls.certSecretName }}
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    resourceNames:
+      - model-booster-controller-config
+    verbs:
+      - get


### PR DESCRIPTION
## Summary

Fixes #1479.

`kthena-controller-manager` and `kthena-router` were each installed with a cluster-scoped `ClusterRole` granting `get/list/watch/create` on **Secrets in every namespace of the cluster** (and `list/watch` on ConfigMaps for the controller-manager), even though the only code path that touches Secrets (`pkg/webhook/cert/secret.go`) ever does a `Get`/`Create` of a single fixed-name Secret in the component's own installation namespace, and no code anywhere lists or watches Secrets or ConfigMaps. This PR replaces those cluster-wide grants with namespaced `Role`/`RoleBinding`s scoped to exactly what each component's code does.

## Changes

- **`charts/kthena/charts/workload/templates/kthena-controller-manager/rbac/`**
  - Added `role.yaml` / `role-binding.yaml`: a `Role` in `.Release.Namespace` granting
    - `create` on `secrets` (unrestricted verb, since the object doesn't exist yet on first bootstrap — `resourceNames` cannot gate `create`)
    - `get` on `secrets`, restricted via `resourceNames` to `.Values.controllerManager.webhook.tls.certSecretName`
    - `get` on `configmaps`, restricted via `resourceNames` to `model-booster-controller-config` (the fixed name used in `pkg/model-booster-controller/controller/model_booster_controller.go`)
  - Removed the `secrets` rule and the `configmaps` rule from `cluster-role.yaml`.
- **`charts/kthena/charts/networking/templates/kthena-router/rbac/`**
  - Added `role.yaml` / `role-binding.yaml`: a `Role` in `.Release.Namespace` granting
    - `create` on `secrets`
    - `get` on `secrets`, restricted via `resourceNames` to `.Values.kthenaRouter.webhook.tls.secretName`
  - Removed the `secrets` rule from `cluster-role.yaml`.

Both components resolve their own namespace at runtime from the `POD_NAMESPACE` env var (already wired in `deployment.yaml`), which is always `.Release.Namespace`, so the namespaced Role covers the same runtime behavior with a much smaller blast radius: neither component can read, list, watch, or create Secrets outside its own namespace, and can no longer enumerate arbitrary Secrets even within its own namespace (`get` is pinned to a specific `resourceName`).

Everything else in both `ClusterRole`s (ModelServer/ModelRoute/ModelServing/ModelBooster CRs, Pods, Services, PodGroups, webhook configurations, CRDs, LeaderWorkerSets, Gateway API resources, etc.) is untouched — those genuinely need cluster or cross-namespace scope.

## Testing

- `helm lint charts/kthena` — passes (same as the existing CI `go-check.yml` step).
- `helm template kthena ./charts/kthena --namespace kthena-system --include-crds` — renders cleanly; verified by inspecting the rendered manifests:
  - Both `ClusterRole`s no longer contain a `secrets` rule (controller-manager's also no longer contains `configmaps`).
  - The new `Role`s render with the correct namespace and correctly interpolate `resourceNames` from `values.yaml` (`kthena-controller-manager-webhook-certs`, `model-booster-controller-config`, `kthena-router-webhook-certs`).
  - The new `RoleBinding`s correctly bind each component's existing `ServiceAccount`.
- No Go code changed, so existing unit/e2e test suites are unaffected; `pkg/webhook/cert/secret_test.go` behavior (Get/Create of a named Secret in a namespace) is unchanged by this PR since it operates against a fake clientset with no RBAC enforcement — the fix is purely at the RBAC-manifest layer that gates the real clientset in-cluster.

## Acceptance criteria (from #1479)

- [x] Cluster-wide Secrets grant replaced with namespaced `Role`/`RoleBinding` for both components, restricted to `get`/`create` (no `list`/`watch`), with `get` scoped via `resourceNames`.
- [x] Unused `list`/`watch` on `configmaps` removed from the controller-manager `ClusterRole`; remaining `get` access moved to the namespaced `Role`, scoped via `resourceNames`.
- [x] `ClusterRoleBinding`s untouched — cluster scope retained only for genuinely cluster-scoped resources.
- [x] Verified via `helm lint` / `helm template` that rendered manifests no longer contain a cluster-scoped Secrets grant.
- [x] No behavioral change expected for `EnsureCertificate`/`LoadCertBundleFromSecret`, including the concurrent-create (`IsAlreadyExists`) fallback path, since both components still have `create` and namespace-scoped `get` on their own Secret.
