### PR TITLE
Fix ModelBooster spec.name routing lookup

### DIFF
--- a/pkg/kthena-router/datastore/store_test.go
+++ b/pkg/kthena-router/datastore/store_test.go
@@ -38,7 +38,9 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	aiv1alpha1 "github.com/volcano-sh/kthena/pkg/apis/networking/v1alpha1"
+	workloadv1alpha1 "github.com/volcano-sh/kthena/pkg/apis/workload/v1alpha1"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/utils"
+	"github.com/volcano-sh/kthena/pkg/model-booster-controller/convert"
 )
 
 // ptr is a helper function to get pointer to a value
@@ -1642,6 +1644,33 @@ func TestStoreMatchModelTargetExternalProvider(t *testing.T) {
 	assert.Equal(t, mr, route)
 	assert.Equal(t, ModelTargetKindExternalModelProvider, target.Kind)
 	assert.Equal(t, types.NamespacedName{Namespace: "default", Name: "openai-provider"}, target.Name)
+}
+
+func TestStoreMatchesModelBoosterSpecName(t *testing.T) {
+	model := &workloadv1alpha1.ModelBooster{
+		ObjectMeta: metav1.ObjectMeta{Name: "qwen25", Namespace: "default"},
+		Spec: workloadv1alpha1.ModelBoosterSpec{
+			Name: "qwen25-coder-32b",
+			Backend: workloadv1alpha1.ModelBackend{
+				Name: "backend",
+			},
+		},
+	}
+
+	route := convert.BuildModelRoute(model)
+	store := New()
+	assert.NoError(t, store.AddOrUpdateModelRoute(route))
+
+	target, isLora, matchedRoute, err := store.MatchModelTarget(
+		model.Spec.Name,
+		&http.Request{URL: &url.URL{Path: "/v1/chat/completions"}},
+		"",
+	)
+	assert.NoError(t, err)
+	assert.False(t, isLora)
+	assert.Equal(t, ModelTargetKindModelServer, target.Kind)
+	assert.Equal(t, types.NamespacedName{Namespace: "default", Name: "qwen25-backend"}, target.Name)
+	assert.Equal(t, route, matchedRoute)
 }
 
 type fakePodRuntimeInspector struct {

--- a/pkg/model-booster-controller/controller/model_booster_controller_test.go
+++ b/pkg/model-booster-controller/controller/model_booster_controller_test.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"os"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -27,7 +28,9 @@ import (
 	workload "github.com/volcano-sh/kthena/pkg/apis/workload/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 	"sigs.k8s.io/yaml"
 )
 
@@ -119,6 +122,48 @@ func TestReconcile(t *testing.T) {
 		}
 		return len(modelList.Items) == 0
 	}))
+}
+
+func TestReconcileRecreatesModelRouteWhenModelRequestNameChanges(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	kubeClient := fake.NewClientset()
+	kthenaClient := kthenafake.NewSimpleClientset()
+	controller := NewModelBoosterController(kubeClient, kthenaClient)
+	go controller.Run(ctx, 1)
+	assert.True(t, waitForControllerCacheSync(controller), "controller informers did not sync")
+
+	model := loadYaml[workload.ModelBooster](t, "../convert/testdata/input/model.yaml")
+	createdModel, err := kthenaClient.WorkloadV1alpha1().ModelBoosters(model.Namespace).Create(ctx, model, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	assert.True(t, waitForCondition(func() bool {
+		route, err := kthenaClient.NetworkingV1alpha1().ModelRoutes(model.Namespace).Get(ctx, model.Name, metav1.GetOptions{})
+		return err == nil && route.Spec.ModelName == model.Name
+	}))
+
+	var deletes, creates atomic.Int32
+	kthenaClient.PrependReactor("delete", "modelroutes", func(k8stesting.Action) (bool, runtime.Object, error) {
+		deletes.Add(1)
+		return false, nil, nil
+	})
+	kthenaClient.PrependReactor("create", "modelroutes", func(k8stesting.Action) (bool, runtime.Object, error) {
+		creates.Add(1)
+		return false, nil, nil
+	})
+
+	createdModel.Spec.Name = "deepseek-v3-request"
+	createdModel.Generation++
+	_, err = kthenaClient.WorkloadV1alpha1().ModelBoosters(createdModel.Namespace).Update(ctx, createdModel, metav1.UpdateOptions{})
+	assert.NoError(t, err)
+
+	assert.True(t, waitForCondition(func() bool {
+		route, err := kthenaClient.NetworkingV1alpha1().ModelRoutes(model.Namespace).Get(ctx, model.Name, metav1.GetOptions{})
+		return err == nil && route.Spec.ModelName == createdModel.Spec.Name
+	}))
+	assert.Equal(t, int32(1), deletes.Load())
+	assert.Equal(t, int32(1), creates.Load())
 }
 
 func TestReconcile_ReturnsError(t *testing.T) {

--- a/pkg/model-booster-controller/controller/model_booster_controller_test.go
+++ b/pkg/model-booster-controller/controller/model_booster_controller_test.go
@@ -26,6 +26,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	kthenafake "github.com/volcano-sh/kthena/client-go/clientset/versioned/fake"
 	workload "github.com/volcano-sh/kthena/pkg/apis/workload/v1alpha1"
+	"github.com/volcano-sh/kthena/pkg/model-booster-controller/convert"
+	"github.com/volcano-sh/kthena/pkg/model-booster-controller/utils"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -164,6 +166,48 @@ func TestReconcileRecreatesModelRouteWhenModelRequestNameChanges(t *testing.T) {
 	}))
 	assert.Equal(t, int32(1), deletes.Load())
 	assert.Equal(t, int32(1), creates.Load())
+}
+
+func TestCreateOrUpdateModelRouteUpdatesLiveRouteWhenListerIsStale(t *testing.T) {
+	ctx := context.Background()
+	kubeClient := fake.NewClientset()
+	kthenaClient := kthenafake.NewSimpleClientset()
+	controller := NewModelBoosterController(kubeClient, kthenaClient)
+
+	model := loadYaml[workload.ModelBooster](t, "../convert/testdata/input/model.yaml")
+	model.Spec.Name = "deepseek-v3-request"
+	model.Spec.Backend.Name = "new-backend"
+	desiredRoute := convert.BuildModelRoute(model)
+
+	liveRoute := desiredRoute.DeepCopy()
+	liveRoute.Spec.Rules[0].TargetModels[0].ModelServerName = "test-model-old-backend"
+	liveRoute.Labels[utils.RevisionLabelKey] = "outdated"
+	_, err := kthenaClient.NetworkingV1alpha1().ModelRoutes(model.Namespace).Create(ctx, liveRoute, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	staleRoute := liveRoute.DeepCopy()
+	staleRoute.Spec.ModelName = "test-model"
+	assert.NoError(t, controller.modelRoutesInformer.GetStore().Add(staleRoute))
+
+	var updates, deletes atomic.Int32
+	kthenaClient.PrependReactor("update", "modelroutes", func(k8stesting.Action) (bool, runtime.Object, error) {
+		updates.Add(1)
+		return false, nil, nil
+	})
+	kthenaClient.PrependReactor("delete", "modelroutes", func(k8stesting.Action) (bool, runtime.Object, error) {
+		deletes.Add(1)
+		return false, nil, nil
+	})
+
+	assert.NoError(t, controller.createOrUpdateModelRoute(ctx, model))
+	assert.Equal(t, int32(1), updates.Load())
+	assert.Zero(t, deletes.Load())
+
+	updatedRoute, err := kthenaClient.NetworkingV1alpha1().ModelRoutes(model.Namespace).Get(ctx, model.Name, metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, desiredRoute.Spec.ModelName, updatedRoute.Spec.ModelName)
+	assert.Equal(t, desiredRoute.Spec.Rules, updatedRoute.Spec.Rules)
+	assert.Equal(t, desiredRoute.Labels[utils.RevisionLabelKey], updatedRoute.Labels[utils.RevisionLabelKey])
 }
 
 func TestReconcile_ReturnsError(t *testing.T) {

--- a/pkg/model-booster-controller/controller/model_route_handler.go
+++ b/pkg/model-booster-controller/controller/model_route_handler.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 
+	networkingv1alpha1 "github.com/volcano-sh/kthena/pkg/apis/networking/v1alpha1"
 	workloadv1alpha1 "github.com/volcano-sh/kthena/pkg/apis/workload/v1alpha1"
 	"github.com/volcano-sh/kthena/pkg/model-booster-controller/convert"
 	"github.com/volcano-sh/kthena/pkg/model-booster-controller/utils"
@@ -53,8 +54,13 @@ func (mc *ModelBoosterController) createOrUpdateModelRoute(ctx context.Context, 
 			klog.Errorf("failed to get ModelRoute %s before recreation: %v", klog.KObj(modelRoute), err)
 			return err
 		}
-		if currentModelRoute.DeletionTimestamp != nil || currentModelRoute.Spec.ModelName == modelRoute.Spec.ModelName {
+		if currentModelRoute.DeletionTimestamp != nil {
 			return nil
+		}
+		if currentModelRoute.Spec.ModelName == modelRoute.Spec.ModelName {
+			// The informer can still hold the pre-recreation route. Reconcile the
+			// live route so concurrent rule changes are not lost.
+			return mc.updateModelRoute(ctx, currentModelRoute, modelRoute)
 		}
 
 		klog.Infof("Delete ModelBooster Route %s because spec.modelName is immutable", modelRoute.Name)
@@ -66,12 +72,16 @@ func (mc *ModelBoosterController) createOrUpdateModelRoute(ctx context.Context, 
 		// observes the missing route and creates it with the desired model name.
 		return nil
 	}
-	if oldModelRoute.Labels[utils.RevisionLabelKey] == modelRoute.Labels[utils.RevisionLabelKey] {
-		klog.Infof("ModelBooster Route %s of model %s does not need to update", modelRoute.Name, model.Name)
+	return mc.updateModelRoute(ctx, oldModelRoute, modelRoute)
+}
+
+func (mc *ModelBoosterController) updateModelRoute(ctx context.Context, currentModelRoute, modelRoute *networkingv1alpha1.ModelRoute) error {
+	if currentModelRoute.Labels[utils.RevisionLabelKey] == modelRoute.Labels[utils.RevisionLabelKey] {
+		klog.Infof("ModelBooster Route %s does not need to update", modelRoute.Name)
 		return nil
 	}
-	modelRoute.ResourceVersion = oldModelRoute.ResourceVersion
-	if _, err := mc.client.NetworkingV1alpha1().ModelRoutes(model.Namespace).Update(ctx, modelRoute, metav1.UpdateOptions{}); err != nil {
+	modelRoute.ResourceVersion = currentModelRoute.ResourceVersion
+	if _, err := mc.client.NetworkingV1alpha1().ModelRoutes(modelRoute.Namespace).Update(ctx, modelRoute, metav1.UpdateOptions{}); err != nil {
 		klog.Errorf("failed to update ModelRoute %s: %v", klog.KObj(modelRoute), err)
 		return err
 	}

--- a/pkg/model-booster-controller/controller/model_route_handler.go
+++ b/pkg/model-booster-controller/controller/model_route_handler.go
@@ -43,6 +43,20 @@ func (mc *ModelBoosterController) createOrUpdateModelRoute(ctx context.Context, 
 		return err
 	}
 	if oldModelRoute.Spec.ModelName != modelRoute.Spec.ModelName {
+		currentModelRoute, err := mc.client.NetworkingV1alpha1().ModelRoutes(model.Namespace).Get(ctx, modelRoute.Name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			// The informer cache is stale after the previous delete. The delete
+			// event will enqueue a reconcile that creates the desired route.
+			return nil
+		}
+		if err != nil {
+			klog.Errorf("failed to get ModelRoute %s before recreation: %v", klog.KObj(modelRoute), err)
+			return err
+		}
+		if currentModelRoute.DeletionTimestamp != nil || currentModelRoute.Spec.ModelName == modelRoute.Spec.ModelName {
+			return nil
+		}
+
 		klog.Infof("Delete ModelBooster Route %s because spec.modelName is immutable", modelRoute.Name)
 		if err := mc.client.NetworkingV1alpha1().ModelRoutes(model.Namespace).Delete(ctx, modelRoute.Name, metav1.DeleteOptions{}); err != nil {
 			klog.Errorf("failed to delete ModelRoute %s for recreation: %v", klog.KObj(oldModelRoute), err)

--- a/pkg/model-booster-controller/controller/model_route_handler.go
+++ b/pkg/model-booster-controller/controller/model_route_handler.go
@@ -42,6 +42,16 @@ func (mc *ModelBoosterController) createOrUpdateModelRoute(ctx context.Context, 
 		klog.Errorf("failed to get ModelRoute %s: %v", klog.KObj(modelRoute), err)
 		return err
 	}
+	if oldModelRoute.Spec.ModelName != modelRoute.Spec.ModelName {
+		klog.Infof("Delete ModelBooster Route %s because spec.modelName is immutable", modelRoute.Name)
+		if err := mc.client.NetworkingV1alpha1().ModelRoutes(model.Namespace).Delete(ctx, modelRoute.Name, metav1.DeleteOptions{}); err != nil {
+			klog.Errorf("failed to delete ModelRoute %s for recreation: %v", klog.KObj(oldModelRoute), err)
+			return err
+		}
+		// The delete event enqueues the owning ModelBooster. Its next reconcile
+		// observes the missing route and creates it with the desired model name.
+		return nil
+	}
 	if oldModelRoute.Labels[utils.RevisionLabelKey] == modelRoute.Labels[utils.RevisionLabelKey] {
 		klog.Infof("ModelBooster Route %s of model %s does not need to update", modelRoute.Name, model.Name)
 		return nil

--- a/pkg/model-booster-controller/convert/model_route.go
+++ b/pkg/model-booster-controller/convert/model_route.go
@@ -40,12 +40,21 @@ func BuildModelRoute(model *workload.ModelBooster) *networking.ModelRoute {
 			},
 		},
 		Spec: networking.ModelRouteSpec{
-			ModelName: model.Name,
+			ModelName: modelRequestName(model),
 			Rules:     rules,
 		},
 	}
 	route.Labels = utils.GetModelControllerLabels(model, "", icUtils.Revision(route.Spec))
 	return route
+}
+
+// modelRequestName returns the client-facing model name used as the ModelRoute lookup key.
+// ModelBooster metadata.name remains the Kubernetes identity for generated resources.
+func modelRequestName(model *workload.ModelBooster) string {
+	if model.Spec.Name != "" {
+		return model.Spec.Name
+	}
+	return model.Name
 }
 
 // getRules generates routing rules based on the model's backend.

--- a/pkg/model-booster-controller/convert/model_route_test.go
+++ b/pkg/model-booster-controller/convert/model_route_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	networking "github.com/volcano-sh/kthena/pkg/apis/networking/v1alpha1"
 	registry "github.com/volcano-sh/kthena/pkg/apis/workload/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestBuildModelRoute(t *testing.T) {
@@ -42,4 +43,32 @@ func TestBuildModelRoute(t *testing.T) {
 			assert.Equal(t, tt.expected, got)
 		})
 	}
+}
+
+func TestBuildModelRouteUsesModelBoosterSpecName(t *testing.T) {
+	model := &registry.ModelBooster{
+		ObjectMeta: metav1.ObjectMeta{Name: "qwen25", Namespace: "default"},
+		Spec: registry.ModelBoosterSpec{
+			Name: "qwen25-coder-32b",
+			Backend: registry.ModelBackend{
+				Name: "backend",
+				Type: registry.ModelBackendTypeVLLM,
+				Workers: []registry.ModelWorker{{
+					Type: registry.ModelWorkerTypeServer,
+				}},
+			},
+		},
+	}
+
+	route := BuildModelRoute(model)
+	assert.Equal(t, model.Spec.Name, route.Spec.ModelName)
+}
+
+func TestBuildModelRouteUsesMetadataNameWhenSpecNameIsEmpty(t *testing.T) {
+	model := &registry.ModelBooster{
+		ObjectMeta: metav1.ObjectMeta{Name: "qwen25", Namespace: "default"},
+	}
+
+	route := BuildModelRoute(model)
+	assert.Equal(t, model.Name, route.Spec.ModelName)
 }

--- a/pkg/model-booster-controller/convert/model_server_test.go
+++ b/pkg/model-booster-controller/convert/model_server_test.go
@@ -85,6 +85,16 @@ func TestBuildModelServerCustomPort(t *testing.T) {
 	assert.Equal(t, int32(9000), servers[0].Spec.WorkloadPort.Port)
 }
 
+func TestBuildModelServerExplicitServedModelNameOverridesModelBoosterSpecName(t *testing.T) {
+	model := loadYaml[registry.ModelBooster](t, "testdata/input/model.yaml")
+	model.Spec.Name = "client-facing-model-name"
+
+	modelServers, err := BuildModelServer(model)
+	assert.NoError(t, err)
+	assert.Len(t, modelServers, 1)
+	assert.Equal(t, "deepseek-v3", *modelServers[0].Spec.Model)
+}
+
 func mooncakeWorker(workerType registry.ModelWorkerType, role string) registry.ModelWorker {
 	return registry.ModelWorker{
 		Type: workerType,

--- a/pkg/model-booster-controller/convert/model_server_test.go
+++ b/pkg/model-booster-controller/convert/model_server_test.go
@@ -92,6 +92,7 @@ func TestBuildModelServerExplicitServedModelNameOverridesModelBoosterSpecName(t 
 	modelServers, err := BuildModelServer(model)
 	assert.NoError(t, err)
 	assert.Len(t, modelServers, 1)
+	assert.NotNil(t, modelServers[0].Spec.Model)
 	assert.Equal(t, "deepseek-v3", *modelServers[0].Spec.Model)
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Uses `ModelBooster.spec.name` as `ModelRoute.spec.modelName` when it is set. This lets clients request a model using its declared name, including names not valid for Kubernetes resource metadata.

When `spec.name` is empty, the generated ModelRoute retains the existing `metadata.name` fallback.

Generated child resource names, labels, owner references, and ModelServer served-model behavior remain unchanged.

**Which issue(s) this PR fixes**:

Fixes #1489

**Bug evidence (required for bug-related PRs)**:

Before this change, `BuildModelRoute` always set `ModelRoute.spec.modelName` to `ModelBooster.metadata.name`, ignoring a non-empty `ModelBooster.spec.name`.

For example:

```yaml
metadata:
  name: qwen25
spec:
  name: qwen25-coder-32b
```

Previously generated:

```yaml
spec:
  modelName: qwen25
```

The router indexes ModelRoutes by `spec.modelName`, so a request for `qwen25-coder-32b` could not find this route.

This PR generates:

```yaml
spec:
  modelName: qwen25-coder-32b
```

Regression coverage verifies conversion, empty-value fallback, datastore lookup with the declared name, and preservation of an explicit worker `served-model-name`.

**Special notes for your reviewer**:

`spec.name` changes only the client-facing ModelRoute lookup key. Kubernetes identities remain based on `metadata.name`.

Tested with:

```text
go test ./pkg/model-booster-controller/convert ./pkg/kthena-router/datastore -count=1
```

**Does this PR introduce a user-facing change?**:

```release-note
ModelBooster.spec.name is now used as the generated ModelRoute model name, allowing requests to use the declared model name.
```