### PR TITLE
build: support repo paths containing spaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -213,9 +213,9 @@ docker-buildx: ## Build and push docker image for cross-platform support
 ##@ Dependencies
 
 ## Location to install dependencies to
-LOCALBIN ?= $(shell pwd)/bin
+LOCALBIN ?= bin
 $(LOCALBIN):
-	mkdir -p $(LOCALBIN)
+	mkdir -p "$(LOCALBIN)"
 
 ## Tool Binaries
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
@@ -286,9 +286,9 @@ define go-install-tool
 set -e; \
 package=$(2)@$(3) ;\
 echo "Downloading $${package}" ;\
-rm -f $(1) || true ;\
-GOBIN=$(LOCALBIN) go install $${package} ;\
-mv $(1) $(1)-$(3) ;\
+rm -f "$(1)" || true ;\
+GOBIN="$(abspath $(LOCALBIN))" go install $${package} ;\
+mv "$(1)" "$(1)-$(3)" ;\
 } ;\
-ln -sf $(1)-$(3) $(1)
+ln -sf "$(notdir $(1)-$(3))" "$(1)"
 endef


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`LOCALBIN` was an absolute path from `pwd` and was used as a make target, and make splits target lists on whitespace. So on a checkout under a directory with a space in the name it became two targets and everything going through `generate` or the tool binaries died with `Circular ... dependency dropped`. That is `make build`, `test`, `gen-check`, `lint` and all the `docker-build-*` targets.

`LOCALBIN` is now relative so the target names carry no space, and the recipe uses are quoted. The symlink needed `$(notdir ...)` as well, since it was relying on `LOCALBIN` being absolute and would otherwise point at `bin/bin/<tool>`. `GOBIN` keeps an absolute path via `$(abspath ...)` because `go install` requires one.

**Which issue(s) this PR fixes**:
Fixes #1519

**Bug evidence (required for bug-related PRs)**:

Before, on a path with a space:

```
make: Circular /work/my <- /work/my dependency dropped.
rm: cannot remove '/work/my': Is a directory
bash: line 1: projects/kthena/bin: Is a directory
make: *** [Makefile:252: /work/my] Error 126
```

`/work/my` and `projects/kthena/bin` are the two halves of the checkout path.

The code is here, `LOCALBIN` absolute and used as a target on the next line:

https://github.com/volcano-sh/kthena/blob/4eb3d79c87ecdaf2db60c63dad7f1adb344c1f71/Makefile#L216-L218

and the tool targets take it as a prerequisite:

https://github.com/volcano-sh/kthena/blob/4eb3d79c87ecdaf2db60c63dad7f1adb344c1f71/Makefile#L234-L253

Checked in golang:1.26-bookworm with make 4.3, copying the same tree to two paths in one container. Before the change `/work/plain/kthena` runs `make gen-crd` fine and `/work/my projects/kthena` fails as above. After it, both exit 0 and resolve the symlink correctly:

```
path='/work/my projects/kthena'  make gen-crd exit=0  symlink=controller-gen-v0.17.2
path='/work/plain/kthena'        make gen-crd exit=0  symlink=controller-gen-v0.17.2
```

**Special notes for your reviewer**:

`bin` is already gitignored so the relative path lands in the same place as before.

Not adding a test, there is no harness for the Makefile in this repo and I did not want to invent one for a six line change. Happy to if you would rather.

One thing I left out: on Windows `go-install-tool` also assumes the built binary has no extension, so the `mv`/`ln` pair misses the `.exe` that `go install` produces. Separate problem, not touched here.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```