### PR TITLE
docs: propose external model provider routing

### DIFF
--- a/docs/proposal/kthena-router-third-party-model-api.md
+++ b/docs/proposal/kthena-router-third-party-model-api.md
@@ -1,0 +1,740 @@
+---
+title: Kthena Router Support for Third-Party Model APIs
+authors:
+- "@Oxidaner"
+reviewers:
+- "@YaoZengzeng"
+approvers:
+- "@LiZhenCheng9527"
+
+creation-date: 2026-06-15
+---
+
+## Kthena Router Support for Third-Party Model APIs
+
+### Summary
+
+Kthena Router is documented as a unified LLM entry point for both privately deployed models and public AI service providers. The current implementation, however, only routes to in-cluster, Pod-backed `ModelServer`:
+
+```mermaid
+graph LR
+    A[ModelRoute] --> B[ModelServer]
+    B --> C[workloadSelector]
+    C --> D[Pods]
+    D --> E[scheduler]
+    E --> F["podIP:port"]
+```
+
+This proposal adds a second upstream destination type for third-party providers. The LFX delivery scope covers both OpenAI-compatible providers such as OpenAI, DeepSeek, or compatible gateways, and Anthropic-compatible providers that expose the Messages API. Clients continue to call the Router with a virtual model name; the Router decides whether the request goes to an in-cluster model or an external provider.
+
+```mermaid
+graph LR
+    C["Client (/v1/chat/completions, /v1/completions, /v1/responses, /v1/messages)"] --> R[Kthena Router]
+    R -->|in-cluster| MS["ModelServer → Pods"]
+    R -->|external| EP["ExternalModelProvider → third-party API"]
+```
+
+This proposal evaluates two API shapes. **Option A** extends `ModelServer` with external provider fields. **Option B** adds a dedicated `ExternalModelProvider` CRD. The selected design is Option B; Option A remains documented below to preserve the trade-off analysis and explain why it was not selected.
+
+The MVP endpoint scope is intentionally small:
+
+| Endpoint | MVP | Notes |
+|---|---|---|
+| `/v1/chat/completions` | Supported | OpenAI-compatible native messages, tools, and multimodal fields |
+| `/v1/completions` | Supported | OpenAI-compatible completions with a string `prompt` |
+| `/v1/responses` | Supported | OpenAI Responses API native input, including streaming, tools, and multimodal fields |
+| `/v1/messages` | Supported | Anthropic-compatible native messages, tools, and multimodal content blocks |
+
+### Motivation
+
+The existing Router pipeline is already mostly independent of where the final upstream lives:
+
+```mermaid
+graph LR
+    A[Parse request] --> B[Auth]
+    B --> C[Rate limit]
+    C --> D[Access log / Metrics]
+    D --> E[ModelRoute match]
+    E --> F[Weighted target selection]
+    F --> G([Upstream hop])
+    style G fill:#f9d,stroke:#333
+```
+
+Everything up to the upstream hop is protocol-agnostic. Only the **final hop** is tightly coupled to in-cluster Pods:
+
+| Coupling point | What it does | Why it breaks for external APIs |
+|:--|:--|:--|
+| `getPodsAndServer()` | Requires target Pods for a `ModelServer` | External APIs have no Pods |
+| `doRequest()` | Rewrites the request to `podIP:port` | No Pod IP to rewrite to |
+| Scheduler | Scores Pods by runtime metrics, KV cache, LoRA, in-flight count | No `WorkloadSelector`, no vLLM/SGLang metrics |
+
+External providers should therefore **skip Pod scheduling** and go directly through a provider client, while reusing the rest of the Router pipeline.
+
+### Goals
+
+- Route native `/v1/chat/completions`, `/v1/completions`, and `/v1/responses` requests, including tool and multimodal fields, to an external OpenAI-compatible API.
+- Route native `/v1/messages` requests, including tool and multimodal content blocks, to an external Anthropic-compatible API.
+- Reference credentials through Kubernetes `Secret`s, never inline plaintext.
+- Reuse Router auth, rate limiting, access logging, metrics, model rewrite, and weighted traffic splitting.
+- Support streaming SSE passthrough for OpenAI chat/completion, OpenAI Responses, and Anthropic messages requests.
+- Preserve backward compatibility for existing `ModelRoute` and `ModelServer` manifests.
+- Provide unit tests, user docs, examples, and in-cluster mock-server e2e coverage.
+
+### Non-Goals
+
+- Native Gemini, Bedrock, or Vertex request/response translation. (Note: Gemini and Cohere expose OpenAI-compatible endpoints — e.g. Gemini's `/v1beta/openai` prefix — so they work day-one via `baseURL` without a new adapter. Only their *native* formats are out of scope.)
+- OpenAI-to-Anthropic or Anthropic-to-OpenAI request translation. The MVP supports each protocol at its own Router endpoint and provider adapter; it does not translate one client protocol into another upstream protocol.
+- Complete local token accounting, input-token rate limiting, or prompt/KV-cache scheduling semantics for non-text content.
+- Pod scheduling, KV-cache-aware routing, prefix-aware routing, LoRA affinity, or PD disaggregation for external providers.
+- LoRA routes targeting external providers. `ModelRoute.spec.loraAdapters[]` remains an in-cluster ModelServer feature in the MVP.
+- Managing the external service lifecycle.
+- Provider-side multi-endpoint load balancing beyond what weighted `targetModels[]` can already express.
+- Automatic failure fallback from one selected target to another.
+- Automatic retry of external-provider requests and configurable timeout/retry policies.
+
+### API Options
+
+#### Option A: Extend ModelServer
+
+Option A adds external-provider fields directly to `ModelServerSpec`. A `ModelRoute` would continue to target a `ModelServer`, and the router would decide whether that `ModelServer` points to Pods or to an external endpoint.
+
+This is the lower-churn shape because it preserves the existing `ModelRoute -> ModelServer` user model and reuses the current store path. The cost is that `ModelServer` would describe two different backend types. Pod-oriented fields such as `workloadSelector`, `inferenceEngine`, and `workloadPort` would need to become optional or conditional, and the controller/router would need extra branches for the no-Pod case.
+
+#### Option B: Add ExternalModelProvider
+
+Option B adds a namespaced `ExternalModelProvider` CRD and extends `ModelRoute.targetModels[]` with an `externalModelProviderName`. `ModelServer` remains the resource for Pod-backed serving, while external providers get their own fields for endpoint, credentials, model override, and protocol.
+
+This proposal selects Option B because Kthena is CRD-native and `ModelServer` is already documented and implemented around Pods. Separating the resources keeps lifecycle, validation, status, and future provider-specific fields cleaner.
+
+| Dimension | Option A: extend `ModelServer` | Option B: new `ExternalModelProvider` |
+|---|---|---|
+| Decision | Not selected; retained for comparison | Selected |
+| Router path change | Smaller | Larger |
+| User-facing concepts | Reuses `ModelServer` | Adds one CRD |
+| API clarity | `ModelServer` mixes Pod and external fields | Single-purpose resources |
+| Existing required fields | Must relax Pod-oriented required fields | No need to relax `ModelServer` |
+| Controller changes | Add no-Pod branches to `ModelServerController` | Add a small provider controller |
+| Datastore | External entries share ModelServer map | Separate provider registry |
+| Long-term evolution | Provider fields accumulate in `ModelServerSpec` | Providers evolve independently |
+
+### Recommended API: ExternalModelProvider
+
+Add a namespaced `ExternalModelProvider` CRD under `networking.serving.volcano.sh/v1alpha1`.
+
+Resource relationships (all within one namespace):
+
+```mermaid
+graph TD
+    MR["ModelRoute<br/>modelName: deepseek"] -->|externalModelProviderName| EP["ExternalModelProvider<br/>deepseek-provider<br/>model: deepseek-chat"]
+    MR -->|modelServerName| MS["ModelServer<br/>(in-cluster, unchanged)"]
+    EP -->|auth.secretRef| SEC["Secret<br/>deepseek-api-key"]
+    EP -->|baseURL| API["Third-party API<br/>api.deepseek.com"]
+```
+
+`ExternalModelProviderSpec` fields:
+
+| Field | Type | Required | Default | Notes |
+|---|---|---|---|---|
+| `providerType` | enum | no | `OpenAI` | `OpenAI` or `Anthropic`; selects the protocol adapter. `OpenAI` means OpenAI-compatible, not only the OpenAI vendor |
+| `model` | string | no | — | Actual upstream model name; when set, overrides the request model like `ModelServer.spec.model`; when unset, preserves the request model |
+| `baseURL` | string | yes | — | `^https://.+`; external providers must use HTTPS |
+| `insecureSkipVerify` | bool | no | `false` | For HTTPS only, skips server certificate-chain and hostname verification; use only when the endpoint cannot present a certificate trusted by the Router |
+| `auth` | `ProviderAuth` | no | — | Credential Secret reference; the selected adapter injects it using the provider protocol's auth scheme; if unset, no auth header is injected |
+| `headers` | map | no | — | Non-sensitive static upstream headers; credentials must use `auth.secretRef` |
+
+`ProviderAuth` fields:
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `scheme` | enum | adapter default | `Bearer` sends `Authorization: Bearer <secret value>`; `APIKey` sends `x-api-key: <secret value>`; OpenAI defaults to `Bearer` and Anthropic defaults to `APIKey` |
+| `secretRef` | `corev1.SecretKeySelector` | — | `{name, key}`, same namespace; `optional` must be unset or `false`; the selected value is sent with the adapter-specific authentication scheme |
+
+```go
+type ExternalProviderType string
+
+const (
+    OpenAI    ExternalProviderType = "OpenAI"
+    Anthropic ExternalProviderType = "Anthropic"
+)
+
+type ProviderAuthScheme string
+
+const (
+    ProviderAuthSchemeBearer ProviderAuthScheme = "Bearer"
+    ProviderAuthSchemeAPIKey ProviderAuthScheme = "APIKey"
+)
+
+// The BaseURL pattern requires HTTPS. These external providers run outside the
+// cluster boundary, so plain HTTP is not supported.
+type ExternalModelProviderSpec struct {
+    // MVP supports OpenAI-compatible and Anthropic-compatible API adapters.
+    // +optional
+    // +kubebuilder:validation:Enum=OpenAI;Anthropic
+    // +kubebuilder:default=OpenAI
+    ProviderType ExternalProviderType `json:"providerType,omitempty"`
+
+    // Model is the actual upstream model name. When set, it overwrites the
+    // model in the request, matching ModelServer.Spec.Model behavior.
+    // +optional
+    // +kubebuilder:validation:MaxLength=256
+    Model *string `json:"model,omitempty"`
+
+    // BaseURL is the provider endpoint root. External providers must use HTTPS.
+    // Example: https://api.deepseek.com
+    // +kubebuilder:validation:Required
+    // +kubebuilder:validation:MinLength=1
+    // +kubebuilder:validation:Pattern=^https://.+
+    BaseURL string `json:"baseURL"`
+
+    // InsecureSkipVerify disables server certificate-chain and hostname
+    // verification for HTTPS. It does not enable plain HTTP.
+    // +optional
+    // +kubebuilder:default=false
+    InsecureSkipVerify bool `json:"insecureSkipVerify,omitempty"`
+
+    // Auth references a credential Secret in the same namespace. The selected
+    // provider adapter decides how the value is injected into the upstream request.
+    // +optional
+    Auth *ProviderAuth `json:"auth,omitempty"`
+
+    // Non-sensitive static headers added to upstream requests. Credentials must use
+    // Auth.SecretRef. Authorization, x-api-key, other credential-bearing headers,
+    // hop-by-hop headers, and request-routing headers such as Host and Content-Length are forbidden.
+    // +optional
+    Headers map[string]string `json:"headers,omitempty"`
+}
+
+// +kubebuilder:validation:XValidation:rule="!has(self.secretRef.optional) || !self.secretRef.optional",message="secretRef.optional must be false or unset"
+type ProviderAuth struct {
+    // Scheme overrides the adapter default when an Anthropic-compatible gateway
+    // uses Bearer auth or an OpenAI-compatible gateway uses x-api-key.
+    // +optional
+    // +kubebuilder:validation:Enum=Bearer;APIKey
+    Scheme ProviderAuthScheme `json:"scheme,omitempty"`
+
+    // +kubebuilder:validation:Required
+    SecretRef corev1.SecretKeySelector `json:"secretRef"`
+}
+
+type ExternalModelProviderStatus struct {
+    // +optional
+    ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+
+    // +optional
+    Conditions []metav1.Condition `json:"conditions,omitempty"`
+}
+```
+
+`corev1.SecretKeySelector` is used intentionally instead of a custom selector. It keeps the API aligned with Kubernetes conventions while still allowing users to customize both the Secret name and the Secret key.
+
+Status should only report whether the provider config and referenced credentials can be used in the MVP. The controller can report conditions such as `Ready` and `CredentialsResolved`, but it should not actively call third-party APIs to check health in the first implementation. Secret add, update, and delete events must reconcile affected providers so these conditions do not become stale.
+
+Extend `TargetModel` with an external destination:
+
+```go
+// +kubebuilder:validation:XValidation:rule="(has(self.modelServerName) && self.modelServerName != '') != (has(self.externalModelProviderName) && self.externalModelProviderName != '')",message="exactly one of modelServerName or externalModelProviderName must be set"
+type TargetModel struct {
+    // Existing in-cluster target. Mutually exclusive with ExternalModelProviderName.
+    ModelServerName string `json:"modelServerName,omitempty"`
+
+    // ExternalModelProviderName references an ExternalModelProvider in the same
+    // namespace. It is mutually exclusive with ModelServerName.
+    ExternalModelProviderName string `json:"externalModelProviderName,omitempty"`
+
+    // Existing weighted splitting field.
+    Weight *uint32 `json:"weight,omitempty"`
+}
+```
+
+Validation:
+
+- Exactly one of `modelServerName` and `externalModelProviderName` must be set.
+- If `ModelRoute.spec.loraAdapters[]` is non-empty, every `targetModels[]` entry must use `modelServerName`; `externalModelProviderName` is rejected for that route. OpenAI-compatible passthrough has no standard way to express a Kthena LoRA adapter to an arbitrary provider.
+- `baseURL` must be HTTPS. Plain HTTP is not supported for external providers.
+- `insecureSkipVerify` is valid only with an HTTPS `baseURL`. It leaves the connection encrypted but disables certificate-chain and hostname verification.
+- `baseURL` must be parsed and must not contain URL userinfo, query, or
+  fragment. This should be enforced by webhook validation because CEL is not a
+  good fit for full URL parsing.
+- Static `headers` are for non-sensitive values only. Always reject credential-bearing headers such as `Authorization`, `Proxy-Authorization`, `Cookie`, and `x-api-key`, plus `Host`, `Content-Length`, and hop-by-hop headers. Header names must be validated case-insensitively, for example by canonicalizing with `http.CanonicalHeaderKey` or comparing with `strings.EqualFold` in webhook validation.
+- `auth` may be omitted for providers that require no credential. When `auth` is present, its Secret and key are mandatory; reject `secretRef.optional=true` rather than silently sending an unauthenticated request.
+- When `auth` is present, use `auth.scheme` when it is set. Otherwise, inject `Authorization: Bearer <secret value>` for OpenAI-compatible providers and `x-api-key: <secret value>` for Anthropic-compatible providers. Reject values other than `Bearer` and `APIKey`.
+- `secretRef.name` and `secretRef.key` are structurally validated at admission time. Secret existence and key availability are resolved asynchronously by the controller/router lister and reported through provider status.
+- The request protocol must match the selected external provider adapter. OpenAI-compatible endpoints route only to `providerType: OpenAI`; Anthropic-compatible `/v1/messages` routes only to `providerType: Anthropic`. The MVP does not translate between the two protocols.
+
+Example:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: deepseek-api-key
+  namespace: default
+  labels:
+    networking.serving.volcano.sh/external-model-provider-credential: "true"
+type: Opaque
+stringData:
+  apiKey: "<redacted>"
+---
+apiVersion: networking.serving.volcano.sh/v1alpha1
+kind: ExternalModelProvider
+metadata:
+  name: deepseek-provider
+  namespace: default
+spec:
+  providerType: OpenAI
+  model: deepseek-chat
+  baseURL: https://api.deepseek.com
+  auth:
+    secretRef:
+      name: deepseek-api-key
+      key: apiKey
+---
+apiVersion: networking.serving.volcano.sh/v1alpha1
+kind: ModelRoute
+metadata:
+  name: deepseek-route
+  namespace: default
+spec:
+  modelName: deepseek
+  rules:
+  - name: default
+    targetModels:
+    - externalModelProviderName: deepseek-provider
+```
+
+Anthropic-compatible provider example:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: anthropic-api-key
+  namespace: default
+  labels:
+    networking.serving.volcano.sh/external-model-provider-credential: "true"
+type: Opaque
+stringData:
+  apiKey: "<redacted>"
+---
+apiVersion: networking.serving.volcano.sh/v1alpha1
+kind: ExternalModelProvider
+metadata:
+  name: anthropic-provider
+  namespace: default
+spec:
+  providerType: Anthropic
+  model: "<anthropic-model>"
+  baseURL: https://api.anthropic.com
+  auth:
+    secretRef:
+      name: anthropic-api-key
+      key: apiKey
+  headers:
+    anthropic-version: "2023-06-01"
+---
+apiVersion: networking.serving.volcano.sh/v1alpha1
+kind: ModelRoute
+metadata:
+  name: anthropic-route
+  namespace: default
+spec:
+  modelName: claude
+  rules:
+  - name: default
+    targetModels:
+    - externalModelProviderName: anthropic-provider
+```
+
+Hybrid split also works:
+
+```yaml
+rules:
+- name: default
+  targetModels:
+  - modelServerName: qwen-local
+    weight: 80
+  - externalModelProviderName: openai-provider
+    weight: 20
+```
+
+In this example, `openai-provider` sets `spec.model: gpt-4o-mini` when the external target should override the request model. If `spec.model` is unset, the request model is forwarded unchanged.
+
+If a base model should use an external provider while LoRA adapters remain in-cluster, split them into separate `ModelRoute` resources instead of mixing `modelName` and `loraAdapters[]` in one route:
+
+```yaml
+apiVersion: networking.serving.volcano.sh/v1alpha1
+kind: ModelRoute
+metadata:
+  name: qwen-external
+  namespace: default
+spec:
+  modelName: qwen
+  rules:
+  - name: external
+    targetModels:
+    - externalModelProviderName: qwen-provider
+---
+apiVersion: networking.serving.volcano.sh/v1alpha1
+kind: ModelRoute
+metadata:
+  name: qwen-lora
+  namespace: default
+spec:
+  loraAdapters:
+  - qwen-lora-a
+  - qwen-lora-b
+  rules:
+  - name: lora
+    targetModels:
+    - modelServerName: qwen-lora-server
+```
+
+This is traffic splitting, not failure fallback. The MVP selects one target by weight at the beginning of the request; it does not automatically try the external provider after an in-cluster target fails, or vice versa.
+
+### Request Flow
+
+```mermaid
+graph TD
+    C["Client<br/>POST /v1/chat/completions, /v1/completions, /v1/responses, or /v1/messages"] --> H[Router Handler]
+    H --> P[Parse request and model]
+    P --> F[Auth / RateLimit / AccessLog / Metrics]
+    F --> M[ModelRoute rule match]
+    M --> W[Weighted target selection]
+    W --> Q{Target kind?}
+
+    Q -->|ModelServer| K1[Get Pods]
+    K1 --> K2[Scheduler]
+    K2 --> K3["Proxy to podIP:port"]
+
+    Q -->|ExternalModelProvider| E1[Resolve provider]
+    E1 --> E2[Resolve Secret]
+    E2 --> E3[Rewrite model]
+    E3 --> E4[Rebuild request body]
+    E4 --> E5[Call provider]
+
+    K3 --> FR[forwardResponse - shared]
+    E5 --> FR
+
+    style Q fill:#f9d,stroke:#333
+    style FR fill:#9df,stroke:#333
+```
+
+Mapped onto the documented Router pipeline stages, the external path is **additive, not a rewrite**:
+
+| Stage | In-cluster path | External path |
+|---|---|---|
+| Auth | ✅ reuse | ✅ reuse |
+| RateLimit | ✅ reuse | ✅ reuse |
+| Fairness | ✅ reuse | ✅ reuse |
+| Target selection | weighted `targetModels[]` pick | ✅ reuse |
+| Pod scheduling | Pod filter/score | ⏭️ **skipped** (no Pods) |
+| Upstream execution | `doRequest(podIP)` | 🔁 **replaced** by provider call |
+| Response forwarding | Shared body/SSE mechanics after Pod-specific status handling | Shared body/SSE mechanics; provider HTTP errors pass through |
+
+The external path skips Pod scheduling, reuses the front half of the pipeline, and shares response-copying, SSE, and usage-parsing mechanics. Status acceptance, retry, and fallback behavior remain path-specific.
+
+### Implementation Details
+
+#### Route Target
+
+`selectDestination()` already returns the selected `TargetModel`, but `MatchModelServer()` currently collapses it into `ModelServerName`. For Option B, return a more general target:
+
+```go
+type RouteTarget struct {
+    Kind DestinationKind
+    Name types.NamespacedName
+
+    IsLora     bool
+    ModelRoute *aiv1alpha1.ModelRoute
+}
+```
+
+Only the target representation changes; rule matching and weighted selection stay the same. `Kind` identifies whether `Name` refers to a `ModelServer` or an `ExternalModelProvider`; this avoids pointer combinations such as `Kind=ExternalProvider` with a populated `ModelServer` branch. `IsLora` is only valid for `Kind=ModelServer` in the MVP. After entering the external branch, the Router resolves the `ExternalModelProvider` and computes the upstream model from `provider.spec.model`, preserving the request model when that field is unset. This mirrors the existing ModelServer path, which resolves `ModelServer.spec.model` after route selection.
+
+The signature change is mechanical but touches the `Store` interface, `MockStore`, and a handful of existing tests, plus the single live caller in `doLoadbalance` (a router-level wrapper with no callers can be deleted).
+
+#### Provider Adapter Layer
+
+Add a provider adapter layer under `pkg/kthena-router/providers/`.
+
+| File | Responsibility |
+|---|---|
+| `adapter.go` | `Adapter` and response-parser interfaces, adapter selection, shared request construction, configuration validation, header policy, credential lookup, and HTTP execution |
+| `openai.go` | OpenAI-compatible request construction and usage parsing |
+| `anthropic.go` | Anthropic-compatible request construction and usage parsing |
+
+The Router selects one adapter from `providerType`, then uses the interface for both request construction and response parsing:
+
+```go
+type Adapter interface {
+    BuildRequest(
+        c *gin.Context,
+        req *http.Request,
+        provider *networkingv1alpha1.ExternalModelProvider,
+        secret *corev1.Secret,
+        modelRequest map[string]interface{},
+    ) (*http.Request, error)
+    ResponseParser(path string) ResponseUsageParser
+}
+
+type ResponseUsageParser interface {
+    ParseStreamLine(line string) (TokenUsage, bool)
+    ParseBody(body []byte) (TokenUsage, bool)
+    FinalStreamUsage() (TokenUsage, bool)
+    RecordStreamLineWritten(line string)
+    StreamCompleted() bool
+}
+```
+
+The adapter owns protocol-specific URL mapping, model rewriting, authentication headers, streaming completion detection, and usage normalization. Router code must not branch on OpenAI versus Anthropic behavior after selecting the adapter. Secret lookup remains part of Router state resolution; the selected Secret is passed to `BuildRequest`, while credential extraction and injection stay inside the adapter package.
+
+Shared request construction and HTTP execution handle header filtering, static headers, connection pooling, TLS policy, redirect policy, and connection-level timeouts. Redirects are disabled by default. The provider's `insecureSkipVerify` setting selects the shared secure or opt-in insecure client; protocol adapters do not implement separate network rules. The MVP does not automatically retry external-provider requests.
+
+The transport should keep separate long-lived secure and skip-verification clients, each built from its own clone of the base `http.Transport`. The secure client uses normal certificate and hostname verification. The opt-in client uses an isolated `tls.Config` with `InsecureSkipVerify=true`. Never mutate `http.DefaultTransport`, a shared `tls.Config`, or the secure client when processing a provider with `insecureSkipVerify=true`; otherwise one provider could silently disable verification for every provider sharing the connection pool.
+
+The MVP providers cover OpenAI-compatible passthrough and Anthropic-compatible Messages API passthrough. They share request and transport helpers but differ in URL mapping, authentication headers, streaming event semantics, and usage parsing.
+
+OpenAI-compatible adapter behavior:
+
+- Treat `baseURL` as the provider's OpenAI-compatible API root. Strip the public Router `/v1` prefix from the original path before joining. For example, `/v1/chat/completions` joined with `https://api.example.com/v1` becomes `https://api.example.com/v1/chat/completions`, and the same request joined with `https://generativelanguage.googleapis.com/v1beta/openai` becomes `https://generativelanguage.googleapis.com/v1beta/openai/chat/completions`.
+- If `auth` is configured, inject the selected Secret value as `Authorization: Bearer <secret value>` by default. `auth.scheme: APIKey` overrides this for compatible gateways that require `x-api-key`.
+- If `ExternalModelProvider.spec.model` is set, rewrite the request `model` to that value; otherwise preserve the request model. This matches the existing `ModelServer.spec.model` override behavior.
+- Accept native Responses API requests on `/v1/responses`, including tool, image, audio, file, and provider-extension items. The Router extracts `instructions` and text-bearing input only for local prompt accounting; it forwards other fields unchanged for the selected backend to interpret.
+- Do not inject chat/completions-specific `include_usage` or `stream_options` fields into Responses API requests. Responses usage is returned in the native response envelope and terminal streaming events.
+- Normalize Responses API `usage.input_tokens`, `usage.output_tokens`, and `usage.total_tokens` into the Router's provider-independent upstream usage view. Upstream input and output usage feed per-user token accounting, while upstream output usage also updates output rate limiting, access logs, and metrics. Input rate limiting, access logs, and metrics retain the Router's pre-dispatch tokenizer observation, matching the existing ModelServer path and remaining available when a provider omits usage.
+
+Anthropic-compatible adapter behavior:
+
+- Accept Router requests on `/v1/messages` and forward them to the provider's Anthropic-compatible Messages API path under `baseURL`. Append `/v1/messages` when `baseURL` is an unversioned host or custom prefix; append only `/messages` when `baseURL` already ends in `/v1`.
+- If `auth` is configured, inject the selected Secret value as `x-api-key: <secret value>` by default. `auth.scheme: Bearer` supports Claude Code and other Anthropic-compatible gateways that expect `Authorization: Bearer <secret value>`.
+- Forward or set required non-sensitive Anthropic protocol headers such as `anthropic-version` and `anthropic-beta` through the static header and downstream-header allowlist path. Credential-bearing headers still must come from `auth.secretRef`.
+- If `ExternalModelProvider.spec.model` is set, rewrite the Anthropic request `model` to that value; otherwise preserve the request model.
+- Parse Anthropic usage fields from non-streaming responses and streaming events. Normalize total input as `input_tokens + cache_creation_input_tokens + cache_read_input_tokens`. The adapter must not use OpenAI-specific `stream_options.include_usage`.
+
+Common adapter behavior:
+
+- Preserve provider-native tool, multimodal, and extension fields when forwarding the raw request or rewriting `model`. The adapter validates endpoint compatibility, credential/header policy, and URL construction, not individual model capabilities.
+- Do not copy downstream headers wholesale. Forward only `Content-Type`, `Accept`, protocol-required non-sensitive headers such as `anthropic-version` and `anthropic-beta`, and explicitly allowed tracing/request-correlation headers. Strip `Authorization`, `Proxy-Authorization`, `Cookie`, `x-api-key`, `Host`, `Content-Length`, and hop-by-hop headers; apply static headers and then inject the configured credential scheme last so client input cannot override it.
+- Use request context for cancellation.
+- Execute the request through the shared transport.
+
+The MVP should not translate between OpenAI and Anthropic request formats. An OpenAI-compatible client request is handled by the OpenAI adapter, and an Anthropic-compatible `/v1/messages` request is handled by the Anthropic adapter.
+
+#### Provider Protocol Support
+
+The API should keep provider-specific behavior inside adapters. Native providers usually differ in request body, URL format, authentication, streaming format, and usage fields, so they should be handled in provider adapters instead of adding provider-specific checks throughout the router.
+
+| `providerType` | Scope |
+|---|---|
+| `OpenAI` | MVP OpenAI-compatible chat/completions, completions, and Responses API passthrough |
+| `Anthropic` | MVP Anthropic-compatible Messages API (`/v1/messages`) passthrough |
+| `AzureOpenAI` | Future adapter; OpenAI-like request body, but deployment-based paths, API versions, and auth differ |
+| `AWSBedrock` | Future adapter; service-specific signing/auth, model identifiers, and response envelopes differ |
+| `Custom` | Future adapter; user-controlled OpenAI-compatible or organization-specific gateway behavior |
+
+Here, `OpenAI` identifies the OpenAI-compatible API adapter, so compatible services such as DeepSeek do not need separate provider types. `Anthropic` identifies the Anthropic-compatible Messages API adapter, so providers exposing that API can be added without changing `ModelRoute` or `ExternalModelProvider` references.
+
+#### Streaming Support
+
+Streaming should behave consistently for in-cluster and external targets. For OpenAI-compatible providers, if the downstream request contains `stream: true`, the provider path should forward the upstream SSE response line by line without buffering the full response. Responses API streams retain their `event:` and `data:` lines and parse usage from terminal response events such as `response.completed`. For Anthropic-compatible providers, `/v1/messages` streaming should forward Anthropic SSE events while parsing usage from Anthropic event payloads when available.
+
+The external path should:
+
+- Preserve `text/event-stream` behavior and flush chunks as they arrive.
+- Parse usage chunks when the provider returns them.
+- For streaming OpenAI-compatible chat/completions requests, inject `stream_options.include_usage=true` when needed for token accounting. Do not inject `include_usage` or `stream_options` into non-streaming requests.
+- If Router injects OpenAI-compatible `stream_options.include_usage=true`, parse the usage chunk and suppress the injected usage-only chunk before forwarding. If the downstream request already asked for usage, forward the usage chunk.
+- For Responses API requests, do not inject chat/completions usage options. Parse native non-streaming usage fields and aggregate the latest complete usage from streaming response events, while forwarding every SSE line unchanged.
+- For Anthropic-compatible requests, do not inject OpenAI-specific usage options; parse Anthropic-native usage fields and streaming events instead. Count uncached input, cache creation input, and cache read input in the normalized provider-reported input total.
+- Record output tokens for rate limiting, access logs, and metrics when usage is available.
+- Continue forwarding the stream even if usage is absent.
+- For OpenAI-compatible chat/completions streams, forward `data: [DONE]` when the upstream sends it, and finish when the upstream response body reaches EOF.
+- For OpenAI Responses API streams, forward terminal response events and finish when the upstream response body reaches EOF.
+- If a downstream client cancels after the protocol's terminal marker (`data: [DONE]`, Responses `response.completed`, or Anthropic `message_stop`) has been forwarded successfully, treat the resulting post-terminal cancellation as normal completion for request observability. Cancellation before the terminal marker or failure to write the marker remains an error.
+- For Anthropic-compatible messages streams, finish when the provider sends the terminal Anthropic message event and closes the response body.
+- Cancel the upstream request and exit the forwarding loop when the downstream client disconnects.
+- Never automatically retry the provider request, including after a stream has started.
+
+Streaming requests should follow the existing ModelServer path and must not use `http.Client.Timeout` as a total request timeout, because a valid model stream can last longer than a normal non-streaming request. Normal stream completion is upstream-driven: OpenAI-compatible chat/completions streams normally send `data: [DONE]` and then close the response body, while Anthropic-compatible streams send their own terminal event and close the response body. In both cases, the forwarding loop exits on EOF. The request context still handles downstream client disconnects and router shutdown. The external transport can add connection-stage bounds such as dial, TLS handshake, and response-header timeouts; `IdleConnTimeout` only controls pooled idle connections and is not an active stream-idle timeout. More specific first-token or active stream-idle timeout fields can be added later as explicit API decisions.
+
+The streaming copy and usage-parsing mechanics should be shared instead of implemented separately for providers. Status acceptance, retry, and fallback decisions remain path-specific and happen before response forwarding starts.
+
+#### Body and Usage Handling
+
+`ParseModelRequest()` consumes `c.Request.Body` today for the OpenAI-compatible path. The external path should read the body once, keep the raw bytes, and decode protocol-specific fields with `json.Decoder.UseNumber()`:
+
+```go
+type ParsedRequest struct {
+    RawBody []byte
+    Fields  map[string]any
+}
+```
+
+The provider adapter should rebuild the JSON body only when it needs to rewrite `model` or apply protocol-specific usage accounting options. This preserves unknown provider-specific fields and avoids changing large JSON numbers into `float64` during passthrough.
+
+Response forwarding and provider-neutral usage callbacks should be shared with the existing Pod path. Request mutation remains protocol-specific: the OpenAI adapter owns external Chat/Completions usage-option injection, while the existing ModelServer connector keeps its OpenAI-compatible request handling. Anthropic and Responses requests are not passed through an OpenAI Chat/Completions mutation helper.
+
+For OpenAI-compatible chat/completions requests, usage-option injection applies only to streaming requests. If the downstream request already asks for `stream_options.include_usage=true`, forward the provider's usage chunk to the client and also use it for internal accounting. Otherwise, Router may merge `include_usage=true` into the existing `stream_options` object, parse the usage chunk, and suppress the injected usage-only chunk before forwarding so the downstream response shape stays unchanged. Non-streaming requests are forwarded without Router-injected `include_usage` or `stream_options`; their normal response envelope already contains usage when the provider reports it. The internal ModelServer path keeps its existing behavior.
+
+For OpenAI Responses API requests, preserve the native request shape and do not inject chat/completions usage fields. Parse `input_tokens`, `output_tokens`, and `total_tokens` from the non-streaming response envelope or the latest complete response carried by a streaming event.
+
+For Anthropic-compatible requests, do not inject OpenAI-specific usage fields. The Anthropic adapter should parse usage from the Anthropic response body and streaming events. Its normalized input total is the sum of `input_tokens`, `cache_creation_input_tokens`, and `cache_read_input_tokens`.
+
+#### Response Forwarding
+
+Extract the response-forwarding block from `proxyRequest()` into a reusable function that receives the parser selected by the adapter:
+
+```go
+func forwardResponseWithUsageParser(
+    c *gin.Context,
+    resp *http.Response,
+    stream bool,
+    parser providers.ResponseUsageParser,
+    onUsage func(providers.TokenUsage),
+) error
+```
+
+`TokenUsage` and `ResponseUsageParser` live with the provider adapters. They expose a provider-neutral accounting view without leaking OpenAI- or Anthropic-specific response structs into Router code.
+
+The code that receives `resp` from the transport should close `resp.Body`. `forwardResponseWithUsageParser()` should only copy headers/status/body, stream data, and parse usage. It must not decide whether a status is acceptable or whether another upstream should be attempted. The Pod path and external path should follow the same rule for who closes the response body.
+
+After path-specific status handling accepts a response, both Pod and external paths should reuse the same forwarding mechanics:
+
+- Copy end-to-end upstream headers. Strip hop-by-hop headers, and omit the upstream `Content-Length` when streaming or when the forwarded body is modified.
+- Copy the accepted upstream status and body.
+- Stream SSE line by line.
+- Parse usage chunks when available.
+- Record output tokens for rate limit and metrics.
+
+This does not make the two paths' error semantics identical. The existing Pod path keeps its current error and retry semantics: it treats a non-2xx response as a failed Pod attempt, tries another candidate Pod when available, and returns a Router-generated error after all candidates fail. Shared forwarding may still intentionally standardize response-header filtering, such as stripping hop-by-hop headers and stale `Content-Length`.
+
+The external provider path has no implicit fallback to another weighted target after target selection, so an upstream HTTP error response is passed through to the client.
+
+For external providers, every non-2xx response is passed through unchanged; only transport failures without an upstream response are created by the Router. The handler must set the fixed completion category before `RequestMetricsRecorder.Finish()` runs so a forwarded provider response is never incorrectly recorded as `successful_request`:
+
+| Upstream outcome | What the client receives | `error_type` | `error_origin` |
+|---|---|---|---|
+| `3xx` (automatic redirects are disabled) | Pass through status, headers, and body unchanged | `upstream_response` | `upstream` |
+| `4xx` with body (including `401` and `429`) | Pass through status + body unchanged | `upstream_response` | `upstream` |
+| `5xx` with body (including `500`, `502`, and `503`) | Pass through status + body unchanged | `upstream_response` | `upstream` |
+| Connection refused / TLS failure | Router-created `502 Bad Gateway` | `upstream_transport` | `router` |
+| Timeout, no response bytes | Router-created `504 Gateway Timeout` | `upstream_transport` | `router` |
+
+Access logs should record the provider status code and a bounded message such as `provider returned HTTP 429`; they must not copy an arbitrary provider error body into logs. Successful provider responses keep `error_type="successful_request"` and omit `error_origin`.
+
+Errors produced before an upstream response exists use the existing Router response contract: the client receives a JSON string containing a safe message, matching the internal ModelServer path. The fixed categories are `provider_discovery`, `request_protocol`, `provider_request_build`, `response_forwarding`, and `external_provider_proxy`. Once an upstream response exists, Kthena does not translate its error envelope: OpenAI-compatible responses retain the top-level `error` object and Anthropic responses retain their `type`/`error` structure.
+
+#### Secret Resolution
+
+Use a dedicated Secret informer factory with the label selector `networking.serving.volcano.sh/external-model-provider-credential=true`. Do not create the Secret informer from the unfiltered factory used for Pods and Namespaces. Only labeled credential Secrets enter the informer cache; an unlabeled referenced Secret is treated as unavailable.
+
+Secret rotation takes effect after the informer event reconciles the selected key into the Router datastore. The next request uses the updated value. The datastore projection retains only keys referenced by ExternalModelProviders and does not retain `StringData`.
+
+The informer still caches the complete data map of every labeled Secret. Credential Secrets should therefore be dedicated to external providers instead of sharing unrelated keys.
+
+The provider controller should maintain an index from `<namespace>/<secret-name>` to the ExternalModelProviders that reference that Secret. ExternalModelProvider events reconcile the provider itself; Secret add, update, and delete events use the index to enqueue every affected provider. Reconciliation reads the Secret from the lister, checks the selected key, and updates `ObservedGeneration`, `CredentialsResolved`, and `Ready`. Status updates need RBAC for the `externalmodelproviders/status` subresource.
+
+Missing Secret or missing key should set provider status to `Ready=False` with a configuration reason such as `CredentialNotFound`. Requests targeting an unresolved provider should return `503 Service Unavailable`. Error messages must name the provider but never print the key value.
+
+#### Observability
+
+`InferencePool` is an existing Gateway API Inference Extension destination reached through `HTTPRoute`; this proposal does not introduce or change that routing path. It is included below only because changing the shared Router metric schemas must keep every existing destination observable.
+
+Do not create external-only metric names. Extend the existing request and upstream metrics with one shared set of bounded destination labels so the same PromQL can compare ModelServer, ExternalModelProvider, and existing InferencePool traffic.
+
+Destination labels:
+
+| Label | Values | Source |
+|---|---|---|
+| `model_route` | namespaced ModelRoute name, or `none` | The matched ModelRoute; `none` when no ModelRoute was selected |
+| `backend_type` | `model_server`, `external_provider`, `inference_pool`, or `unresolved` | The selected destination kind; `unresolved` when the request ends before destination selection |
+| `backend_name` | namespaced backend resource name, or `none` | The selected ModelServer, ExternalModelProvider, or InferencePool |
+| `upstream_model` | configured upstream model, or `none` | For an external request, `ExternalModelProvider.spec.model` or the matched `ModelRoute.spec.modelName` when `spec.model` is unset; for a LoRA ModelServer request, the matched `ModelRoute.spec.loraAdapters[]` name; otherwise `ModelServer.spec.model` or the matched `ModelRoute.spec.modelName` when `spec.model` is unset |
+
+These labels are added only to metrics that describe a completed routed request or a real upstream attempt:
+
+| Metric | Existing labels | Labels to add |
+|---|---|---|
+| `kthena_router_requests_total` | `model`, `path`, `status_code`, `error_type` | `model_route`, `backend_type`, `backend_name`, `upstream_model` |
+| `kthena_router_request_duration_seconds` | `model`, `path`, `status_code` | `model_route`, `backend_type`, `backend_name`, `upstream_model` |
+| `kthena_router_tokens_total` | `model`, `path`, `token_type` | `model_route`, `backend_type`, `backend_name`, `upstream_model` |
+| `kthena_router_active_upstream_requests` | `model_server`, `model_route` | `backend_type`, `backend_name`, `upstream_model` |
+
+Keep the existing `model_server` label on `kthena_router_active_upstream_requests` for query compatibility. Set it to `none` for ExternalModelProvider and InferencePool attempts; `backend_name` is the destination-neutral replacement for new queries.
+
+The following metrics keep their current label sets because they observe work before destination selection or a ModelServer-only internal phase: `kthena_router_active_requests`, `kthena_router_active_downstream_requests`, `kthena_router_rate_limit_exceeded_total`, the prefill/decode duration metrics, scheduler plugin metrics, fairness queue metrics, and tokenizer metrics.
+
+The router should use one request-scoped observation recorder rather than passing independent label strings to each metric call. The recorder starts with the client model and path, buffers input-token observations, and exposes a one-time `BindDestination()` operation after route target selection. Binding stores all four destination labels from the resolved Kubernetes configuration. Input tokens are emitted when the destination is bound; if the request ends before binding, `Finish()` emits them with the unresolved values. Output tokens, the final request counter, and request duration use the same bound label set. This avoids recording input and output tokens for the same request under different destinations.
+
+`BindDestination()` only records metric dimensions; it does not affect routing. The ModelRoute path calls it after selecting a ModelServer or ExternalModelProvider target. The existing HTTPRoute path must also call it after resolving an InferencePool, using `model_route="none"`, `backend_type="inference_pool"`, the namespaced InferencePool name as `backend_name`, and `upstream_model="none"`.
+
+For a LoRA request, binding uses the adapter name that was successfully matched from `ModelRoute.spec.loraAdapters[]` as `upstream_model`. This is metric attribution only; it does not change existing LoRA matching, scheduling, or model rewrite behavior.
+
+`kthena_router_active_upstream_requests` remains attempt-scoped rather than request-scoped. Increment it immediately before each actual Pod or provider call and decrement it on every completion path. A request that tries three Pods contributes three sequential upstream attempts but only one completed request to `kthena_router_requests_total`.
+
+All label values must be controlled:
+
+- Use `none`, never an absent or empty label value, when a dimension does not apply.
+- Use `unresolved` only for `backend_type` when routing never selected a destination.
+- Read `model_route`, `backend_name`, and `upstream_model` from resolved Kubernetes objects, not arbitrary request headers or error messages.
+- Never use Pod IPs, request IDs, Secret names or values, raw URLs, or raw errors as metric labels.
+- Continue using HTTP codes and fixed error categories for `status_code` and `error_type`: `successful_request` for provider 2xx responses, `upstream_response` for provider 3xx/4xx/5xx responses, and `upstream_transport` for connection, TLS, and timeout failures.
+
+Changing a Prometheus label set is a schema migration even when metric names remain unchanged. Update every metric call, dashboard, alert, recording rule, observability document, and e2e assertion in the same change. E2E helpers must aggregate every matching series instead of returning the first partial-label match, because one client model can now produce separate ModelServer and ExternalModelProvider series. A dedicated time-to-first-token metric would require a new metric name, so it remains outside the MVP.
+
+Access logs carry per-request diagnostic detail that is unsuitable for Prometheus labels. Add `backend_type`, `backend_name`, `upstream_model`, `upstream_status_code`, `upstream_attempts`, and a bounded `error_origin` (`router` or `upstream`) while retaining the existing `model_server`, `selected_pod`, and gateway fields.
+
+#### Future Work: Cost-Aware Routing
+
+The MVP keeps the existing weighted `targetModels[]` selection model. This already lets users manually shift traffic toward lower-cost providers by assigning higher weights to cheaper targets.
+
+A future API could add cost-aware routing policies, for example selecting the lowest-cost compatible target under latency, availability, or budget constraints. This should be added as a route-level policy rather than hard-coded into `ExternalModelProvider`, because cost-based routing needs more inputs than the provider endpoint itself: pricing metadata, model capability equivalence, token accounting, latency SLOs, and fallback behavior.
+
+Possible future extension:
+
+```yaml
+selectionPolicy:
+  type: CostOptimized
+  constraints:
+    maxLatency: 2s
+    maxCostPer1KTokens: "0.01"
+```
+
+This proposal intentionally does not implement cost-aware routing in the first version. It only keeps `ModelRoute` target selection extensible so a future policy can be added without changing the external-provider resource model.
+
+### Security and Validation
+
+- Treat ExternalModelProvider as an administrator API in the initial implementation. Do not grant tenant roles permission to create or update it.
+- Create or update permission carries two capabilities: selecting any destination reachable from the Router Pod and using any Secret in the provider's namespace. A user can point `baseURL` at a server they control and cause the Router to send the selected Secret as provider credentials. Same-namespace references and URL validation do not prevent this confused-deputy path.
+- Require credential Secrets to have `networking.serving.volcano.sh/external-model-provider-credential=true`. The Router's dedicated informer uses this label selector so unrelated Secrets do not enter its normal cache or event queue.
+- Kubernetes RBAC does not support label-scoped Secret permissions. The Router therefore still needs cluster-level `list` and `watch` permission for Secrets; the informer selector reduces normal memory exposure but is not an authorization boundary. Protect the Router Pod, service account, logs, and memory dumps accordingly.
+- Cluster administrators should constrain Router egress with NetworkPolicy or an egress proxy. Installations that later delegate ExternalModelProvider must add an environment-specific admission policy for allowed Secrets and destinations first.
+- Never log Secret contents or upstream auth headers.
+- Require HTTPS by default.
+- `insecureSkipVerify` applies only to HTTPS and disables both certificate-chain and hostname verification. Restrict its use to trusted provider configuration where the endpoint cannot present a certificate trusted by the Router; prefer adding the organization CA to the Router trust store because skip-verification permits man-in-the-middle attacks.
+- Reject `baseURL` values with URL userinfo, query, or fragments.
+- Disable automatic redirects by default so an allowed provider endpoint cannot redirect the router to a different host.
+- Reject credential-bearing static headers, `Host`, `Content-Length`, and hop-by-hop headers; static header values must be non-sensitive.
+- Forward downstream headers through an explicit allowlist, strip client credentials and cookies, and inject provider credentials last.
+- Strip hop-by-hop response headers, and do not forward a stale `Content-Length` after streaming or body modification.
+- Keep provider, Secret, and ModelRoute references in the same namespace.
+
+### Test Plan
+
+Unit tests should not call real third-party APIs. Use `httptest.Server` and fake Kubernetes clients/listers.
+
+| Area | Coverage |
+|---|---|
+| API validation | `modelServerName` XOR `externalModelProviderName`; reject `externalModelProviderName` on routes with `loraAdapters[]`; optional provider `model` length; require HTTPS `baseURL`; URL userinfo/query/fragment rejection; credential/reserved static-header rejection; reject unsupported `auth.scheme`; anonymous provider without `auth`; reject `secretRef.optional=true` when `auth` is present |
+| Request scope | OpenAI and Anthropic native tool and multimodal fields pass through unchanged; local prompt accounting remains text-only; unsupported provider paths remain rejected |
+| Secret resolution | label-filtered LIST/WATCH and cache contents; unlabeled, missing, and missing-key cases; valid key; rotation behavior; Secret add/update/delete event mapping; `ObservedGeneration`, `CredentialsResolved`, and `Ready` transitions |
+| Route resolution | external target, internal target, weighted internal/external split, LoRA route remains ModelServer-only, request protocol matches selected provider type |
+| Request building | OpenAI chat/completions, Responses, and Anthropic path joining; raw body preservation; `UseNumber`; configured model override and unset-model passthrough; streaming-only OpenAI usage-option injection with existing `stream_options` fields preserved; no usage-option injection for non-streaming OpenAI requests or Responses; default and overridden auth schemes; `anthropic-beta` forwarding; reserved credential static-header rejection; downstream header allowlist; credential precedence |
+| TLS | trusted certificate succeeds by default; self-signed certificate fails by default; the same self-signed endpoint succeeds only with `insecureSkipVerify=true`; plain HTTP `baseURL` is rejected; secure and skip-verification connection pools remain isolated |
+| Streaming | SSE passthrough, line-by-line flush, usage callback, streaming-only OpenAI chat/completions usage-option injection with existing options preserved, downstream-requested usage chunks forwarded, Router-injected usage-only chunks suppressed, Responses terminal-event usage parsing with unchanged event forwarding, Anthropic-native streaming events and cache-token usage parsing, terminal event handling, EOF completion, cancellation before and after a terminal event, response header filtering, no mid-stream retry |
+| Non-streaming | body passthrough, OpenAI chat/completions, Responses, and Anthropic usage parsing including cache token fields when present, response header filtering |
+| Errors | Router-generated errors keep the internal ModelServer response shape (a JSON string with a safe message); classify request/protocol/build/forwarding failures with bounded types; pass through every upstream non-2xx response with `upstream_response`/`upstream` attribution and the provider-native error envelope; create 502/504 with `upstream_transport`/`router` attribution; bounded access-log messages; no automatic provider retry |
+| Compatibility | existing ModelServer-only routes unchanged |
+| Observability | exact label schemas; ModelServer, matched LoRA adapter, provider, explicitly bound InferencePool, and unresolved values; buffered input tokens; consistent input/output attribution; balanced upstream gauges across retries and cancellation; no external-only metrics; controlled label values; e2e aggregation across matching series |
+
+E2E can use in-cluster HTTPS mock OpenAI-compatible and Anthropic-compatible servers with self-signed certificates and `insecureSkipVerify=true` where needed. This avoids depending on real external providers or free API availability while still exercising the HTTPS-only provider path.


### PR DESCRIPTION
/kind design

## What this PR does

This PR proposes a dedicated `ExternalModelProvider` API that allows Kthena Router to route requests to external OpenAI-compatible and Anthropic-compatible HTTPS endpoints.

The proposal covers:

- the `ExternalModelProvider` CRD and its relationship with `ModelRoute`
- provider-specific request and response adapters
- streaming and non-streaming request handling
- Secret-based authentication and header filtering
- local input-token estimation and provider-reported output usage
- Prometheus metrics, structured access logs, error handling, and Mock E2E coverage

The selected design uses a separate resource instead of extending `ModelServer`. `ModelServer` remains focused on in-cluster Pods, inference-engine discovery, and KV-cache-aware scheduling.

This PR changes documentation only. The implementation is split across the related PRs below.

## History

This PR supersedes #1198 and carries forward its design discussion and reviewer feedback on a fresh branch based on the latest `main`.

The proposal has been updated to match the implementation and test coverage in:

- #1369: core API, controller, routing, and provider adapters
- #1370: observability and token accounting
- #1371: Mock E2E, User Guide, and examples

## Related issues

Refs #939
Refs #1024
Supersedes #1198

## Testing

- `make test-docs`
- `make gen-check`
- `git diff --check`
