### PR TITLE
autoscaler: validate pod metric source endpoints

### DIFF
--- a/charts/kthena/charts/workload/crds/workload.serving.volcano.sh_autoscalingpolicies.yaml
+++ b/charts/kthena/charts/workload/crds/workload.serving.volcano.sh_autoscalingpolicies.yaml
@@ -310,11 +310,14 @@ spec:
                                     description: Port defines the network port where
                                       metrics are exposed by the pods (e.g., 8000).
                                     format: int32
+                                    maximum: 65535
+                                    minimum: 1
                                     type: integer
                                   uri:
                                     default: /metrics
                                     description: Uri defines the HTTP path where metrics
                                       are exposed (e.g., "/metrics").
+                                    pattern: ^/
                                     type: string
                                 type: object
                               prometheus:
@@ -591,11 +594,14 @@ spec:
                                           where metrics are exposed by the pods (e.g.,
                                           8000).
                                         format: int32
+                                        maximum: 65535
+                                        minimum: 1
                                         type: integer
                                       uri:
                                         default: /metrics
                                         description: Uri defines the HTTP path where
                                           metrics are exposed (e.g., "/metrics").
+                                        pattern: ^/
                                         type: string
                                     type: object
                                   prometheus:
@@ -793,11 +799,14 @@ spec:
                                   description: Port defines the network port where
                                     metrics are exposed by the pods (e.g., 8000).
                                   format: int32
+                                  maximum: 65535
+                                  minimum: 1
                                   type: integer
                                 uri:
                                   default: /metrics
                                   description: Uri defines the HTTP path where metrics
                                     are exposed (e.g., "/metrics").
+                                  pattern: ^/
                                   type: string
                               type: object
                             prometheus:

--- a/docs/kthena/docs/reference/crd/workload.serving.volcano.sh.md
+++ b/docs/kthena/docs/reference/crd/workload.serving.volcano.sh.md
@@ -763,8 +763,8 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `name` _string_ | Name is the Prometheus metric name matched against labels in the pod's scraped output.<br />Defaults to the policy metric key when omitted.<br />For example, set it to "vllm:gpu_cache_usage_perc" to read that exact series. |  |  |
-| `uri` _string_ | Uri defines the HTTP path where metrics are exposed (e.g., "/metrics"). | /metrics |  |
-| `port` _integer_ | Port defines the network port where metrics are exposed by the pods (e.g., 8000). | 8100 |  |
+| `uri` _string_ | Uri defines the HTTP path where metrics are exposed (e.g., "/metrics"). | /metrics | Pattern: `^/` <br /> |
+| `port` _integer_ | Port defines the network port where metrics are exposed by the pods (e.g., 8000). | 8100 | Maximum: 65535 <br />Minimum: 1 <br /> |
 
 
 #### PodTemplateSpec

--- a/pkg/apis/workload/v1alpha1/autoscalingpolicy_types.go
+++ b/pkg/apis/workload/v1alpha1/autoscalingpolicy_types.go
@@ -308,10 +308,13 @@ type PodMetricSource struct {
 	// Uri defines the HTTP path where metrics are exposed (e.g., "/metrics").
 	// +optional
 	// +kubebuilder:default="/metrics"
+	// +kubebuilder:validation:Pattern="^/"
 	Uri string `json:"uri,omitempty"`
 	// Port defines the network port where metrics are exposed by the pods (e.g., 8000).
 	// +optional
 	// +kubebuilder:default=8100
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=65535
 	Port int32 `json:"port,omitempty"`
 	// LabelSelector defines additional filtering for pods exposing this metric.
 	// Only pods matching both the target and this selector are scraped, e.g.


### PR DESCRIPTION
### What type of PR is this?

/kind bug

### What this PR does / why we need it

AutoscalingPolicy currently admits invalid Pod metric source endpoints. A `uri` without a leading slash or a `port` outside the TCP port range is only rejected later by the HTTP client, so the Autoscaler repeatedly fails to scrape metrics and cannot calculate scaling recommendations.

This change adds CRD-level validation to `PodMetricSource`:

- `uri` must start with `/`;
- `port` must be between `1` and `65535`;
- omitted values continue to use the existing `/metrics` and `8100` defaults.

The generated AutoscalingPolicy CRD is updated for homogeneous, heterogeneous, and disaggregated target metric source schemas. Invalid policies now fail admission with an actionable schema error instead of failing during reconciliation.

### Which issue(s) this PR fixes

Fixes #1524

### Special notes for your reviewer

The CRD was regenerated with the repository's controller-gen version (`v0.17.2`). No runtime scraping behavior changes for valid configurations.

### How was this change tested?

```bash
go run sigs.k8s.io/controller-tools/cmd/controller-gen@v0.17.2 \
  crd paths="./pkg/apis/workload/v1alpha1" \
  output:crd:artifacts:config=charts/kthena/charts/workload/crds

go test ./pkg/apis/workload/v1alpha1 ./pkg/autoscaler/webhook -count=1
git diff --check
```

The generated CRD contains the new port and URI constraints in all three Pod metric source schema locations.

### Does this PR introduce a user-facing change?

```release-note
Reject AutoscalingPolicy Pod metric sources with invalid ports or metric paths.
```
