### PR TITLE
router: handle histogram resets after backend restarts

### DIFF
--- a/pkg/kthena-router/backend/metrics/metrics.go
+++ b/pkg/kthena-router/backend/metrics/metrics.go
@@ -71,6 +71,17 @@ func LastPeriodAvg(previous, current *dto.Histogram) float64 {
 
 	currentSum := current.GetSampleSum()
 	currentCount := current.GetSampleCount()
+	if currentCount == 0 {
+		return 0
+	}
+
+	// Prometheus histogram sums and counts are cumulative for non-negative
+	// observations. If either value decreases, the backend process has likely
+	// restarted and reset its metrics. In that case, use the samples collected
+	// since the reset instead of subtracting values from the previous process.
+	if currentCount < previousCount || currentSum < previousSum {
+		return currentSum / float64(currentCount)
+	}
 
 	deltaSum := currentSum - previousSum
 	deltaCount := currentCount - previousCount

--- a/pkg/kthena-router/backend/metrics/metrics_test.go
+++ b/pkg/kthena-router/backend/metrics/metrics_test.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package metrics
 
-import "testing"
+import (
+	"testing"
+
+	dto "github.com/prometheus/client_model/go"
+)
 
 func TestPodEndpointURL(t *testing.T) {
 	tests := []struct {
@@ -47,6 +51,58 @@ func TestPodEndpointURL(t *testing.T) {
 			got := PodEndpointURL(tt.ip, tt.port, tt.path)
 			if got != tt.want {
 				t.Fatalf("PodEndpointURL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLastPeriodAvg(t *testing.T) {
+	histogram := func(sum float64, count uint64) *dto.Histogram {
+		return &dto.Histogram{SampleSum: &sum, SampleCount: &count}
+	}
+
+	tests := []struct {
+		name     string
+		previous *dto.Histogram
+		current  *dto.Histogram
+		want     float64
+	}{
+		{
+			name:     "new observations",
+			previous: histogram(10, 5),
+			current:  histogram(18, 9),
+			want:     2,
+		},
+		{
+			name:     "no new observations",
+			previous: histogram(10, 5),
+			current:  histogram(10, 5),
+			want:     0,
+		},
+		{
+			name:     "count reset",
+			previous: histogram(10, 5),
+			current:  histogram(9, 2),
+			want:     4.5,
+		},
+		{
+			name:     "sum reveals reset after count catches up",
+			previous: histogram(100, 10),
+			current:  histogram(15, 15),
+			want:     1,
+		},
+		{
+			name:     "reset without new observations",
+			previous: histogram(10, 5),
+			current:  histogram(0, 0),
+			want:     0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := LastPeriodAvg(tt.previous, tt.current); got != tt.want {
+				t.Fatalf("LastPeriodAvg() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Detects resets of the cumulative Prometheus histogram sum or count used for router TTFT/TPOT calculations. After a backend process restart, the router now calculates the average from the samples collected by the new process instead of subtracting them from the previous process's counters.

This prevents stale or incorrect latency values from influencing least-latency scheduling after an inference container restarts in the same Pod.

**Which issue(s) this PR fixes**:

Fixes #1487

**Bug evidence (required for bug-related PRs)**:

The router intentionally preserves runtime histogram state when a Pod update keeps the same namespace/name. A container restart is such an update, while the inference process's Prometheus histogram counters start again from zero.

Before this change, `LastPeriodAvg` always subtracted the previous sum and count.

Calculation example:

- During normal operation, a previous scrape of `sum=10, count=5` followed by `sum=18, count=9` represents four new observations with a total of eight, so the period average is `(18-10)/(9-5) = 2`.
- If the backend then restarts in the same Pod, its histogram starts from zero while the router still has the previous sample. A new scrape of `sum=9, count=2` was incorrectly calculated as `(9-10)/(2-5) = 0.333...`.
- Those two post-restart observations actually have an average of `9/2 = 4.5`. The new code detects the cumulative counter decrease and uses this post-reset average instead.

The production paths involved are:

- Pod updates preserve runtime metrics: https://github.com/volcano-sh/kthena/blob/d6f9d234f796bf4489beacdbe804b3faf3c66a25/pkg/kthena-router/datastore/store.go#L982-L1020
- Histogram samples are differenced for TTFT/TPOT: https://github.com/volcano-sh/kthena/blob/d6f9d234f796bf4489beacdbe804b3faf3c66a25/pkg/kthena-router/backend/metrics/metrics.go#L68-L86
- The resulting values feed least-latency scoring: https://github.com/volcano-sh/kthena/blob/d6f9d234f796bf4489beacdbe804b3faf3c66a25/pkg/kthena-router/scheduler/plugins/least_latency.go#L76-L99

The regression test covers normal deltas, no new observations, count resets, sum resets after the count has caught up, and a reset with no new observations.

**Special notes for your reviewer**:

Prometheus histogram sums are monotonic only for non-negative observations. The router applies this helper to TTFT and TPOT latency histograms, whose observations are non-negative.

Validation:

```text
go test ./pkg/kthena-router/backend/... ./pkg/kthena-router/scheduler/plugins
go test ./pkg/kthena-router/...
```

Both commands pass. `go test -race` could not run on the Windows host because the installed C compiler does not support the required 64-bit cgo mode (`cc1.exe: sorry, unimplemented: 64-bit mode not compiled in`).

**Does this PR introduce a user-facing change?**:

```release-note
Fix router latency metrics after an inference backend process restarts and resets its Prometheus histograms.
```
