### PR TITLE
fix(router): harden observability endpoints

### DIFF
--- a/charts/kthena/charts/networking/README.md
+++ b/charts/kthena/charts/networking/README.md
@@ -36,6 +36,22 @@ kthenaRouter:
 Prefer `stdout` in Kubernetes. A file path writes inside the router container
 and requires a mounted volume and separate collection strategy.
 
+#### Metrics Configuration
+
+Prometheus metrics use a dedicated ClusterIP Service and are not exposed on the
+public inference listener by default:
+
+```yaml
+kthenaRouter:
+  metrics:
+    port: 9090
+    exposeOnRouterPort: false
+```
+
+Set `exposeOnRouterPort` only when compatibility with the legacy
+`/metrics` endpoint is required and the inference listener is appropriately
+restricted.
+
 #### Request Scheduling Configuration
 
 The router schedules requests through a per-model queue using one of two mutually
@@ -70,6 +86,8 @@ kthenaRouter:
 
 | Parameter                                  | Type    | Default          | Description                                                                   |
 | ------------------------------------------ | ------- | ---------------- | ----------------------------------------------------------------------------- |
+| `kthenaRouter.metrics.port`                | int     | `9090`           | Dedicated internal Prometheus listener and Service port                       |
+| `kthenaRouter.metrics.exposeOnRouterPort`  | boolean | `false`          | Also expose `/metrics` on the inference listener for legacy compatibility     |
 | `kthenaRouter.fairness.enabled`            | boolean | `false`          | Enable user-fairness scheduling (mutually exclusive with boost)               |
 | `kthenaRouter.fairness.windowSize`         | string  | `"1h"`           | Fairness: sliding window duration (1m-1h)                                     |
 | `kthenaRouter.fairness.inputTokenWeight`   | float   | `1.0`            | Fairness: weight for input tokens (≥0)                                        |

--- a/charts/kthena/charts/networking/templates/kthena-router/component/deployment.yaml
+++ b/charts/kthena/charts/networking/templates/kthena-router/component/deployment.yaml
@@ -24,6 +24,8 @@ spec:
           imagePullPolicy: {{ .Values.kthenaRouter.image.pullPolicy }}
           args:
             - --port={{ .Values.kthenaRouter.port }}
+            - --metrics-port={{ .Values.kthenaRouter.metrics.port }}
+            - --expose-metrics-on-router-port={{ .Values.kthenaRouter.metrics.exposeOnRouterPort }}
             - --debug-port={{ .Values.kthenaRouter.debugPort }}
             - --enable-webhook={{ .Values.kthenaRouter.webhook.enabled }}
             - --enable-gateway-api={{ .Values.kthenaRouter.gatewayAPI.enabled }}
@@ -50,6 +52,9 @@ spec:
           ports:
             - containerPort: {{ .Values.kthenaRouter.port }}
               name: http
+            - containerPort: {{ .Values.kthenaRouter.metrics.port }}
+              name: metrics
+              protocol: TCP
             {{- if .Values.kthenaRouter.webhook.enabled }}
             - containerPort: {{ .Values.kthenaRouter.webhook.port }}
               name: webhook
@@ -139,7 +144,7 @@ spec:
             periodSeconds: 5
           readinessProbe:
             httpGet:
-              path: /healthz
+              path: /readyz
               port: {{ .Values.kthenaRouter.port }}
               {{- if and (eq .Values.global.certManagementMode "cert-manager") .Values.kthenaRouter.tls.enabled }}
               scheme: HTTPS

--- a/charts/kthena/charts/networking/templates/kthena-router/component/service.yaml
+++ b/charts/kthena/charts/networking/templates/kthena-router/component/service.yaml
@@ -16,6 +16,24 @@ spec:
       name: http
   type: LoadBalancer
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kthena-router-metrics
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: kthena-router-metrics
+    {{- include "kthena.labels" . | nindent 4 }}
+spec:
+  selector:
+    app.kubernetes.io/component: kthena-router
+    {{- include "kthena.selectorLabels" . | nindent 4 }}
+  ports:
+    - port: {{ .Values.kthenaRouter.metrics.port }}
+      targetPort: metrics
+      name: metrics
+  type: ClusterIP
+---
 {{- if and .Values.kthenaRouter.enabled .Values.kthenaRouter.webhook.enabled }}
 apiVersion: v1
 kind: Service

--- a/charts/kthena/charts/networking/values.yaml
+++ b/charts/kthena/charts/networking/values.yaml
@@ -2,6 +2,13 @@ kthenaRouter:
   # replicas is the number of kthena-router instances to run.
   replicas: 1
   enabled: true
+  # metrics configures the dedicated internal Prometheus listener.
+  metrics:
+    # port is the internal metrics listener and Service port.
+    port: 9090
+    # exposeOnRouterPort restores the legacy /metrics endpoint on the inference listener.
+    # Keep disabled when the inference Service is publicly reachable.
+    exposeOnRouterPort: false
   tls:
     enabled: false
     # The DNS name to use for the certificate.

--- a/charts/kthena/values.yaml
+++ b/charts/kthena/values.yaml
@@ -45,6 +45,11 @@ networking:
     replicas: 1
     # -- Container port for Kthena Router.
     port: 8080
+    metrics:
+      # -- Internal Prometheus metrics port for Kthena Router.
+      port: 9090
+      # -- Also expose /metrics on the public inference listener. Enable only for legacy compatibility.
+      exposeOnRouterPort: false
     # -- Debug server port for Kthena Router (localhost only).
     debugPort: 15000
     image:

--- a/cmd/kthena-router/app/metrics_server.go
+++ b/cmd/kthena-router/app/metrics_server.go
@@ -1,0 +1,62 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"k8s.io/klog/v2"
+)
+
+const metricsShutdownTimeout = 15 * time.Second
+
+func (s *Server) startMetricsServer(ctx context.Context) {
+	server := newMetricsServer(s.MetricsPort)
+
+	go func() {
+		klog.Infof("Starting metrics server on %s", server.Addr)
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			klog.Fatalf("Metrics server listen failed: %v", err)
+		}
+	}()
+
+	go func() {
+		<-ctx.Done()
+		klog.Info("Shutting down metrics HTTP server ...")
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), metricsShutdownTimeout)
+		defer cancel()
+		if err := server.Shutdown(shutdownCtx); err != nil {
+			klog.Errorf("Metrics server shutdown failed: %v", err)
+		}
+		klog.Info("Metrics HTTP server exited")
+	}()
+}
+
+func newMetricsServer(port int) *http.Server {
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.Handler())
+
+	return &http.Server{
+		Addr:              fmt.Sprintf(":%d", port),
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+}

--- a/cmd/kthena-router/app/metrics_server_test.go
+++ b/cmd/kthena-router/app/metrics_server_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestMetricsServerOnlyServesMetrics(t *testing.T) {
+	server := newMetricsServer(9090)
+	if server.Addr != ":9090" {
+		t.Fatalf("metrics server address = %q, want :9090", server.Addr)
+	}
+
+	tests := []struct {
+		path       string
+		wantStatus int
+		wantBody   string
+	}{
+		{path: "/metrics", wantStatus: http.StatusOK, wantBody: "kthena_router_active_requests"},
+		{path: "/healthz", wantStatus: http.StatusNotFound},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			request := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			server.Handler.ServeHTTP(recorder, request)
+			if recorder.Code != tt.wantStatus {
+				t.Fatalf("GET %s status = %d, want %d", tt.path, recorder.Code, tt.wantStatus)
+			}
+			if tt.wantBody != "" && !strings.Contains(recorder.Body.String(), tt.wantBody) {
+				t.Fatalf("GET %s body does not contain %q", tt.path, tt.wantBody)
+			}
+		})
+	}
+}
+
+func TestDebugServerBindsToLoopback(t *testing.T) {
+	server := newDebugServer(15000, nil)
+	if server.Addr != "localhost:15000" {
+		t.Fatalf("debug server address = %q, want localhost:15000", server.Addr)
+	}
+}

--- a/cmd/kthena-router/app/router.go
+++ b/cmd/kthena-router/app/router.go
@@ -49,6 +49,10 @@ func NewRouter(store datastore.Store) *router.Router {
 func (s *Server) startRouter(ctx context.Context, router *router.Router, store datastore.Store) {
 	gin.SetMode(gin.ReleaseMode)
 
+	// Metrics are served separately so the public inference listener does not
+	// expose operational data unless compatibility mode is explicitly enabled.
+	s.startMetricsServer(ctx)
+
 	// Start debug server on localhost
 	s.startDebugServer(ctx, store)
 
@@ -90,6 +94,7 @@ func (s *Server) startRouter(ctx context.Context, router *router.Router, store d
 			tlsMissingMsg:    "",
 			defaultRouter:    router,
 			readyCheck:       s.HasSynced,
+			exposeMetrics:    s.ExposeMetricsOnRouterPort,
 			activeRequests:   router.ActiveRequestCount,
 			drainTimeout:     s.drainTimeout,
 			startLog:         fmt.Sprintf("Starting default server on port %s", s.Port),
@@ -109,6 +114,29 @@ func (s *Server) startRouter(ctx context.Context, router *router.Router, store d
 // startDebugServer starts a separate debug server on localhost
 // This server only handles debug endpoints and is not accessible from outside
 func (s *Server) startDebugServer(ctx context.Context, store datastore.Store) {
+	server := newDebugServer(s.DebugPort, store)
+
+	go func() {
+		klog.Infof("Starting debug server on %s", server.Addr)
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			klog.Fatalf("Debug server listen failed: %v", err)
+		}
+	}()
+
+	go func() {
+		<-ctx.Done()
+		// graceful shutdown with timeout to allow ongoing debug requests to complete
+		klog.Info("Shutting down debug HTTP server ...")
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		if err := server.Shutdown(shutdownCtx); err != nil {
+			klog.Errorf("Debug server shutdown failed: %v", err)
+		}
+		klog.Info("Debug HTTP server exited")
+	}()
+}
+
+func newDebugServer(port int, store datastore.Store) *http.Server {
 	engine := gin.New()
 	engine.Use(gin.Recovery())
 
@@ -145,28 +173,10 @@ func (s *Server) startDebugServer(ctx context.Context, store datastore.Store) {
 		pprofGroup.GET("/mutex", gin.WrapF(pprof.Handler("mutex").ServeHTTP))
 	}
 
-	server := &http.Server{
-		Addr:    fmt.Sprintf("localhost:%d", s.DebugPort),
+	return &http.Server{
+		Addr:    fmt.Sprintf("localhost:%d", port),
 		Handler: engine.Handler(),
 	}
-	go func() {
-		klog.Infof("Starting debug server on localhost:%d", s.DebugPort)
-		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			klog.Fatalf("Debug server listen failed: %v", err)
-		}
-	}()
-
-	go func() {
-		<-ctx.Done()
-		// graceful shutdown with timeout to allow ongoing debug requests to complete
-		klog.Info("Shutting down debug HTTP server ...")
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-		defer cancel()
-		if err := server.Shutdown(shutdownCtx); err != nil {
-			klog.Errorf("Debug server shutdown failed: %v", err)
-		}
-		klog.Info("Debug HTTP server exited")
-	}()
 }
 
 func writeHealthzJSON(c *gin.Context) {
@@ -203,6 +213,7 @@ type listenerConfig struct {
 	// Default-server mode: health, metrics, /v1.
 	defaultRouter  *router.Router
 	readyCheck     func() bool
+	exposeMetrics  bool
 	activeRequests func() int64
 	drainTimeout   time.Duration
 	// Gateway mode (non-nil => use gateway branch).
@@ -214,8 +225,7 @@ type listenerConfig struct {
 	logListenErr     func(err error)
 }
 
-// startListener: build Gin, listen, graceful shutdown on ctx.
-func startListener(ctx context.Context, cfg listenerConfig) *http.Server {
+func newListenerHandler(cfg listenerConfig) http.Handler {
 	engine := gin.New()
 	if g := cfg.gateway; g != nil {
 		lm := g.lm
@@ -234,7 +244,7 @@ func startListener(ctx context.Context, cfg listenerConfig) *http.Server {
 					c.Abort()
 					return
 				}
-				if path == "/metrics" {
+				if cfg.exposeMetrics && path == "/metrics" {
 					promhttp.Handler().ServeHTTP(c.Writer, c.Request)
 					c.Abort()
 					return
@@ -271,7 +281,9 @@ func startListener(ctx context.Context, cfg listenerConfig) *http.Server {
 		engine.GET("/readyz", func(c *gin.Context) {
 			writeReadyzJSON(c, cfg.readyCheck())
 		})
-		engine.GET("/metrics", gin.WrapH(promhttp.Handler()))
+		if cfg.exposeMetrics {
+			engine.GET("/metrics", gin.WrapH(promhttp.Handler()))
+		}
 		v1Group := engine.Group("/v1")
 		v1Group.Use(AccessLogMiddleware(cfg.defaultRouter))
 		v1Group.Use(AuthMiddleware(cfg.defaultRouter))
@@ -279,9 +291,14 @@ func startListener(ctx context.Context, cfg listenerConfig) *http.Server {
 	} else {
 		klog.Fatal("startListener: invalid listenerConfig (need gateway or defaultRouter+readyCheck)")
 	}
+	return engine.Handler()
+}
+
+// startListener builds the HTTP handler, listens, and gracefully shuts down on ctx.
+func startListener(ctx context.Context, cfg listenerConfig) *http.Server {
 	srv := &http.Server{
 		Addr:    cfg.addr,
-		Handler: engine.Handler(),
+		Handler: newListenerHandler(cfg),
 	}
 
 	go func() {
@@ -525,6 +542,7 @@ func (lm *ListenerManager) addListenerToPort(port int32, config ListenerConfig, 
 			tlsKeyFile:       tlsKeyFile,
 			tlsMissingMsg:    fmt.Sprintf("TLS enabled but cert or key file not specified for port %d", port),
 			gateway:          &listenerGatewayConfig{lm: lm, port: port},
+			exposeMetrics:    lm.server.ExposeMetricsOnRouterPort,
 			activeRequests:   lm.router.ActiveRequestCount,
 			drainTimeout:     lm.server.drainTimeout,
 			startLog:         fmt.Sprintf("Starting Gateway listener server on port %d", port),

--- a/cmd/kthena-router/app/router_listener_test.go
+++ b/cmd/kthena-router/app/router_listener_test.go
@@ -17,11 +17,41 @@ limitations under the License.
 package app
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	routerpkg "github.com/volcano-sh/kthena/pkg/kthena-router/router"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
+
+func TestInferenceListenerMetricsExposure(t *testing.T) {
+	tests := []struct {
+		name          string
+		exposeMetrics bool
+		wantStatus    int
+	}{
+		{name: "disabled by default", exposeMetrics: false, wantStatus: http.StatusNotFound},
+		{name: "explicit compatibility endpoint", exposeMetrics: true, wantStatus: http.StatusOK},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := newListenerHandler(listenerConfig{
+				defaultRouter: &routerpkg.Router{},
+				readyCheck:    func() bool { return true },
+				exposeMetrics: tt.exposeMetrics,
+			})
+			recorder := httptest.NewRecorder()
+			request := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+			handler.ServeHTTP(recorder, request)
+			if recorder.Code != tt.wantStatus {
+				t.Fatalf("GET /metrics status = %d, want %d", recorder.Code, tt.wantStatus)
+			}
+		})
+	}
+}
 
 func TestWildcardHostnameMatch(t *testing.T) {
 	tests := []struct {

--- a/cmd/kthena-router/app/server.go
+++ b/cmd/kthena-router/app/server.go
@@ -41,13 +41,15 @@ type Server struct {
 	EnableGatewayAPI                   bool
 	EnableGatewayAPIInferenceExtension bool
 	DebugPort                          int
+	MetricsPort                        int
+	ExposeMetricsOnRouterPort          bool
 	KubeAPIQPS                         float32
 	KubeAPIBurst                       int
 	// drainTimeout is HTTP server shutdown grace; not datastore state.
 	drainTimeout time.Duration
 }
 
-func NewServer(port string, enableTLS bool, cert, key string, enableGatewayAPI bool, enableGatewayAPIInferenceExtension bool, debugPort int, kubeAPIQPS float32, kubeAPIBurst int) *Server {
+func NewServer(port string, enableTLS bool, cert, key string, enableGatewayAPI bool, enableGatewayAPIInferenceExtension bool, debugPort, metricsPort int, exposeMetricsOnRouterPort bool, kubeAPIQPS float32, kubeAPIBurst int) *Server {
 	return &Server{
 		store:                              nil,
 		EnableTLS:                          enableTLS,
@@ -57,6 +59,8 @@ func NewServer(port string, enableTLS bool, cert, key string, enableGatewayAPI b
 		EnableGatewayAPI:                   enableGatewayAPI,
 		EnableGatewayAPIInferenceExtension: enableGatewayAPIInferenceExtension,
 		DebugPort:                          debugPort,
+		MetricsPort:                        metricsPort,
+		ExposeMetricsOnRouterPort:          exposeMetricsOnRouterPort,
 		KubeAPIQPS:                         kubeAPIQPS,
 		KubeAPIBurst:                       kubeAPIBurst,
 		drainTimeout:                       parseDrainTimeout(),

--- a/cmd/kthena-router/app/server_test.go
+++ b/cmd/kthena-router/app/server_test.go
@@ -22,21 +22,23 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestNewServerDebugPortDefault tests that NewServer accepts different debug port values
-func TestNewServerDebugPortDefault(t *testing.T) {
+func TestNewServerManagementConfiguration(t *testing.T) {
 	testCases := []struct {
-		name      string
-		debugPort int
+		name               string
+		debugPort          int
+		metricsPort        int
+		exposeOnRouterPort bool
 	}{
-		{"default port", 15000},
-		{"custom port", 16000},
-		{"another custom port", 17000},
+		{"default ports", 15000, 9090, false},
+		{"custom ports with compatibility endpoint", 16000, 9191, true},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			server := NewServer("8080", false, "", "", false, false, tc.debugPort, 0, 0)
+			server := NewServer("8080", false, "", "", false, false, tc.debugPort, tc.metricsPort, tc.exposeOnRouterPort, 0, 0)
 			assert.Equal(t, tc.debugPort, server.DebugPort, "DebugPort should match the provided value")
+			assert.Equal(t, tc.metricsPort, server.MetricsPort, "MetricsPort should match the provided value")
+			assert.Equal(t, tc.exposeOnRouterPort, server.ExposeMetricsOnRouterPort)
 		})
 	}
 }

--- a/cmd/kthena-router/main.go
+++ b/cmd/kthena-router/main.go
@@ -51,6 +51,8 @@ func main() {
 		certSecretName                     string
 		serviceName                        string
 		debugPort                          int
+		metricsPort                        int
+		exposeMetricsOnRouterPort          bool
 		kubeAPIQPS                         float32
 		kubeAPIBurst                       int
 	)
@@ -76,6 +78,8 @@ func main() {
 	pflag.StringVar(&certSecretName, "cert-secret-name", "kthena-router-webhook-certs", "Name of the secret to store auto-generated webhook certificates")
 	pflag.StringVar(&serviceName, "webhook-service-name", "kthena-router-webhook", "Service name for the webhook server")
 	pflag.IntVar(&debugPort, "debug-port", 15000, "The port for the debug server (localhost only)")
+	pflag.IntVar(&metricsPort, "metrics-port", 9090, "The port for the Prometheus metrics server")
+	pflag.BoolVar(&exposeMetricsOnRouterPort, "expose-metrics-on-router-port", false, "Also expose /metrics on the inference listener for compatibility (not recommended for public listeners)")
 	pflag.Float32Var(&kubeAPIQPS, "kube-api-qps", 0, "QPS to use while talking with kubernetes apiserver. If 0, use default value.")
 	pflag.IntVar(&kubeAPIBurst, "kube-api-burst", 0, "Burst to use while talking with kubernetes apiserver. If 0, use default value.")
 	defer klog.Flush()
@@ -95,6 +99,9 @@ func main() {
 
 	if debugPort <= 0 || debugPort > 65535 {
 		klog.Fatalf("invalid debug port: %d", debugPort)
+	}
+	if metricsPort <= 0 || metricsPort > 65535 {
+		klog.Fatalf("invalid metrics port: %d", metricsPort)
 	}
 
 	pflag.CommandLine.VisitAll(func(f *pflag.Flag) {
@@ -118,7 +125,7 @@ func main() {
 		klog.Info("Webhook server is disabled")
 	}
 
-	app.NewServer(routerPort, tlsCert != "" && tlsKey != "", tlsCert, tlsKey, enableGatewayAPI, enableGatewayAPIInferenceExtension, debugPort, kubeAPIQPS, kubeAPIBurst).Run(ctx)
+	app.NewServer(routerPort, tlsCert != "" && tlsKey != "", tlsCert, tlsKey, enableGatewayAPI, enableGatewayAPIInferenceExtension, debugPort, metricsPort, exposeMetricsOnRouterPort, kubeAPIQPS, kubeAPIBurst).Run(ctx)
 }
 
 // ensureWebhookCertificate generates a certificate secret if needed and returns the CA bundle.

--- a/docs/kthena/docs/reference/helm-chart-values.md
+++ b/docs/kthena/docs/reference/helm-chart-values.md
@@ -34,6 +34,8 @@ A Helm chart for deploying Kthena
 | networking.kthenaRouter.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy for Kthena Router. |
 | networking.kthenaRouter.image.repository | string | `"ghcr.io/volcano-sh/kthena-router"` | Image repository for Kthena Router. |
 | networking.kthenaRouter.image.tag | string | `"latest"` | Image tag for Kthena Router. |
+| networking.kthenaRouter.metrics.exposeOnRouterPort | bool | `false` | Also expose /metrics on the public inference listener. Enable only for legacy compatibility. |
+| networking.kthenaRouter.metrics.port | int | `9090` | Internal Prometheus metrics port for Kthena Router. |
 | networking.kthenaRouter.port | int | `8080` | Container port for Kthena Router. |
 | networking.kthenaRouter.replicas | int | `1` | Number of Kthena Router instances to run. |
 | networking.kthenaRouter.sessionBoost.enabled | bool | `false` | Enable session-boost scheduling. Mutually exclusive with fairness. |

--- a/docs/kthena/docs/user-guide/fairness-scheduling.md
+++ b/docs/kthena/docs/user-guide/fairness-scheduling.md
@@ -186,13 +186,13 @@ Confirm that the router is running with the fairness variables you expect.
 Port-forward the router metrics endpoint:
 
 ```bash
-kubectl -n kthena-system port-forward deploy/kthena-router 8080:8080
+kubectl -n kthena-system port-forward svc/kthena-router-metrics 9090:9090
 ```
 
 Then inspect fairness metrics:
 
 ```bash
-curl -s http://localhost:8080/metrics | grep kthena_router_fairness_queue
+curl -s http://localhost:9090/metrics | grep kthena_router_fairness_queue
 ```
 
 Key metrics to watch:
@@ -204,6 +204,10 @@ Key metrics to watch:
 - `kthena_router_fairness_queue_inflight`
 - `kthena_router_fairness_queue_priority_refresh_total`
 - `kthena_router_fairness_queue_heap_rebuild_total`
+
+Fairness metrics are aggregated per model. Their `user_id` label is fixed to
+`_all`; raw user identities are not exported, which bounds Prometheus series
+cardinality and avoids exposing identity data.
 
 ### 3. Compare Competing Users
 

--- a/docs/kthena/docs/user-guide/kvcache-aware.md
+++ b/docs/kthena/docs/user-guide/kvcache-aware.md
@@ -363,8 +363,8 @@ The output shows pod identifiers (e.g., `pod-name.namespace`) as field names and
 The router exposes scheduler plugin metrics at the `/metrics` endpoint. You can check for score plugin activity:
 
 ```bash
-kubectl port-forward service/kthena-router 8080:80 -n <namespace>
-curl -s http://localhost:8080/metrics | grep -i kvcache
+kubectl port-forward svc/kthena-router-metrics 9090:9090 -n <namespace>
+curl -s http://localhost:9090/metrics | grep -i kvcache
 ```
 
 ### 5. Send Test Requests

--- a/docs/kthena/docs/user-guide/router-observability.md
+++ b/docs/kthena/docs/user-guide/router-observability.md
@@ -8,25 +8,27 @@ The Kthena router exposes three complementary observability surfaces:
 
 ## Endpoint map
 
-The current Helm chart serves health and metrics routes on the inference
-listener. The debug listener is a separate loopback-only server inside the
-router pod.
+The current Helm chart serves metrics on a dedicated internal listener. Health
+routes remain on the inference listener, while the debug listener is a separate
+loopback-only server inside the router pod.
 
 | Listener | Default | Endpoints | Exposure |
 | --- | --- | --- | --- |
-| Router | Container port `8080`; Service port `80` | `/healthz`, `/readyz`, `/metrics`, inference APIs | The `kthena-router` LoadBalancer Service |
+| Router | Container port `8080`; Service port `80` | `/healthz`, `/readyz`, inference APIs | The `kthena-router` LoadBalancer Service |
+| Metrics | Container and Service port `9090` | `/metrics` | The internal `kthena-router-metrics` ClusterIP Service |
 | Debug | `localhost:15000` | `/debug/config_dump/*`, `/debug/pprof/*` | Pod loopback only; no Service port |
 
-The chart does not currently provide an `observability.metrics` values block.
-The metrics path is fixed at `/metrics`, and its port follows
-`networking.kthenaRouter.port`. Do not set the previously documented
-`observability.metrics` keys; Helm ignores them.
+The metrics path is fixed at `/metrics`. Set
+`networking.kthenaRouter.metrics.port` to change its port. Metrics are not served
+on the public inference listener unless
+`networking.kthenaRouter.metrics.exposeOnRouterPort` is explicitly enabled for
+legacy compatibility.
 
 To inspect these endpoints without relying on their external exposure:
 
 ```bash
-# The Service listens on 80 and forwards to the router's default port, 8080.
-kubectl port-forward -n kthena-system service/kthena-router 8080:80
+# The internal Service forwards to the dedicated metrics listener.
+kubectl port-forward -n kthena-system service/kthena-router-metrics 9090:9090
 
 # Run separately when debug access is needed. This selects a router pod and
 # reaches the process's loopback-only listener from inside its network namespace.
@@ -65,17 +67,17 @@ been exercised.
 | Metric | Type | Labels | Description |
 | --- | --- | --- | --- |
 | `kthena_router_scheduler_plugin_duration_seconds` | Histogram | `model`, `plugin`, `type` | Scheduler plugin execution time; `type` is `filter` or `score` |
-| `kthena_router_fairness_queue_size` | Gauge | `model`, `user_id` | Pending requests in the fairness queue |
-| `kthena_router_fairness_queue_duration_seconds` | Histogram | `model`, `user_id` | Time spent waiting in the fairness queue |
-| `kthena_router_fairness_queue_cancelled_total` | Counter | `model`, `user_id` | Requests cancelled or timed out while queued |
-| `kthena_router_fairness_queue_dequeue_total` | Counter | `model`, `user_id` | Requests successfully dequeued |
+| `kthena_router_fairness_queue_size` | Gauge | `model`, `user_id="_all"` | Pending requests in the fairness queue, aggregated across users |
+| `kthena_router_fairness_queue_duration_seconds` | Histogram | `model`, `user_id="_all"` | Time spent waiting in the fairness queue, aggregated across users |
+| `kthena_router_fairness_queue_cancelled_total` | Counter | `model`, `user_id="_all"` | Requests cancelled or timed out while queued, aggregated across users |
+| `kthena_router_fairness_queue_dequeue_total` | Counter | `model`, `user_id="_all"` | Requests successfully dequeued, aggregated across users |
 | `kthena_router_fairness_queue_inflight` | Gauge | `model` | Requests admitted through the fairness semaphore |
 | `kthena_router_fairness_queue_priority_refresh_total` | Counter | `model` | Dequeue-time priority refresh and reinsert operations |
 | `kthena_router_fairness_queue_heap_rebuild_total` | Counter | `model` | Full heap rebuilds caused by priority drift |
 
-`user_id` values originate from authenticated request identity. Treat them as
-sensitive, and account for their cardinality when retaining or federating these
-series.
+Raw user identifiers are deliberately not exported. The `user_id` label is
+fixed to `_all`, keeping cardinality bounded and avoiding exposure of user
+identity through the metrics endpoint.
 
 ### Tokenizer and cache-aware scheduling
 
@@ -230,7 +232,7 @@ After starting both port-forwards from the [endpoint map](#endpoint-map):
 
 ```bash
 # Request counters by model and result.
-curl -s http://localhost:8080/metrics \
+curl -s http://localhost:9090/metrics \
   | grep '^kthena_router_requests_total'
 
 # Router configuration and currently known pods.

--- a/examples/keda-autoscaling/servicemonitor.yaml
+++ b/examples/keda-autoscaling/servicemonitor.yaml
@@ -9,8 +9,8 @@ spec:
       - kthena-system
   selector:
     matchLabels:
-      app.kubernetes.io/component: kthena-router
+      app.kubernetes.io/component: kthena-router-metrics
   endpoints:
-    - port: http
+    - port: metrics
       path: /metrics
       interval: 15s

--- a/examples/observability/router-servicemonitor.yaml
+++ b/examples/observability/router-servicemonitor.yaml
@@ -11,10 +11,10 @@ spec:
   endpoints:
     - interval: 15s
       path: /metrics
-      port: http
+      port: metrics
   namespaceSelector:
     matchNames:
       - kthena-system
   selector:
     matchLabels:
-      app.kubernetes.io/component: kthena-router
+      app.kubernetes.io/component: kthena-router-metrics

--- a/pkg/kthena-router/datastore/fairness_queue_test.go
+++ b/pkg/kthena-router/datastore/fairness_queue_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	dto "github.com/prometheus/client_model/go"
+	"github.com/volcano-sh/kthena/pkg/kthena-router/metrics"
 )
 
 func TestNewRequestPriorityQueue(t *testing.T) {
@@ -539,7 +540,7 @@ func TestRequeueRequestRestoresQueueSizeMetric(t *testing.T) {
 	pq.requeueRequest(req)
 
 	var metric dto.Metric
-	if err := pq.metrics.FairnessQueueSize.WithLabelValues(model, user).Write(&metric); err != nil {
+	if err := pq.metrics.FairnessQueueSize.WithLabelValues(model, metrics.FairnessAggregateUserID).Write(&metric); err != nil {
 		t.Fatalf("failed to read queue size metric: %v", err)
 	}
 	got := metric.GetGauge().GetValue()

--- a/pkg/kthena-router/metrics/metrics.go
+++ b/pkg/kthena-router/metrics/metrics.go
@@ -40,7 +40,8 @@ const (
 	LabelUserID      = "user_id"
 	LabelStage       = "stage"
 
-	UnknownModel = "unknown"
+	UnknownModel            = "unknown"
+	FairnessAggregateUserID = "_all"
 
 	// kvcache-aware error stage values
 	StageTokenize = "tokenize"
@@ -201,7 +202,7 @@ func NewMetrics() *Metrics {
 		FairnessQueueSize: *promauto.NewGaugeVec(
 			prometheus.GaugeOpts{
 				Name: "kthena_router_fairness_queue_size",
-				Help: "Current fairness queue size for pending requests",
+				Help: "Current fairness queue size for pending requests, aggregated across users",
 			},
 			[]string{LabelModel, LabelUserID},
 		),
@@ -209,7 +210,7 @@ func NewMetrics() *Metrics {
 		FairnessQueueDuration: *promauto.NewHistogramVec(
 			prometheus.HistogramOpts{
 				Name:    "kthena_router_fairness_queue_duration_seconds",
-				Help:    "Time requests spend in fairness queue before processing",
+				Help:    "Time requests spend in fairness queue before processing, aggregated across users",
 				Buckets: []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5},
 			},
 			[]string{LabelModel, LabelUserID},
@@ -218,7 +219,7 @@ func NewMetrics() *Metrics {
 		FairnessQueueCancelledTotal: *promauto.NewCounterVec(
 			prometheus.CounterOpts{
 				Name: "kthena_router_fairness_queue_cancelled_total",
-				Help: "Total number of requests cancelled or timed out while in fairness queue",
+				Help: "Total number of requests cancelled or timed out while in fairness queue, aggregated across users",
 			},
 			[]string{LabelModel, LabelUserID},
 		),
@@ -226,7 +227,7 @@ func NewMetrics() *Metrics {
 		FairnessQueueDequeueTotal: *promauto.NewCounterVec(
 			prometheus.CounterOpts{
 				Name: "kthena_router_fairness_queue_dequeue_total",
-				Help: "Total number of requests successfully dequeued from fairness queue",
+				Help: "Total number of requests successfully dequeued from fairness queue, aggregated across users",
 			},
 			[]string{LabelModel, LabelUserID},
 		),
@@ -498,34 +499,35 @@ func (m *Metrics) DecActiveUpstreamRequests(modelServer, modelRoute string) {
 	m.ActiveUpstreamRequests.WithLabelValues(modelServer, modelRoute).Dec()
 }
 
-// IncFairnessQueueSize increments the fairness queue size
-func (m *Metrics) IncFairnessQueueSize(model, userID string) {
-	m.FairnessQueueSize.WithLabelValues(model, userID).Inc()
+// IncFairnessQueueSize increments the fairness queue size. Raw user identifiers
+// are deliberately collapsed into one bounded label value.
+func (m *Metrics) IncFairnessQueueSize(model, _ string) {
+	m.FairnessQueueSize.WithLabelValues(model, FairnessAggregateUserID).Inc()
 }
 
 // DecFairnessQueueSize decrements the fairness queue size
-func (m *Metrics) DecFairnessQueueSize(model, userID string) {
-	m.FairnessQueueSize.WithLabelValues(model, userID).Dec()
+func (m *Metrics) DecFairnessQueueSize(model, _ string) {
+	m.FairnessQueueSize.WithLabelValues(model, FairnessAggregateUserID).Dec()
 }
 
 // SetFairnessQueueSize sets the current fairness queue size
-func (m *Metrics) SetFairnessQueueSize(model, userID string, size float64) {
-	m.FairnessQueueSize.WithLabelValues(model, userID).Set(size)
+func (m *Metrics) SetFairnessQueueSize(model, _ string, size float64) {
+	m.FairnessQueueSize.WithLabelValues(model, FairnessAggregateUserID).Set(size)
 }
 
 // RecordFairnessQueueDuration records the time a request spent in fairness queue
-func (m *Metrics) RecordFairnessQueueDuration(model, userID string, duration time.Duration) {
-	m.FairnessQueueDuration.WithLabelValues(model, userID).Observe(duration.Seconds())
+func (m *Metrics) RecordFairnessQueueDuration(model, _ string, duration time.Duration) {
+	m.FairnessQueueDuration.WithLabelValues(model, FairnessAggregateUserID).Observe(duration.Seconds())
 }
 
 // IncFairnessQueueCancelled increments the fairness queue cancelled counter
-func (m *Metrics) IncFairnessQueueCancelled(model, userID string) {
-	m.FairnessQueueCancelledTotal.WithLabelValues(model, userID).Inc()
+func (m *Metrics) IncFairnessQueueCancelled(model, _ string) {
+	m.FairnessQueueCancelledTotal.WithLabelValues(model, FairnessAggregateUserID).Inc()
 }
 
 // IncFairnessQueueDequeue increments the fairness queue dequeue counter
-func (m *Metrics) IncFairnessQueueDequeue(model, userID string) {
-	m.FairnessQueueDequeueTotal.WithLabelValues(model, userID).Inc()
+func (m *Metrics) IncFairnessQueueDequeue(model, _ string) {
+	m.FairnessQueueDequeueTotal.WithLabelValues(model, FairnessAggregateUserID).Inc()
 }
 
 // IncFairnessQueueInflight increments the fairness queue inflight gauge

--- a/pkg/kthena-router/metrics/metrics_test.go
+++ b/pkg/kthena-router/metrics/metrics_test.go
@@ -83,6 +83,54 @@ func counterVal(t *testing.T, vec *prometheus.CounterVec, lvs ...string) float64
 	return m.GetCounter().GetValue()
 }
 
+func TestFairnessMetricsAggregateUserIdentity(t *testing.T) {
+	m := DefaultMetrics
+	const model = "metricstest-fairness-aggregate-user"
+
+	m.IncFairnessQueueSize(model, "alice@example.com")
+	m.IncFairnessQueueSize(model, "bob@example.com")
+	m.RecordFairnessQueueDuration(model, "alice@example.com", time.Millisecond)
+	m.RecordFairnessQueueDuration(model, "bob@example.com", 2*time.Millisecond)
+	m.IncFairnessQueueCancelled(model, "alice@example.com")
+	m.IncFairnessQueueDequeue(model, "bob@example.com")
+
+	families, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("gather metrics: %v", err)
+	}
+
+	wantFamilies := map[string]bool{
+		"kthena_router_fairness_queue_size":             false,
+		"kthena_router_fairness_queue_duration_seconds": false,
+		"kthena_router_fairness_queue_cancelled_total":  false,
+		"kthena_router_fairness_queue_dequeue_total":    false,
+	}
+	for _, family := range families {
+		if _, ok := wantFamilies[family.GetName()]; !ok {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			labels := make(map[string]string, len(metric.GetLabel()))
+			for _, label := range metric.GetLabel() {
+				labels[label.GetName()] = label.GetValue()
+			}
+			if labels[LabelModel] != model {
+				continue
+			}
+			if got := labels[LabelUserID]; got != FairnessAggregateUserID {
+				t.Errorf("%s user_id = %q, want %q", family.GetName(), got, FairnessAggregateUserID)
+			}
+			wantFamilies[family.GetName()] = true
+		}
+	}
+
+	for family, found := range wantFamilies {
+		if !found {
+			t.Errorf("did not find %s for model %q", family, model)
+		}
+	}
+}
+
 func TestPrefixCacheMatchRatio(t *testing.T) {
 	m := DefaultMetrics
 	const model = "metricstest-prefix-matchratio"

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -29,7 +29,8 @@ import (
 )
 
 var (
-	pfForwarder utils.PortForwarder
+	pfForwarder        utils.PortForwarder
+	metricsPFForwarder utils.PortForwarder
 )
 
 // KthenaConfig holds the configuration for installing kthena
@@ -128,6 +129,12 @@ func InstallKthena(cfg *KthenaConfig) error {
 		if err != nil {
 			return fmt.Errorf("failed to setup port-forward: %v", err)
 		}
+		metricsPFForwarder, err = utils.SetupPortForward(cfg.Namespace, utils.RouterMetricsService, utils.RouterMetricsPort, utils.RouterMetricsPort)
+		if err != nil {
+			pfForwarder.Close()
+			pfForwarder = nil
+			return fmt.Errorf("failed to setup metrics port-forward: %v", err)
+		}
 		// Note: SetupPortForward already waits for the port-forward to be ready.
 		// Cleanup is handled by UninstallKthena via the global pfForwarder.
 	}
@@ -143,6 +150,12 @@ func UninstallKthena(namespace string) error {
 	if pfForwarder != nil {
 		fmt.Println("Stopping port-forward process...")
 		pfForwarder.Close()
+		pfForwarder = nil
+	}
+	if metricsPFForwarder != nil {
+		fmt.Println("Stopping metrics port-forward process...")
+		metricsPFForwarder.Close()
+		metricsPFForwarder = nil
 	}
 
 	cmd := exec.Command("helm", "uninstall", "kthena", "--namespace", namespace)

--- a/test/e2e/router/shared.go
+++ b/test/e2e/router/shared.go
@@ -53,7 +53,7 @@ import (
 )
 
 const (
-	defaultMetricsURL     = "http://127.0.0.1:8080/metrics"
+	defaultMetricsURL     = "http://127.0.0.1:9090/metrics"
 	defaultScalingTimeout = 3 * time.Minute
 
 	modelServingVLLMPDDisaggregationFixture   = "ModelServing-ds1.5b-pd-disaggregation.yaml"
@@ -1868,19 +1868,9 @@ func TestRouterConfigUpdateShared(t *testing.T, testCtx *routercontext.RouterTes
 	utils.WaitForDeploymentReady(t, ctx, testCtx.KubeClient, kthenaNamespace, routerDeploymentName, expectedReplicas, defaultScalingTimeout)
 	t.Log("Router deployment is ready after restart")
 
-	// Set up port-forward to the restarted router on a dynamically selected local port
-	// to avoid conflicts with the framework port-forward on 8080 and other parallel tests.
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err, "Failed to find an available port")
-	restartedRouterPort := fmt.Sprintf("%d", listener.Addr().(*net.TCPAddr).Port)
-	listener.Close()
-
-	pf, err := utils.SetupPortForward(kthenaNamespace, routerDeploymentName, restartedRouterPort, "80")
-	require.NoError(t, err, "Failed to setup port-forward to restarted router")
-	defer pf.Close()
-
-	restartedRouterURL := fmt.Sprintf("http://127.0.0.1:%s/v1/chat/completions", restartedRouterPort)
-	restartedMetricsURL := fmt.Sprintf("http://127.0.0.1:%s/metrics", restartedRouterPort)
+	// Set up independent inference and metrics port-forwards to the restarted router.
+	restartedRouterURL, restartedMetricsURL, closePF := utils.SetupRouterPortForwardAfterRestart(t, kthenaNamespace)
+	defer closePF()
 
 	// Verify routing works after config update and restart.
 	WaitForKthenaRouterValidatingWebhook(t, ctx, testCtx.KthenaClient, kthenaNamespace)

--- a/test/e2e/utils/router.go
+++ b/test/e2e/utils/router.go
@@ -32,6 +32,8 @@ const (
 	RouterConfigMapName  = "kthena-router-config"
 	RouterConfigKey      = "routerConfiguration"
 	RouterDeploymentName = "kthena-router"
+	RouterMetricsService = "kthena-router-metrics"
+	RouterMetricsPort    = "9090"
 	RouterRolloutTimeout = 3 * time.Minute
 	RouterDebugPort      = "15000"
 )
@@ -40,12 +42,23 @@ const (
 // break the framework TestMain port-forward on :8080.
 func SetupRouterPortForwardAfterRestart(t *testing.T, kthenaNamespace string) (chatURL, metricsURL string, closePF func()) {
 	t.Helper()
-	localPort := AllocateLocalPort(t)
-	pf, err := SetupPortForward(kthenaNamespace, RouterDeploymentName, localPort, "80")
+	chatLocalPort := AllocateLocalPort(t)
+	chatPF, err := SetupPortForward(kthenaNamespace, RouterDeploymentName, chatLocalPort, "80")
 	require.NoError(t, err, "failed to setup port-forward to restarted router")
-	chatURL = fmt.Sprintf("http://127.0.0.1:%s/v1/chat/completions", localPort)
-	metricsURL = fmt.Sprintf("http://127.0.0.1:%s/metrics", localPort)
-	return chatURL, metricsURL, func() { pf.Close() }
+
+	metricsLocalPort := AllocateLocalPort(t)
+	metricsPF, err := SetupPortForward(kthenaNamespace, RouterMetricsService, metricsLocalPort, RouterMetricsPort)
+	if err != nil {
+		chatPF.Close()
+	}
+	require.NoError(t, err, "failed to setup port-forward to restarted router metrics")
+
+	chatURL = fmt.Sprintf("http://127.0.0.1:%s/v1/chat/completions", chatLocalPort)
+	metricsURL = fmt.Sprintf("http://127.0.0.1:%s/metrics", metricsLocalPort)
+	return chatURL, metricsURL, func() {
+		metricsPF.Close()
+		chatPF.Close()
+	}
 }
 
 // ApplySchedulerConfig patches router scheduler config, restarts the router, and returns URLs plus a restore func.


### PR DESCRIPTION
**What type of PR is this?**
/kind enhancement
<!--
Add one of the following kinds
-->

**What this PR does / why we need it**:
  - Add a dedicated metrics listener and internal ClusterIP Service on port 9090.
  - Disable /metrics on the public inference listener by default.
  - Change the readiness probe from /healthz to /readyz.
  - Aggregate fairness metrics under user_id="_all".
  - Confirm debug/pprof remains localhost-only.
  - Update Helm values, ServiceMonitors, E2E helpers, tests, and documentation.

**Which issue(s) this PR fixes**:
Fixes #1482

**Bug evidence (required for bug-related PRs)**:
<!--
For a bug-related PR, provide evidence from the production path:
- Include the relevant workload configuration and logs or events.
- For a panic, include the complete panic trace.
- Describe the user action or cluster event that triggers the problem and how the
  change fixes it.
- Use source permalinks that point to the exact commit when citing code.

AI-generated analysis, a static scan, or a unit test that only calls an internal
function does not prove a bug on its own. If the reported bug relies solely on AI
analysis without reproduction instructions or production-path evidence, maintainers
may close the issue and the related PR.

Write "N/A" for PRs that are not bug-related.
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
