### PR TITLE
docs: fix default block size in kvcache-aware design doc

### DIFF
--- a/docs/proposal/kvcache-aware-plugin-design.md
+++ b/docs/proposal/kvcache-aware-plugin-design.md
@@ -42,7 +42,7 @@ The plugin addresses the challenge of efficiently routing inference requests to 
 
 **Token Block Matching**
 - Tokenizes input prompts using model-specific tokenizers
-- Divides token sequences into fixed-size blocks (default: 128 tokens)
+- Divides token sequences into fixed-size blocks (default: 16 tokens)
 - Generates standardized SHA-256 hashes for each token block
 - Queries Redis to find pods with cached token blocks
 
@@ -66,7 +66,7 @@ Input Prompt → Tokenization → Block Division → Hash Generation → Redis Q
 ```
 
 1. **Tokenization**: Convert input text/messages to token sequences using model-specific tokenizers
-2. **Block Division**: Split tokens into fixed-size blocks (configurable, default 128)
+2. **Block Division**: Split tokens into fixed-size blocks (configurable, default 16)
 3. **Hash Generation**: Generate SHA-256 hashes for each token block
 4. **Redis Query**: Batch query Redis for pods that have cached each block
 5. **Pod Scoring**: Calculate scores based on consecutive block matches
@@ -138,7 +138,7 @@ Uses the existing Redis infrastructure:
 **Block Size Tuning**
 - Larger blocks: Fewer Redis queries, less granular matching
 - Smaller blocks: More Redis queries, more granular matching
-- Default 128 tokens balances performance and accuracy
+- The default block size is 16 tokens
 
 **Maximum Block Limits**
 - Prevents excessive processing for very long prompts


### PR DESCRIPTION
/kind documentation

**What this PR does / why we need it**:

The KVCacheAware design doc (`docs/proposal/kvcache-aware-plugin-design.md`)
states in prose that the default token block size is 128 (three places), but
the actual default is 16 — `defaultBlockSizeToHash = 16` in
`pkg/kthena-router/scheduler/plugins/kvcache_aware.go`. The configuration
example in the same document already shows the correct value
(`blockSizeToHash: 16`). The `128` appears to be a mix-up with
`maxBlocksToMatch`, whose default is 128.

This corrects the three prose lines. On the "Block Size Tuning" line I also
dropped the unsupported claim that 16 "balances performance and accuracy" and
left only the verifiable fact. Docs-only; no behavior change.

**Which issue(s) this PR fixes**:
N/A

**Bug evidence (required for bug-related PRs)**:
N/A (documentation-only change)

**Special notes for your reviewer**:
This PR was written in part with the assistance of generative AI; the wording
and review are my own. The change is a one-to-one correction against the source
default in kvcache_aware.go.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
