### PR TITLE
router: clean up rate limiters when spec.rateLimit is cleared from ModelRoute

### DIFF
--- a/pkg/kthena-router/filters/ratelimit/ratelimit.go
+++ b/pkg/kthena-router/filters/ratelimit/ratelimit.go
@@ -212,6 +212,16 @@ func (r *TokenRateLimiter) DeleteLimiter(model string) {
 	delete(r.outputLimiter, model)
 }
 
+// HasLimiter returns true if an input or output rate limiter is configured for the model
+func (r *TokenRateLimiter) HasLimiter(model string) bool {
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
+
+	_, hasInput := r.inputLimiter[model]
+	_, hasOutput := r.outputLimiter[model]
+	return hasInput || hasOutput
+}
+
 func getTimeUnitDuration(unit networkingv1alpha1.RateLimitUnit) time.Duration {
 	switch unit {
 	case networkingv1alpha1.Second:

--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -142,17 +142,46 @@ func NewRouter(store datastore.Store, routerConfigPath string) *Router {
 	store.RegisterCallback("ModelRoute", func(data datastore.EventData) {
 		switch data.EventType {
 		case datastore.EventAdd, datastore.EventUpdate:
-			if data.ModelRoute == nil || data.ModelRoute.Spec.RateLimit == nil {
+			if data.ModelRoute == nil {
 				return
 			}
-			klog.Infof("add or update rate limit for model %s", data.ModelName)
+			namespacedName := data.ModelRoute.Namespace + "/" + data.ModelRoute.Name
+			currentMR := store.GetModelRoute(namespacedName)
 
+			if data.ModelRoute.Spec.RateLimit == nil {
+				// Reject stale deletion if the current route in store has a rate limit configured
+				if currentMR != nil && currentMR.Spec.RateLimit != nil {
+					klog.V(4).Infof("ignoring stale rate limit removal for model %s (current spec has rate limit)", data.ModelName)
+					return
+				}
+				klog.Infof("delete rate limit for model %s as rateLimit is nil", data.ModelName)
+				loadRateLimiter.DeleteLimiter(data.ModelName)
+				return
+			}
+
+			// Reject stale update if the current route in store has cleared the rate limit
+			if currentMR != nil && currentMR.Spec.RateLimit == nil {
+				klog.V(4).Infof("ignoring stale rate limit update for model %s (current spec cleared rate limit)", data.ModelName)
+				loadRateLimiter.DeleteLimiter(data.ModelName)
+				return
+			}
+
+			klog.Infof("add or update rate limit for model %s", data.ModelName)
 			// Configure the unified rate limiter for this model
 			if err := loadRateLimiter.AddOrUpdateLimiter(data.ModelName, data.ModelRoute.Spec.RateLimit); err != nil {
 				klog.Errorf("failed to configure rate limiter for model %s: %v", data.ModelName, err)
 			}
 
 		case datastore.EventDelete:
+			if data.ModelRoute != nil {
+				namespacedName := data.ModelRoute.Namespace + "/" + data.ModelRoute.Name
+				currentMR := store.GetModelRoute(namespacedName)
+				// Reject stale deletion if a newer route exists in store with a rate limit
+				if currentMR != nil && currentMR.Spec.RateLimit != nil {
+					klog.V(4).Infof("ignoring stale rate limit deletion for model %s (current spec has rate limit)", data.ModelName)
+					return
+				}
+			}
 			klog.Infof("delete rate limit for model %s", data.ModelName)
 			loadRateLimiter.DeleteLimiter(data.ModelName)
 		}

--- a/pkg/kthena-router/router/router_test.go
+++ b/pkg/kthena-router/router/router_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"istio.io/istio/pkg/util/sets"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -3072,4 +3073,92 @@ func TestRouter_HandlerFunc_UnknownModel_RejectsBeforeQueueing(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRouter_ModelRouteRateLimitClearedOnUpdate(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	store := datastore.New()
+	router := NewRouter(store, "../scheduler/testdata/configmap.yaml")
+
+	modelName := "model-rate-limit-test"
+	tokens := uint32(5)
+	unit := aiv1alpha1.Minute
+	prompt := "hello world" // 3 tokens
+
+	// 1. Add ModelRoute with restrictive rateLimit (5 tokens/minute)
+	mrWithLimit := &aiv1alpha1.ModelRoute{
+		ObjectMeta: v1.ObjectMeta{Name: "mr-test", Namespace: "default"},
+		Spec: aiv1alpha1.ModelRouteSpec{
+			ModelName: modelName,
+			RateLimit: &aiv1alpha1.RateLimit{
+				InputTokensPerUnit: &tokens,
+				Unit:               unit,
+			},
+		},
+	}
+	store.AddOrUpdateModelRoute(mrWithLimit)
+
+	// Wait for the rate limiter to be registered via callback
+	require.Eventually(t, func() bool {
+		return router.loadRateLimiter.HasLimiter(modelName)
+	}, time.Second, 5*time.Millisecond, "rate limiter should be registered for model")
+
+	// First request succeeds (consumes 3 of 5 tokens)
+	err := router.loadRateLimiter.RateLimit(modelName, prompt)
+	assert.NoError(t, err, "first request within limit should succeed")
+
+	// Second request requires 3 tokens (only 2 left out of 5), so it must be rate limited
+	err = router.loadRateLimiter.RateLimit(modelName, prompt)
+	assert.Error(t, err, "second request exceeding remaining quota should be rate limited")
+
+	// 2. Update ModelRoute clearing rateLimit (setting it to nil)
+	mrWithoutLimit := &aiv1alpha1.ModelRoute{
+		ObjectMeta: v1.ObjectMeta{Name: "mr-test", Namespace: "default"},
+		Spec: aiv1alpha1.ModelRouteSpec{
+			ModelName: modelName,
+			RateLimit: nil,
+		},
+	}
+	store.AddOrUpdateModelRoute(mrWithoutLimit)
+
+	// Wait for the rate limiter to be deleted via callback
+	require.Eventually(t, func() bool {
+		return !router.loadRateLimiter.HasLimiter(modelName)
+	}, time.Second, 5*time.Millisecond, "rate limiter should be removed after spec.rateLimit is set to nil")
+
+	// Both requests should now succeed continuously because rate limiting is removed
+	err1 := router.loadRateLimiter.RateLimit(modelName, prompt)
+	err2 := router.loadRateLimiter.RateLimit(modelName, prompt)
+	assert.NoError(t, err1, "first request after clearing rate limit should succeed")
+	assert.NoError(t, err2, "second request after clearing rate limit should succeed")
+}
+
+func TestRouter_ModelRouteRateLimitStaleEventRejection(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	store := datastore.New()
+	router := NewRouter(store, "../scheduler/testdata/configmap.yaml")
+
+	modelName := "model-stale-test"
+	tokens := uint32(10)
+	unit := aiv1alpha1.Minute
+
+	// Current live ModelRoute in store has a rate limit configured
+	mrWithLimit := &aiv1alpha1.ModelRoute{
+		ObjectMeta: v1.ObjectMeta{Name: "mr-stale", Namespace: "default"},
+		Spec: aiv1alpha1.ModelRouteSpec{
+			ModelName: modelName,
+			RateLimit: &aiv1alpha1.RateLimit{
+				InputTokensPerUnit: &tokens,
+				Unit:               unit,
+			},
+		},
+	}
+	store.AddOrUpdateModelRoute(mrWithLimit)
+
+	require.Eventually(t, func() bool {
+		return router.loadRateLimiter.HasLimiter(modelName)
+	}, time.Second, 5*time.Millisecond, "rate limiter should be registered for model")
+
+	// Verify that the rate limiter is retained as long as the store's ModelRoute has a rate limit
+	assert.True(t, router.loadRateLimiter.HasLimiter(modelName))
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When an existing `ModelRoute` custom resource is updated to remove its `spec.rateLimit` configuration (clearing `spec.rateLimit` so traffic for that model is no longer rate-limited), the router's event callback in `pkg/kthena-router/router/router.go` previously returned early without calling `loadRateLimiter.DeleteLimiter`. Consequently, the router retained active input and output token rate limiters in memory and continued enforcing stale rate limits (TPS/TPM) against all requests for that model indefinitely.

This PR addresses the issue by:
1. Updating the `ModelRoute` event handler in `pkg/kthena-router/router/router.go` to invoke `loadRateLimiter.DeleteLimiter(data.ModelName)` when `spec.rateLimit` is `nil` during `EventAdd` or `EventUpdate` events.
2. Updating `AddOrUpdateLimiter` in `pkg/kthena-router/filters/ratelimit/ratelimit.go` to delete specific directional limiters (`inputLimiter` or `outputLimiter`) when `InputTokensPerUnit` or `OutputTokensPerUnit` is set to `nil` on update.
3. Adding unit test cases in `ratelimit_test.go` and `router_test.go` verifying that rate limiters are cleared when `spec.rateLimit` is removed.

**Which issue(s) this PR fixes**:
Fixes #1505

**Bug evidence (required for bug-related PRs)**:
- Issue: https://github.com/volcano-sh/kthena/issues/1505
- Source permalinks:
  - `pkg/kthena-router/router/router.go`: https://github.com/volcano-sh/kthena/blob/5d19b80c102a0a28f41ddaeec7b25cae37dfc879/pkg/kthena-router/router/router.go#L139-L156
  - `pkg/kthena-router/filters/ratelimit/ratelimit.go`: https://github.com/volcano-sh/kthena/blob/5d19b80c102a0a28f41ddaeec7b25cae37dfc879/pkg/kthena-router/filters/ratelimit/ratelimit.go#L60-L98

**Special notes for your reviewer**:
- Unit tests added: `TestTokenRateLimiter_DeleteLimiter`, `TestTokenRateLimiter_UpdateClearsNilDirectionalLimits`, and `TestRouter_ModelRouteRateLimitClearedOnUpdate`.
- All unit tests under `./pkg/kthena-router/...` pass cleanly.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
