### PR TITLE
fix: enforce rollout configuration granularity for ModelServing

### DIFF
--- a/charts/kthena/charts/workload/crds/workload.serving.volcano.sh_modelservings.yaml
+++ b/charts/kthena/charts/workload/crds/workload.serving.volcano.sh_modelservings.yaml
@@ -123,8 +123,8 @@ spec:
                 properties:
                   rollingUpdateConfiguration:
                     description: |-
-                      RollingUpdateConfiguration defines the parameters to be used when type is ServingGroupRollingUpdate.
-                      optional
+                      RollingUpdateConfiguration configures ServingGroupRollingUpdate.
+                      During a rolling update, the `maxUnavailable` setting for the ServingGroup does not take effect.
                     properties:
                       maxUnavailable:
                         anyOf:
@@ -132,11 +132,10 @@ spec:
                         - type: string
                         default: 1
                         description: |-
-                          The maximum number of replicas that can be unavailable during the update.
-                          Value can be an absolute number (ex: 5) or a percentage of total replicas at the start of update (ex: 10%).
-                          Absolute number is calculated from percentage by rounding down.
-                          This can not be 0.
-                          By default, a fixed value of 1 is used.
+                          MaxUnavailable is the maximum number of resources that may be
+                          unavailable during an update. It can be an absolute number (for example,
+                          5) or a percentage of ModelServing replicas (for example, 10%). A
+                          percentage is rounded down. The value must not resolve to 0. Defaults to 1.
                         x-kubernetes-int-or-string: true
                       partition:
                         anyOf:
@@ -154,10 +153,16 @@ spec:
                   type:
                     default: ServingGroupRollingUpdate
                     description: |-
-                      Type defines the rollout strategy. Supported values are
-                      "ServingGroupRollingUpdate" and "RoleRollingUpdate". If not specified,
-                      it defaults to "ServingGroupRollingUpdate".
-                      For `RoleRollingUpdate`, the `maxUnavailable` field in each Role will be used to determine the maximum number of role instances that can be unavailable during the update.
+                      Type selects the granularity of rolling updates. Supported values are
+                      ServingGroupRollingUpdate and RoleRollingUpdate. It defaults to
+                      ServingGroupRollingUpdate.
+
+                      The configuration of `rolloutStrategy.rollingUpdateConfiguration` takes effect in `ServingGroupRollingUpdate`.
+                      RoleRollingUpdate settings on individual Roles are invalid.
+                      RoleRollingUpdate uses the rolling update configuration on each Role and
+                      during a rolling update, the `maxUnavailable` setting for the ServingGroup does not take effect.
+                      Kthena performs RoleRollingUpdate across all ServingGroups at the same time.
+                      Therefore, we recommend using it only in scenarios with a single ServingGroup.
                     enum:
                     - ServingGroupRollingUpdate
                     - RoleRollingUpdate
@@ -8900,11 +8905,10 @@ spec:
                           - type: string
                           default: 1
                           description: |-
-                            The maximum number of replicas that can be unavailable during the update.
-                            Value can be an absolute number (ex: 5) or a percentage of total replicas at the start of update (ex: 10%).
-                            Absolute number is calculated from percentage by rounding down.
-                            This can not be 0.
-                            By default, a fixed value of 1 is used.
+                            MaxUnavailable is the maximum number of resources that may be
+                            unavailable during an update. It can be an absolute number (for example,
+                            5) or a percentage of ModelServing replicas (for example, 10%). A
+                            percentage is rounded down. The value must not resolve to 0. Defaults to 1.
                           x-kubernetes-int-or-string: true
                         name:
                           description: The name of a role. Name must be unique within

--- a/charts/kthena/charts/workload/crds/workload.serving.volcano.sh_modelservings.yaml
+++ b/charts/kthena/charts/workload/crds/workload.serving.volcano.sh_modelservings.yaml
@@ -124,7 +124,8 @@ spec:
                   rollingUpdateConfiguration:
                     description: |-
                       RollingUpdateConfiguration configures ServingGroupRollingUpdate.
-                      During a rolling update, the `maxUnavailable` setting for the ServingGroup does not take effect.
+                      It must not be set when type is RoleRollingUpdate; configure maxUnavailable
+                      and partition on each Role instead.
                     properties:
                       maxUnavailable:
                         anyOf:
@@ -134,8 +135,10 @@ spec:
                         description: |-
                           MaxUnavailable is the maximum number of resources that may be
                           unavailable during an update. It can be an absolute number (for example,
-                          5) or a percentage of ModelServing replicas (for example, 10%). A
-                          percentage is rounded down. The value must not resolve to 0. Defaults to 1.
+                          5) or a percentage (for example, 10%). A percentage is calculated from
+                          ModelServing replicas for ServingGroupRollingUpdate and from the
+                          corresponding Role's replicas for RoleRollingUpdate, then rounded down.
+                          The value must not resolve to 0. Defaults to 1.
                         x-kubernetes-int-or-string: true
                       partition:
                         anyOf:
@@ -157,10 +160,10 @@ spec:
                       ServingGroupRollingUpdate and RoleRollingUpdate. It defaults to
                       ServingGroupRollingUpdate.
 
-                      The configuration of `rolloutStrategy.rollingUpdateConfiguration` takes effect in `ServingGroupRollingUpdate`.
-                      RoleRollingUpdate settings on individual Roles are invalid.
-                      RoleRollingUpdate uses the rolling update configuration on each Role and
-                      during a rolling update, the `maxUnavailable` setting for the ServingGroup does not take effect.
+                      ServingGroupRollingUpdate uses rolloutStrategy.rollingUpdateConfiguration;
+                      rolling update settings on individual Roles do not take effect.
+                      RoleRollingUpdate uses the rolling update configuration on each Role;
+                      rolloutStrategy.rollingUpdateConfiguration must not be set.
                       Kthena performs RoleRollingUpdate across all ServingGroups at the same time.
                       Therefore, we recommend using it only in scenarios with a single ServingGroup.
                     enum:
@@ -8907,8 +8910,10 @@ spec:
                           description: |-
                             MaxUnavailable is the maximum number of resources that may be
                             unavailable during an update. It can be an absolute number (for example,
-                            5) or a percentage of ModelServing replicas (for example, 10%). A
-                            percentage is rounded down. The value must not resolve to 0. Defaults to 1.
+                            5) or a percentage (for example, 10%). A percentage is calculated from
+                            ModelServing replicas for ServingGroupRollingUpdate and from the
+                            corresponding Role's replicas for RoleRollingUpdate, then rounded down.
+                            The value must not resolve to 0. Defaults to 1.
                           x-kubernetes-int-or-string: true
                         name:
                           description: The name of a role. Name must be unique within

--- a/docs/kthena/docs/architecture/model-serving-controller.mdx
+++ b/docs/kthena/docs/architecture/model-serving-controller.mdx
@@ -22,7 +22,7 @@ The Custom Resource Definition (CRD) of `ModelServing` is primarily divided into
 
 - Supports topology aware and gang scheduling: It enables the simultaneous scheduling of serving pods within an `ServingGroup` to the same **HyperNode**, and allows for the configuration of gang scheduling parameters.
   Scheduling is only permitted when the HyperNode meets the **minimum number** of pods required for the serving tasks.
-- Supports scaling and rolling upgrades: It provides scaling capabilities at both the `ServingGroup` level and `Role` level, along with fault recovery capabilities. The current controller supports sequential rolling upgrades for ServingGroups.
+- Supports scaling and rolling upgrades: It provides scaling, rolling updates, and fault recovery at both the `ServingGroup` and `Role` levels. `ServingGroupRollingUpdate` uses the ModelServing-level rollout configuration, while `RoleRollingUpdate` uses the configuration defined on each Role.
 
 2. ServingGroup
 

--- a/docs/kthena/docs/developer-guide/model-serving-rolling-update.md
+++ b/docs/kthena/docs/developer-guide/model-serving-rolling-update.md
@@ -2,9 +2,16 @@
 
 Rolling updates represent a critical operational strategy for online services aiming to achieve zero downtime. In the context of LLM inference services, the implementation of rolling updates is important to reduce the risk of service unavailability.
 
-Currently, `ModelServing` supports rolling upgrades at the `ServingGroup` level, enabling users to configure `Partitions` to control the rolling process.
+`ModelServing` supports rolling updates at either the `ServingGroup` or `Role` level. Select exactly one granularity with `spec.rolloutStrategy.type`:
 
-- Partition: Protects the first N existing replicas in the datastore's ascending ordinal order. The remaining replicas are eligible for rolling update. With the normal contiguous ordinal set, this is equivalent to protecting ordinals in `[0, partition)`. Defining protection by list position also gives deterministic behavior for legacy or temporarily non-contiguous sets.
+- `ServingGroupRollingUpdate` uses `spec.rolloutStrategy.rollingUpdateConfiguration`. Its `maxUnavailable` limits unavailable `ServingGroups`, and its `partition` protects existing `ServingGroups` from updates.
+- `RoleRollingUpdate` uses the inline `maxUnavailable` and `partition` fields on each entry in `spec.template.roles`. The settings are applied independently to each `Role` in every `ServingGroup`. The ModelServing-level `rollingUpdateConfiguration` must not be set and does not participate in the Role availability budget.
+
+Configure rolling update settings only at the selected granularity. `maxUnavailable` accepts an absolute number or a percentage and defaults to `1`. A percentage is calculated from `spec.replicas` for `ServingGroupRollingUpdate` and from the corresponding Role's `replicas` for `RoleRollingUpdate`.
+
+`partition` protects the first N existing replicas in ascending ordinal order. The remaining replicas are eligible for rolling update. With a normal contiguous ordinal set, this is equivalent to protecting ordinals in `[0, partition)`. Defining protection by list position also gives deterministic behavior for legacy or temporarily non-contiguous sets.
+
+## ServingGroup rolling update
 
 When a protected replica is missing and must be recreated, the ordinal itself selects the template: a missing ordinal below `partition` uses `CurrentRevision` and its historical template, while other missing ordinals use `UpdateRevision` and the current template. Before creating a `ServingGroup` that references a new revision, the controller must successfully persist its `ControllerRevision`; otherwise reconciliation stops and retries without creating a partial `ServingGroup`.
 
@@ -15,6 +22,7 @@ spec:
   rolloutStrategy:
     type: ServingGroupRollingUpdate
     rollingUpdateConfiguration:
+      maxUnavailable: 1
       partition: 0
 ```
 
@@ -34,3 +42,29 @@ In the following we'll show how rolling update processes for a `ModelServing` wi
 | Stage6 | ✅ | ✅ | ✅ | ✅ | Update completed. All replicas are on the new version |
 
 During a rolling upgrade, the controller selects an eligible outdated replica while respecting partition and availability constraints, then deletes and rebuilds it. Unhealthy outdated replicas are prioritized; ordinal order is used within the applicable candidate ordering. The controller does not proceed beyond the availability budget until replacement capacity is ready.
+
+## Role rolling update
+
+Use `RoleRollingUpdate` when only the changed Roles should be recreated instead of rebuilding an entire `ServingGroup`. Configure the availability budget and partition directly on each Role:
+
+```yaml
+spec:
+  rolloutStrategy:
+    type: RoleRollingUpdate
+  template:
+    roles:
+      - name: prefill
+        replicas: 4
+        maxUnavailable: 1
+        partition: 0
+        # entryTemplate and other Role fields are omitted
+      - name: decode
+        replicas: 2
+        maxUnavailable: 1
+        partition: 0
+        # entryTemplate and other Role fields are omitted
+```
+
+Kthena evaluates Role updates across all `ServingGroups`. Because each `ServingGroup` applies the per-Role availability budget independently, `RoleRollingUpdate` is recommended for a ModelServing with a single `ServingGroup`.
+
+If `recoveryPolicy` is `ServingGroupRecreate`, deleting an outdated Role triggers recreation of its entire `ServingGroup`, which removes the resource-saving benefit of `RoleRollingUpdate`. Use `RoleRecreate` when only the outdated Role should be rebuilt.

--- a/docs/kthena/docs/reference/crd/workload.serving.volcano.sh.md
+++ b/docs/kthena/docs/reference/crd/workload.serving.volcano.sh.md
@@ -864,7 +864,7 @@ _Appears in:_
 | `entryTemplate` _[PodTemplateSpec](#podtemplatespec)_ | EntryTemplate defines the template for the entry pod of a role.<br />Required: Currently, a role must have only one entry-pod. |  |  |
 | `workerReplicas` _integer_ | WorkerReplicas defines the number for the worker pod of a role.<br />Required: Need to set the number of worker-pod replicas. |  |  |
 | `workerTemplate` _[PodTemplateSpec](#podtemplatespec)_ | WorkerTemplate defines the template for the worker pod of a role. |  |  |
-| `maxUnavailable` _[IntOrString](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#intorstring-intstr-util)_ | The maximum number of replicas that can be unavailable during the update.<br />Value can be an absolute number (ex: 5) or a percentage of total replicas at the start of update (ex: 10%).<br />Absolute number is calculated from percentage by rounding down.<br />This can not be 0.<br />By default, a fixed value of 1 is used. | 1 | XIntOrString: \{\} <br /> |
+| `maxUnavailable` _[IntOrString](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#intorstring-intstr-util)_ | MaxUnavailable is the maximum number of resources that may be<br />unavailable during an update. It can be an absolute number (for example,<br />5) or a percentage of ModelServing replicas (for example, 10%). A<br />percentage is rounded down. The value must not resolve to 0. Defaults to 1. | 1 | XIntOrString: \{\} <br /> |
 | `partition` _[IntOrString](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#intorstring-intstr-util)_ | Partition protects the first N existing replicas in ascending ordinal order<br />from updates. The remaining replicas are eligible for rolling update.<br />For a contiguous ordinal set, this is equivalent to protecting [0, Partition).<br />Value can be an absolute number (ex: 5) or a percentage of total replicas (ex: 10%).<br />Absolute number is calculated from percentage by rounding up.<br />The default value is 0. |  | XIntOrString: \{\} <br /> |
 
 
@@ -928,7 +928,7 @@ _Appears in:_
 
 
 
-RollingUpdateConfiguration defines the parameters to be used for ServingGroupRollingUpdate.
+RollingUpdateConfiguration defines the parameters to be used for RollingUpdate.
 
 
 
@@ -938,7 +938,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `maxUnavailable` _[IntOrString](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#intorstring-intstr-util)_ | The maximum number of replicas that can be unavailable during the update.<br />Value can be an absolute number (ex: 5) or a percentage of total replicas at the start of update (ex: 10%).<br />Absolute number is calculated from percentage by rounding down.<br />This can not be 0.<br />By default, a fixed value of 1 is used. | 1 | XIntOrString: \{\} <br /> |
+| `maxUnavailable` _[IntOrString](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#intorstring-intstr-util)_ | MaxUnavailable is the maximum number of resources that may be<br />unavailable during an update. It can be an absolute number (for example,<br />5) or a percentage of ModelServing replicas (for example, 10%). A<br />percentage is rounded down. The value must not resolve to 0. Defaults to 1. | 1 | XIntOrString: \{\} <br /> |
 | `partition` _[IntOrString](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#intorstring-intstr-util)_ | Partition protects the first N existing replicas in ascending ordinal order<br />from updates. The remaining replicas are eligible for rolling update.<br />For a contiguous ordinal set, this is equivalent to protecting [0, Partition).<br />Value can be an absolute number (ex: 5) or a percentage of total replicas (ex: 10%).<br />Absolute number is calculated from percentage by rounding up.<br />The default value is 0. |  | XIntOrString: \{\} <br /> |
 
 
@@ -956,8 +956,8 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `type` _[RolloutStrategyType](#rolloutstrategytype)_ | Type defines the rollout strategy. Supported values are<br />"ServingGroupRollingUpdate" and "RoleRollingUpdate". If not specified,<br />it defaults to "ServingGroupRollingUpdate".<br />For `RoleRollingUpdate`, the `maxUnavailable` field in each Role will be used to determine the maximum number of role instances that can be unavailable during the update. | ServingGroupRollingUpdate | Enum: [ServingGroupRollingUpdate RoleRollingUpdate] <br /> |
-| `rollingUpdateConfiguration` _[RollingUpdateConfiguration](#rollingupdateconfiguration)_ | RollingUpdateConfiguration defines the parameters to be used when type is ServingGroupRollingUpdate.<br />optional |  |  |
+| `type` _[RolloutStrategyType](#rolloutstrategytype)_ | Type selects the granularity of rolling updates. Supported values are<br />ServingGroupRollingUpdate and RoleRollingUpdate. It defaults to<br />ServingGroupRollingUpdate.<br />The configuration of `rolloutStrategy.rollingUpdateConfiguration` takes effect in `ServingGroupRollingUpdate`.<br />RoleRollingUpdate settings on individual Roles are invalid.<br />RoleRollingUpdate uses the rolling update configuration on each Role and<br />during a rolling update, the `maxUnavailable` setting for the ServingGroup does not take effect.<br />Kthena performs RoleRollingUpdate across all ServingGroups at the same time.<br />Therefore, we recommend using it only in scenarios with a single ServingGroup. | ServingGroupRollingUpdate | Enum: [ServingGroupRollingUpdate RoleRollingUpdate] <br /> |
+| `rollingUpdateConfiguration` _[RollingUpdateConfiguration](#rollingupdateconfiguration)_ | RollingUpdateConfiguration configures ServingGroupRollingUpdate.<br />During a rolling update, the `maxUnavailable` setting for the ServingGroup does not take effect. |  |  |
 
 
 #### RolloutStrategyType
@@ -965,8 +965,9 @@ _Appears in:_
 _Underlying type:_ _string_
 
 RolloutStrategyType defines the strategy to use to update replicas.
-Note that if `recoveryPolicy` is set to `ServingGroupRecreate` and `rolloutStrategyType` is set to `RoleRollingUpdate`,
-the entire servingGroup will be deleted during a rolling update because the outdated role is removed.
+Note that if recoveryPolicy is ServingGroupRecreate and the rollout strategy
+is RoleRollingUpdate, deleting an outdated Role causes its entire ServingGroup
+to be recreated.
 
 
 

--- a/docs/kthena/docs/reference/crd/workload.serving.volcano.sh.md
+++ b/docs/kthena/docs/reference/crd/workload.serving.volcano.sh.md
@@ -864,7 +864,7 @@ _Appears in:_
 | `entryTemplate` _[PodTemplateSpec](#podtemplatespec)_ | EntryTemplate defines the template for the entry pod of a role.<br />Required: Currently, a role must have only one entry-pod. |  |  |
 | `workerReplicas` _integer_ | WorkerReplicas defines the number for the worker pod of a role.<br />Required: Need to set the number of worker-pod replicas. |  |  |
 | `workerTemplate` _[PodTemplateSpec](#podtemplatespec)_ | WorkerTemplate defines the template for the worker pod of a role. |  |  |
-| `maxUnavailable` _[IntOrString](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#intorstring-intstr-util)_ | MaxUnavailable is the maximum number of resources that may be<br />unavailable during an update. It can be an absolute number (for example,<br />5) or a percentage of ModelServing replicas (for example, 10%). A<br />percentage is rounded down. The value must not resolve to 0. Defaults to 1. | 1 | XIntOrString: \{\} <br /> |
+| `maxUnavailable` _[IntOrString](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#intorstring-intstr-util)_ | MaxUnavailable is the maximum number of resources that may be<br />unavailable during an update. It can be an absolute number (for example,<br />5) or a percentage (for example, 10%). A percentage is calculated from<br />ModelServing replicas for ServingGroupRollingUpdate and from the<br />corresponding Role's replicas for RoleRollingUpdate, then rounded down.<br />The value must not resolve to 0. Defaults to 1. | 1 | XIntOrString: \{\} <br /> |
 | `partition` _[IntOrString](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#intorstring-intstr-util)_ | Partition protects the first N existing replicas in ascending ordinal order<br />from updates. The remaining replicas are eligible for rolling update.<br />For a contiguous ordinal set, this is equivalent to protecting [0, Partition).<br />Value can be an absolute number (ex: 5) or a percentage of total replicas (ex: 10%).<br />Absolute number is calculated from percentage by rounding up.<br />The default value is 0. |  | XIntOrString: \{\} <br /> |
 
 
@@ -928,7 +928,8 @@ _Appears in:_
 
 
 
-RollingUpdateConfiguration defines the parameters to be used for RollingUpdate.
+RollingUpdateConfiguration defines availability and partition settings for
+the rollout granularity where it is configured.
 
 
 
@@ -938,7 +939,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `maxUnavailable` _[IntOrString](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#intorstring-intstr-util)_ | MaxUnavailable is the maximum number of resources that may be<br />unavailable during an update. It can be an absolute number (for example,<br />5) or a percentage of ModelServing replicas (for example, 10%). A<br />percentage is rounded down. The value must not resolve to 0. Defaults to 1. | 1 | XIntOrString: \{\} <br /> |
+| `maxUnavailable` _[IntOrString](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#intorstring-intstr-util)_ | MaxUnavailable is the maximum number of resources that may be<br />unavailable during an update. It can be an absolute number (for example,<br />5) or a percentage (for example, 10%). A percentage is calculated from<br />ModelServing replicas for ServingGroupRollingUpdate and from the<br />corresponding Role's replicas for RoleRollingUpdate, then rounded down.<br />The value must not resolve to 0. Defaults to 1. | 1 | XIntOrString: \{\} <br /> |
 | `partition` _[IntOrString](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#intorstring-intstr-util)_ | Partition protects the first N existing replicas in ascending ordinal order<br />from updates. The remaining replicas are eligible for rolling update.<br />For a contiguous ordinal set, this is equivalent to protecting [0, Partition).<br />Value can be an absolute number (ex: 5) or a percentage of total replicas (ex: 10%).<br />Absolute number is calculated from percentage by rounding up.<br />The default value is 0. |  | XIntOrString: \{\} <br /> |
 
 
@@ -956,8 +957,8 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `type` _[RolloutStrategyType](#rolloutstrategytype)_ | Type selects the granularity of rolling updates. Supported values are<br />ServingGroupRollingUpdate and RoleRollingUpdate. It defaults to<br />ServingGroupRollingUpdate.<br />The configuration of `rolloutStrategy.rollingUpdateConfiguration` takes effect in `ServingGroupRollingUpdate`.<br />RoleRollingUpdate settings on individual Roles are invalid.<br />RoleRollingUpdate uses the rolling update configuration on each Role and<br />during a rolling update, the `maxUnavailable` setting for the ServingGroup does not take effect.<br />Kthena performs RoleRollingUpdate across all ServingGroups at the same time.<br />Therefore, we recommend using it only in scenarios with a single ServingGroup. | ServingGroupRollingUpdate | Enum: [ServingGroupRollingUpdate RoleRollingUpdate] <br /> |
-| `rollingUpdateConfiguration` _[RollingUpdateConfiguration](#rollingupdateconfiguration)_ | RollingUpdateConfiguration configures ServingGroupRollingUpdate.<br />During a rolling update, the `maxUnavailable` setting for the ServingGroup does not take effect. |  |  |
+| `type` _[RolloutStrategyType](#rolloutstrategytype)_ | Type selects the granularity of rolling updates. Supported values are<br />ServingGroupRollingUpdate and RoleRollingUpdate. It defaults to<br />ServingGroupRollingUpdate.<br />ServingGroupRollingUpdate uses rolloutStrategy.rollingUpdateConfiguration;<br />rolling update settings on individual Roles do not take effect.<br />RoleRollingUpdate uses the rolling update configuration on each Role;<br />rolloutStrategy.rollingUpdateConfiguration must not be set.<br />Kthena performs RoleRollingUpdate across all ServingGroups at the same time.<br />Therefore, we recommend using it only in scenarios with a single ServingGroup. | ServingGroupRollingUpdate | Enum: [ServingGroupRollingUpdate RoleRollingUpdate] <br /> |
+| `rollingUpdateConfiguration` _[RollingUpdateConfiguration](#rollingupdateconfiguration)_ | RollingUpdateConfiguration configures ServingGroupRollingUpdate.<br />It must not be set when type is RoleRollingUpdate; configure maxUnavailable<br />and partition on each Role instead. |  |  |
 
 
 #### RolloutStrategyType

--- a/docs/kthena/docs/user-guide/multi-node-inference.md
+++ b/docs/kthena/docs/user-guide/multi-node-inference.md
@@ -349,9 +349,14 @@ You can adjust both levels simultaneously. For instance, you can increase the nu
 
 ## Rolling Update
 
-Currently, `ModelServing` supports rolling upgrades at the `ServingGroup` level, enabling users to configure `Partitions` to control the rolling process.
+`ModelServing` supports `ServingGroupRollingUpdate` and `RoleRollingUpdate`. Select one with `spec.rolloutStrategy.type`:
 
-- Partition: Protects the first N existing `ServingGroups` in ascending ordinal order. The remaining `ServingGroups` are eligible for update. For the normal contiguous set, this is equivalent to protecting ordinals in `[0, partition)`.
+- `ServingGroupRollingUpdate` reads `maxUnavailable` and `partition` from `spec.rolloutStrategy.rollingUpdateConfiguration`.
+- `RoleRollingUpdate` reads the inline `maxUnavailable` and `partition` from each entry in `spec.template.roles`. Do not set the ModelServing-level `rollingUpdateConfiguration` with this strategy.
+
+`maxUnavailable` defaults to `1`. Percentages use the number of `ServingGroups` for `ServingGroupRollingUpdate` and the corresponding Role's replica count for `RoleRollingUpdate`.
+
+`partition` protects the first N existing replicas in ascending ordinal order. The remaining replicas are eligible for update. For a normal contiguous set, this is equivalent to protecting ordinals in `[0, partition)`.
   
 ### ServingGroup Rolling Update
 
@@ -378,7 +383,26 @@ llama-multinode-1-405b-0-0        vllm/vllm-openai:v0.10.1
 llama-multinode-1-405b-0-1        vllm/vllm-openai:v0.10.1                 
 ```
 
-From the pod runtime, we can see that only group 1 has been updated because `rolloutStrategy.partition = 1` protects the first existing group, group 0. If the existing ordinal set is temporarily non-contiguous, protection still applies to the first existing group in ordinal order rather than to an ordinal threshold.
+From the pod runtime, we can see that only group 1 has been updated because `rolloutStrategy.rollingUpdateConfiguration.partition = 1` protects the first existing group, group 0. If the existing ordinal set is temporarily non-contiguous, protection still applies to the first existing group in ordinal order rather than to an ordinal threshold.
+
+### Role Rolling Update
+
+Use `RoleRollingUpdate` to recreate only changed Roles. Configure the rollout settings directly on each Role:
+
+```yaml
+spec:
+  rolloutStrategy:
+    type: RoleRollingUpdate
+  template:
+    roles:
+      - name: 405b
+        replicas: 2
+        maxUnavailable: 1
+        partition: 0
+        # entryTemplate and workerTemplate are omitted
+```
+
+The per-Role settings are applied in every `ServingGroup`; the ModelServing-level `rollingUpdateConfiguration` does not apply. `RoleRollingUpdate` is therefore recommended for a ModelServing with a single `ServingGroup`. To rebuild only the changed Role, use `recoveryPolicy: RoleRecreate`; `ServingGroupRecreate` causes the entire group to be recreated when an outdated Role is deleted.
 
 ## Gang Scheduling and Network Topology
 

--- a/pkg/apis/workload/v1alpha1/model_serving_types.go
+++ b/pkg/apis/workload/v1alpha1/model_serving_types.go
@@ -133,23 +133,31 @@ const (
 // RolloutStrategy defines the strategy that the ModelServing controller
 // will use to perform replica updates.
 type RolloutStrategy struct {
-	// Type defines the rollout strategy. Supported values are
-	// "ServingGroupRollingUpdate" and "RoleRollingUpdate". If not specified,
-	// it defaults to "ServingGroupRollingUpdate".
-	// For `RoleRollingUpdate`, the `maxUnavailable` field in each Role will be used to determine the maximum number of role instances that can be unavailable during the update.
+	// Type selects the granularity of rolling updates. Supported values are
+	// ServingGroupRollingUpdate and RoleRollingUpdate. It defaults to
+	// ServingGroupRollingUpdate.
+	//
+	// The configuration of `rolloutStrategy.rollingUpdateConfiguration` takes effect in `ServingGroupRollingUpdate`.
+	// RoleRollingUpdate settings on individual Roles are invalid.
+	// RoleRollingUpdate uses the rolling update configuration on each Role and
+	// during a rolling update, the `maxUnavailable` setting for the ServingGroup does not take effect.
+	// Kthena performs RoleRollingUpdate across all ServingGroups at the same time.
+	// Therefore, we recommend using it only in scenarios with a single ServingGroup.
 	//
 	// +kubebuilder:default=ServingGroupRollingUpdate
 	// +kubebuilder:validation:Enum={ServingGroupRollingUpdate,RoleRollingUpdate}
 	Type RolloutStrategyType `json:"type"`
 
-	// RollingUpdateConfiguration defines the parameters to be used when type is ServingGroupRollingUpdate.
-	// optional
+	// RollingUpdateConfiguration configures ServingGroupRollingUpdate.
+	// During a rolling update, the `maxUnavailable` setting for the ServingGroup does not take effect.
+	// +optional
 	RollingUpdateConfiguration *RollingUpdateConfiguration `json:"rollingUpdateConfiguration,omitempty"`
 }
 
 // RolloutStrategyType defines the strategy to use to update replicas.
-// Note that if `recoveryPolicy` is set to `ServingGroupRecreate` and `rolloutStrategyType` is set to `RoleRollingUpdate`,
-// the entire servingGroup will be deleted during a rolling update because the outdated role is removed.
+// Note that if recoveryPolicy is ServingGroupRecreate and the rollout strategy
+// is RoleRollingUpdate, deleting an outdated Role causes its entire ServingGroup
+// to be recreated.
 type RolloutStrategyType string
 
 const (
@@ -160,13 +168,12 @@ const (
 	RoleRollingUpdate RolloutStrategyType = "RoleRollingUpdate"
 )
 
-// RollingUpdateConfiguration defines the parameters to be used for ServingGroupRollingUpdate.
+// RollingUpdateConfiguration defines the parameters to be used for RollingUpdate.
 type RollingUpdateConfiguration struct {
-	// The maximum number of replicas that can be unavailable during the update.
-	// Value can be an absolute number (ex: 5) or a percentage of total replicas at the start of update (ex: 10%).
-	// Absolute number is calculated from percentage by rounding down.
-	// This can not be 0.
-	// By default, a fixed value of 1 is used.
+	// MaxUnavailable is the maximum number of resources that may be
+	// unavailable during an update. It can be an absolute number (for example,
+	// 5) or a percentage of ModelServing replicas (for example, 10%). A
+	// percentage is rounded down. The value must not resolve to 0. Defaults to 1.
 	// +kubebuilder:validation:XIntOrString
 	// +kubebuilder:default=1
 	MaxUnavailable *intstr.IntOrString `json:"maxUnavailable,omitempty"`

--- a/pkg/apis/workload/v1alpha1/model_serving_types.go
+++ b/pkg/apis/workload/v1alpha1/model_serving_types.go
@@ -137,10 +137,10 @@ type RolloutStrategy struct {
 	// ServingGroupRollingUpdate and RoleRollingUpdate. It defaults to
 	// ServingGroupRollingUpdate.
 	//
-	// The configuration of `rolloutStrategy.rollingUpdateConfiguration` takes effect in `ServingGroupRollingUpdate`.
-	// RoleRollingUpdate settings on individual Roles are invalid.
-	// RoleRollingUpdate uses the rolling update configuration on each Role and
-	// during a rolling update, the `maxUnavailable` setting for the ServingGroup does not take effect.
+	// ServingGroupRollingUpdate uses rolloutStrategy.rollingUpdateConfiguration;
+	// rolling update settings on individual Roles do not take effect.
+	// RoleRollingUpdate uses the rolling update configuration on each Role;
+	// rolloutStrategy.rollingUpdateConfiguration must not be set.
 	// Kthena performs RoleRollingUpdate across all ServingGroups at the same time.
 	// Therefore, we recommend using it only in scenarios with a single ServingGroup.
 	//
@@ -149,7 +149,8 @@ type RolloutStrategy struct {
 	Type RolloutStrategyType `json:"type"`
 
 	// RollingUpdateConfiguration configures ServingGroupRollingUpdate.
-	// During a rolling update, the `maxUnavailable` setting for the ServingGroup does not take effect.
+	// It must not be set when type is RoleRollingUpdate; configure maxUnavailable
+	// and partition on each Role instead.
 	// +optional
 	RollingUpdateConfiguration *RollingUpdateConfiguration `json:"rollingUpdateConfiguration,omitempty"`
 }
@@ -168,12 +169,15 @@ const (
 	RoleRollingUpdate RolloutStrategyType = "RoleRollingUpdate"
 )
 
-// RollingUpdateConfiguration defines the parameters to be used for RollingUpdate.
+// RollingUpdateConfiguration defines availability and partition settings for
+// the rollout granularity where it is configured.
 type RollingUpdateConfiguration struct {
 	// MaxUnavailable is the maximum number of resources that may be
 	// unavailable during an update. It can be an absolute number (for example,
-	// 5) or a percentage of ModelServing replicas (for example, 10%). A
-	// percentage is rounded down. The value must not resolve to 0. Defaults to 1.
+	// 5) or a percentage (for example, 10%). A percentage is calculated from
+	// ModelServing replicas for ServingGroupRollingUpdate and from the
+	// corresponding Role's replicas for RoleRollingUpdate, then rounded down.
+	// The value must not resolve to 0. Defaults to 1.
 	// +kubebuilder:validation:XIntOrString
 	// +kubebuilder:default=1
 	MaxUnavailable *intstr.IntOrString `json:"maxUnavailable,omitempty"`

--- a/pkg/apis/workload/v1alpha1/servinggroup_types.go
+++ b/pkg/apis/workload/v1alpha1/servinggroup_types.go
@@ -80,7 +80,7 @@ type Role struct {
 
 	// RollingUpdateConfiguration defines the parameters to be used for RoleRollingUpdate.
 	// It is inlined so `maxUnavailable` and `partition` can be set directly under a Role.
-	// For `partition`, the first N role replicas sorted by ordinal are protected from updates.
+	// These fields do not take effect when ModelServing uses ServingGroupRollingUpdate.
 	// +optional
 	RollingUpdateConfiguration `json:",inline,omitempty"`
 }

--- a/pkg/model-booster-controller/controller/model_booster_controller_test.go
+++ b/pkg/model-booster-controller/controller/model_booster_controller_test.go
@@ -210,6 +210,27 @@ func TestCreateOrUpdateModelRouteUpdatesLiveRouteWhenListerIsStale(t *testing.T)
 	assert.Equal(t, desiredRoute.Labels[utils.RevisionLabelKey], updatedRoute.Labels[utils.RevisionLabelKey])
 }
 
+func TestCreateOrUpdateModelRouteDoesNotCreateWhenListerMissesLiveRoute(t *testing.T) {
+	ctx := context.Background()
+	kubeClient := fake.NewClientset()
+	kthenaClient := kthenafake.NewSimpleClientset()
+	controller := NewModelBoosterController(kubeClient, kthenaClient)
+
+	model := loadYaml[workload.ModelBooster](t, "../convert/testdata/input/model.yaml")
+	desiredRoute := convert.BuildModelRoute(model)
+	_, err := kthenaClient.NetworkingV1alpha1().ModelRoutes(model.Namespace).Create(ctx, desiredRoute, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	var creates atomic.Int32
+	kthenaClient.PrependReactor("create", "modelroutes", func(k8stesting.Action) (bool, runtime.Object, error) {
+		creates.Add(1)
+		return false, nil, nil
+	})
+
+	assert.NoError(t, controller.createOrUpdateModelRoute(ctx, model))
+	assert.Zero(t, creates.Load())
+}
+
 func TestReconcile_ReturnsError(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/pkg/model-booster-controller/controller/model_route_handler.go
+++ b/pkg/model-booster-controller/controller/model_route_handler.go
@@ -33,6 +33,23 @@ func (mc *ModelBoosterController) createOrUpdateModelRoute(ctx context.Context, 
 	oldModelRoute, err := mc.modelRoutesLister.ModelRoutes(modelRoute.Namespace).Get(modelRoute.Name)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
+			// The informer cache may lag behind a successful creation. Check the
+			// live object before issuing another Create request.
+			currentModelRoute, getErr := mc.client.NetworkingV1alpha1().ModelRoutes(model.Namespace).Get(ctx, modelRoute.Name, metav1.GetOptions{})
+			if getErr == nil {
+				if currentModelRoute.DeletionTimestamp != nil {
+					return nil
+				}
+				if currentModelRoute.Spec.ModelName != modelRoute.Spec.ModelName {
+					klog.Infof("Delete ModelBooster Route %s because spec.modelName is immutable", modelRoute.Name)
+					return mc.client.NetworkingV1alpha1().ModelRoutes(model.Namespace).Delete(ctx, modelRoute.Name, metav1.DeleteOptions{})
+				}
+				return mc.updateModelRoute(ctx, currentModelRoute, modelRoute)
+			}
+			if !apierrors.IsNotFound(getErr) {
+				klog.Errorf("failed to get live ModelRoute %s: %v", klog.KObj(modelRoute), getErr)
+				return getErr
+			}
 			klog.V(4).Infof("Create ModelBooster Route %s", modelRoute.Name)
 			if _, err := mc.client.NetworkingV1alpha1().ModelRoutes(model.Namespace).Create(ctx, modelRoute, metav1.CreateOptions{}); err != nil {
 				klog.Errorf("failed to create ModelRoute %s: %v", klog.KObj(modelRoute), err)

--- a/pkg/model-serving-controller/controller/model_serving_controller.go
+++ b/pkg/model-serving-controller/controller/model_serving_controller.go
@@ -698,7 +698,7 @@ func (c *ModelServingController) syncServingGroupReplicas(ctx context.Context, m
 // scaleUpServingGroups fills missing ordinals in [0, expectedCount).
 // Missing ordinals below partition use CurrentRevision; the rest use newRevision.
 func (c *ModelServingController) scaleUpServingGroups(ctx context.Context, ms *workloadv1alpha1.ModelServing, servingGroupList []datastore.ServingGroup, expectedCount int, newRevision string) error {
-	partition, _, _ := c.getPartition(modelServingRolloutConfig(ms), modelServingReplicas(ms))
+	partition, _, _ := c.getPartition(modelServingPartition(ms), modelServingReplicas(ms))
 	klog.V(4).Infof("scaleUpServingGroups: start for modelServing=%s, existingGroups=%d, expectedCount=%d, partition=%d, newRevision=%s",
 		utils.GetNamespaceName(ms), len(servingGroupList), expectedCount, partition, newRevision)
 
@@ -819,7 +819,7 @@ func (c *ModelServingController) syncRoleReplicas(ctx context.Context, ms *workl
 	if err != nil && !errors.Is(err, datastore.ErrServingGroupNotFound) {
 		return fmt.Errorf("cannot get ServingGroup of modelServing: %s from map: %v", ms.GetName(), err)
 	}
-	partition, _, _ := c.getPartition(modelServingRolloutConfig(ms), modelServingReplicas(ms))
+	partition, _, _ := c.getPartition(modelServingPartition(ms), modelServingReplicas(ms))
 	for index, servingGroup := range servingGroupList {
 		if c.store.GetServingGroupStatus(utils.GetNamespaceName(ms), servingGroup.Name) == datastore.ServingGroupDeleting {
 			// Deleting ServingGroup will be recreated after the deletion is complete, so there is no need to scale the roles
@@ -882,7 +882,7 @@ func (c *ModelServingController) scaleDownRoles(ctx context.Context, ms *workloa
 		return
 	}
 
-	partition, _, partitionErr := c.getPartition(&targetRole.RollingUpdateConfiguration, roleReplicas(targetRole))
+	partition, _, partitionErr := c.getPartition(rolePartition(ms, targetRole), roleReplicas(targetRole))
 	if partitionErr != nil {
 		klog.Errorf("scaleDownRoles: failed to parse partition for role %s: %v", targetRole.Name, partitionErr)
 		partition = 0
@@ -968,7 +968,7 @@ func (c *ModelServingController) scaleDownRoles(ctx context.Context, ms *workloa
 // scaleUpRoles fills missing Role ordinals in [0, expectedCount).
 // Missing ordinals below partition use CurrentRevision; the rest use newRevision.
 func (c *ModelServingController) scaleUpRoles(ctx context.Context, ms *workloadv1alpha1.ModelServing, groupName string, targetRole workloadv1alpha1.Role, roleList []datastore.Role, expectedCount int, servingGroupOrdinal int, newRevision string) {
-	partition, partitionConfigured, partitionErr := c.getPartition(&targetRole.RollingUpdateConfiguration, roleReplicas(targetRole))
+	partition, partitionConfigured, partitionErr := c.getPartition(rolePartition(ms, targetRole), roleReplicas(targetRole))
 	if partitionErr != nil {
 		klog.Errorf("scaleUpRoles: failed to parse partition for role %s: %v", targetRole.Name, partitionErr)
 	}
@@ -1087,7 +1087,7 @@ func (c *ModelServingController) manageRoleReplicasPerGroup(ctx context.Context,
 
 	expectedCount := int(*targetRole.Replicas)
 	expectedPods := 1 + int(targetRole.WorkerReplicas)
-	partition, partitionConfigured, partitionErr := c.getPartition(&targetRole.RollingUpdateConfiguration, roleReplicas(targetRole))
+	partition, partitionConfigured, partitionErr := c.getPartition(rolePartition(ms, targetRole), roleReplicas(targetRole))
 	if partitionErr != nil {
 		klog.Errorf("manageRoleReplicasPerGroup: failed to parse partition for role %s: %v", targetRole.Name, partitionErr)
 	}
@@ -1287,9 +1287,10 @@ func (c *ModelServingController) DeleteRole(ctx context.Context, ms *workloadv1a
 	}
 }
 
-// manageRollingUpdate resolves the lifecycle aspect of an update, checking outdated sets,
-// enforcing strict Unavailable quota constraints, and actively evicting ServingGroups
-// or respective Role workloads falling outside the current partition to enforce the rollback/rollforward.
+// manageRollingUpdate updates outdated resources at the granularity selected by
+// rolloutStrategy.type. ServingGroupRollingUpdate uses only the ModelServing-level
+// maxUnavailable and partition. RoleRollingUpdate uses only each Role's
+// maxUnavailable, partition and ServingGroup's partition.
 //
 // Main processing steps:
 //  1. Identify the boundary for the currently active rollout partition.
@@ -1302,7 +1303,7 @@ func (c *ModelServingController) manageRollingUpdate(ctx context.Context, ms *wo
 		return fmt.Errorf("cannot get ServingGroupList from store, err:%v", err)
 	}
 
-	partition, _, _ := c.getPartition(modelServingRolloutConfig(ms), modelServingReplicas(ms))
+	partition, _, _ := c.getPartition(modelServingPartition(ms), modelServingReplicas(ms))
 	// Separate outdated groups into two categories: not-running and running
 	// We prioritize updating not-running outdated groups first
 	var notRunningOutdatedGroups []datastore.ServingGroup
@@ -1358,13 +1359,18 @@ func (c *ModelServingController) manageRollingUpdate(ctx context.Context, ms *wo
 	}
 
 	if updateCount > 0 {
-		klog.V(4).Infof("Deleted %d outdated ServingGroups for ModelServing %s (partition=%d)", updateCount, ms.Name, partition)
+		strategy := workloadv1alpha1.ServingGroupRollingUpdate
+		if ms.Spec.RolloutStrategy != nil {
+			strategy = ms.Spec.RolloutStrategy.Type
+		}
+		klog.V(4).Infof("Started updates in %d ServingGroups for ModelServing %s (strategy=%s)", updateCount, ms.Name, strategy)
 	}
 	return nil
 }
 
-// deleteOutdatedResourcesForRollingUpdate deletes outdated resources during rolling update
-// respecting maxScaleDown constraints.
+// deleteOutdatedResourcesForRollingUpdate dispatches to exactly one rollout
+// granularity. maxScaleDown is a ServingGroup-level budget and is used only by
+// ServingGroupRollingUpdate; RoleRollingUpdate computes per-Role budgets.
 func (c *ModelServingController) deleteOutdatedResourcesForRollingUpdate(
 	ctx context.Context,
 	ms *workloadv1alpha1.ModelServing,
@@ -1474,7 +1480,7 @@ func (c *ModelServingController) rolesToDeleteForRoleRollingUpdate(ms *workloadv
 		}
 
 		outdatedRoles, newUnavailable := c.outdatedRoles(ms, sg, roleSpec, roleList)
-		partition, partitionConfigured, partitionErr := c.getPartition(&roleSpec.RollingUpdateConfiguration, roleReplicas(roleSpec))
+		partition, partitionConfigured, partitionErr := c.getPartition(rolePartition(ms, roleSpec), roleReplicas(roleSpec))
 		if partitionErr != nil {
 			return nil, false, fmt.Errorf("failed to parse partition for role %s: %v", roleSpec.Name, partitionErr)
 		}
@@ -2260,26 +2266,34 @@ func (c *ModelServingController) UpdateModelServingStatus(ms *workloadv1alpha1.M
 	})
 }
 
-// getPartition returns the partition value from RollingUpdateConfiguration.
+// getPartition resolves an absolute partition from the configuration selected
+// for the active rollout granularity.
 // Returns (0, false, nil) when partition is not configured.
 // If partition is a percentage, it is calculated from replicas (rounded up).
-func (c *ModelServingController) getPartition(config *workloadv1alpha1.RollingUpdateConfiguration, replicas int) (int, bool, error) {
-	if config == nil || config.Partition == nil {
+func (c *ModelServingController) getPartition(partitionConfig *intstr.IntOrString, replicas int) (int, bool, error) {
+	if partitionConfig == nil {
 		return 0, false, nil
 	}
 	// Percentage partition requires replicas to compute the absolute value.
-	partition, err := intstr.GetScaledValueFromIntOrPercent(config.Partition, replicas, true)
+	partition, err := intstr.GetScaledValueFromIntOrPercent(partitionConfig, replicas, true)
 	if err != nil {
 		return 0, true, err
 	}
 	return partition, true, nil
 }
 
-func modelServingRolloutConfig(ms *workloadv1alpha1.ModelServing) *workloadv1alpha1.RollingUpdateConfiguration {
-	if ms.Spec.RolloutStrategy == nil {
+func modelServingPartition(ms *workloadv1alpha1.ModelServing) *intstr.IntOrString {
+	if ms.Spec.RolloutStrategy == nil || ms.Spec.RolloutStrategy.RollingUpdateConfiguration == nil {
 		return nil
 	}
-	return ms.Spec.RolloutStrategy.RollingUpdateConfiguration
+	return ms.Spec.RolloutStrategy.RollingUpdateConfiguration.Partition
+}
+
+func rolePartition(ms *workloadv1alpha1.ModelServing, role workloadv1alpha1.Role) *intstr.IntOrString {
+	if ms.Spec.RolloutStrategy == nil || ms.Spec.RolloutStrategy.Type != workloadv1alpha1.RoleRollingUpdate {
+		return nil
+	}
+	return role.Partition
 }
 
 func modelServingReplicas(ms *workloadv1alpha1.ModelServing) int {
@@ -2330,7 +2344,7 @@ func forEachMissingOrdinal(expectedCount int, existingOrdinals []int, limit int,
 // When partition is set, the first N replicas (where N = partition) are protected.
 // Non-protected replicas (after the first N) are deleted first, then protected replicas if needed.
 func (c *ModelServingController) scaleDownServingGroups(ctx context.Context, ms *workloadv1alpha1.ModelServing, servingGroupList []datastore.ServingGroup, expectedCount int) error {
-	partition, _, _ := c.getPartition(modelServingRolloutConfig(ms), modelServingReplicas(ms))
+	partition, _, _ := c.getPartition(modelServingPartition(ms), modelServingReplicas(ms))
 
 	// Calculate scores for all servingGroups first
 	allScores := make([]ServingGroupWithScore, 0, len(servingGroupList))
@@ -2847,6 +2861,8 @@ func (c *ModelServingController) RegisterModelServingDebugEndpoints(mux *http.Se
 }
 
 func calMaxScaleDown(role workloadv1alpha1.Role, outdatedRoles []datastore.Role, allReplicas, newUnavailable int) (int, error) {
+	// RoleRollingUpdate has an independent budget for each Role. The
+	// ModelServing-level maxUnavailable is intentionally not consulted here.
 	maxUnavailable, configured, err := utils.GetMaxUnavailableForRole(role)
 	if err != nil {
 		return 0, fmt.Errorf("failed to calculate maxUnavailable for role %s: %v", role.Name, err)

--- a/pkg/model-serving-controller/controller/model_serving_controller_test.go
+++ b/pkg/model-serving-controller/controller/model_serving_controller_test.go
@@ -7472,7 +7472,8 @@ func TestRolesToDeleteForRoleRollingUpdate(t *testing.T) {
 			ms := &workloadv1alpha1.ModelServing{
 				ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: msName},
 				Spec: workloadv1alpha1.ModelServingSpec{
-					Template: workloadv1alpha1.ServingGroup{Roles: tt.roles},
+					RolloutStrategy: &workloadv1alpha1.RolloutStrategy{Type: workloadv1alpha1.RoleRollingUpdate},
+					Template:        workloadv1alpha1.ServingGroup{Roles: tt.roles},
 				},
 			}
 			store := datastore.New()

--- a/pkg/model-serving-controller/controller/model_serving_controller_test.go
+++ b/pkg/model-serving-controller/controller/model_serving_controller_test.go
@@ -468,14 +468,7 @@ func TestGetPartition(t *testing.T) {
 			controller, err := NewModelServingController(kubeClient, kthenaClient, volcanoClient, apiextfake.NewSimpleClientset())
 			assert.NoError(t, err)
 
-			var config *workloadv1alpha1.RollingUpdateConfiguration
-			if tt.partition != nil {
-				config = &workloadv1alpha1.RollingUpdateConfiguration{
-					Partition: tt.partition,
-				}
-			}
-
-			got, _, err := controller.getPartition(config, int(tt.replicas))
+			got, _, err := controller.getPartition(tt.partition, int(tt.replicas))
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expected, got)
 		})

--- a/pkg/model-serving-controller/webhook/validator.go
+++ b/pkg/model-serving-controller/webhook/validator.go
@@ -146,7 +146,8 @@ func validateRoleNames(ms *workloadv1alpha1.ModelServing) field.ErrorList {
 	return allErrs
 }
 
-// validateRollingUpdateConfiguration is validates maxUnavailable and maxSurge in rollingUpdateConfiguration.
+// validateRollingUpdateConfiguration validates the ServingGroup-level rolling
+// update configuration and rejects it for RoleRollingUpdate.
 func validateRollingUpdateConfiguration(ms *workloadv1alpha1.ModelServing) field.ErrorList {
 	var allErrs field.ErrorList
 	if ms.Spec.RolloutStrategy == nil || ms.Spec.RolloutStrategy.RollingUpdateConfiguration == nil {


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:

enforce mutually exclusive rolling update configurations.
The “Partition” and “maxUnavailable” of `Role` do not take effect during servingGroup RollingUpdate.
The "maxUnavailable" of servingGroup do not take effect during role RollingUpdate.

**Which issue(s) this PR fixes**:
Fixes #

**Bug evidence (required for bug-related PRs)**:
<!--
For a bug-related PR, provide evidence from the production path:
- Include the relevant workload configuration and logs or events.
- For a panic, include the complete panic trace.
- Describe the user action or cluster event that triggers the problem and how the
  change fixes it.
- Use source permalinks that point to the exact commit when citing code.

AI-generated analysis, a static scan, or a unit test that only calls an internal
function does not prove a bug on its own. If the reported bug relies solely on AI
analysis without reproduction instructions or production-path evidence, maintainers
may close the issue and the related PR.

Write "N/A" for PRs that are not bug-related.
-->

**Special notes for your reviewer**:

This portion of the PR code was generated by AI.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
