### PR TITLE
router: respecting HTTPRoute listener

### DIFF
--- a/cmd/kthena-router/app/router.go
+++ b/cmd/kthena-router/app/router.go
@@ -257,6 +257,7 @@ func startListener(ctx context.Context, cfg listenerConfig) *http.Server {
 
 			c.Set(router.GatewayKey, matched.GatewayKey)
 			c.Set(router.GatewayListenerNameKey, matched.ListenerName)
+			c.Set(router.GatewayListenerPortKey, int(matched.Port))
 			c.Next()
 		})
 		engine.Use(AccessLogMiddleware(lm.router))

--- a/cmd/kthena-router/app/router.go
+++ b/cmd/kthena-router/app/router.go
@@ -256,6 +256,7 @@ func startListener(ctx context.Context, cfg listenerConfig) *http.Server {
 			}
 
 			c.Set(router.GatewayKey, matched.GatewayKey)
+			c.Set(router.GatewayListenerNameKey, matched.ListenerName)
 			c.Next()
 		})
 		engine.Use(AccessLogMiddleware(lm.router))

--- a/pkg/kthena-router/controller/httproute_controller.go
+++ b/pkg/kthena-router/controller/httproute_controller.go
@@ -187,8 +187,9 @@ func (c *HTTPRouteController) syncHandler(key string) error {
 	}
 
 	// Only process HTTPRoutes that reference kthena-router GatewayClass
-	// Check all parentRefs - process immediately if any matches, retry only if no match and a Gateway is pending
+	// Check all parentRefs and keep the listeners that accept the route
 	var gatewayPending bool
+	var acceptedParentRefs []gatewayv1.ParentReference
 	for _, parentRef := range httpRoute.Spec.ParentRefs {
 		if !isGatewayParentRef(parentRef) {
 			continue
@@ -208,14 +209,17 @@ func (c *HTTPRouteController) syncHandler(key string) error {
 			gw = informerGateway
 		}
 		if string(gw.Spec.GatewayClassName) == DefaultGatewayClassName {
-			allowed, err := c.gatewayAllowsHTTPRoute(gw, httpRoute, parentRef)
+			parentRefs, err := c.acceptedGatewayParentRefs(gw, httpRoute, parentRef)
 			if err != nil {
 				return err
 			}
-			if allowed {
-				return c.store.AddOrUpdateHTTPRoute(httpRoute)
-			}
+			acceptedParentRefs = append(acceptedParentRefs, parentRefs...)
 		}
+	}
+	if len(acceptedParentRefs) > 0 {
+		storedRoute := httpRoute.DeepCopy()
+		storedRoute.Spec.ParentRefs = acceptedParentRefs
+		return c.store.AddOrUpdateHTTPRoute(storedRoute)
 	}
 	if gatewayPending {
 		return fmt.Errorf("gateway not synced yet")
@@ -268,7 +272,8 @@ func isGatewayParentRef(parentRef gatewayv1.ParentReference) bool {
 	return parentRef.Kind == nil || *parentRef.Kind == "Gateway"
 }
 
-func (c *HTTPRouteController) gatewayAllowsHTTPRoute(gw *gatewayv1.Gateway, httpRoute *gatewayv1.HTTPRoute, parentRef gatewayv1.ParentReference) (bool, error) {
+func (c *HTTPRouteController) acceptedGatewayParentRefs(gw *gatewayv1.Gateway, httpRoute *gatewayv1.HTTPRoute, parentRef gatewayv1.ParentReference) ([]gatewayv1.ParentReference, error) {
+	var acceptedParentRefs []gatewayv1.ParentReference
 	for _, listener := range gw.Spec.Listeners {
 		if !parentRefSelectsListener(parentRef, listener) {
 			continue
@@ -278,13 +283,18 @@ func (c *HTTPRouteController) gatewayAllowsHTTPRoute(gw *gatewayv1.Gateway, http
 		}
 		allowed, err := c.listenerAllowsRouteNamespace(listener, gw.Namespace, httpRoute.Namespace)
 		if err != nil {
-			return false, err
+			return nil, err
 		}
 		if allowed {
-			return true, nil
+			acceptedParentRef := parentRef
+			sectionName := listener.Name
+			port := listener.Port
+			acceptedParentRef.SectionName = &sectionName
+			acceptedParentRef.Port = &port
+			acceptedParentRefs = append(acceptedParentRefs, acceptedParentRef)
 		}
 	}
-	return false, nil
+	return acceptedParentRefs, nil
 }
 
 func parentRefSelectsListener(parentRef gatewayv1.ParentReference, listener gatewayv1.Listener) bool {

--- a/pkg/kthena-router/controller/httproute_controller_test.go
+++ b/pkg/kthena-router/controller/httproute_controller_test.go
@@ -196,8 +196,10 @@ func TestHTTPRouteController_AllowedRoutesNamespaces(t *testing.T) {
 		routeNS       string
 		routeLabels   map[string]string
 		allowedRoutes *gatewayv1.AllowedRoutes
+		listeners     []gatewayv1.Listener
 		defaultParent bool
 		wantStored    bool
+		wantListener  gatewayv1.SectionName
 	}{
 		{
 			name:          "default same namespace allows same namespace",
@@ -250,6 +252,30 @@ func TestHTTPRouteController_AllowedRoutesNamespaces(t *testing.T) {
 			},
 			wantStored: false,
 		},
+		{
+			name:    "unscoped parent stores only accepting listener",
+			routeNS: "default",
+			listeners: []gatewayv1.Listener{
+				{
+					Name:     gatewayv1.SectionName("public"),
+					Port:     gatewayv1.PortNumber(8080),
+					Protocol: gatewayv1.HTTPProtocolType,
+				},
+				{
+					Name:     gatewayv1.SectionName("private"),
+					Port:     gatewayv1.PortNumber(8081),
+					Protocol: gatewayv1.HTTPProtocolType,
+					AllowedRoutes: &gatewayv1.AllowedRoutes{
+						Namespaces: &gatewayv1.RouteNamespaces{
+							From:     &nsFromSelector,
+							Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"access": "private"}},
+						},
+					},
+				},
+			},
+			wantStored:   true,
+			wantListener: gatewayv1.SectionName("public"),
+		},
 	}
 
 	for _, tt := range tests {
@@ -266,18 +292,22 @@ func TestHTTPRouteController_AllowedRoutesNamespaces(t *testing.T) {
 			gatewayInformerFactory := gatewayinformers.NewSharedInformerFactory(gatewayClient, 0)
 			store := datastore.New()
 
+			listeners := tt.listeners
+			if len(listeners) == 0 {
+				listeners = []gatewayv1.Listener{
+					{
+						Name:          gatewayv1.SectionName("http"),
+						Port:          gatewayv1.PortNumber(80),
+						Protocol:      gatewayv1.HTTPProtocolType,
+						AllowedRoutes: tt.allowedRoutes,
+					},
+				}
+			}
 			gw := &gatewayv1.Gateway{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "gateway"},
 				Spec: gatewayv1.GatewaySpec{
 					GatewayClassName: gatewayv1.ObjectName(DefaultGatewayClassName),
-					Listeners: []gatewayv1.Listener{
-						{
-							Name:          gatewayv1.SectionName("http"),
-							Port:          gatewayv1.PortNumber(80),
-							Protocol:      gatewayv1.HTTPProtocolType,
-							AllowedRoutes: tt.allowedRoutes,
-						},
-					},
+					Listeners:        listeners,
 				},
 			}
 			assert.NoError(t, store.AddOrUpdateGateway(gw))
@@ -318,6 +348,14 @@ func TestHTTPRouteController_AllowedRoutesNamespaces(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, tt.wantStored, store.GetHTTPRoute(tt.routeNS+"/route") != nil)
 			assert.Equal(t, tt.wantStored, len(store.GetHTTPRoutesByGateway("default/gateway")) > 0)
+			if tt.wantListener != "" {
+				storedRoute := store.GetHTTPRoute(tt.routeNS + "/route")
+				require.Len(t, storedRoute.Spec.ParentRefs, 1)
+				require.NotNil(t, storedRoute.Spec.ParentRefs[0].SectionName)
+				require.NotNil(t, storedRoute.Spec.ParentRefs[0].Port)
+				assert.Equal(t, tt.wantListener, *storedRoute.Spec.ParentRefs[0].SectionName)
+				assert.Equal(t, gatewayv1.PortNumber(8080), *storedRoute.Spec.ParentRefs[0].Port)
+			}
 		})
 	}
 }

--- a/pkg/kthena-router/router/httproute_match.go
+++ b/pkg/kthena-router/router/httproute_match.go
@@ -75,9 +75,13 @@ func (r *Router) findHTTPRouteMatch(c *gin.Context, gatewayKey string) (httpRout
 	if len(httpRoutes) == 0 {
 		return httpRouteMatchResult{}, false
 	}
+	listenerName := c.GetString(GatewayListenerNameKey)
 
 	for _, route := range httpRoutes {
 		if route == nil {
+			continue
+		}
+		if !httpRouteMatchesGatewayListenerName(route, gatewayKey, listenerName) {
 			continue
 		}
 		if !matchHTTPRouteHostnames(route.Spec.Hostnames, c.Request.Host) {
@@ -89,6 +93,28 @@ func (r *Router) findHTTPRouteMatch(c *gin.Context, gatewayKey string) (httpRout
 		}
 	}
 	return httpRouteMatchResult{}, false
+}
+
+func httpRouteMatchesGatewayListenerName(route *gatewayv1.HTTPRoute, gatewayKey, listenerName string) bool {
+	for _, parentRef := range route.Spec.ParentRefs {
+		if parentRef.Group != nil && string(*parentRef.Group) != gatewayv1.GroupName {
+			continue
+		}
+		if parentRef.Kind != nil && *parentRef.Kind != "Gateway" {
+			continue
+		}
+		gatewayNamespace := route.Namespace
+		if parentRef.Namespace != nil {
+			gatewayNamespace = string(*parentRef.Namespace)
+		}
+		if gatewayNamespace+"/"+string(parentRef.Name) != gatewayKey {
+			continue
+		}
+		if parentRef.SectionName == nil || string(*parentRef.SectionName) == listenerName {
+			return true
+		}
+	}
+	return false
 }
 
 func findBestHTTPRouteRuleMatch(route *gatewayv1.HTTPRoute, requestPath string) (httpRouteMatchResult, bool) {

--- a/pkg/kthena-router/router/httproute_match.go
+++ b/pkg/kthena-router/router/httproute_match.go
@@ -76,12 +76,13 @@ func (r *Router) findHTTPRouteMatch(c *gin.Context, gatewayKey string) (httpRout
 		return httpRouteMatchResult{}, false
 	}
 	listenerName := c.GetString(GatewayListenerNameKey)
+	listenerPort := c.GetInt(GatewayListenerPortKey)
 
 	for _, route := range httpRoutes {
 		if route == nil {
 			continue
 		}
-		if !httpRouteMatchesGatewayListenerName(route, gatewayKey, listenerName) {
+		if !httpRouteMatchesGatewayListener(route, gatewayKey, listenerName, listenerPort) {
 			continue
 		}
 		if !matchHTTPRouteHostnames(route.Spec.Hostnames, c.Request.Host) {
@@ -95,12 +96,9 @@ func (r *Router) findHTTPRouteMatch(c *gin.Context, gatewayKey string) (httpRout
 	return httpRouteMatchResult{}, false
 }
 
-func httpRouteMatchesGatewayListenerName(route *gatewayv1.HTTPRoute, gatewayKey, listenerName string) bool {
+func httpRouteMatchesGatewayListener(route *gatewayv1.HTTPRoute, gatewayKey, listenerName string, listenerPort int) bool {
 	for _, parentRef := range route.Spec.ParentRefs {
-		if parentRef.Group != nil && string(*parentRef.Group) != gatewayv1.GroupName {
-			continue
-		}
-		if parentRef.Kind != nil && *parentRef.Kind != "Gateway" {
+		if !isGatewayParentRef(parentRef) {
 			continue
 		}
 		gatewayNamespace := route.Namespace
@@ -110,11 +108,22 @@ func httpRouteMatchesGatewayListenerName(route *gatewayv1.HTTPRoute, gatewayKey,
 		if gatewayNamespace+"/"+string(parentRef.Name) != gatewayKey {
 			continue
 		}
-		if parentRef.SectionName == nil || string(*parentRef.SectionName) == listenerName {
+		if listenerName == "" && listenerPort == 0 {
+			return parentRef.SectionName == nil && parentRef.Port == nil
+		}
+		if parentRef.SectionName != nil && string(*parentRef.SectionName) == listenerName &&
+			parentRef.Port != nil && int(*parentRef.Port) == listenerPort {
 			return true
 		}
 	}
 	return false
+}
+
+func isGatewayParentRef(parentRef gatewayv1.ParentReference) bool {
+	if parentRef.Group != nil && string(*parentRef.Group) != gatewayv1.GroupName {
+		return false
+	}
+	return parentRef.Kind == nil || *parentRef.Kind == "Gateway"
 }
 
 func findBestHTTPRouteRuleMatch(route *gatewayv1.HTTPRoute, requestPath string) (httpRouteMatchResult, bool) {

--- a/pkg/kthena-router/router/httproute_match_test.go
+++ b/pkg/kthena-router/router/httproute_match_test.go
@@ -83,16 +83,72 @@ func TestRouter_FindHTTPRouteMatch(t *testing.T) {
 		}
 	}
 	method := gatewayv1.HTTPMethodGet
+	routeForListener := func(name, listenerName string, rules []gatewayv1.HTTPRouteRule) *gatewayv1.HTTPRoute {
+		httpRoute := route(name, nil, rules)
+		sectionName := gatewayv1.SectionName(listenerName)
+		httpRoute.Spec.ParentRefs[0].SectionName = &sectionName
+		return httpRoute
+	}
 
 	tests := []struct {
 		name           string
 		routes         []*gatewayv1.HTTPRoute
 		host           string
 		path           string
+		listenerName   string
 		expectedRoute  string
 		expectedPool   string
 		expectedPrefix string
 	}{
+		{
+			name: "matches route without section name",
+			routes: []*gatewayv1.HTTPRoute{
+				route("route", nil, []gatewayv1.HTTPRouteRule{
+					pathRule("/chat", "pool"),
+				}),
+			},
+			host:           "api.example.com",
+			path:           "/chat",
+			listenerName:   "public",
+			expectedRoute:  "route",
+			expectedPool:   "pool",
+			expectedPrefix: "/chat",
+		},
+		{
+			name: "matches route attached to selected listener",
+			routes: []*gatewayv1.HTTPRoute{
+				routeForListener("route", "private", []gatewayv1.HTTPRouteRule{
+					pathRule("/chat", "pool"),
+				}),
+			},
+			host:           "api.example.com",
+			path:           "/chat",
+			listenerName:   "private",
+			expectedRoute:  "route",
+			expectedPool:   "pool",
+			expectedPrefix: "/chat",
+		},
+		{
+			name: "skips route attached to another listener",
+			routes: []*gatewayv1.HTTPRoute{
+				routeForListener("route", "private", []gatewayv1.HTTPRouteRule{
+					pathRule("/chat", "pool"),
+				}),
+			},
+			host:         "api.example.com",
+			path:         "/chat",
+			listenerName: "public",
+		},
+		{
+			name: "skips listener-scoped route without listener context",
+			routes: []*gatewayv1.HTTPRoute{
+				routeForListener("route", "private", []gatewayv1.HTTPRouteRule{
+					pathRule("/chat", "pool"),
+				}),
+			},
+			host: "api.example.com",
+			path: "/chat",
+		},
 		{
 			name: "prefers longest prefix in a single route",
 			routes: []*gatewayv1.HTTPRoute{
@@ -199,6 +255,9 @@ func TestRouter_FindHTTPRouteMatch(t *testing.T) {
 			c, _ := gin.CreateTestContext(w)
 			c.Request, _ = http.NewRequest(http.MethodPost, tt.path, nil)
 			c.Request.Host = tt.host
+			if tt.listenerName != "" {
+				c.Set(GatewayListenerNameKey, tt.listenerName)
+			}
 
 			result, matched := router.findHTTPRouteMatch(c, "default/gw")
 			if tt.expectedRoute == "" {

--- a/pkg/kthena-router/router/httproute_match_test.go
+++ b/pkg/kthena-router/router/httproute_match_test.go
@@ -83,10 +83,11 @@ func TestRouter_FindHTTPRouteMatch(t *testing.T) {
 		}
 	}
 	method := gatewayv1.HTTPMethodGet
-	routeForListener := func(name, listenerName string, rules []gatewayv1.HTTPRouteRule) *gatewayv1.HTTPRoute {
+	routeForListener := func(name, listenerName string, listenerPort gatewayv1.PortNumber, rules []gatewayv1.HTTPRouteRule) *gatewayv1.HTTPRoute {
 		httpRoute := route(name, nil, rules)
 		sectionName := gatewayv1.SectionName(listenerName)
 		httpRoute.Spec.ParentRefs[0].SectionName = &sectionName
+		httpRoute.Spec.ParentRefs[0].Port = &listenerPort
 		return httpRoute
 	}
 
@@ -96,20 +97,22 @@ func TestRouter_FindHTTPRouteMatch(t *testing.T) {
 		host           string
 		path           string
 		listenerName   string
+		listenerPort   int
 		expectedRoute  string
 		expectedPool   string
 		expectedPrefix string
 	}{
 		{
-			name: "matches route without section name",
+			name: "matches route accepted by selected listener",
 			routes: []*gatewayv1.HTTPRoute{
-				route("route", nil, []gatewayv1.HTTPRouteRule{
+				routeForListener("route", "public", 8080, []gatewayv1.HTTPRouteRule{
 					pathRule("/chat", "pool"),
 				}),
 			},
 			host:           "api.example.com",
 			path:           "/chat",
 			listenerName:   "public",
+			listenerPort:   8080,
 			expectedRoute:  "route",
 			expectedPool:   "pool",
 			expectedPrefix: "/chat",
@@ -117,13 +120,14 @@ func TestRouter_FindHTTPRouteMatch(t *testing.T) {
 		{
 			name: "matches route attached to selected listener",
 			routes: []*gatewayv1.HTTPRoute{
-				routeForListener("route", "private", []gatewayv1.HTTPRouteRule{
+				routeForListener("route", "private", 8081, []gatewayv1.HTTPRouteRule{
 					pathRule("/chat", "pool"),
 				}),
 			},
 			host:           "api.example.com",
 			path:           "/chat",
 			listenerName:   "private",
+			listenerPort:   8081,
 			expectedRoute:  "route",
 			expectedPool:   "pool",
 			expectedPrefix: "/chat",
@@ -131,18 +135,43 @@ func TestRouter_FindHTTPRouteMatch(t *testing.T) {
 		{
 			name: "skips route attached to another listener",
 			routes: []*gatewayv1.HTTPRoute{
-				routeForListener("route", "private", []gatewayv1.HTTPRouteRule{
+				routeForListener("route", "private", 8081, []gatewayv1.HTTPRouteRule{
 					pathRule("/chat", "pool"),
 				}),
 			},
 			host:         "api.example.com",
 			path:         "/chat",
 			listenerName: "public",
+			listenerPort: 8080,
+		},
+		{
+			name: "skips route attached to another port",
+			routes: []*gatewayv1.HTTPRoute{
+				routeForListener("route", "http", 8081, []gatewayv1.HTTPRouteRule{
+					pathRule("/chat", "pool"),
+				}),
+			},
+			host:         "api.example.com",
+			path:         "/chat",
+			listenerName: "http",
+			listenerPort: 8080,
+		},
+		{
+			name: "skips unprocessed route with listener context",
+			routes: []*gatewayv1.HTTPRoute{
+				route("route", nil, []gatewayv1.HTTPRouteRule{
+					pathRule("/chat", "pool"),
+				}),
+			},
+			host:         "api.example.com",
+			path:         "/chat",
+			listenerName: "public",
+			listenerPort: 8080,
 		},
 		{
 			name: "skips listener-scoped route without listener context",
 			routes: []*gatewayv1.HTTPRoute{
-				routeForListener("route", "private", []gatewayv1.HTTPRouteRule{
+				routeForListener("route", "private", 8081, []gatewayv1.HTTPRouteRule{
 					pathRule("/chat", "pool"),
 				}),
 			},
@@ -257,6 +286,7 @@ func TestRouter_FindHTTPRouteMatch(t *testing.T) {
 			c.Request.Host = tt.host
 			if tt.listenerName != "" {
 				c.Set(GatewayListenerNameKey, tt.listenerName)
+				c.Set(GatewayListenerPortKey, tt.listenerPort)
 			}
 
 			result, matched := router.findHTTPRouteMatch(c, "default/gw")

--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -58,6 +58,7 @@ const (
 	// Context keys for gin context
 	GatewayKey             = "gatewayKey"
 	GatewayListenerNameKey = "gatewayListenerName"
+	GatewayListenerPortKey = "gatewayListenerPort"
 	PromptKey              = "promptKey" // store parsed ChatMessage, which will be reused
 
 	successfulRequestFinishReason = "successful_request"

--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -56,8 +56,9 @@ import (
 
 const (
 	// Context keys for gin context
-	GatewayKey = "gatewayKey"
-	PromptKey  = "promptKey" // store parsed ChatMessage, which will be reused
+	GatewayKey             = "gatewayKey"
+	GatewayListenerNameKey = "gatewayListenerName"
+	PromptKey              = "promptKey" // store parsed ChatMessage, which will be reused
 
 	successfulRequestFinishReason = "successful_request"
 	failedRequestFinishReason     = "request_failed"


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

HTTPRoute matching was scoped to the Gateway, not the listener handling the request. This allowed a route with parentRefs[].sectionName to match requests received by another listener on the same Gateway.

This change passes the selected listener name through the request context and filters HTTPRoutes before hostname and path matching. Listener-scoped routes also fail closed when listener context is missing.

**Which issue(s) this PR fixes**:

Fixes #1476

**Bug evidence (required for bug-related PRs)**:

Reproduction steps and the affected Gateway/HTTPRoute configuration are documented in #1476.

Before this change, listener selection stored only the Gateway key:
https://github.com/volcano-sh/kthena/blob/5d19b80c4027c93fc02c3f7a6acd9baece2ecd91/cmd/kthena-router/app/router.go#L258

Request matching then loaded every HTTPRoute indexed under that Gateway:
https://github.com/volcano-sh/kthena/blob/5d19b80c4027c93fc02c3f7a6acd9baece2ecd91/pkg/kthena-router/router/httproute_match.go#L73-L74

For a Gateway with `public` and `private` listeners, a route attached with `sectionName: private` could therefore participate in matching on `public` when its hostname and path matched.

The selected listener is now added to the request context:
https://github.com/volcano-sh/kthena/blob/c3da1904336efedf4bd91f4a5adece5605500a48/cmd/kthena-router/app/router.go#L258-L259

Routes are filtered against the matching Gateway parentRef and `sectionName` before normal request matching:
https://github.com/volcano-sh/kthena/blob/c3da1904336efedf4bd91f4a5adece5605500a48/pkg/kthena-router/router/httproute_match.go#L84-L118

This was identified by tracing the production request path. It has not been reproduced in a cluster.

**Special notes for your reviewer**:

Tests run:

- go test -p 1 -count=1 ./pkg/kthena-router/router -run TestRouter_FindHTTPRouteMatch`
- go test -p 1 ./pkg/kthena-router/...
- go test -p 1 ./cmd/kthena-router/app

**Does this PR introduce a user-facing change?**:

```release-note
Kthena router now respects HTTPRoute parentRefs sectionName during request matching
```