### PR TITLE
fix(router): preserve rate limiter state during reconciliation

### DIFF
--- a/pkg/kthena-router/filters/ratelimit/ratelimit.go
+++ b/pkg/kthena-router/filters/ratelimit/ratelimit.go
@@ -179,13 +179,10 @@ func (r *TokenRateLimiter) AddOrUpdateLimiter(model string, ratelimit *networkin
 	}
 
 	oldConfig := r.limiterConfigs[model]
-	if !configChanged(oldConfig, newConfig) {
+	if oldConfig != nil && *oldConfig == *newConfig {
 		// Preserve existing limiter state if config is unchanged
 		return nil
 	}
-
-	// Save new config
-	r.limiterConfigs[model] = newConfig
 
 	if useGlobal {
 		// Initialize Redis client if not already done
@@ -243,6 +240,7 @@ func (r *TokenRateLimiter) AddOrUpdateLimiter(model string, ratelimit *networkin
 		}
 	}
 
+	r.limiterConfigs[model] = newConfig
 	return nil
 }
 
@@ -254,16 +252,6 @@ func (r *TokenRateLimiter) DeleteLimiter(model string) {
 	delete(r.inputLimiter, model)
 	delete(r.outputLimiter, model)
 	delete(r.limiterConfigs, model)
-}
-
-func configChanged(oldConfig, newConfig *LimiterConfig) bool {
-	if oldConfig == nil {
-		return true
-	}
-	return oldConfig.InputTokensPerUnit != newConfig.InputTokensPerUnit ||
-		oldConfig.OutputTokensPerUnit != newConfig.OutputTokensPerUnit ||
-		oldConfig.Unit != newConfig.Unit ||
-		oldConfig.RedisAddress != newConfig.RedisAddress
 }
 
 func getTimeUnitDuration(unit networkingv1alpha1.RateLimitUnit) time.Duration {

--- a/pkg/kthena-router/filters/ratelimit/ratelimit.go
+++ b/pkg/kthena-router/filters/ratelimit/ratelimit.go
@@ -57,6 +57,15 @@ type Limiter interface {
 	Tokens() float64
 }
 
+// LimiterConfig stores the configuration used to create a rate limiter,
+// so that we can avoid recreating limiters if the configuration hasn't changed.
+type LimiterConfig struct {
+	InputTokensPerUnit  int64
+	OutputTokensPerUnit int64
+	Unit                networkingv1alpha1.RateLimitUnit
+	RedisAddress        string
+}
+
 // TokenRateLimiter provides rate limiting functionality for both input and output tokens
 type TokenRateLimiter struct {
 	mutex sync.RWMutex
@@ -64,6 +73,9 @@ type TokenRateLimiter struct {
 	// Unified rate limiters using Limiter interface
 	inputLimiter  map[string]Limiter
 	outputLimiter map[string]Limiter
+
+	// Configs to avoid recreating unchanged limiters
+	limiterConfigs map[string]*LimiterConfig
 
 	// Redis client for global rate limiting
 	redisClient *redis.Client
@@ -91,9 +103,10 @@ func (l *LocalLimiter) Tokens() float64 {
 // NewTokenRateLimiter creates a new TokenRateLimiter instance
 func NewTokenRateLimiter() *TokenRateLimiter {
 	return &TokenRateLimiter{
-		inputLimiter:  make(map[string]Limiter),
-		outputLimiter: make(map[string]Limiter),
-		tokenizer:     tokenizer.NewSimpleEstimateTokenizer(),
+		inputLimiter:   make(map[string]Limiter),
+		outputLimiter:  make(map[string]Limiter),
+		limiterConfigs: make(map[string]*LimiterConfig),
+		tokenizer:      tokenizer.NewSimpleEstimateTokenizer(),
 	}
 }
 
@@ -141,8 +154,38 @@ func (r *TokenRateLimiter) AddOrUpdateLimiter(model string, ratelimit *networkin
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
 
-	// Determine if we should use global or local rate limiting
+	// Extract incoming config
+	var input int64 = -1
+	if ratelimit.InputTokensPerUnit != nil {
+		input = int64(*ratelimit.InputTokensPerUnit)
+	}
+
+	var output int64 = -1
+	if ratelimit.OutputTokensPerUnit != nil {
+		output = int64(*ratelimit.OutputTokensPerUnit)
+	}
+
+	var redisAddr string
 	useGlobal := ratelimit.Global != nil && ratelimit.Global.Redis != nil
+	if useGlobal {
+		redisAddr = ratelimit.Global.Redis.Address
+	}
+
+	newConfig := &LimiterConfig{
+		InputTokensPerUnit:  input,
+		OutputTokensPerUnit: output,
+		Unit:                ratelimit.Unit,
+		RedisAddress:        redisAddr,
+	}
+
+	oldConfig := r.limiterConfigs[model]
+	if !configChanged(oldConfig, newConfig) {
+		// Preserve existing limiter state if config is unchanged
+		return nil
+	}
+
+	// Save new config
+	r.limiterConfigs[model] = newConfig
 
 	if useGlobal {
 		// Initialize Redis client if not already done
@@ -210,6 +253,17 @@ func (r *TokenRateLimiter) DeleteLimiter(model string) {
 
 	delete(r.inputLimiter, model)
 	delete(r.outputLimiter, model)
+	delete(r.limiterConfigs, model)
+}
+
+func configChanged(oldConfig, newConfig *LimiterConfig) bool {
+	if oldConfig == nil {
+		return true
+	}
+	return oldConfig.InputTokensPerUnit != newConfig.InputTokensPerUnit ||
+		oldConfig.OutputTokensPerUnit != newConfig.OutputTokensPerUnit ||
+		oldConfig.Unit != newConfig.Unit ||
+		oldConfig.RedisAddress != newConfig.RedisAddress
 }
 
 func getTimeUnitDuration(unit networkingv1alpha1.RateLimitUnit) time.Duration {

--- a/pkg/kthena-router/filters/ratelimit/ratelimit_test.go
+++ b/pkg/kthena-router/filters/ratelimit/ratelimit_test.go
@@ -276,3 +276,52 @@ func TestTokenRateLimiter_InputAndOutputErrors(t *testing.T) {
 		t.Fatalf("expected OutputRateLimitExceededError, got %T: %v", err, err)
 	}
 }
+
+func TestTokenRateLimiter_PreserveStateOnReconciliation(t *testing.T) {
+	rl := NewTokenRateLimiter()
+	model := "test-model-reconciliation"
+	prompt := "hello world" // 3 tokens
+	tokens := uint32(5)
+	unit := networkingv1alpha1.Hour // Use Hour so it doesn't refill during the test
+
+	rl.AddOrUpdateLimiter(model, &networkingv1alpha1.RateLimit{
+		InputTokensPerUnit: &tokens,
+		Unit:               unit,
+	})
+
+	// 1. Consume all tokens
+	err := rl.RateLimit(model, prompt) // consumes ~3 tokens
+	if err != nil {
+		t.Fatalf("first request should be allowed: %v", err)
+	}
+
+	err = rl.RateLimit(model, prompt) // tries to consume ~3 more tokens, but only ~2 left -> should block
+	if err == nil {
+		t.Fatalf("second request should be blocked due to rate limit")
+	}
+
+	// 2. Simulate reconciliation with the EXACT SAME config
+	rl.AddOrUpdateLimiter(model, &networkingv1alpha1.RateLimit{
+		InputTokensPerUnit: &tokens,
+		Unit:               unit,
+	})
+
+	// 3. Request should STILL be blocked because state was preserved!
+	err = rl.RateLimit(model, prompt)
+	if err == nil {
+		t.Fatalf("BUG REPRODUCED: request was allowed after reconciliation despite quota being exhausted!")
+	}
+
+	// 4. Simulate reconciliation with a CHANGED config
+	newTokens := uint32(100)
+	rl.AddOrUpdateLimiter(model, &networkingv1alpha1.RateLimit{
+		InputTokensPerUnit: &newTokens,
+		Unit:               unit,
+	})
+
+	// 5. Request should now be allowed because the config changed and limiter was recreated
+	err = rl.RateLimit(model, prompt)
+	if err != nil {
+		t.Fatalf("request should be allowed after config changed, got: %v", err)
+	}
+}

--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -143,6 +143,7 @@ func NewRouter(store datastore.Store, routerConfigPath string) *Router {
 		switch data.EventType {
 		case datastore.EventAdd, datastore.EventUpdate:
 			if data.ModelRoute == nil || data.ModelRoute.Spec.RateLimit == nil {
+				loadRateLimiter.DeleteLimiter(data.ModelName)
 				return
 			}
 			klog.Infof("add or update rate limit for model %s", data.ModelName)


### PR DESCRIPTION
Problem
This PR addresses the issue where rate limiter state (consumed tokens) is silently lost on every controller reconciliation event. Because Kubernetes triggers reconciliation for many non-spec reasons (like label updates or periodic informer resyncs), the AddOrUpdateLimiter() function was unconditionally recreating token buckets. This inadvertently allowed users to bypass quota exhaustion, and led to severe flakiness in the TestModelRouteWithRateLimit/VerifyRateLimitResetMechanism E2E suite.


Solution
Introduced configuration-aware reconciliation logic to make AddOrUpdateLimiter() idempotent:

Created a LimiterConfig struct to represent the rate-limiting configuration (input/output tokens, time unit, and redis settings).
Added a limiterConfigs cache inside TokenRateLimiter to track the active configuration for each model.
Updated AddOrUpdateLimiter() to compare the incoming configuration against the cached configuration. The rate limiter instances are now only recreated if the actual configuration parameters have changed. Otherwise, the existing token bucket state is safely preserved.
Testing Done
Added a new unit test TestTokenRateLimiter_PreserveStateOnReconciliation which explicitly verifies that identical config updates preserve an exhausted token bucket state without resetting it to full capacity.
go test ./pkg/kthena-router/filters/ratelimit/... - Pass

Fixes: #1013