### PR TITLE
fix: handle PodGroup CRD tombstone deletion

### DIFF
--- a/pkg/model-serving-controller/podgroupmanager/manager.go
+++ b/pkg/model-serving-controller/podgroupmanager/manager.go
@@ -130,15 +130,31 @@ func NewManager(kubeClient kubernetes.Interface, volcanoClient volcanoclient.Int
 
 			newManager.handlePodGroupCRDChange(newCrd, false)
 		},
-		DeleteFunc: func(obj interface{}) {
-			crd := obj.(*apiextv1.CustomResourceDefinition)
-			newManager.handlePodGroupCRDChange(crd, true)
-		},
+		DeleteFunc: newManager.handlePodGroupCRDDelete,
 	})
 
 	newManager.CrdInformer = crdInformer
 
 	return &newManager
+}
+
+func (m *Manager) handlePodGroupCRDDelete(obj interface{}) {
+	crd, ok := obj.(*apiextv1.CustomResourceDefinition)
+	if !ok {
+		tombstone, tombstoneOK := obj.(cache.DeletedFinalStateUnknown)
+		if !tombstoneOK {
+			klog.Errorf("failed to parse CustomResourceDefinition type when deleting: %#v", obj)
+			return
+		}
+
+		crd, ok = tombstone.Obj.(*apiextv1.CustomResourceDefinition)
+		if !ok {
+			klog.Errorf("failed to parse CustomResourceDefinition from tombstone: %#v", tombstone.Obj)
+			return
+		}
+	}
+
+	m.handlePodGroupCRDChange(crd, true)
 }
 
 func (m *Manager) HasPodGroupCRD() bool {

--- a/pkg/model-serving-controller/podgroupmanager/manager_test.go
+++ b/pkg/model-serving-controller/podgroupmanager/manager_test.go
@@ -1243,6 +1243,59 @@ func TestHandlePodGroupCRDChange(t *testing.T) {
 	})
 }
 
+func TestHandlePodGroupCRDDelete(t *testing.T) {
+	crd := &apiextv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: podGroupCRDName},
+	}
+
+	tests := []struct {
+		name        string
+		obj         interface{}
+		wantDeleted bool
+	}{
+		{
+			name:        "direct CRD",
+			obj:         crd,
+			wantDeleted: true,
+		},
+		{
+			name: "tombstone CRD",
+			obj: cache.DeletedFinalStateUnknown{
+				Key: podGroupCRDName,
+				Obj: crd,
+			},
+			wantDeleted: true,
+		},
+		{
+			name:        "unexpected object",
+			obj:         &corev1.Pod{},
+			wantDeleted: false,
+		},
+		{
+			name: "unexpected tombstone object",
+			obj: cache.DeletedFinalStateUnknown{
+				Key: podGroupCRDName,
+				Obj: &corev1.Pod{},
+			},
+			wantDeleted: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manager := &Manager{}
+			manager.hasPodGroupCRD.Store(true)
+			manager.hasSubGroupPolicy.Store(true)
+
+			assert.NotPanics(t, func() {
+				manager.handlePodGroupCRDDelete(tt.obj)
+			})
+			assert.Equal(t, !tt.wantDeleted, manager.hasPodGroupCRD.Load())
+			assert.Equal(t, !tt.wantDeleted, manager.hasSubGroupPolicy.Load())
+		})
+	}
+}
+
 // TestExtractQueueName verifies the extractQueueName helper directly.
 func TestExtractQueueName(t *testing.T) {
 	t.Run("nil ModelServing returns empty string", func(t *testing.T) {


### PR DESCRIPTION
### What type of PR is this?

/kind bug

### What this PR does / why we need it

The PodGroup CRD informer assumed every delete notification contained a direct `CustomResourceDefinition` object. Kubernetes informers can instead deliver `cache.DeletedFinalStateUnknown` tombstones when the object is no longer present in the local cache, causing the unchecked type assertion to panic.

This change moves delete handling into a dedicated helper that:

- handles direct CRD delete events;
- unwraps tombstone delete events before updating PodGroup support state;
- logs and ignores unexpected object types instead of panicking.

Regression tests cover direct deletes, tombstone deletes, unexpected objects, and tombstones containing unexpected objects.

### Which issue(s) this PR fixes

None.

### Special notes for your reviewer

The change only affects the PodGroup CRD informer delete path. Add and update behavior is unchanged.

### How was this change tested?

```bash
go test ./pkg/model-serving-controller/podgroupmanager -run 'TestHandlePodGroupCRD(Delete|Change)$' -count=1
go test ./pkg/model-serving-controller/podgroupmanager -count=1
```

### Does this PR introduce a user-facing change?

```release-note
NONE
```
