### PR TITLE
test(router): prevent observability contract drift

### DIFF
--- a/charts/kthena/observability_contract_test.go
+++ b/charts/kthena/observability_contract_test.go
@@ -1,0 +1,217 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kthena
+
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"helm.sh/helm/v3/pkg/chart/loader"
+	"helm.sh/helm/v3/pkg/chartutil"
+	"helm.sh/helm/v3/pkg/engine"
+	"helm.sh/helm/v3/pkg/releaseutil"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/yaml"
+)
+
+const testRouterPort int32 = 18080
+
+type renderedChart struct {
+	deployments map[string]appsv1.Deployment
+	services    map[string]corev1.Service
+}
+
+func TestRouterServicePorts(t *testing.T) {
+	rendered := renderChart(t, routerValues(false))
+
+	deployment, ok := rendered.deployments["kthena-router"]
+	require.True(t, ok, "kthena-router Deployment was not rendered")
+	router := findContainer(t, deployment, "kthena-router")
+	httpPort := findContainerPort(t, router, "http")
+	require.Equal(t, testRouterPort, httpPort.ContainerPort)
+	require.Equal(t, corev1.ProtocolTCP, effectiveProtocol(httpPort.Protocol))
+
+	service, ok := rendered.services["kthena-router"]
+	require.True(t, ok, "kthena-router Service was not rendered")
+	require.Equal(t, corev1.ServiceTypeLoadBalancer, service.Spec.Type)
+	require.Len(t, service.Spec.Ports, 1, "the public inference Service must expose only its HTTP port")
+	require.Equal(t, "http", service.Spec.Ports[0].Name)
+	require.EqualValues(t, 80, service.Spec.Ports[0].Port)
+	require.Equal(t, intstr.FromInt32(testRouterPort), service.Spec.Ports[0].TargetPort)
+
+	webhookService, ok := rendered.services["kthena-router-webhook"]
+	require.True(t, ok, "kthena-router-webhook Service was not rendered")
+	require.Equal(t, corev1.ServiceTypeClusterIP, webhookService.Spec.Type)
+	require.Len(t, webhookService.Spec.Ports, 1)
+	require.Equal(t, "webhook", webhookService.Spec.Ports[0].Name)
+	require.EqualValues(t, 443, webhookService.Spec.Ports[0].Port)
+	require.Equal(t, intstr.FromInt32(8443), webhookService.Spec.Ports[0].TargetPort)
+}
+
+func TestRouterHealthAndReadinessProbes(t *testing.T) {
+	tests := []struct {
+		name       string
+		tlsEnabled bool
+		wantScheme corev1.URIScheme
+	}{
+		{
+			name:       "HTTP",
+			wantScheme: corev1.URISchemeHTTP,
+		},
+		{
+			name:       "HTTPS",
+			tlsEnabled: true,
+			wantScheme: corev1.URISchemeHTTPS,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rendered := renderChart(t, routerValues(tt.tlsEnabled))
+			deployment, ok := rendered.deployments["kthena-router"]
+			require.True(t, ok, "kthena-router Deployment was not rendered")
+			router := findContainer(t, deployment, "kthena-router")
+
+			require.NotNil(t, router.LivenessProbe)
+			require.NotNil(t, router.LivenessProbe.HTTPGet)
+			require.Equal(t, "/healthz", router.LivenessProbe.HTTPGet.Path)
+			require.Equal(t, intstr.FromInt32(testRouterPort), router.LivenessProbe.HTTPGet.Port)
+			require.Equal(t, tt.wantScheme, effectiveScheme(router.LivenessProbe.HTTPGet.Scheme))
+
+			require.NotNil(t, router.ReadinessProbe)
+			require.NotNil(t, router.ReadinessProbe.HTTPGet)
+			require.Contains(t, []string{"/healthz", "/readyz"}, router.ReadinessProbe.HTTPGet.Path)
+			require.Equal(t, intstr.FromInt32(testRouterPort), router.ReadinessProbe.HTTPGet.Port)
+			require.Equal(t, tt.wantScheme, effectiveScheme(router.ReadinessProbe.HTTPGet.Scheme))
+		})
+	}
+}
+
+func routerValues(tlsEnabled bool) map[string]interface{} {
+	values := map[string]interface{}{
+		"workload": map[string]interface{}{
+			"enabled": false,
+		},
+		"networking": map[string]interface{}{
+			"enabled": true,
+			"kthenaRouter": map[string]interface{}{
+				"port": testRouterPort,
+			},
+		},
+	}
+
+	if tlsEnabled {
+		values["global"] = map[string]interface{}{
+			"certManagementMode": "cert-manager",
+		}
+		values["networking"].(map[string]interface{})["kthenaRouter"].(map[string]interface{})["tls"] = map[string]interface{}{
+			"enabled": true,
+		}
+	}
+
+	return values
+}
+
+func renderChart(t *testing.T, values map[string]interface{}) renderedChart {
+	t.Helper()
+
+	_, filename, _, ok := runtime.Caller(0)
+	require.True(t, ok, "resolve chart directory")
+	chartDir := filepath.Dir(filename)
+
+	chart, err := loader.Load(chartDir)
+	require.NoError(t, err)
+	renderValues, err := chartutil.ToRenderValues(chart, values, chartutil.ReleaseOptions{
+		Name:      "observability-contract",
+		Namespace: "kthena-system",
+		Revision:  1,
+		IsInstall: true,
+	}, chartutil.DefaultCapabilities)
+	require.NoError(t, err)
+
+	files, err := engine.Render(chart, renderValues)
+	require.NoError(t, err)
+
+	result := renderedChart{
+		deployments: make(map[string]appsv1.Deployment),
+		services:    make(map[string]corev1.Service),
+	}
+	for _, file := range files {
+		for _, manifest := range releaseutil.SplitManifests(file) {
+			var header struct {
+				Kind     string `yaml:"kind"`
+				Metadata struct {
+					Name string `yaml:"name"`
+				} `yaml:"metadata"`
+			}
+			require.NoError(t, yaml.Unmarshal([]byte(manifest), &header))
+
+			switch header.Kind {
+			case "Deployment":
+				var deployment appsv1.Deployment
+				require.NoError(t, yaml.Unmarshal([]byte(manifest), &deployment))
+				result.deployments[header.Metadata.Name] = deployment
+			case "Service":
+				var service corev1.Service
+				require.NoError(t, yaml.Unmarshal([]byte(manifest), &service))
+				result.services[header.Metadata.Name] = service
+			}
+		}
+	}
+
+	return result
+}
+
+func findContainer(t *testing.T, deployment appsv1.Deployment, name string) corev1.Container {
+	t.Helper()
+	for _, container := range deployment.Spec.Template.Spec.Containers {
+		if container.Name == name {
+			return container
+		}
+	}
+	t.Fatalf("container %q was not rendered", name)
+	return corev1.Container{}
+}
+
+func findContainerPort(t *testing.T, container corev1.Container, name string) corev1.ContainerPort {
+	t.Helper()
+	for _, port := range container.Ports {
+		if port.Name == name {
+			return port
+		}
+	}
+	t.Fatalf("container port %q was not rendered", name)
+	return corev1.ContainerPort{}
+}
+
+func effectiveProtocol(protocol corev1.Protocol) corev1.Protocol {
+	if protocol == "" {
+		return corev1.ProtocolTCP
+	}
+	return protocol
+}
+
+func effectiveScheme(scheme corev1.URIScheme) corev1.URIScheme {
+	if scheme == "" {
+		return corev1.URISchemeHTTP
+	}
+	return scheme
+}

--- a/pkg/kthena-router/accesslog/logger_test.go
+++ b/pkg/kthena-router/accesslog/logger_test.go
@@ -18,6 +18,7 @@ package accesslog
 
 import (
 	"encoding/json"
+	"sort"
 	"testing"
 	"time"
 
@@ -27,16 +28,23 @@ import (
 
 func TestAccessLogEntry_ToJSON(t *testing.T) {
 	entry := &AccessLogEntry{
-		Timestamp:                  time.Date(2024, 1, 15, 10, 30, 45, 123000000, time.UTC),
-		Method:                     "POST",
-		Path:                       "/v1/chat/completions",
-		Protocol:                   "HTTP/1.1",
-		StatusCode:                 200,
+		Timestamp:  time.Date(2024, 1, 15, 10, 30, 45, 123000000, time.UTC),
+		Method:     "POST",
+		Path:       "/v1/chat/completions",
+		Protocol:   "HTTP/1.1",
+		StatusCode: 502,
+		Error: &ErrorInfo{
+			Type:    "upstream_error",
+			Message: "backend unavailable",
+		},
 		ModelName:                  "llama2-7b",
 		ModelRoute:                 "default/llama2-route-v1",
 		ModelServer:                "default/llama2-server",
 		SelectedPod:                "llama2-deployment-5f7b8c9d-xk2p4",
 		RequestID:                  "test-request-id",
+		Gateway:                    "default/gateway",
+		HTTPRoute:                  "default/chat-route",
+		InferencePool:              "default/llama2-pool",
 		InputTokens:                150,
 		OutputTokens:               75,
 		DurationTotal:              2350,
@@ -63,11 +71,15 @@ func TestAccessLogEntry_ToJSON(t *testing.T) {
 
 	assert.Equal(t, "POST", parsed["method"])
 	assert.Equal(t, "/v1/chat/completions", parsed["path"])
-	assert.Equal(t, float64(200), parsed["status_code"])
+	assert.Equal(t, float64(502), parsed["status_code"])
 	assert.Equal(t, "llama2-7b", parsed["model_name"])
 	assert.Equal(t, "default/llama2-route-v1", parsed["model_route"])
 	assert.Equal(t, "default/llama2-server", parsed["model_server"])
 	assert.Equal(t, "llama2-deployment-5f7b8c9d-xk2p4", parsed["selected_pod"])
+	assert.Equal(t, "test-request-id", parsed["request_id"])
+	assert.Equal(t, "default/gateway", parsed["gateway"])
+	assert.Equal(t, "default/chat-route", parsed["http_route"])
+	assert.Equal(t, "default/llama2-pool", parsed["inference_pool"])
 	assert.Equal(t, float64(150), parsed["input_tokens"])
 	assert.Equal(t, float64(75), parsed["output_tokens"])
 
@@ -76,6 +88,64 @@ func TestAccessLogEntry_ToJSON(t *testing.T) {
 	assert.Equal(t, float64(45), parsed["duration_request_processing"])
 	assert.Equal(t, float64(2180), parsed["duration_upstream_processing"])
 	assert.Equal(t, float64(5), parsed["duration_response_processing"])
+	errorInfo, ok := parsed["error"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, []string{"message", "type"}, sortedJSONKeys(errorInfo))
+	assert.Equal(t, "upstream_error", errorInfo["type"])
+	assert.Equal(t, "backend unavailable", errorInfo["message"])
+
+	assert.Equal(t, []string{
+		"duration_request_processing",
+		"duration_response_processing",
+		"duration_total",
+		"duration_upstream_processing",
+		"error",
+		"gateway",
+		"http_route",
+		"inference_pool",
+		"input_tokens",
+		"method",
+		"model_name",
+		"model_route",
+		"model_server",
+		"output_tokens",
+		"path",
+		"protocol",
+		"request_id",
+		"selected_pod",
+		"status_code",
+		"timestamp",
+	}, sortedJSONKeys(parsed), "access-log JSON field names are part of the observable contract")
+}
+
+func TestAccessLogEntry_JSONRequiredFields(t *testing.T) {
+	logger := &accessLoggerImpl{config: &AccessLoggerConfig{Format: FormatJSON}}
+	output, err := logger.formatJSON(&AccessLogEntry{})
+	require.NoError(t, err)
+
+	var parsed map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(output), &parsed))
+	assert.Equal(t, []string{
+		"duration_request_processing",
+		"duration_response_processing",
+		"duration_total",
+		"duration_upstream_processing",
+		"method",
+		"model_name",
+		"path",
+		"protocol",
+		"status_code",
+		"timestamp",
+	}, sortedJSONKeys(parsed), "required fields must remain present even when their values are empty")
+}
+
+func sortedJSONKeys(value map[string]interface{}) []string {
+	keys := make([]string, 0, len(value))
+	for key := range value {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 func TestAccessLogEntry_ToText(t *testing.T) {

--- a/pkg/kthena-router/metrics/observability_contract_test.go
+++ b/pkg/kthena-router/metrics/observability_contract_test.go
@@ -1,0 +1,159 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	descriptorMetricNamePattern = regexp.MustCompile(`fqName: "([^"]+)"`)
+	dashboardMetricNamePattern  = regexp.MustCompile(`\bkthena_router_[a-zA-Z0-9_:]*\b`)
+	documentedMetricNamePattern = regexp.MustCompile("`(kthena_router_[a-zA-Z_:][a-zA-Z0-9_:]*)`")
+)
+
+func TestGrafanaDashboardMetricNamesAreRegistered(t *testing.T) {
+	data, err := os.ReadFile(repositoryFile(t, "examples", "observability", "grafana-dashboard-score-plugins.json"))
+	require.NoError(t, err)
+
+	var dashboard interface{}
+	require.NoError(t, json.Unmarshal(data, &dashboard), "dashboard must be valid JSON")
+
+	references := make(map[string]struct{})
+	collectDashboardMetricNames(dashboard, references)
+	require.NotEmpty(t, references, "dashboard must contain router metric references")
+	requireMetricReferencesRegistered(t, references, registeredRouterMetricNames(t))
+}
+
+func TestDocumentedRouterMetricNamesAreRegistered(t *testing.T) {
+	data, err := os.ReadFile(repositoryFile(t, "docs", "kthena", "docs", "user-guide", "router-observability.md"))
+	require.NoError(t, err)
+
+	references := make(map[string]struct{})
+	for _, match := range documentedMetricNamePattern.FindAllSubmatch(data, -1) {
+		references[string(match[1])] = struct{}{}
+	}
+	require.NotEmpty(t, references, "router observability documentation must name router metrics")
+	requireMetricReferencesRegistered(t, references, registeredRouterMetricNames(t))
+}
+
+func registeredRouterMetricNames(t *testing.T) map[string]struct{} {
+	t.Helper()
+
+	names := make(map[string]struct{})
+	metricsValue := reflect.ValueOf(DefaultMetrics).Elem()
+	for i := 0; i < metricsValue.NumField(); i++ {
+		collector, ok := prometheusCollector(metricsValue.Field(i))
+		if !ok {
+			continue
+		}
+		_, alreadyRegistered := prometheus.DefaultRegisterer.Register(collector).(prometheus.AlreadyRegisteredError)
+		require.True(t, alreadyRegistered, "router metric collector is not registered with the default registry")
+
+		descriptors := make(chan *prometheus.Desc, 16)
+		collector.Describe(descriptors)
+		close(descriptors)
+		for descriptor := range descriptors {
+			match := descriptorMetricNamePattern.FindStringSubmatch(descriptor.String())
+			require.Len(t, match, 2, "extract metric name from descriptor %s", descriptor)
+			if strings.HasPrefix(match[1], "kthena_router_") {
+				names[match[1]] = struct{}{}
+			}
+		}
+	}
+
+	require.NotEmpty(t, names, "router metrics registry must expose descriptors")
+	return names
+}
+
+func prometheusCollector(field reflect.Value) (prometheus.Collector, bool) {
+	if field.CanInterface() {
+		if collector, ok := field.Interface().(prometheus.Collector); ok {
+			return collector, true
+		}
+	}
+	if field.CanAddr() && field.Addr().CanInterface() {
+		if collector, ok := field.Addr().Interface().(prometheus.Collector); ok {
+			return collector, true
+		}
+	}
+	return nil, false
+}
+
+func collectDashboardMetricNames(value interface{}, names map[string]struct{}) {
+	switch value := value.(type) {
+	case string:
+		for _, name := range dashboardMetricNamePattern.FindAllString(value, -1) {
+			names[name] = struct{}{}
+		}
+	case []interface{}:
+		for _, item := range value {
+			collectDashboardMetricNames(item, names)
+		}
+	case map[string]interface{}:
+		for _, item := range value {
+			collectDashboardMetricNames(item, names)
+		}
+	}
+}
+
+func requireMetricReferencesRegistered(t *testing.T, references, registered map[string]struct{}) {
+	t.Helper()
+
+	var unknown []string
+	for reference := range references {
+		require.True(t, model.MetricNameRE.MatchString(reference), "%q is not a valid Prometheus metric name", reference)
+		if !isRegisteredMetricReference(reference, registered) {
+			unknown = append(unknown, reference)
+		}
+	}
+	sort.Strings(unknown)
+	require.Empty(t, unknown, "metric references do not correspond to registered router metrics")
+}
+
+func isRegisteredMetricReference(reference string, registered map[string]struct{}) bool {
+	if _, ok := registered[reference]; ok {
+		return true
+	}
+	for _, suffix := range []string{"_bucket", "_count", "_sum"} {
+		if strings.HasSuffix(reference, suffix) {
+			_, ok := registered[strings.TrimSuffix(reference, suffix)]
+			return ok
+		}
+	}
+	return false
+}
+
+func repositoryFile(t *testing.T, elements ...string) string {
+	t.Helper()
+	_, filename, _, ok := runtime.Caller(0)
+	require.True(t, ok, "resolve repository root")
+	root := filepath.Clean(filepath.Join(filepath.Dir(filename), "..", "..", ".."))
+	return filepath.Join(append([]string{root}, elements...)...)
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind enhancement

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:
- render the Helm chart with non-default ports and both HTTP and TLS settings, then verify router container/Service port wiring and health/readiness probes;
- assert the exact JSON field set emitted by a fully populated access-log entry and the required fields retained for a minimal entry;
- parse the example Grafana dashboard as JSON and verify every referenced `kthena_router_*` PromQL metric name maps to a registered collector, including histogram `_bucket`, `_count`, and `_sum` series;
- verify router metric names listed in the canonical observability guide map to registered router collectors.

**Which issue(s) this PR fixes**:
Fixes #1510 

**Bug evidence (required for bug-related PRs)**:
<!--
For a bug-related PR, provide evidence from the production path:
- Include the relevant workload configuration and logs or events.
- For a panic, include the complete panic trace.
- Describe the user action or cluster event that triggers the problem and how the
  change fixes it.
- Use source permalinks that point to the exact commit when citing code.

AI-generated analysis, a static scan, or a unit test that only calls an internal
function does not prove a bug on its own. If the reported bug relies solely on AI
analysis without reproduction instructions or production-path evidence, maintainers
may close the issue and the related PR.

Write "N/A" for PRs that are not bug-related.
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
