### PR TITLE
Ordinal

### DIFF
--- a/charts/kthena/charts/workload/crds/workload.serving.volcano.sh_modelservings.yaml
+++ b/charts/kthena/charts/workload/crds/workload.serving.volcano.sh_modelservings.yaml
@@ -143,9 +143,9 @@ spec:
                         - type: integer
                         - type: string
                         description: |-
-                          Partition indicates the ordinal at which the ModelServing should be partitioned
-                          for updates. During a rolling update, all ServingGroups from ordinal Replicas-1 to
-                          Partition are updated. All ServingGroups from ordinal Partition-1 to 0 remain untouched.
+                          Partition protects the first N existing replicas in ascending ordinal order
+                          from updates. The remaining replicas are eligible for rolling update.
+                          For a contiguous ordinal set, this is equivalent to protecting [0, Partition).
                           Value can be an absolute number (ex: 5) or a percentage of total replicas (ex: 10%).
                           Absolute number is calculated from percentage by rounding up.
                           The default value is 0.
@@ -8917,9 +8917,9 @@ spec:
                           - type: integer
                           - type: string
                           description: |-
-                            Partition indicates the ordinal at which the ModelServing should be partitioned
-                            for updates. During a rolling update, all ServingGroups from ordinal Replicas-1 to
-                            Partition are updated. All ServingGroups from ordinal Partition-1 to 0 remain untouched.
+                            Partition protects the first N existing replicas in ascending ordinal order
+                            from updates. The remaining replicas are eligible for rolling update.
+                            For a contiguous ordinal set, this is equivalent to protecting [0, Partition).
                             Value can be an absolute number (ex: 5) or a percentage of total replicas (ex: 10%).
                             Absolute number is calculated from percentage by rounding up.
                             The default value is 0.
@@ -17658,8 +17658,8 @@ spec:
                 type: integer
               currentRevision:
                 description: |-
-                  CurrentRevision, if not empty, indicates the ControllerRevision version used to generate
-                  ServingGroups in the sequence [0,currentReplicas).
+                  CurrentRevision, if not empty, indicates the ControllerRevision version preserved by
+                  ServingGroups that have not been updated.
                 type: string
               labelSelector:
                 description: LabelSelector is a label query over pods that should
@@ -17678,8 +17678,8 @@ spec:
                 type: integer
               updateRevision:
                 description: |-
-                  UpdateRevision, if not empty, indicates the ControllerRevision version used to generate
-                  ServingGroups in the sequence [replicas-updatedReplicas,replicas).
+                  UpdateRevision, if not empty, indicates the ControllerRevision version targeted by
+                  the current ModelServing spec.
                 type: string
               updatedReplicas:
                 description: UpdatedReplicas track the number of ServingGroup that

--- a/docs/kthena/docs/developer-guide/model-serving-rolling-update.md
+++ b/docs/kthena/docs/developer-guide/model-serving-rolling-update.md
@@ -4,7 +4,9 @@ Rolling updates represent a critical operational strategy for online services ai
 
 Currently, `ModelServing` supports rolling upgrades at the `ServingGroup` level, enabling users to configure `Partitions` to control the rolling process.
 
-- Partition: Indicates the ordinal at which the `ModelServing` should be partitioned for updates. During a rolling update, replicas with an ordinal greater than or equal to `Partition` will be updated. Replicas with an ordinal less than `Partition` will not be updated.
+- Partition: Protects the first N existing replicas in the datastore's ascending ordinal order. The remaining replicas are eligible for rolling update. With the normal contiguous ordinal set, this is equivalent to protecting ordinals in `[0, partition)`. Defining protection by list position also gives deterministic behavior for legacy or temporarily non-contiguous sets.
+
+When a protected replica is missing and must be recreated, the ordinal itself selects the template: a missing ordinal below `partition` uses `CurrentRevision` and its historical template, while other missing ordinals use `UpdateRevision` and the current template. Before creating a `ServingGroup` that references a new revision, the controller must successfully persist its `ControllerRevision`; otherwise reconciliation stops and retries without creating a partial `ServingGroup`.
 
 Here's a ModelServing configured with rollout strategy:
 
@@ -22,13 +24,13 @@ In the following we'll show how rolling update processes for a `ModelServing` wi
 - ❎ Replica hasn't been updated
 - ⏳ Replica is in rolling update
 
-|        | R-0 | R-1 | R-2 | R-3 | Note                                                                          |
-|--------|-----|-----|-----|-----|-------------------------------------------------------------------------------|
-| Stage1 | ✅   | ✅   | ✅   | ✅   | Before rolling update                                                         |
-| Stage2 | ❎   | ❎   | ❎   | ⏳   | Rolling update started, The replica with the highest ordinal (R-3) is updated |
-| Stage3 | ❎   | ❎   | ⏳   | ✅   | R-3 is updated. The next replica (R-2) is now being updated                   |
-| Stage4 | ❎   | ⏳   | ✅   | ✅   | R-2 is updated. The next replica (R-1) is now being updated                   |
-| Stage5 | ⏳   | ✅   | ✅   | ✅   | R-1 is updated. The last replica (R-0) is now being updated                   |
-| Stage6 | ✅   | ✅   | ✅   | ✅   | Update completed. All replicas are on the new version                         |
+| | R-0 | R-1 | R-2 | R-3 | Note |
+| --- | --- | --- | --- | --- | --- |
+| Stage1 | ✅ | ✅ | ✅ | ✅ | Before rolling update |
+| Stage2 | ❎ | ❎ | ❎ | ⏳ | Rolling update started; R-3 is selected first in this example |
+| Stage3 | ❎ | ❎ | ⏳ | ✅ | R-3 is updated. The next replica (R-2) is now being updated |
+| Stage4 | ❎ | ⏳ | ✅ | ✅ | R-2 is updated. The next replica (R-1) is now being updated |
+| Stage5 | ⏳ | ✅ | ✅ | ✅ | R-1 is updated. The last replica (R-0) is now being updated |
+| Stage6 | ✅ | ✅ | ✅ | ✅ | Update completed. All replicas are on the new version |
 
-During a rolling upgrade, the controller deletes and rebuilds the replica with the highest sequence number among the replicas need to be updated. The next replica will not be updated until the new replica is running normally.
+During a rolling upgrade, the controller selects an eligible outdated replica while respecting partition and availability constraints, then deletes and rebuilds it. Unhealthy outdated replicas are prioritized; ordinal order is used within the applicable candidate ordering. The controller does not proceed beyond the availability budget until replacement capacity is ready.

--- a/docs/kthena/docs/developer-guide/model-serving-scaling.md
+++ b/docs/kthena/docs/developer-guide/model-serving-scaling.md
@@ -12,7 +12,11 @@ When scaling is triggered, the status of the entire `ServingGroup` is set to `Cr
 
 After the `replicas` of `ServingGroups` meets expectations. Then update the status of the ServingGroup based on the status of all the pods in the ServingGroup.
 
-Because `ServingGroups` are ordered in modelServing similar to statefulSet. Therefore, the expansion and contraction of the `ServingGroup level` are processed from the last ServingGroup. For example, when `replicas` increase from 2 to 4, first create `G-2`, then create `G-3`. When `replicas` reduces from 4 to 2, `G-3` is deleted first, followed by `G-2`.
+`ServingGroups` use deterministic ordinal-based identities similar to StatefulSet Pods. When scaling up, the controller creates only missing ordinals in `[0, replicas)`, in ascending order. For example, scaling from the contiguous set `G-0`, `G-1` to four replicas creates `G-2` and `G-3`. If the existing set is `G-0`, `G-2`, and `G-3`, scaling to four replicas recreates `G-1` instead of appending `G-4`.
+
+A `ServingGroup` that is being deleted continues to reserve its ordinal in the controller datastore until all of its resources are gone. This prevents a replacement with the same deterministic name from being created too early. After deletion is observed and the datastore entry is removed, a later reconciliation can reuse that ordinal. Existing out-of-range ordinals from an older controller version are not proactively renumbered; the invariant applies to newly created `ServingGroups`.
+
+Scale-down selection continues to consider readiness and deletion cost, with the ordinal used as a tie-breaker. It therefore does not always remove the highest ordinal first.
 
 ### ServingGroup Scaling Process
 
@@ -25,19 +29,19 @@ In the following we'll show how scaling processes for a `ServingGroup` with four
 
 **Scaling up:**
 
-|        | G-0 | G-1 | G-2 | G-3 | Note                                                                          |
-|--------|-----|-----|-----|-----|-------------------------------------------------------------------------------|
-| Stage1 | ✅  | ✅   | ✅   | | Before Scaling up |
-| Stage2 | ✅  | ✅   | ✅   | ⏳   | Scaling up started, The replica with the highest ordinal (G-3) is creating |
-| Stage3 | ✅   | ✅   | ✅   | ✅   | After Scaling update |
+| | G-0 | G-1 | G-2 | G-3 | Note |
+| --- | --- | --- | --- | --- | --- |
+| Stage1 | ✅ | ✅ | ✅ | | Before scaling up |
+| Stage2 | ✅ | ✅ | ✅ | ⏳ | Scaling up started; the missing ordinal G-3 is being created |
+| Stage3 | ✅ | ✅ | ✅ | ✅ | After scaling up |
 
 **Scaling Down:**
 
-|        | G-0 | G-1 | G-2 | G-3 | Note                                                                          |
-|--------|-----|-----|-----|-----|-------------------------------------------------------------------------------|
-| Stage1 | ✅   | ✅   | ✅   | ✅   | Before Scaling update |
-| Stage2 | ✅   | ✅   | ✅   | ⏳   | Scaling down started, The replica with the highest ordinal (G-3) is deleting |
-| Stage3 | ✅   | ✅   | ✅   | | After Scaling down |
+| | G-0 | G-1 | G-2 | G-3 | Note |
+| --- | --- | --- | --- | --- | --- |
+| Stage1 | ✅ | ✅ | ✅ | ✅ | Before scaling down |
+| Stage2 | ✅ | ✅ | ✅ | ⏳ | Scaling down started; G-3 is selected for deletion in this example |
+| Stage3 | ✅ | ✅ | ✅ | | After scaling down |
 
 ## Role Scaling
 
@@ -53,17 +57,17 @@ When scaling is triggered, the status of the entire `ServingGroup` is set to sca
 
 After the replicas of pods meets expectations. Then update the status of the ServingGroup based on the status of all the pods in the `ServingGroup`.
 
-And because the pods in the role are carrying sequential and labeled. All scaling is processed from the last pod.
+Role instances also use deterministic ordinals. Within each `ServingGroup`, scale-up fills missing Role ordinals in `[0, role.replicas)` instead of appending after the maximum ordinal. A deleting Role reserves its ordinal until its Pods and Services are fully deleted, after which the ordinal can be reused. Scale-down uses readiness and deletion cost before the ordinal tie-breaker.
 
 ## Role Scaling Process
 
 Symbol meaning identical to [ServingGroup Scaling Process](#servinggroup-scaling-process)
 
-|        | G-0 | G-1 | G-2 | G-3 | Note                                                                          |
-|--------|-----|-----|-----|-----|-------------------------------------------------------------------------------|
-| Stage1 | ✅   | ✅   | ✅   | ✅   | Before scaling up/down                                                         |
-| Stage2 | ❎   | ❎   | ❎   | ⏳   | Scaling up/down started, The replica with the highest ordinal (G-3) is start. Creating/Deleting roles in the (G-3) |
-| Stage3 | ❎   | ❎   | ⏳   | ✅   | G-3 is scaled. The roles in next replica (G-2) is now scaling                    |
-| Stage4 | ❎   | ⏳   | ✅   | ✅   | G-2 is scaled. The roles in next replica (G-1) is now scaling                   |
-| Stage5 | ⏳   | ✅   | ✅   | ✅   | G-1 is scaled. The roles in last replica (G-0) is now scaling                   |
-| Stage6 | ✅   | ✅   | ✅   | ✅   | Scale completed.                         |
+| | G-0 | G-1 | G-2 | G-3 | Note |
+| --- | --- | --- | --- | --- | --- |
+| Stage1 | ✅ | ✅ | ✅ | ✅ | Before scaling up/down |
+| Stage2 | ⏳ | ❎ | ❎ | ❎ | Scaling has started for one ServingGroup |
+| Stage3 | ✅ | ⏳ | ❎ | ❎ | The next ServingGroup is scaling |
+| Stage4 | ✅ | ✅ | ⏳ | ❎ | Role replicas in the next ServingGroup are scaling |
+| Stage5 | ✅ | ✅ | ✅ | ⏳ | Role replicas in the final ServingGroup are scaling |
+| Stage6 | ✅ | ✅ | ✅ | ✅ | Scale completed |

--- a/docs/kthena/docs/reference/crd/workload.serving.volcano.sh.md
+++ b/docs/kthena/docs/reference/crd/workload.serving.volcano.sh.md
@@ -577,8 +577,8 @@ _Appears in:_
 | `currentReplicas` _integer_ | CurrentReplicas is the number of ServingGroup created by the ModelServing controller from the ModelServing version |  |  |
 | `updatedReplicas` _integer_ | UpdatedReplicas track the number of ServingGroup that have been updated (ready or not). |  |  |
 | `availableReplicas` _integer_ | AvailableReplicas track the number of ServingGroup that are in ready state (updated or not). |  |  |
-| `currentRevision` _string_ | CurrentRevision, if not empty, indicates the ControllerRevision version used to generate<br />ServingGroups in the sequence [0,currentReplicas). |  |  |
-| `updateRevision` _string_ | UpdateRevision, if not empty, indicates the ControllerRevision version used to generate<br />ServingGroups in the sequence [replicas-updatedReplicas,replicas). |  |  |
+| `currentRevision` _string_ | CurrentRevision, if not empty, indicates the ControllerRevision version preserved by<br />ServingGroups that have not been updated. |  |  |
+| `updateRevision` _string_ | UpdateRevision, if not empty, indicates the ControllerRevision version targeted by<br />the current ModelServing spec. |  |  |
 | `labelSelector` _string_ | LabelSelector is a label query over pods that should match the replica count. |  |  |
 
 
@@ -865,7 +865,7 @@ _Appears in:_
 | `workerReplicas` _integer_ | WorkerReplicas defines the number for the worker pod of a role.<br />Required: Need to set the number of worker-pod replicas. |  |  |
 | `workerTemplate` _[PodTemplateSpec](#podtemplatespec)_ | WorkerTemplate defines the template for the worker pod of a role. |  |  |
 | `maxUnavailable` _[IntOrString](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#intorstring-intstr-util)_ | The maximum number of replicas that can be unavailable during the update.<br />Value can be an absolute number (ex: 5) or a percentage of total replicas at the start of update (ex: 10%).<br />Absolute number is calculated from percentage by rounding down.<br />This can not be 0.<br />By default, a fixed value of 1 is used. | 1 | XIntOrString: \{\} <br /> |
-| `partition` _[IntOrString](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#intorstring-intstr-util)_ | Partition indicates the ordinal at which the ModelServing should be partitioned<br />for updates. During a rolling update, all ServingGroups from ordinal Replicas-1 to<br />Partition are updated. All ServingGroups from ordinal Partition-1 to 0 remain untouched.<br />Value can be an absolute number (ex: 5) or a percentage of total replicas (ex: 10%).<br />Absolute number is calculated from percentage by rounding up.<br />The default value is 0. |  | XIntOrString: \{\} <br /> |
+| `partition` _[IntOrString](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#intorstring-intstr-util)_ | Partition protects the first N existing replicas in ascending ordinal order<br />from updates. The remaining replicas are eligible for rolling update.<br />For a contiguous ordinal set, this is equivalent to protecting [0, Partition).<br />Value can be an absolute number (ex: 5) or a percentage of total replicas (ex: 10%).<br />Absolute number is calculated from percentage by rounding up.<br />The default value is 0. |  | XIntOrString: \{\} <br /> |
 
 
 #### RoleRatioConstraint
@@ -939,7 +939,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `maxUnavailable` _[IntOrString](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#intorstring-intstr-util)_ | The maximum number of replicas that can be unavailable during the update.<br />Value can be an absolute number (ex: 5) or a percentage of total replicas at the start of update (ex: 10%).<br />Absolute number is calculated from percentage by rounding down.<br />This can not be 0.<br />By default, a fixed value of 1 is used. | 1 | XIntOrString: \{\} <br /> |
-| `partition` _[IntOrString](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#intorstring-intstr-util)_ | Partition indicates the ordinal at which the ModelServing should be partitioned<br />for updates. During a rolling update, all ServingGroups from ordinal Replicas-1 to<br />Partition are updated. All ServingGroups from ordinal Partition-1 to 0 remain untouched.<br />Value can be an absolute number (ex: 5) or a percentage of total replicas (ex: 10%).<br />Absolute number is calculated from percentage by rounding up.<br />The default value is 0. |  | XIntOrString: \{\} <br /> |
+| `partition` _[IntOrString](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#intorstring-intstr-util)_ | Partition protects the first N existing replicas in ascending ordinal order<br />from updates. The remaining replicas are eligible for rolling update.<br />For a contiguous ordinal set, this is equivalent to protecting [0, Partition).<br />Value can be an absolute number (ex: 5) or a percentage of total replicas (ex: 10%).<br />Absolute number is calculated from percentage by rounding up.<br />The default value is 0. |  | XIntOrString: \{\} <br /> |
 
 
 #### RolloutStrategy

--- a/docs/kthena/docs/user-guide/multi-node-inference.md
+++ b/docs/kthena/docs/user-guide/multi-node-inference.md
@@ -351,7 +351,7 @@ You can adjust both levels simultaneously. For instance, you can increase the nu
 
 Currently, `ModelServing` supports rolling upgrades at the `ServingGroup` level, enabling users to configure `Partitions` to control the rolling process.
 
-- Partition: Indicates the ordinal at which the `ModelServing` should be partitioned for updates. During a rolling update, replicas with an ordinal greater than or equal to `Partition` will be updated. Replicas with an ordinal less than `Partition` will not be updated.
+- Partition: Protects the first N existing `ServingGroups` in ascending ordinal order. The remaining `ServingGroups` are eligible for update. For the normal contiguous set, this is equivalent to protecting ordinals in `[0, partition)`.
   
 ### ServingGroup Rolling Update
 
@@ -378,7 +378,7 @@ llama-multinode-1-405b-0-0        vllm/vllm-openai:v0.10.1
 llama-multinode-1-405b-0-1        vllm/vllm-openai:v0.10.1                 
 ```
 
-From the pod runtime, we can see that only group 1 has been updated because we set `rolloutStrategy.partition = 1`.
+From the pod runtime, we can see that only group 1 has been updated because `rolloutStrategy.partition = 1` protects the first existing group, group 0. If the existing ordinal set is temporarily non-contiguous, protection still applies to the first existing group in ordinal order rather than to an ordinal threshold.
 
 ## Gang Scheduling and Network Topology
 

--- a/docs/proposal/modelserving-partition-revision-control.md
+++ b/docs/proposal/modelserving-partition-revision-control.md
@@ -28,12 +28,14 @@ documentation such as release notes or a development roadmap.
 A good summary is probably at least a paragraph in length.
 -->
 
-This proposal introduces partition-aware revision control for `ModelServing` scaling and rolling update operations. When a `partition` is configured in the rollout strategy, the system will intelligently fill missing ordinals within the partition range during scale-up operations and respect partition boundaries during rolling updates. This ensures that partition-protected replicas maintain their current revision while allowing controlled updates to replicas outside the partition range.
+This proposal introduces partition-aware revision control for `ModelServing` scaling and rolling update operations. Scale-up fills missing ordinals in `[0, replicas)` rather than appending after the maximum ordinal. During rolling updates, `partition` protects the first N existing replicas in ascending ordinal order. This ensures that protected replicas retain their current revision while allowing controlled updates to the remaining replicas.
 
 Key improvements:
-- **Scale-up with partition**: When partition is set, missing ordinals in `[0, partition)` are filled using `CurrentRevision` instead of always creating new replicas at the end.
-- **Rolling update with partition**: When partition is set, only replicas with `ordinal >= partition` are updated, protecting lower-ordinal replicas from updates.
-- **Revision management**: Proper creation of `ControllerRevision` and status updates (`UpdateRevision`) when scaling up with new revisions.
+
+- **Bounded ordinal allocation**: Newly created `ServingGroups` and Roles fill missing ordinals in `[0, replicas)`.
+- **Scale-up with partition**: A missing ordinal below `partition` is recreated using `CurrentRevision`; other missing ordinals use the new revision.
+- **Rolling update with partition**: The first N existing replicas in ascending ordinal order are protected, and the remaining replicas are eligible for update.
+- **Revision management**: A new `ControllerRevision` must be persisted before any `ServingGroup` is created with that revision.
 
 ### Motivation
 
@@ -44,9 +46,9 @@ this proposal.  Describe why the change is important and the benefits to users.
 
 In production environments, users often need to maintain a subset of replicas at a stable version while gradually rolling out updates to other replicas. The current implementation has limitations:
 
-1. **Scale-up gap issue**: When scaling up with partition set, if some replicas in `[0, partition)` are missing (e.g., due to deletion or failure), the system would create new replicas at the end (maxOrdinal + 1) instead of filling the gaps, breaking the partition semantics.
+1. **Scale-up gap issue**: Creating replicas at `maxOrdinal + 1` can leave gaps and create ordinals outside `[0, replicas)`, breaking deterministic recovery and partition semantics.
 
-2. **Rolling update boundary**: The rolling update logic needs to respect partition boundaries to ensure that replicas below the partition threshold are not updated.
+2. **Rolling update boundary**: The rolling update logic needs to protect the first N existing replicas even when a legacy or transient ordinal set is non-contiguous.
 
 3. **Revision tracking**: When scaling up with new revisions, proper `ControllerRevision` creation and status updates are needed to track the update state correctly.
 
@@ -57,10 +59,11 @@ List the specific goals of the proposal. What is it trying to achieve? How will 
 know that this has succeeded?
 -->
 
-- Support partition-aware scale-up that fills missing ordinals in `[0, partition)` using `CurrentRevision`.
-- Ensure rolling updates respect partition boundaries by only updating replicas with `ordinal >= partition`.
-- Properly create `ControllerRevision` and update `status.UpdateRevision` when scaling up with new revisions.
-- Maintain backward compatibility: when partition is not set, fall back to existing behavior.
+- Fill missing ServingGroup and Role ordinals in `[0, replicas)` during scale-up.
+- Recreate missing ordinals below `partition` using `CurrentRevision` and its historical template.
+- Ensure rolling updates protect the first N existing replicas in ascending ordinal order.
+- Persist `ControllerRevision` before creating resources that reference a new revision.
+- Keep deleting datastore records reserved until deletion is fully observed, then allow their ordinals to be reused.
 
 #### Non-Goals
 
@@ -69,7 +72,7 @@ What is out of scope for this proposal? Listing non-goals helps to focus discuss
 and make progress.
 -->
 
-- This proposal does not change the partition semantics itself, only how scaling and rolling updates interact with partitions.
+- This proposal does not proactively renumber legacy resources whose ordinals are already outside the desired range.
 
 ### Proposal
 
@@ -93,8 +96,9 @@ bogged down.
 
 ##### Story 1: Scale-up with Partition Gap Filling
 
-A user has a `ModelServing` with `partition=3` and `replicas=5`. Initially, replicas R-0, R-1, R-2 exist. After R-1 is deleted (e.g., due to node failure), the user scales up to `replicas=5`. With this proposal, the system will:
-1. Detect that R-1 is missing in `[0, 3)`
+A user has a `ModelServing` with `partition=3` and `replicas=5`. Initially, replicas R-0, R-1, R-2 exist. After deletion of R-1 and all of its resources is observed, the user scales up to `replicas=5`. With this proposal, the system will:
+
+1. Detect that R-1 is missing in `[0, 5)`
 2. Recreate R-1 using `CurrentRevision` (not the new revision)
 3. Then create R-3 and R-4 using the new revision
 
@@ -103,8 +107,9 @@ This ensures partition semantics are maintained: R-0, R-1, R-2 remain on the old
 ##### Story 2: Rolling Update with Partition Protection
 
 A user has a `ModelServing` with `partition=2` and 5 replicas (R-0 to R-4). When a rolling update is triggered:
-- R-0 and R-1 (ordinal < partition) are protected and remain on `CurrentRevision`
-- R-2, R-3, R-4 (ordinal >= partition) are updated to the new revision
+
+- R-0 and R-1, the first two existing replicas in ordinal order, are protected and remain on `CurrentRevision`
+- R-2, R-3, and R-4 are eligible for update to the new revision
 
 This allows gradual rollout while keeping critical low-ordinal replicas stable.
 
@@ -116,7 +121,6 @@ What are some important details that didn't come across above?
 Go in to as much detail as necessary here.
 This might be a good place to talk about core concepts and how they relate.
 -->
-
 
 #### Risks and Mitigations
 
@@ -145,36 +149,28 @@ In `scaleUpServingGroups`, the logic is enhanced as follows:
 
 1. **Detect partition value**: Read from `ms.Spec.RolloutStrategy.RollingUpdateConfiguration.Partition`.
 
-2. **Fill missing ordinals in partition range**: If `partition > 0`, iterate through `[0, partition)` and create missing `ServingGroups` using `CurrentRevision`:
-   - Use `CurrentRevision` from `ms.Status.CurrentRevision` if available
-   - Retrieve template from `ControllerRevision` if it exists, otherwise use `ms.Spec.Template.Roles`
-   - This ensures partition-protected replicas maintain their revision even when recreated
+2. **Find bounded missing ordinals**: Read all datastore records, including records in `Deleting`, and find the ordinals missing from `[0, expectedCount)` in ascending order. A deleting record continues to reserve its ordinal until all child resources are gone and its datastore entry is removed.
 
-3. **Create new replicas beyond partition**: After filling partition gaps, create additional replicas starting from `maxOrdinal + 1` using the new revision:
-   - Create `ControllerRevision` for the new revision
-   - Update `status.UpdateRevision` to track the new revision being applied
+3. **Select revision and template**: For each missing ordinal:
+    - If `ordinal < partition`, use `CurrentRevision` from `ms.Status.CurrentRevision` when available and retrieve its template from `ControllerRevision`
+    - Otherwise, use the new revision and the current template
+    - This ensures a protected identity maintains its revision when recreated
 
-4. **Fallback behavior**: If `partition` is not set or `partition=0`, use the original logic (create replicas from `maxOrdinal + 1`).
+4. **Persist the new template snapshot**: Before creating the first `ServingGroup` that references the new revision, create its `ControllerRevision`. If this fails, stop reconciliation before creating Pods or datastore state and let the workqueue retry. The snapshot is created lazily because a reconciliation that only restores protected ordinals does not need a new one.
+
+5. **Do not rewrite history during deletion**: Deleting a `ServingGroup` must not create or overwrite a `ControllerRevision` with the current mutable template.
 
 ```go
-if partition > 0 {
-    // Fill missing ordinals in [0, partition) using CurrentRevision
-    for ordinal := 0; ordinal < partition && ordinal < expectedCount; ordinal++ {
-        if !existingOrdinals[ordinal] {
-            revisionToUse := ms.Status.CurrentRevision
-            // Create ServingGroup with CurrentRevision
-            createServingGroup(ordinal, revisionToUse, rolesFromRevision)
-        }
+forEachMissingOrdinal(expectedCount, existingOrdinals, toCreate, func(ordinal int) bool {
+    if ordinal < partition {
+        return createServingGroup(ordinal, currentRevision, rolesFromRevision) == nil
     }
-}
 
-// Create new ServingGroups beyond partition with newRevision
-if toCreate > 0 {
-    createControllerRevision(newRevision)
-    for i := maxOrdinal + 1; i < maxOrdinal + 1 + toCreate; i++ {
-        createServingGroup(i, newRevision, ms.Spec.Template.Roles)
+    if err := ensureControllerRevision(newRevision); err != nil {
+        return false
     }
-}
+    return createServingGroup(ordinal, newRevision, ms.Spec.Template.Roles) == nil
+})
 ```
 
 #### Rolling Update Logic with Partition Support
@@ -184,29 +180,17 @@ In `manageServingGroupRollingUpdate`, the logic is enhanced as follows:
 1. **Detect partition value**: Read from `ms.Spec.RolloutStrategy.RollingUpdateConfiguration.Partition`.
 
 2. **Partition-aware deletion**: If `partition > 0`:
-   - Iterate through `servingGroupList` in reverse order (highest ordinal first)
-   - Skip replicas with `ordinal < partition` (protected)
-   - Delete replicas with `ordinal >= partition` that are outdated
-   - Stop when reaching protected replicas (`ordinal < partition`)
+    - Treat the first `partition` entries in the ordinal-sorted datastore list as protected
+    - Consider outdated replicas after that protected prefix for deletion
+    - Apply readiness and availability budgets before selecting a replica
 
-3. **Fallback behavior**: If `partition` is not set, use the original logic (update from highest ordinal downward).
+3. **Fallback behavior**: If `partition` is not set, no existing replica is protected by partition.
 
 ```go
-if partition > 0 {
-    // Delete ServingGroups with ordinal >= partition
-    for i := len(servingGroupList) - 1; i >= 0; i-- {
-        _, ordinal := getOrdinal(servingGroupList[i].Name)
-        if ordinal < partition {
-            break // Skip partition-protected ServingGroups
-        }
-        if isOutdated(servingGroupList[i], revision) {
-            deleteServingGroup(servingGroupList[i].Name)
-            return
-        }
-    }
-} else {
-    // Original behavior: update from highest ordinal
-    // ...
+protected := servingGroupList[:min(partition, len(servingGroupList))]
+eligible := servingGroupList[len(protected):]
+for _, group := range selectOutdatedWithinBudget(eligible) {
+    deleteServingGroup(group.Name)
 }
 ```
 
@@ -217,33 +201,36 @@ The following example demonstrates how partition gap filling works during scale-
 **Scenario**: `ModelServing` with `partition=3`, `replicas=5`. Initially, R-0, R-1, R-2 exist. R-1 is deleted, then scale-up to `replicas=5` is triggered.
 
 **Before modification (original behavior)**:
+
 - Missing ordinals in `[0, partition)` are not filled
 - New replicas are created at the end (maxOrdinal + 1)
 - Partition semantics are broken
 
-|        | R-0 | R-1 | R-2 | R-3 | R-4 | Note                                                                          |
-|--------|-----|-----|-----|-----|-----|-------------------------------------------------------------------------------|
-| Stage1 | ✅   | ✅   | ✅   | | | Initial state (partition=3) |
-| Stage2 | ✅   | | ✅   | | | R-1 deleted (e.g., node failure) |
-| Stage3 | ✅   | | ✅   | ⏳ | | Scale up to 5 replicas. R-3 created (maxOrdinal + 1) |
-| Stage4 | ✅   | | ✅   | ✅   | ⏳ | R-4 created |
-| Stage5 | ✅   | | ✅   | ✅   | ✅ | Scale-up complete, but R-1 gap remains |
+| | R-0 | R-1 | R-2 | R-3 | R-4 | Note |
+| --- | --- | --- | --- | --- | --- | --- |
+| Stage1 | ✅ | ✅ | ✅ | | | Initial state (partition=3) |
+| Stage2 | ✅ | | ✅ | | | R-1 deleted (e.g., node failure) |
+| Stage3 | ✅ | | ✅ | ⏳ | | Scale up to 5 replicas. R-3 created (maxOrdinal + 1) |
+| Stage4 | ✅ | | ✅ | ✅ | ⏳ | R-4 created |
+| Stage5 | ✅ | | ✅ | ✅ | ✅ | Scale-up complete, but R-1 gap remains |
 
 **After modification (partition-aware)**:
-- Missing ordinals in `[0, partition)` are filled first using `CurrentRevision`
-- Then new replicas are created beyond partition using new revision
+
+- Missing ordinals are selected in ascending order from `[0, replicas)`
+- A selected ordinal below `partition` uses `CurrentRevision`; a selected ordinal at or above `partition` uses the new revision
 - Partition semantics are maintained
 
-|        | R-0 | R-1 | R-2 | R-3 | R-4 | Note                                                                          |
-|--------|-----|-----|-----|-----|-----|-------------------------------------------------------------------------------|
-| Stage1 | ✅   | ✅   | ✅   | | | Initial state (partition=3) |
-| Stage2 | ✅   | | ✅   | | | R-1 deleted (e.g., node failure) |
-| Stage3 | ✅   | ⏳   | ✅   | | | Scale up to 5 replicas. First fill gap: R-1 recreated with CurrentRevision |
-| Stage4 | ✅   | ✅   | ✅   | ⏳ | | After R-1 recreated. Now create R-3 with new revision |
-| Stage5 | ✅   | ✅   | ✅   | ✅   | ⏳ | After R-3 created. Now create R-4 with new revision |
-| Stage6 | ✅   | ✅   | ✅   | ✅   | ✅ | Scale-up complete. R-0, R-1, R-2 on CurrentRevision; R-3, R-4 on new revision |
+| | R-0 | R-1 | R-2 | R-3 | R-4 | Note |
+| --- | --- | --- | --- | --- | --- | --- |
+| Stage1 | ✅ | ✅ | ✅ | | | Initial state (partition=3) |
+| Stage2 | ✅ | | ✅ | | | R-1 deleted (e.g., node failure) |
+| Stage3 | ✅ | ⏳ | ✅ | | | Scale up to 5 replicas. First fill gap: R-1 recreated with CurrentRevision |
+| Stage4 | ✅ | ✅ | ✅ | ⏳ | | After R-1 recreated. Now create R-3 with new revision |
+| Stage5 | ✅ | ✅ | ✅ | ✅ | ⏳ | After R-3 created. Now create R-4 with new revision |
+| Stage6 | ✅ | ✅ | ✅ | ✅ | ✅ | Scale-up complete. R-0, R-1, R-2 on CurrentRevision; R-3, R-4 on new revision |
 
 **Legend**:
+
 - ✅ Replica exists and running
 - ⏳ Replica is being created
 - (empty) Replica does not exist
@@ -263,7 +250,6 @@ challenging to test, should be called out.
 
 -->
 
-
 ### Alternatives
 
 <!--
@@ -271,7 +257,6 @@ What other approaches did you consider, and why did you rule them out? These do
 not need to be as detailed as the proposal, but should include enough
 information to express the idea and why it was not acceptable.
 -->
-
 
 <!--
 Note: This is a simplified version of kubernetes enhancement proposal template.

--- a/docs/proposal/role-rollingupdate.md
+++ b/docs/proposal/role-rollingupdate.md
@@ -50,10 +50,10 @@ know that this has succeeded?
 
 Support for role-based rolling updates:
 
-- Support Partition. Partitioning is still supported at the serving group level. However, even in role-based rolling updates, partition ensures that some servingGroups remain unchanged.
+- Support Partition at both levels. The ModelServing partition protects the first N existing ServingGroups in ordinal order, while each Role's inline partition protects the first N existing Role replicas in ordinal order within a ServingGroup.
 - Support ControllerRevision history for Roles. Maybe servingGroup ControllerRevision is enough.
 - Support MaxUnavailable
-- Perform a rolling update step by step in descending order of Role IDs.
+- Perform a rolling update step by step, prioritizing unavailable outdated Roles and using descending Role ordinal within the same status class.
 
 #### Non-Goals
 

--- a/pkg/apis/workload/v1alpha1/model_serving_types.go
+++ b/pkg/apis/workload/v1alpha1/model_serving_types.go
@@ -171,9 +171,9 @@ type RollingUpdateConfiguration struct {
 	// +kubebuilder:default=1
 	MaxUnavailable *intstr.IntOrString `json:"maxUnavailable,omitempty"`
 
-	// Partition indicates the ordinal at which the ModelServing should be partitioned
-	// for updates. During a rolling update, all ServingGroups from ordinal Replicas-1 to
-	// Partition are updated. All ServingGroups from ordinal Partition-1 to 0 remain untouched.
+	// Partition protects the first N existing replicas in ascending ordinal order
+	// from updates. The remaining replicas are eligible for rolling update.
+	// For a contiguous ordinal set, this is equivalent to protecting [0, Partition).
 	// Value can be an absolute number (ex: 5) or a percentage of total replicas (ex: 10%).
 	// Absolute number is calculated from percentage by rounding up.
 	// The default value is 0.
@@ -221,13 +221,13 @@ type ModelServingStatus struct {
 	// AvailableReplicas track the number of ServingGroup that are in ready state (updated or not).
 	AvailableReplicas int32 `json:"availableReplicas,omitempty"`
 
-	// CurrentRevision, if not empty, indicates the ControllerRevision version used to generate
-	// ServingGroups in the sequence [0,currentReplicas).
+	// CurrentRevision, if not empty, indicates the ControllerRevision version preserved by
+	// ServingGroups that have not been updated.
 	// +optional
 	CurrentRevision string `json:"currentRevision,omitempty"`
 
-	// UpdateRevision, if not empty, indicates the ControllerRevision version used to generate
-	// ServingGroups in the sequence [replicas-updatedReplicas,replicas).
+	// UpdateRevision, if not empty, indicates the ControllerRevision version targeted by
+	// the current ModelServing spec.
 	// +optional
 	UpdateRevision string `json:"updateRevision,omitempty"`
 

--- a/pkg/model-serving-controller/controller/model_serving_controller.go
+++ b/pkg/model-serving-controller/controller/model_serving_controller.go
@@ -700,11 +700,9 @@ func (c *ModelServingController) scaleUpServingGroups(ctx context.Context, ms *w
 		existingOrdinals = append(existingOrdinals, ordinal)
 	}
 
-	missingOrdinals := findMissingOrdinals(expectedCount, existingOrdinals)
-	toCreate := min(max(0, expectedCount-len(servingGroupList)), len(missingOrdinals))
-	missingOrdinals = missingOrdinals[:toCreate]
-	klog.V(4).Infof("scaleUpServingGroups: modelServing=%s, existingOrdinals=%v, missingOrdinals=%v",
-		utils.GetNamespaceName(ms), existingOrdinals, missingOrdinals)
+	toCreate := max(0, expectedCount-len(servingGroupList))
+	klog.V(4).Infof("scaleUpServingGroups: modelServing=%s, existingOrdinals=%v, groupsToCreate=%d",
+		utils.GetNamespaceName(ms), existingOrdinals, toCreate)
 
 	// Helper function to create a ServingGroup
 	createServingGroup := func(ordinal int, revision string, roles []workloadv1alpha1.Role) error {
@@ -731,7 +729,8 @@ func (c *ModelServingController) scaleUpServingGroups(ctx context.Context, ms *w
 	// Create it lazily because restoring only ordinals below partition uses the
 	// existing CurrentRevision and does not need a new snapshot.
 	newRevisionCreated := false
-	for _, ordinal := range missingOrdinals {
+	var scaleUpErr error
+	forEachMissingOrdinal(expectedCount, existingOrdinals, toCreate, func(ordinal int) bool {
 		if partition > 0 && ordinal < partition {
 			// Use CurrentRevision for partition-protected ordinals
 			revisionToUse := newRevision
@@ -763,9 +762,10 @@ func (c *ModelServingController) scaleUpServingGroups(ctx context.Context, ms *w
 			}
 
 			if err := createServingGroup(ordinal, revisionToUse, rolesToUse); err != nil {
-				return err
+				scaleUpErr = err
+				return false
 			}
-			continue
+			return true
 		}
 
 		if !newRevisionCreated {
@@ -773,14 +773,20 @@ func (c *ModelServingController) scaleUpServingGroups(ctx context.Context, ms *w
 			// it only once during this reconciliation.
 			klog.V(4).Infof("scaleUpServingGroups: creating ControllerRevision for newRevision=%s, modelServing=%s", newRevision, utils.GetNamespaceName(ms))
 			if _, err := utils.CreateControllerRevision(ctx, c.kubeClientSet, ms, newRevision, ms.Spec.Template.Roles); err != nil {
-				return fmt.Errorf("failed to create ControllerRevision for new revision %s: %w", newRevision, err)
+				scaleUpErr = fmt.Errorf("failed to create ControllerRevision for new revision %s: %w", newRevision, err)
+				return false
 			}
 			newRevisionCreated = true
 		}
 		klog.V(4).Infof("scaleUpServingGroups: creating new ServingGroup at ordinal=%d with newRevision=%s for modelServing=%s", ordinal, newRevision, utils.GetNamespaceName(ms))
 		if err := createServingGroup(ordinal, newRevision, ms.Spec.Template.Roles); err != nil {
-			return err
+			scaleUpErr = err
+			return false
 		}
+		return true
+	})
+	if scaleUpErr != nil {
+		return scaleUpErr
 	}
 
 	klog.V(4).Infof("scaleUpServingGroups: done for modelServing=%s", utils.GetNamespaceName(ms))
@@ -964,9 +970,7 @@ func (c *ModelServingController) scaleUpRoles(ctx context.Context, ms *workloadv
 		}
 		existingOrdinals = append(existingOrdinals, ordinal)
 	}
-	missingOrdinals := findMissingOrdinals(expectedCount, existingOrdinals)
-	toCreate := min(max(0, expectedCount-len(roleList)), len(missingOrdinals))
-	missingOrdinals = missingOrdinals[:toCreate]
+	toCreate := max(0, expectedCount-len(roleList))
 
 	// Role needs to scale up, and the ServingGroup status needs to be set to Scaling
 	err := c.store.UpdateServingGroupStatus(utils.GetNamespaceName(ms), groupName, datastore.ServingGroupScaling)
@@ -992,7 +996,7 @@ func (c *ModelServingController) scaleUpRoles(ctx context.Context, ms *workloadv
 		return nil
 	}
 
-	for _, ordinal := range missingOrdinals {
+	forEachMissingOrdinal(expectedCount, existingOrdinals, toCreate, func(ordinal int) bool {
 		if partitionConfigured && partition > 0 && ordinal < partition {
 			// Use CurrentRevision for partition-protected ordinals
 			revisionToUse := newRevision
@@ -1048,13 +1052,14 @@ func (c *ModelServingController) scaleUpRoles(ctx context.Context, ms *workloadv
 			if err := createRole(ordinal, revisionToUse, roleToApply, hashToUse); err != nil {
 				klog.Errorf("scaleUpRoles: failed to create role %s at ordinal %d in ServingGroup %s of ModelServing %s/%s: %v", targetRole.Name, ordinal, groupName, ms.Namespace, ms.Name, err)
 			}
-			continue
+			return true
 		}
 		roleTemplateHash := utils.CalRoleTemplateHash(targetRole)
 		if err := createRole(ordinal, newRevision, targetRole, roleTemplateHash); err != nil {
 			klog.Errorf("scaleUpRoles: failed to create role %s at ordinal %d in ServingGroup %s of ModelServing %s/%s: %v", targetRole.Name, ordinal, groupName, ms.Namespace, ms.Name, err)
 		}
-	}
+		return true
+	})
 }
 
 // manageRoleReplicasPerGroup manages the replicas of a specific role within an Serving group
@@ -2275,27 +2280,32 @@ func roleReplicas(role workloadv1alpha1.Role) int {
 	return int(*role.Replicas)
 }
 
-// findMissingOrdinals returns the missing ordinals in [0, expectedCount).
+// forEachMissingOrdinal visits at most limit missing ordinals in [0, expectedCount).
+// Memory usage depends on the observed ordinals rather than the user-provided
+// expectedCount, which may be as large as math.MaxInt32.
 // Invalid, out-of-range, duplicate, and unsorted existing ordinals are tolerated.
-func findMissingOrdinals(expectedCount int, existingOrdinals []int) []int {
-	if expectedCount <= 0 {
-		return nil
+func forEachMissingOrdinal(expectedCount int, existingOrdinals []int, limit int, handler func(int) bool) {
+	if expectedCount <= 0 || limit <= 0 {
+		return
 	}
 
-	existing := make([]bool, expectedCount)
+	existing := make(map[int]struct{}, min(len(existingOrdinals), expectedCount))
 	for _, ordinal := range existingOrdinals {
 		if ordinal >= 0 && ordinal < expectedCount {
-			existing[ordinal] = true
+			existing[ordinal] = struct{}{}
 		}
 	}
 
-	missing := make([]int, 0, expectedCount)
-	for ordinal, found := range existing {
-		if !found {
-			missing = append(missing, ordinal)
+	visited := 0
+	for ordinal := 0; ordinal < expectedCount && visited < limit; ordinal++ {
+		if _, found := existing[ordinal]; found {
+			continue
+		}
+		visited++
+		if !handler(ordinal) {
+			return
 		}
 	}
-	return missing
 }
 
 // scaleDownServingGroups scales down the ServingGroups to the expected count with two-level priority-based selection:

--- a/pkg/model-serving-controller/controller/model_serving_controller.go
+++ b/pkg/model-serving-controller/controller/model_serving_controller.go
@@ -996,6 +996,7 @@ func (c *ModelServingController) scaleUpRoles(ctx context.Context, ms *workloadv
 		return nil
 	}
 
+	roleTemplateHash := utils.CalRoleTemplateHash(targetRole)
 	forEachMissingOrdinal(expectedCount, existingOrdinals, toCreate, func(ordinal int) bool {
 		if partitionConfigured && partition > 0 && ordinal < partition {
 			// Use CurrentRevision for partition-protected ordinals
@@ -1054,7 +1055,6 @@ func (c *ModelServingController) scaleUpRoles(ctx context.Context, ms *workloadv
 			}
 			return true
 		}
-		roleTemplateHash := utils.CalRoleTemplateHash(targetRole)
 		if err := createRole(ordinal, newRevision, targetRole, roleTemplateHash); err != nil {
 			klog.Errorf("scaleUpRoles: failed to create role %s at ordinal %d in ServingGroup %s of ModelServing %s/%s: %v", targetRole.Name, ordinal, groupName, ms.Namespace, ms.Name, err)
 		}

--- a/pkg/model-serving-controller/controller/model_serving_controller.go
+++ b/pkg/model-serving-controller/controller/model_serving_controller.go
@@ -27,6 +27,7 @@ import (
 	"sync"
 	"time"
 
+	"istio.io/istio/pkg/util/sets"
 	corev1 "k8s.io/api/core/v1"
 	apiextClientSet "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -682,29 +683,28 @@ func (c *ModelServingController) syncServingGroupReplicas(ctx context.Context, m
 	return nil
 }
 
-// scaleUpServingGroups scales up the ServingGroups to the expected count.
-// When partition is set, it fills missing ordinals in [0, partition) using CurrentRevision.
-// Otherwise, it creates new ServingGroups with increasing indices starting from the current max index + 1.
+// scaleUpServingGroups fills missing ordinals in [0, expectedCount).
+// Missing ordinals below partition use CurrentRevision; the rest use newRevision.
 func (c *ModelServingController) scaleUpServingGroups(ctx context.Context, ms *workloadv1alpha1.ModelServing, servingGroupList []datastore.ServingGroup, expectedCount int, newRevision string) error {
 	partition, _, _ := c.getPartition(modelServingRolloutConfig(ms), modelServingReplicas(ms))
 	klog.V(4).Infof("scaleUpServingGroups: start for modelServing=%s, existingGroups=%d, expectedCount=%d, partition=%d, newRevision=%s",
 		utils.GetNamespaceName(ms), len(servingGroupList), expectedCount, partition, newRevision)
 
-	// Find the maximum ordinal in existing servingGroups
-	// Since servingGroupList is already sorted in ascending order by ordinal,
-	// we can directly get the maxOrdinal from the last element
-	maxOrdinal := -1
-	existingOrdinals := make(map[int]bool)
+	existingOrdinals := make([]int, 0, len(servingGroupList))
 	for _, group := range servingGroupList {
 		_, ordinal := utils.GetParentNameAndOrdinal(group.Name)
-		existingOrdinals[ordinal] = true
+		if ordinal < 0 {
+			klog.Warningf("scaleUpServingGroups: cannot parse ordinal from ServingGroup %s", group.Name)
+			continue
+		}
+		existingOrdinals = append(existingOrdinals, ordinal)
 	}
-	// Get maxOrdinal from the last element (list is sorted in ascending order)
-	if len(servingGroupList) > 0 {
-		_, maxOrdinal = utils.GetParentNameAndOrdinal(servingGroupList[len(servingGroupList)-1].Name)
-	}
-	klog.V(4).Infof("scaleUpServingGroups: modelServing=%s, existingOrdinals=%v, maxOrdinal=%d",
-		utils.GetNamespaceName(ms), existingOrdinals, maxOrdinal)
+
+	missingOrdinals := findMissingOrdinals(expectedCount, existingOrdinals)
+	toCreate := min(max(0, expectedCount-len(servingGroupList)), len(missingOrdinals))
+	missingOrdinals = missingOrdinals[:toCreate]
+	klog.V(4).Infof("scaleUpServingGroups: modelServing=%s, existingOrdinals=%v, missingOrdinals=%v",
+		utils.GetNamespaceName(ms), existingOrdinals, missingOrdinals)
 
 	// Helper function to create a ServingGroup
 	createServingGroup := func(ordinal int, revision string, roles []workloadv1alpha1.Role) error {
@@ -725,16 +725,14 @@ func (c *ModelServingController) scaleUpServingGroups(ctx context.Context, ms *w
 		return nil
 	}
 
-	if partition > 0 {
-		klog.V(4).Infof("scaleUpServingGroups: partition=%d set, filling missing ordinals in [0, %d) for modelServing=%s",
-			partition, partition, utils.GetNamespaceName(ms))
-		// When partition is set, fill missing ordinals in [0, partition) using CurrentRevision
-		for ordinal := 0; ordinal < partition && ordinal < expectedCount; ordinal++ {
-			if existingOrdinals[ordinal] {
-				klog.V(4).Infof("scaleUpServingGroups: ordinal %d already exists, skipping", ordinal)
-				continue
-			}
-
+	// Persist the template snapshot before creating a ServingGroup that references
+	// newRevision. ModelServing.Spec.Template is mutable, while ControllerRevision
+	// lets a future partition-protected recovery resolve this revision's template.
+	// Create it lazily because restoring only ordinals below partition uses the
+	// existing CurrentRevision and does not need a new snapshot.
+	newRevisionCreated := false
+	for _, ordinal := range missingOrdinals {
+		if partition > 0 && ordinal < partition {
 			// Use CurrentRevision for partition-protected ordinals
 			revisionToUse := newRevision
 			if ms.Status.CurrentRevision != "" {
@@ -767,38 +765,21 @@ func (c *ModelServingController) scaleUpServingGroups(ctx context.Context, ms *w
 			if err := createServingGroup(ordinal, revisionToUse, rolesToUse); err != nil {
 				return err
 			}
-			// Update existingOrdinals and maxOrdinal
-			existingOrdinals[ordinal] = true
-			if ordinal > maxOrdinal {
-				maxOrdinal = ordinal
-			}
-		}
-	}
-
-	// Create new ServingGroups with increasing indices starting from the current max index + 1
-	toCreate := expectedCount - len(existingOrdinals)
-	klog.V(4).Infof("scaleUpServingGroups: toCreate=%d (expectedCount=%d, existingOrdinals=%d), startingIndex=%d, modelServing=%s",
-		toCreate, expectedCount, len(existingOrdinals), maxOrdinal+1, utils.GetNamespaceName(ms))
-
-	if toCreate > 0 {
-		startingIndex := maxOrdinal + 1
-
-		// Create ControllerRevision when scaling up with a new revision
-		// This is done once before the loop since newRevision and templateData are the same for all new groups
-		templateData := ms.Spec.Template.Roles
-		klog.V(4).Infof("scaleUpServingGroups: creating ControllerRevision for newRevision=%s, modelServing=%s", newRevision, utils.GetNamespaceName(ms))
-		_, err := utils.CreateControllerRevision(ctx, c.kubeClientSet, ms, newRevision, templateData)
-		if err != nil {
-			klog.Warningf("Failed to create ControllerRevision for new revision %s: %v", newRevision, err)
+			continue
 		}
 
-		// Create new ServingGroups with increasing indices
-		for i := startingIndex; i < startingIndex+toCreate; i++ {
-			klog.V(4).Infof("scaleUpServingGroups: creating new ServingGroup at ordinal=%d with newRevision=%s for modelServing=%s", i, newRevision, utils.GetNamespaceName(ms))
-			// For newly created ServingGroups (ordinal >= partition), always use current template
-			if err := createServingGroup(i, newRevision, ms.Spec.Template.Roles); err != nil {
-				return err
+		if !newRevisionCreated {
+			// All ServingGroups created with newRevision share this snapshot, so create
+			// it only once during this reconciliation.
+			klog.V(4).Infof("scaleUpServingGroups: creating ControllerRevision for newRevision=%s, modelServing=%s", newRevision, utils.GetNamespaceName(ms))
+			if _, err := utils.CreateControllerRevision(ctx, c.kubeClientSet, ms, newRevision, ms.Spec.Template.Roles); err != nil {
+				return fmt.Errorf("failed to create ControllerRevision for new revision %s: %w", newRevision, err)
 			}
+			newRevisionCreated = true
+		}
+		klog.V(4).Infof("scaleUpServingGroups: creating new ServingGroup at ordinal=%d with newRevision=%s for modelServing=%s", ordinal, newRevision, utils.GetNamespaceName(ms))
+		if err := createServingGroup(ordinal, newRevision, ms.Spec.Template.Roles); err != nil {
+			return err
 		}
 	}
 
@@ -889,16 +870,19 @@ func (c *ModelServingController) scaleDownRoles(ctx context.Context, ms *workloa
 		partition = 0
 	}
 
-	// Split scores by partition.
-	// Align with ServingGroup semantics: partition protects ordinals in [0, partition).
+	// Partition protects the first N records in the ordinal-sorted roleList.
+	protectedRoleNames := sets.New[string]()
+	for i := 0; i < partition && i < len(roleList); i++ {
+		protectedRoleNames.Insert(roleList[i].Name)
+	}
+
 	var protectedScores []RoleWithScore
 	var nonProtectedScores []RoleWithScore
 	if partition > 0 {
 		protectedScores = make([]RoleWithScore, 0, len(allScores))
 		nonProtectedScores = make([]RoleWithScore, 0, len(allScores))
 		for _, score := range allScores {
-			_, ordinal := utils.GetParentNameAndOrdinal(score.Name)
-			if ordinal < partition {
+			if protectedRoleNames.Contains(score.Name) {
 				protectedScores = append(protectedScores, score)
 			} else {
 				nonProtectedScores = append(nonProtectedScores, score)
@@ -963,27 +947,26 @@ func (c *ModelServingController) scaleDownRoles(ctx context.Context, ms *workloa
 	}
 }
 
-// scaleUpRoles handles Role scaling up.
-// When partition is set, it fills missing ordinals in [0, partition) using CurrentRevision.
-// Otherwise, it creates new Roles with increasing indices starting from the current max index + 1.
+// scaleUpRoles fills missing Role ordinals in [0, expectedCount).
+// Missing ordinals below partition use CurrentRevision; the rest use newRevision.
 func (c *ModelServingController) scaleUpRoles(ctx context.Context, ms *workloadv1alpha1.ModelServing, groupName string, targetRole workloadv1alpha1.Role, roleList []datastore.Role, expectedCount int, servingGroupOrdinal int, newRevision string) {
 	partition, partitionConfigured, partitionErr := c.getPartition(&targetRole.RollingUpdateConfiguration, roleReplicas(targetRole))
 	if partitionErr != nil {
 		klog.Errorf("scaleUpRoles: failed to parse partition for role %s: %v", targetRole.Name, partitionErr)
 	}
 
-	// Find the maximum ordinal in existing roles.
-	// Since roleList is already sorted in ascending order by ordinal,
-	// we can directly get the maxOrdinal from the last element.
-	maxOrdinal := -1
-	existingOrdinals := make(map[int]bool)
+	existingOrdinals := make([]int, 0, len(roleList))
 	for _, role := range roleList {
 		_, ordinal := utils.GetParentNameAndOrdinal(role.Name)
-		existingOrdinals[ordinal] = true
+		if ordinal < 0 {
+			klog.Warningf("scaleUpRoles: cannot parse ordinal from Role %s", role.Name)
+			continue
+		}
+		existingOrdinals = append(existingOrdinals, ordinal)
 	}
-	if len(roleList) > 0 {
-		_, maxOrdinal = utils.GetParentNameAndOrdinal(roleList[len(roleList)-1].Name)
-	}
+	missingOrdinals := findMissingOrdinals(expectedCount, existingOrdinals)
+	toCreate := min(max(0, expectedCount-len(roleList)), len(missingOrdinals))
+	missingOrdinals = missingOrdinals[:toCreate]
 
 	// Role needs to scale up, and the ServingGroup status needs to be set to Scaling
 	err := c.store.UpdateServingGroupStatus(utils.GetNamespaceName(ms), groupName, datastore.ServingGroupScaling)
@@ -1009,16 +992,8 @@ func (c *ModelServingController) scaleUpRoles(ctx context.Context, ms *workloadv
 		return nil
 	}
 
-	if partitionConfigured && partition > 0 {
-		klog.V(4).Infof("scaleUpRoles: partition=%d set, filling missing ordinals in [0, %d) for role %s in ServingGroup %s",
-			partition, partition, targetRole.Name, groupName)
-		// When partition is set, fill missing ordinals in [0, partition) using CurrentRevision
-		for ordinal := 0; ordinal < partition && ordinal < expectedCount; ordinal++ {
-			if existingOrdinals[ordinal] {
-				klog.V(4).Infof("scaleUpRoles: ordinal %d already exists, skipping", ordinal)
-				continue
-			}
-
+	for _, ordinal := range missingOrdinals {
+		if partitionConfigured && partition > 0 && ordinal < partition {
 			// Use CurrentRevision for partition-protected ordinals
 			revisionToUse := newRevision
 			if ms.Status.CurrentRevision != "" {
@@ -1072,29 +1047,12 @@ func (c *ModelServingController) scaleUpRoles(ctx context.Context, ms *workloadv
 			hashToUse := utils.CalRoleTemplateHash(roleToApply)
 			if err := createRole(ordinal, revisionToUse, roleToApply, hashToUse); err != nil {
 				klog.Errorf("scaleUpRoles: failed to create role %s at ordinal %d in ServingGroup %s of ModelServing %s/%s: %v", targetRole.Name, ordinal, groupName, ms.Namespace, ms.Name, err)
-				continue
 			}
-			// Update existingOrdinals and maxOrdinal
-			existingOrdinals[ordinal] = true
-			if ordinal > maxOrdinal {
-				maxOrdinal = ordinal
-			}
+			continue
 		}
-	}
-
-	// Create new Roles with increasing indices starting from the current max index + 1
-	// Calculate how many new Roles we need to create
-	toCreate := expectedCount - len(existingOrdinals)
-	klog.V(2).Infof("scaling up role %s in ServingGroup %s: creating %d new replicas", targetRole.Name, groupName, toCreate)
-	if toCreate > 0 {
-		startingIndex := maxOrdinal + 1
 		roleTemplateHash := utils.CalRoleTemplateHash(targetRole)
-		// Create new Roles with increasing indices
-		for i := 0; i < toCreate; i++ {
-			newIndex := startingIndex + i
-			if err := createRole(newIndex, newRevision, targetRole, roleTemplateHash); err != nil {
-				klog.Errorf("scaleUpRoles: failed to create role %s at ordinal %d in ServingGroup %s of ModelServing %s/%s: %v", targetRole.Name, newIndex, groupName, ms.Namespace, ms.Name, err)
-			}
+		if err := createRole(ordinal, newRevision, targetRole, roleTemplateHash); err != nil {
+			klog.Errorf("scaleUpRoles: failed to create role %s at ordinal %d in ServingGroup %s of ModelServing %s/%s: %v", targetRole.Name, ordinal, groupName, ms.Namespace, ms.Name, err)
 		}
 	}
 }
@@ -1503,17 +1461,16 @@ func (c *ModelServingController) rolesToDeleteForRoleRollingUpdate(ms *workloadv
 		if partitionErr != nil {
 			return nil, false, fmt.Errorf("failed to parse partition for role %s: %v", roleSpec.Name, partitionErr)
 		}
-		if partitionConfigured && partition > 0 && len(outdatedRoles) > 0 {
-			protected := make(map[string]struct{}, partition)
-			for _, role := range roleList {
-				_, ordinal := utils.GetParentNameAndOrdinal(role.Name)
-				if ordinal < partition {
-					protected[role.Name] = struct{}{}
-				}
+		protected := sets.New[string]()
+		if partitionConfigured && partition > 0 {
+			for i := 0; i < partition && i < len(roleList); i++ {
+				protected.Insert(roleList[i].Name)
 			}
+		}
+		if len(protected) > 0 && len(outdatedRoles) > 0 {
 			filtered := outdatedRoles[:0]
 			for _, r := range outdatedRoles {
-				if _, ok := protected[r.Name]; ok {
+				if protected.Contains(r.Name) {
 					continue
 				}
 				filtered = append(filtered, r)
@@ -1521,11 +1478,10 @@ func (c *ModelServingController) rolesToDeleteForRoleRollingUpdate(ms *workloadv
 			outdatedRoles = filtered
 		}
 		if len(outdatedRoles) == 0 {
-			if partitionConfigured && partition > 0 {
+			if len(protected) > 0 {
 				expectedHash := utils.CalRoleTemplateHash(roleSpec)
 				for _, role := range roleList {
-					_, ordinal := utils.GetParentNameAndOrdinal(role.Name)
-					if ordinal >= partition {
+					if !protected.Contains(role.Name) {
 						continue
 					}
 					if role.Status == datastore.RoleDeleting {
@@ -2319,6 +2275,29 @@ func roleReplicas(role workloadv1alpha1.Role) int {
 	return int(*role.Replicas)
 }
 
+// findMissingOrdinals returns the missing ordinals in [0, expectedCount).
+// Invalid, out-of-range, duplicate, and unsorted existing ordinals are tolerated.
+func findMissingOrdinals(expectedCount int, existingOrdinals []int) []int {
+	if expectedCount <= 0 {
+		return nil
+	}
+
+	existing := make([]bool, expectedCount)
+	for _, ordinal := range existingOrdinals {
+		if ordinal >= 0 && ordinal < expectedCount {
+			existing[ordinal] = true
+		}
+	}
+
+	missing := make([]int, 0, expectedCount)
+	for ordinal, found := range existing {
+		if !found {
+			missing = append(missing, ordinal)
+		}
+	}
+	return missing
+}
+
 // scaleDownServingGroups scales down the ServingGroups to the expected count with two-level priority-based selection:
 // 1. Primary: Not-ready groups (Creating, NotFound) are deleted first
 // 2. Secondary: Among groups with same status, lower deletion cost = delete first
@@ -2393,7 +2372,6 @@ func (c *ModelServingController) scaleDownServingGroups(ctx context.Context, ms 
 			targetGroup := protectedScores[i]
 			klog.V(2).Infof("Scaling down protected serving group %s (priority: %d, deletion cost: %d, index: %d, partition=%d)",
 				targetGroup.Name, targetGroup.Priority, targetGroup.DeletionCost, targetGroup.Index, partition)
-			// Note: ControllerRevision history recording for partition-protected groups is handled in deleteServingGroup
 			if e := c.deleteServingGroup(ctx, ms, targetGroup.Name); e != nil {
 				err = append(err, e)
 			}
@@ -2578,27 +2556,6 @@ func (c *ModelServingController) deleteServingGroup(ctx context.Context, ms *wor
 	status := c.store.GetServingGroupStatus(utils.GetNamespaceName(ms), servingGroupName)
 	if status == datastore.ServingGroupNotFound {
 		return nil
-	}
-
-	// Record revision history using ControllerRevision before deleting, especially important for partition-protected servingGroups
-	// This ensures that when a partition-protected ServingGroup is deleted (e.g., due to failure),
-	// it can be recreated with its previous revision, following StatefulSet's behavior.
-	if revision, ok := c.store.GetServingGroupRevision(utils.GetNamespaceName(ms), servingGroupName); ok {
-		_, ordinal := utils.GetParentNameAndOrdinal(servingGroupName)
-		partition, _, _ := c.getPartition(modelServingRolloutConfig(ms), modelServingReplicas(ms))
-		// Record revision history using ControllerRevision for partition-protected servingGroups
-		if partition > 0 && ordinal < partition {
-			// Create ControllerRevision to persist the revision history
-			// Store the template roles data for this revision
-			templateData := ms.Spec.Template.Roles
-			_, err := utils.CreateControllerRevision(ctx, c.kubeClientSet, ms, revision, templateData)
-			if err != nil {
-				klog.Warningf("Failed to create ControllerRevision for ServingGroup %s (revision=%s): %v", servingGroupName, revision, err)
-				// Note: We don't fallback to in-memory storage as ControllerRevision is the source of truth
-			} else {
-				klog.V(2).Infof("Created ControllerRevision for partition-protected ServingGroup %s (revision=%s, partition=%d)", servingGroupName, revision, partition)
-			}
-		}
 	}
 
 	// update ServingGroup status to Deleting before deleting pods and services.

--- a/pkg/model-serving-controller/controller/model_serving_controller_test.go
+++ b/pkg/model-serving-controller/controller/model_serving_controller_test.go
@@ -2139,6 +2139,28 @@ func verifyRoles(t *testing.T, controller *ModelServingController, ms *workloadv
 	}
 }
 
+func TestFindMissingOrdinals(t *testing.T) {
+	tests := []struct {
+		name             string
+		expectedCount    int
+		existingOrdinals []int
+		want             []int
+	}{
+		{name: "zero replicas", expectedCount: 0, existingOrdinals: []int{0}, want: nil},
+		{name: "empty", expectedCount: 3, want: []int{0, 1, 2}},
+		{name: "continuous", expectedCount: 3, existingOrdinals: []int{0, 1, 2}, want: []int{}},
+		{name: "gaps", expectedCount: 5, existingOrdinals: []int{0, 2, 4}, want: []int{1, 3}},
+		{name: "unsorted duplicates", expectedCount: 4, existingOrdinals: []int{2, 0, 2}, want: []int{1, 3}},
+		{name: "ignore out of range", expectedCount: 3, existingOrdinals: []int{-1, 1, 10}, want: []int{0, 2}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, findMissingOrdinals(tt.expectedCount, tt.existingOrdinals))
+		})
+	}
+}
+
 // TestScaleUpServingGroups tests the scaleUpServingGroups function with various scenarios
 func TestScaleUpServingGroups(t *testing.T) {
 	tests := []struct {
@@ -2163,17 +2185,17 @@ func TestScaleUpServingGroups(t *testing.T) {
 			expectNoCreation:   false,
 		},
 		{
-			name:               "scale up with gap in indices - should use increasing indices from max",
+			name:               "scale up fills gaps within replicas",
 			existingIndices:    []int{0, 5}, // Gap: indices 1-4 missing
 			expectedCount:      4,
-			expectedNewIndices: []int{6, 7}, // Should continue from max index (5) + 1
+			expectedNewIndices: []int{1, 2},
 			expectNoCreation:   false,
 		},
 		{
 			name:               "scale up with only high index existing",
 			existingIndices:    []int{10},
 			expectedCount:      3,
-			expectedNewIndices: []int{11, 12}, // Should continue from max index (10) + 1
+			expectedNewIndices: []int{0, 1},
 			expectNoCreation:   false,
 		},
 		{
@@ -2284,9 +2306,53 @@ func TestScaleUpServingGroups(t *testing.T) {
 				// Verify total groups count
 				expectedTotal := len(tt.existingIndices) + len(tt.expectedNewIndices)
 				assert.Equal(t, expectedTotal, len(groups), "Total group count should match expected")
+				for _, expectedIdx := range tt.expectedNewIndices {
+					assert.Less(t, expectedIdx, tt.expectedCount, "New ServingGroup ordinal must be within replicas")
+				}
 			}
 		})
 	}
+}
+
+func TestScaleUpServingGroupsStopsWhenControllerRevisionCreationFails(t *testing.T) {
+	kubeClient := kubefake.NewSimpleClientset()
+	kubeClient.PrependReactor("create", "controllerrevisions", func(kubetesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("injected ControllerRevision creation failure")
+	})
+	controller, err := NewModelServingController(
+		kubeClient,
+		kthenafake.NewSimpleClientset(),
+		volcanofake.NewSimpleClientset(),
+		apiextfake.NewSimpleClientset(),
+	)
+	require.NoError(t, err)
+
+	ms := &workloadv1alpha1.ModelServing{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "test-revision-failure"},
+		Spec: workloadv1alpha1.ModelServingSpec{
+			Replicas: ptr.To[int32](1),
+			Template: workloadv1alpha1.ServingGroup{
+				Roles: []workloadv1alpha1.Role{
+					{
+						Name:     "prefill",
+						Replicas: ptr.To[int32](1),
+						EntryTemplate: workloadv1alpha1.PodTemplateSpec{
+							Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "prefill", Image: "test-image"}}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	err = controller.scaleUpServingGroups(context.Background(), ms, nil, 1, "new-revision")
+	require.ErrorContains(t, err, "failed to create ControllerRevision for new revision new-revision")
+
+	_, storeErr := controller.store.GetServingGroupByModelServing(utils.GetNamespaceName(ms))
+	assert.ErrorIs(t, storeErr, datastore.ErrServingGroupNotFound)
+	pods, listErr := kubeClient.CoreV1().Pods(ms.Namespace).List(context.Background(), metav1.ListOptions{})
+	require.NoError(t, listErr)
+	assert.Empty(t, pods.Items)
 }
 
 // TestScaleUpRoles tests the scaleUpRoles function with various scenarios
@@ -2316,17 +2382,17 @@ func TestScaleUpRoles(t *testing.T) {
 			expectNoCreation:   false,
 		},
 		{
-			name:               "scale up with gap in indices - should use increasing indices from max",
+			name:               "scale up fills gaps within replicas",
 			existingIndices:    []int{0, 5}, // Gap: indices 1-4 missing
 			expectedCount:      4,
-			expectedNewIndices: []int{6, 7}, // Should continue from max index (5) + 1
+			expectedNewIndices: []int{1, 2},
 			expectNoCreation:   false,
 		},
 		{
 			name:               "scale up with only high index existing",
 			existingIndices:    []int{10},
 			expectedCount:      3,
-			expectedNewIndices: []int{11, 12}, // Should continue from max index (10) + 1
+			expectedNewIndices: []int{0, 1},
 			expectNoCreation:   false,
 		},
 		{
@@ -2472,6 +2538,9 @@ func TestScaleUpRoles(t *testing.T) {
 				// Verify total roles count
 				expectedTotal := len(tt.existingIndices) + len(tt.expectedNewIndices)
 				assert.Equal(t, expectedTotal, len(roles), "Total role count should match expected")
+				for _, expectedIdx := range tt.expectedNewIndices {
+					assert.Less(t, expectedIdx, tt.expectedCount, "New Role ordinal must be within replicas")
+				}
 			}
 		})
 	}
@@ -4048,8 +4117,9 @@ func TestUpdateModelServingStatusRevisionFields(t *testing.T) {
 func TestScaleDownRoles(t *testing.T) {
 	tests := []struct {
 		name                   string
-		existingIndices        []int    // Indices of existing Roles
-		expectedCount          int      // Target count after scale down
+		existingIndices        []int // Indices of existing Roles
+		expectedCount          int   // Target count after scale down
+		partition              *intstr.IntOrString
 		expectedRemainingNames []string // Expected remaining Role names (without test prefix)
 	}{
 		{
@@ -4081,6 +4151,13 @@ func TestScaleDownRoles(t *testing.T) {
 			existingIndices:        []int{0, 2, 5, 8},
 			expectedCount:          2,
 			expectedRemainingNames: []string{"prefill-0", "prefill-2"}, // Higher indices (5, 8) deleted first
+		},
+		{
+			name:                   "partition protects first replicas with non-continuous indices",
+			existingIndices:        []int{1, 3, 5, 8},
+			expectedCount:          2,
+			partition:              ptr.To(intstr.FromInt(2)),
+			expectedRemainingNames: []string{"prefill-1", "prefill-3"},
 		},
 	}
 
@@ -4127,6 +4204,7 @@ func TestScaleDownRoles(t *testing.T) {
 			}
 
 			targetRole := ms.Spec.Template.Roles[0]
+			targetRole.RollingUpdateConfiguration.Partition = tt.partition
 
 			// Pre-populate the store with ServingGroup and Roles
 			controller.store.AddServingGroup(utils.GetNamespaceName(ms), 0, "test-revision")
@@ -7160,6 +7238,28 @@ func TestRolesToDeleteForRoleRollingUpdate(t *testing.T) {
 				store.AddServingGroup(utils.GetNamespaceName(ms), 0, oldRevision)
 				addRole(t, store, ms, "prefill", "prefill-0", "", datastore.RoleRunning)
 			},
+		},
+		{
+			name: "partition protects first outdated roles with non-continuous ordinals",
+			roles: []workloadv1alpha1.Role{
+				func() workloadv1alpha1.Role {
+					role := newRole("prefill", "nginx:latest", 4, nil)
+					role.RollingUpdateConfiguration.Partition = ptr.To(intstr.FromInt(2))
+					return role
+				}(),
+			},
+			setupStore: func(t *testing.T, store datastore.Store, ms *workloadv1alpha1.ModelServing) {
+				t.Helper()
+				store.AddServingGroup(utils.GetNamespaceName(ms), 0, oldRevision)
+				for _, ordinal := range []int{1, 3, 5, 8} {
+					addRole(t, store, ms, "prefill", fmt.Sprintf("prefill-%d", ordinal), "old-hash", datastore.RoleRunning)
+				}
+			},
+			expected: []roleToDelete{
+				{roleName: "prefill", roleID: "prefill-8"},
+				{roleName: "prefill", roleID: "prefill-5"},
+			},
+			expectedOutdated: true,
 		},
 		{
 			name: "missing serving group returns error",

--- a/pkg/model-serving-controller/controller/model_serving_controller_test.go
+++ b/pkg/model-serving-controller/controller/model_serving_controller_test.go
@@ -2324,8 +2324,16 @@ func TestScaleUpServingGroups(t *testing.T) {
 	}
 }
 
+// TestScaleUpServingGroupsStopsWhenControllerRevisionCreationFails verifies that
+// scale-up does not create a ServingGroup whose revision has no persisted template
+// snapshot. A partition-protected recovery may later need that ControllerRevision
+// to reconstruct the historical Role templates. Continuing after snapshot creation
+// fails would leave Pods and datastore entries referring to a revision that cannot
+// be resolved, so the reconciliation must fail before creating any workload.
 func TestScaleUpServingGroupsStopsWhenControllerRevisionCreationFails(t *testing.T) {
 	kubeClient := kubefake.NewSimpleClientset()
+	// Simulate an API server failure while persisting the template snapshot for
+	// new-revision. The workqueue will retry this reconciliation in production.
 	kubeClient.PrependReactor("create", "controllerrevisions", func(kubetesting.Action) (bool, runtime.Object, error) {
 		return true, nil, fmt.Errorf("injected ControllerRevision creation failure")
 	})
@@ -2358,6 +2366,9 @@ func TestScaleUpServingGroupsStopsWhenControllerRevisionCreationFails(t *testing
 	err = controller.scaleUpServingGroups(context.Background(), ms, nil, 1, "new-revision")
 	require.ErrorContains(t, err, "failed to create ControllerRevision for new revision new-revision")
 
+	// The ControllerRevision must be created before Pods or datastore state. This
+	// keeps the operation retryable and prevents partially created ServingGroups
+	// from referencing a missing historical template.
 	_, storeErr := controller.store.GetServingGroupByModelServing(utils.GetNamespaceName(ms))
 	assert.ErrorIs(t, storeErr, datastore.ErrServingGroupNotFound)
 	pods, listErr := kubeClient.CoreV1().Pods(ms.Namespace).List(context.Background(), metav1.ListOptions{})

--- a/pkg/model-serving-controller/controller/model_serving_controller_test.go
+++ b/pkg/model-serving-controller/controller/model_serving_controller_test.go
@@ -16,6 +16,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"math"
 	"sort"
 	"testing"
 	"time"
@@ -2144,19 +2145,28 @@ func TestFindMissingOrdinals(t *testing.T) {
 		name             string
 		expectedCount    int
 		existingOrdinals []int
+		limit            int
 		want             []int
 	}{
-		{name: "zero replicas", expectedCount: 0, existingOrdinals: []int{0}, want: nil},
-		{name: "empty", expectedCount: 3, want: []int{0, 1, 2}},
-		{name: "continuous", expectedCount: 3, existingOrdinals: []int{0, 1, 2}, want: []int{}},
-		{name: "gaps", expectedCount: 5, existingOrdinals: []int{0, 2, 4}, want: []int{1, 3}},
-		{name: "unsorted duplicates", expectedCount: 4, existingOrdinals: []int{2, 0, 2}, want: []int{1, 3}},
-		{name: "ignore out of range", expectedCount: 3, existingOrdinals: []int{-1, 1, 10}, want: []int{0, 2}},
+		{name: "zero replicas", expectedCount: 0, existingOrdinals: []int{0}, limit: 1, want: []int{}},
+		{name: "zero limit", expectedCount: 3, limit: 0, want: []int{}},
+		{name: "empty", expectedCount: 3, limit: 3, want: []int{0, 1, 2}},
+		{name: "continuous", expectedCount: 3, existingOrdinals: []int{0, 1, 2}, limit: 3, want: []int{}},
+		{name: "gaps", expectedCount: 5, existingOrdinals: []int{0, 2, 4}, limit: 5, want: []int{1, 3}},
+		{name: "limited gaps", expectedCount: 5, existingOrdinals: []int{0, 2, 4}, limit: 1, want: []int{1}},
+		{name: "unsorted duplicates", expectedCount: 4, existingOrdinals: []int{2, 0, 2}, limit: 4, want: []int{1, 3}},
+		{name: "ignore out of range", expectedCount: 3, existingOrdinals: []int{-1, 1, 10}, limit: 3, want: []int{0, 2}},
+		{name: "int32 max replicas is lazy", expectedCount: math.MaxInt32, existingOrdinals: []int{0, 1}, limit: 2, want: []int{2, 3}},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, findMissingOrdinals(tt.expectedCount, tt.existingOrdinals))
+			got := []int{}
+			forEachMissingOrdinal(tt.expectedCount, tt.existingOrdinals, tt.limit, func(ordinal int) bool {
+				got = append(got, ordinal)
+				return true
+			})
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/test/e2e/controller-manager/model_serving_test.go
+++ b/test/e2e/controller-manager/model_serving_test.go
@@ -141,7 +141,7 @@ func TestModelServingLifecycle(t *testing.T) {
 
 // TestModelServingScaleUp tests the ability to scale up a ModelServing's ServingGroup
 func TestModelServingScaleUp(t *testing.T) {
-	ctx, kthenaClient, _ := setupControllerManagerE2ETest(t)
+	ctx, kthenaClient, kubeClient := setupControllerManagerE2ETest(t)
 
 	// Create a basic ModelServing with 1 replica
 	modelServing := createBasicModelServing("test-scale-up", 1, 0)
@@ -174,6 +174,10 @@ func TestModelServingScaleUp(t *testing.T) {
 	finalMS, err := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Get(ctx, updatedMS.Name, metav1.GetOptions{})
 	require.NoError(t, err, "Failed to get final ModelServing")
 	assert.Equal(t, int32(3), *finalMS.Spec.Replicas, "Final ModelServing should have 3 replicas in spec")
+	ordinalStates, err := collectRunningServingGroupStates(ctx, kubeClient, modelServing.Name)
+	require.NoError(t, err)
+	require.True(t, hasExpectedOrdinalRange(ordinalStates, newReplicas),
+		"Scaled-up ServingGroup ordinals should exactly cover [0, %d), got %v", newReplicas, ordinalStates)
 
 	t.Log("ModelServing scale up test passed successfully")
 }
@@ -324,6 +328,8 @@ func TestModelServingServingGroupRecreate(t *testing.T) {
 		originalUIDs[string(pod.UID)] = true
 		t.Logf("Original pod: %s (UID: %s)", pod.Name, pod.UID)
 	}
+	expectedGroupName := podList.Items[0].Labels[workload.GroupNameLabelKey]
+	require.NotEmpty(t, expectedGroupName, "Original pods should have a ServingGroup name")
 
 	// Delete just one pod (e.g., the first one) to trigger ServingGroupRecreate
 	targetPod := podList.Items[0]
@@ -345,6 +351,10 @@ func TestModelServingServingGroupRecreate(t *testing.T) {
 		for _, pod := range pods.Items {
 			isOriginal := originalUIDs[string(pod.UID)]
 			isNonTerminating := pod.DeletionTimestamp == nil
+			if isNonTerminating && pod.Labels[workload.GroupNameLabelKey] != expectedGroupName {
+				t.Logf("Recreated pod %s belongs to ServingGroup %s, expecting %s", pod.Name, pod.Labels[workload.GroupNameLabelKey], expectedGroupName)
+				return false
+			}
 
 			// Check if any original pod is still non-terminating
 			if isOriginal && isNonTerminating {
@@ -480,6 +490,10 @@ func TestModelServingPodRecovery(t *testing.T) {
 
 	originalPodUID := originalPod.UID
 	originalPodName := originalPod.Name
+	originalGroupName := originalPod.Labels[workload.GroupNameLabelKey]
+	originalRoleID := originalPod.Labels[workload.RoleIDKey]
+	require.NotEmpty(t, originalGroupName, "Original pod should have a ServingGroup name")
+	require.NotEmpty(t, originalRoleID, "Original pod should have a Role ID")
 	t.Logf("Deleting pod %s (UID: %s)", originalPodName, originalPodUID)
 
 	// Delete the pod
@@ -489,19 +503,24 @@ func TestModelServingPodRecovery(t *testing.T) {
 	// Wait until ModelServing is ready
 	utils.WaitForModelServingReady(t, ctx, kthenaClient, testNamespace, modelServing.Name)
 
-	// Wait for a new pod with different UID and PodReady condition set to True
-	pods, err := kubeClient.CoreV1().Pods(testNamespace).List(ctx, metav1.ListOptions{
-		LabelSelector: labelSelector,
-	})
-	assert.NoError(t, err, "Failed to list pods when modelserving should be ready after pod deletion")
-	for _, pod := range pods.Items {
-		// Check if it's a new pod (different UID from original)
-		if pod.UID != originalPodUID {
-			if utils.IsPodReady(pod) {
-				t.Logf("New pod created and ready: %s (UID: %s)", pod.Name, pod.UID)
+	// The recovered pod must reuse the deleted Role and ServingGroup ordinals.
+	require.Eventually(t, func() bool {
+		pods, err := kubeClient.CoreV1().Pods(testNamespace).List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
+		if err != nil {
+			return false
+		}
+		for _, pod := range pods.Items {
+			if pod.UID == originalPodUID || pod.DeletionTimestamp != nil || !utils.IsPodReady(pod) {
+				continue
+			}
+			if pod.Labels[workload.GroupNameLabelKey] == originalGroupName &&
+				pod.Labels[workload.RoleIDKey] == originalRoleID {
+				t.Logf("New pod created at the original ordinals: %s (UID: %s)", pod.Name, pod.UID)
+				return true
 			}
 		}
-	}
+		return false
+	}, 2*time.Minute, 2*time.Second, "Recovered pod should reuse ServingGroup %s and Role ID %s", originalGroupName, originalRoleID)
 
 	t.Log("Pod recovery test passed successfully")
 }
@@ -1433,6 +1452,10 @@ func TestModelServingPartitionScaleUp(t *testing.T) {
 			t.Logf("Running serving group count: %d (expecting %d)", len(ordinalStates), scaledReplicas)
 			return false
 		}
+		if !hasExpectedOrdinalRange(ordinalStates, scaledReplicas) {
+			t.Logf("ServingGroup ordinals do not cover [0, %d): %v", scaledReplicas, ordinalStates)
+			return false
+		}
 		protectedCorrect, updatedCorrect := calculateGroupPartitionState(t, ordinalStates, partition, scaledReplicas, initialRevision, updateRevision)
 		t.Logf("Protected: %d/%d, Updated: %d/%d", protectedCorrect, partition, updatedCorrect, scaledReplicas-partition)
 		return protectedCorrect == int(partition) && updatedCorrect == int(scaledReplicas-partition)
@@ -1602,6 +1625,19 @@ type servingGroupState struct {
 	Image     string
 }
 
+// hasExpectedOrdinalRange reports whether the keys exactly cover [0, replicas).
+func hasExpectedOrdinalRange[T any](states map[int32]T, replicas int32) bool {
+	if len(states) != int(replicas) {
+		return false
+	}
+	for ordinal := int32(0); ordinal < replicas; ordinal++ {
+		if _, ok := states[ordinal]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
 func collectRunningServingGroupStates(ctx context.Context, kubeClient *kubernetes.Clientset, msName string) (map[int32]servingGroupState, error) {
 	pods, err := kubeClient.CoreV1().Pods(testNamespace).List(ctx, metav1.ListOptions{
 		LabelSelector: modelServingLabelSelector(msName),
@@ -1662,6 +1698,10 @@ func waitForPartitionState(t *testing.T, ctx context.Context, kthenaClient *clie
 			t.Logf("Running serving group count: %d (expecting %d)", len(ordinalStates), replicas)
 			return false
 		}
+		if !hasExpectedOrdinalRange(ordinalStates, replicas) {
+			t.Logf("ServingGroup ordinals do not cover [0, %d): %v", replicas, ordinalStates)
+			return false
+		}
 		protectedCorrect, updatedCorrect := calculateGroupPartitionState(t, ordinalStates, partition, replicas, initialRevision, ms.Status.UpdateRevision)
 		t.Logf("CurrentRevision: %s, UpdateRevision: %s, Protected: %d/%d, Updated: %d/%d",
 			ms.Status.CurrentRevision, ms.Status.UpdateRevision, protectedCorrect, partition, updatedCorrect, replicas-partition)
@@ -1680,10 +1720,8 @@ func waitForPartitionState(t *testing.T, ctx context.Context, kthenaClient *clie
 }
 
 // waitForRollingUpdateConverged polls until a rolling update without partition has fully converged:
-// CurrentRevision has caught up to UpdateRevision, status counters match Spec.Replicas, and every
-// running serving group is on UpdateRevision with the updated image. Ordinals are not checked because
-// ServingGroupRollingUpdate creates new groups at maxOrdinal+1 and deletes old ones, so indices shift
-// during the rollout.
+// CurrentRevision has caught up to UpdateRevision, status counters match Spec.Replicas, and the
+// running ServingGroups exactly cover [0, replicas) on UpdateRevision with the updated image.
 func waitForRollingUpdateConverged(t *testing.T, ctx context.Context, kthenaClient *clientset.Clientset,
 	kubeClient *kubernetes.Clientset, msName string, replicas int32, initialRevision, updatedImage string) *workload.ModelServing {
 	t.Helper()
@@ -1715,7 +1753,12 @@ func waitForRollingUpdateConverged(t *testing.T, ctx context.Context, kthenaClie
 			t.Logf("Running serving group count: %d (expecting %d)", len(ordinalStates), replicas)
 			return false
 		}
-		for ordinal, state := range ordinalStates {
+		if !hasExpectedOrdinalRange(ordinalStates, replicas) {
+			t.Logf("ServingGroup ordinals do not cover [0, %d): %v", replicas, ordinalStates)
+			return false
+		}
+		for ordinal := int32(0); ordinal < replicas; ordinal++ {
+			state := ordinalStates[ordinal]
 			if state.Revision != ms.Status.UpdateRevision || state.Image != updatedImage {
 				t.Logf("Ordinal %d not on UpdateRevision yet: revision=%s image=%s", ordinal, state.Revision, state.Image)
 				return false
@@ -2282,6 +2325,10 @@ func TestModelServingRoleRollingUpdatePartition(t *testing.T) {
 			t.Logf("Observed running ordinals=%d, expecting %d", len(imageByOrdinal), initialRoleReplicas)
 			return false
 		}
+		if !hasExpectedOrdinalRange(imageByOrdinal, initialRoleReplicas) {
+			t.Logf("Role ordinals do not cover [0, %d): %v", initialRoleReplicas, imageByOrdinal)
+			return false
+		}
 
 		for ord := int32(0); ord < partition; ord++ {
 			if imageByOrdinal[ord] != nginxImage {
@@ -2310,7 +2357,7 @@ func TestModelServingRoleRollingUpdatePartition(t *testing.T) {
 
 // TestModelServingRolePartitionScaleUp verifies that when a partition-protected role replica is
 // deleted under RoleRecreate, scale-up recreates the missing protected ordinal with the historical
-// revision. Non-protected replicas may use non-contiguous ordinals as long as replica count is met.
+// revision and the final Role ordinals exactly cover [0, roleReplicas).
 func TestModelServingRolePartitionScaleUp(t *testing.T) {
 	ctx, kthenaClient, kubeClient := setupControllerManagerE2ETest(t)
 
@@ -2392,6 +2439,10 @@ func TestModelServingRolePartitionScaleUp(t *testing.T) {
 		if len(imageByOrdinal) != int(roleReplicas) {
 			return false
 		}
+		if !hasExpectedOrdinalRange(imageByOrdinal, roleReplicas) {
+			t.Logf("Role ordinals do not cover [0, %d): %v", roleReplicas, imageByOrdinal)
+			return false
+		}
 		for ord := int32(0); ord < partition; ord++ {
 			if imageByOrdinal[ord] != nginxImage {
 				t.Logf("Partition state not ready: protected prefill-%d image=%s", ord, imageByOrdinal[ord])
@@ -2468,6 +2519,10 @@ func TestModelServingRolePartitionScaleUp(t *testing.T) {
 		}
 		if len(imageByOrdinal) != int(roleReplicas) {
 			t.Logf("Observed ordinals=%d, expecting %d", len(imageByOrdinal), roleReplicas)
+			return false
+		}
+		if !hasExpectedOrdinalRange(imageByOrdinal, roleReplicas) {
+			t.Logf("Role ordinals do not cover [0, %d): %v", roleReplicas, imageByOrdinal)
 			return false
 		}
 		if imageByOrdinal[0] != nginxImage {


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:

Fixes ServingGroup and Role ordinal allocation to reuse missing ordinals within [0, replicas) instead of allocating maxOrdinal + 1. This prevents out-of-range ordinals during recovery, scaling, and rolling updates.

**Which issue(s) this PR fixes**:
Fixes #1442 

**Bug evidence (required for bug-related PRs)**:
<!--
For a bug-related PR, provide evidence from the production path:
- Include the relevant workload configuration and logs or events.
- For a panic, include the complete panic trace.
- Describe the user action or cluster event that triggers the problem and how the
  change fixes it.
- Use source permalinks that point to the exact commit when citing code.

AI-generated analysis, a static scan, or a unit test that only calls an internal
function does not prove a bug on its own. If the reported bug relies solely on AI
analysis without reproduction instructions or production-path evidence, maintainers
may close the issue and the related PR.

Write "N/A" for PRs that are not bug-related.
-->

**Special notes for your reviewer**:

Adds unit and E2E coverage for ordinal reuse, partition handling, and recovery. **AI assistance** was used during implementation and test updates.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
