### PR TITLE
test(model-booster): cover PVC URI validation edge cases

### DIFF
--- a/pkg/model-booster-controller/webhook/model_validator_test.go
+++ b/pkg/model-booster-controller/webhook/model_validator_test.go
@@ -230,6 +230,42 @@ func TestValidatePVCURICompatibility(t *testing.T) {
 			expectValid: true,
 		},
 		{
+			name:        "pvc modelURI with trailing slash is valid",
+			modelURI:    "pvc://crater-storage/models/Qwen/",
+			cacheURI:    "pvc://crater-storage",
+			expectValid: true,
+		},
+		{
+			name:        "pvc cacheURI with trailing slash is valid",
+			modelURI:    "pvc:///crater-storage/models/Qwen",
+			cacheURI:    "pvc://crater-storage/",
+			expectValid: true,
+		},
+		{
+			name:        "pvc modelURI with repeated slashes is valid",
+			modelURI:    "pvc://crater-storage//models//Qwen",
+			cacheURI:    "pvc://crater-storage",
+			expectValid: true,
+		},
+		{
+			name:        "s3 modelURI with non-pvc cacheURI is valid",
+			modelURI:    "s3://bucket/models/Qwen",
+			cacheURI:    "hostpath:///tmp/cache",
+			expectValid: true,
+		},
+		{
+			name:        "obs modelURI with non-pvc cacheURI is valid",
+			modelURI:    "obs://bucket/models/Qwen",
+			cacheURI:    "hostpath:///tmp/cache",
+			expectValid: true,
+		},
+		{
+			name:        "ms modelURI with non-pvc cacheURI is valid",
+			modelURI:    "ms://namespace/repo",
+			cacheURI:    "hostpath:///tmp/cache",
+			expectValid: true,
+		},
+		{
 			name:        "pvc modelURI with hostpath cacheURI is invalid",
 			modelURI:    "pvc:///shared/models/Qwen",
 			cacheURI:    "hostpath:///tmp/cache",
@@ -277,6 +313,16 @@ func TestValidatePVCURICompatibility(t *testing.T) {
 			cacheURI:    "pvc://foo/bar",
 			expectValid: false,
 			expectMsg:   "claim names cannot contain '/'",
+		},
+		{
+			// The claim name "foo" must not be treated as a prefix match against a
+			// modelURI whose first path segment is "foobar" - only a full path-segment
+			// match (exact or followed by '/') makes the source reachable through the mount.
+			name:        "pvc modelURI with claim-name-prefix collision is invalid",
+			modelURI:    "pvc:///foobar/models/Qwen",
+			cacheURI:    "pvc://foo",
+			expectValid: false,
+			expectMsg:   "is not reachable via cacheURI mount",
 		},
 	}
 


### PR DESCRIPTION
validatePVCURICompatibility already enforces that a `pvc://` modelURI must resolve to a path reachable through the `cacheURI` mount, but the existing table missed a few cases called out during review of the webhook logic:

* A cacheURI claim name that is a string prefix of the modelURI's first path segment (for example, claim `foo` vs modelURI under `foobar`) must not be treated as reachable.
* Trailing slashes and repeated slashes in either URI must not affect the reachability check.
* Non-pvc modelURI schemes (`s3://`, `obs://`, `ms://`) must continue to skip the check regardless of cacheURI.

All cases already pass against the current implementation; this PR only adds test coverage.

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Adds table-driven test coverage for edge cases in ModelBooster PVC `modelURI`/`cacheURI` compatibility validation.

The validation logic is already implemented correctly. These tests make the expected behavior explicit and protect against regressions in:

* path-segment boundary validation
* trailing/repeated slash normalization
* non-PVC modelURI scheme handling

No production code or user-facing behavior is changed.

**Which issue(s) this PR fixes**:

Fixes #1507

**Bug evidence (required for bug-related PRs)**:

N/A — this PR does not fix a production bug. The underlying validation behavior is already correct; this PR adds regression and edge-case test coverage.

**Special notes for your reviewer**:

The tests were added against the existing `validatePVCURICompatibility` behavior. In particular, the path-prefix case verifies that `/foo/...` is not considered reachable from a `/foobar` mount, while normalization cases verify that trailing and repeated slashes do not change the result.

Non-PVC schemes are also covered to ensure the existing behavior of skipping PVC reachability validation is preserved.

Validation performed:

* `gofmt -l`
* `go vet ./pkg/model-booster-controller/...`
* `go test ./pkg/model-booster-controller/...`
* `go build ./...`

All checks pass.

**Does this PR introduce a user-facing change?**:

NONE

```release-note
```
