### PR TITLE
fix: support IPv6 pod metric and tokenizer URLs

### DIFF
--- a/pkg/autoscaler/autoscaler/metric_collector.go
+++ b/pkg/autoscaler/autoscaler/metric_collector.go
@@ -21,7 +21,9 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"net"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -391,7 +393,8 @@ func (collector *MetricCollector) buildPodMetricURL(pod *corev1.Pod, podSource *
 	if port == 0 {
 		port = 8100
 	}
-	return fmt.Sprintf("http://%s:%d%s", pod.Status.PodIP, port, uri)
+	hostPort := net.JoinHostPort(pod.Status.PodIP, strconv.Itoa(int(port)))
+	return fmt.Sprintf("http://%s%s", hostPort, uri)
 }
 
 // parsePrometheusFamilies decodes a Prometheus text exposition payload once and

--- a/pkg/autoscaler/autoscaler/metric_collector_test.go
+++ b/pkg/autoscaler/autoscaler/metric_collector_test.go
@@ -342,6 +342,39 @@ not a valid prometheus metric line
 	require.Error(t, err)
 }
 
+func TestBuildPodMetricURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		podIP     string
+		podSource *workload.PodMetricSource
+		want      string
+	}{
+		{
+			name:      "IPv4 with defaults",
+			podIP:     "10.1.2.3",
+			podSource: &workload.PodMetricSource{},
+			want:      "http://10.1.2.3:8100/metrics",
+		},
+		{
+			name:  "IPv6 with custom port and path",
+			podIP: "fd00::1",
+			podSource: &workload.PodMetricSource{
+				Port: 8000,
+				Uri:  "/custom-metrics",
+			},
+			want: "http://[fd00::1]:8000/custom-metrics",
+		},
+	}
+
+	collector := &MetricCollector{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pod := &corev1.Pod{Status: corev1.PodStatus{PodIP: tt.podIP}}
+			assert.Equal(t, tt.want, collector.buildPodMetricURL(pod, tt.podSource))
+		})
+	}
+}
+
 func TestUpdateMetricsKeepsReadyPodMetricsWhenAnotherPodIsUnready(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = io.WriteString(w, "# TYPE queue_depth gauge\nqueue_depth 40\n# TYPE queue_depth_alt gauge\nqueue_depth_alt 40\n")

--- a/pkg/kthena-router/scheduler/plugins/kvcache_aware.go
+++ b/pkg/kthena-router/scheduler/plugins/kvcache_aware.go
@@ -155,9 +155,9 @@ func NewKVCacheAware(pluginArg runtime.RawExtension) *KVCacheAware {
 		blockSizeToHash, maxBlocksToMatch, vllmPort, sglangPort)
 
 	managerConfig := tokenization.TokenizerManagerConfig{
-		EndpointTemplates: map[string]string{
-			tokenization.EngineVLLM:   fmt.Sprintf("http://%%s:%d", vllmPort),
-			tokenization.EngineSGLang: fmt.Sprintf("http://%%s:%d", sglangPort),
+		EndpointPorts: map[string]int{
+			tokenization.EngineVLLM:   vllmPort,
+			tokenization.EngineSGLang: sglangPort,
 		},
 	}
 	manager := tokenization.NewTokenizerManager(managerConfig)

--- a/pkg/kthena-router/scheduler/plugins/kvcache_aware_test.go
+++ b/pkg/kthena-router/scheduler/plugins/kvcache_aware_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -767,7 +768,7 @@ func TestKVCacheAware_ScoreMatchesOnlyNamespacedRedisOwner(t *testing.T) {
 		Status: v1.PodStatus{PodIP: "127.0.0.1"},
 	}, tokenization.EngineVLLM)
 
-	endpointTemplate := strings.Replace(tokenizerServer.URL, "127.0.0.1", "%s", 1)
+	tokenizerPort := tokenizerServer.Listener.Addr().(*net.TCPAddr).Port
 	processor := &TokenBlockProcessor{blockSize: 1}
 	blockHashes := processor.TokensToBlockHashes([]uint32{1}, 1)
 	key := KVCacheAwareBlock{ModelName: model, ChunkHash: blockHashes[0]}.String(kvCacheKeyPrefix)
@@ -782,7 +783,7 @@ func TestKVCacheAware_ScoreMatchesOnlyNamespacedRedisOwner(t *testing.T) {
 		redisClient:      redisClient,
 		processor:        processor,
 		tokenizerManager: tokenization.NewTokenizerManager(tokenization.TokenizerManagerConfig{
-			EndpointTemplates: map[string]string{tokenization.EngineVLLM: endpointTemplate},
+			EndpointPorts: map[string]int{tokenization.EngineVLLM: tokenizerPort},
 		}),
 	}
 

--- a/pkg/kthena-router/scheduler/plugins/tokenization/tokenization_test.go
+++ b/pkg/kthena-router/scheduler/plugins/tokenization/tokenization_test.go
@@ -74,9 +74,9 @@ func TestIntToByteArray(t *testing.T) {
 // Test TokenizerManager
 func TestTokenizerManager(t *testing.T) {
 	config := TokenizerManagerConfig{
-		EndpointTemplates: map[string]string{
-			EngineVLLM:   "http://%s:8000",
-			EngineSGLang: "http://%s:30000",
+		EndpointPorts: map[string]int{
+			EngineVLLM:   8000,
+			EngineSGLang: 30000,
 		},
 	}
 
@@ -144,6 +144,50 @@ func TestTokenizerManager(t *testing.T) {
 			t.Fatal("Expected non-nil tokenizer for SGLang pod")
 		}
 	})
+
+	// Test IPv6 endpoint construction through the manager path.
+	t.Run("IPv6 endpoint", func(t *testing.T) {
+		pod := testutil.PodInfoWithEngine("pod-vllm-ipv6", "default", "fd00::1", EngineVLLM)
+
+		tok := manager.GetTokenizer("test-model", []*datastore.PodInfo{pod})
+		remote, ok := tok.(*remoteTokenizerImpl)
+		if !ok {
+			t.Fatalf("Expected remote tokenizer, got %T", tok)
+		}
+		if got, want := remote.GetEndpoint(), "http://[fd00::1]:8000"; got != want {
+			t.Fatalf("Tokenizer endpoint = %q, want %q", got, want)
+		}
+	})
+}
+
+func TestBuildTokenizerEndpoint(t *testing.T) {
+	tests := []struct {
+		name  string
+		podIP string
+		port  int
+		want  string
+	}{
+		{
+			name:  "IPv4",
+			podIP: "10.1.2.3",
+			port:  8000,
+			want:  "http://10.1.2.3:8000",
+		},
+		{
+			name:  "IPv6",
+			podIP: "fd00::1",
+			port:  30000,
+			want:  "http://[fd00::1]:30000",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := buildTokenizerEndpoint(tt.podIP, tt.port); got != tt.want {
+				t.Fatalf("buildTokenizerEndpoint() = %q, want %q", got, tt.want)
+			}
+		})
+	}
 }
 
 // Test error types
@@ -862,7 +906,7 @@ func BenchmarkTokenizeInputText(b *testing.B) {
 // Test TokenizerManager.TokenizePrompt
 func TestTokenizerManagerTokenizePrompt(t *testing.T) {
 	config := TokenizerManagerConfig{
-		EndpointTemplates: map[string]string{EngineVLLM: "http://%s:8000"},
+		EndpointPorts: map[string]int{EngineVLLM: 8000},
 	}
 
 	manager := NewTokenizerManager(config)

--- a/pkg/kthena-router/scheduler/plugins/tokenization/tokenizer_manager.go
+++ b/pkg/kthena-router/scheduler/plugins/tokenization/tokenizer_manager.go
@@ -21,6 +21,8 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math/rand"
+	"net"
+	"strconv"
 	"strings"
 	"time"
 
@@ -30,9 +32,9 @@ import (
 	"k8s.io/klog/v2"
 )
 
-// Remote tokenization is always attempted when an engine template exists
+// Remote tokenization is always attempted when an engine port exists.
 type TokenizerManagerConfig struct {
-	EndpointTemplates map[string]string
+	EndpointPorts map[string]int
 }
 
 type TokenizerManager struct {
@@ -78,12 +80,12 @@ func (m *TokenizerManager) createTokenizerFromPods(model string, pods []*datasto
 			unsupportedEngines[podInfo.GetEngine()] = struct{}{}
 			continue
 		}
-		template, ok := m.config.EndpointTemplates[engine]
-		if !ok || template == "" {
-			klog.Warningf("TokenizerManager: no endpoint template for engine %q, skipping pod %s", engine, pod.Name)
+		port, ok := m.config.EndpointPorts[engine]
+		if !ok || port <= 0 {
+			klog.Warningf("TokenizerManager: no valid endpoint port for engine %q, skipping pod %s", engine, pod.Name)
 			continue
 		}
-		endpoint := fmt.Sprintf(template, pod.Status.PodIP)
+		endpoint := buildTokenizerEndpoint(pod.Status.PodIP, port)
 
 		config := RemoteTokenizerConfig{
 			Engine:             engine,
@@ -110,6 +112,10 @@ func (m *TokenizerManager) createTokenizerFromPods(model string, pods []*datasto
 	}
 	klog.Warningf("Failed to create tokenizer for model %s after trying %d pods", model, len(pods))
 	return nil
+}
+
+func buildTokenizerEndpoint(podIP string, port int) string {
+	return "http://" + net.JoinHostPort(podIP, strconv.Itoa(port))
 }
 
 func normalizeEngine(engine string) (string, error) {


### PR DESCRIPTION
### What type of PR is this?

/kind bug

### What this PR does / why we need it

Autoscaler Pod metric scraping and KV-cache-aware remote tokenization constructed endpoints by inserting `PodIP` directly into strings such as `http://%s:<port>`. An IPv6 literal must be enclosed in brackets when a port is present, so an address such as `fd00::1` produced an invalid URL.

This change:

- uses `net.JoinHostPort` when constructing Autoscaler Pod metric URLs;
- replaces tokenizer endpoint string templates with per-engine port configuration;
- constructs remote tokenizer endpoints with `net.JoinHostPort` for both vLLM and SGLang;
- preserves existing IPv4, default port, custom port, and metric path behavior;
- adds IPv4 and IPv6 regression coverage for both endpoint paths.

This completes the IPv6 Pod endpoint coverage started by #1071, which fixed Router backend URLs but did not cover these paths.

### Which issue(s) this PR fixes

Fixes #1493

### Special notes for your reviewer

`TokenizerManagerConfig` is internal to the scheduler plugin packages. It now stores engine ports instead of URL templates so Pod IP formatting is centralized and cannot produce an unbracketed IPv6 authority.

### How was this change tested?

```bash
go test ./pkg/autoscaler/autoscaler -run '^TestBuildPodMetricURL$' -count=1
go test ./pkg/kthena-router/scheduler/plugins/tokenization -run '^(TestTokenizerManager|TestBuildTokenizerEndpoint)$' -count=1
go test ./pkg/autoscaler/autoscaler ./pkg/kthena-router/scheduler/plugins/tokenization ./pkg/kthena-router/scheduler/plugins -count=1
```

### Does this PR introduce a user-facing change?

```release-note
Fix Autoscaler Pod metric scraping and KV-cache-aware remote tokenization for IPv6 Pod addresses.
```
