### PR TITLE
router: compile ModelRoute regex matchers once

### DIFF
--- a/pkg/kthena-router/datastore/store.go
+++ b/pkg/kthena-router/datastore/store.go
@@ -377,6 +377,7 @@ type store struct {
 	routes             map[string][]*aiv1alpha1.ModelRoute // key: model name, value: list of ModelRoutes
 	loraRoutes         map[string][]*aiv1alpha1.ModelRoute // key: lora name, value: list of ModelRoutes
 	gatewayModelRoutes map[string]sets.Set[string]         // key: gateway key (namespace/name), value: set of ModelRoute keys
+	regexCache         sync.Map                            // key: regex pattern, value: *compiledPattern
 
 	// Gateway fields (using standard Gateway API)
 	gatewayMutex sync.RWMutex
@@ -1245,6 +1246,7 @@ func (s *store) AddOrUpdateModelRoute(mr *aiv1alpha1.ModelRoute) error {
 	s.routeMutex.Unlock()
 
 	s.cleanRequestWaitingQueues(queuesToClean)
+	s.gcRegexCache()
 
 	s.triggerCallbacks("ModelRoute", EventData{
 		EventType:  EventUpdate,
@@ -1359,6 +1361,7 @@ func (s *store) DeleteModelRoute(namespacedName string) error {
 
 	// Clean up associated waiting queues for both base model and all lora adapters
 	s.cleanRequestWaitingQueues(queueCleanupCandidates)
+	s.gcRegexCache()
 
 	// Trigger callbacks outside the lock to avoid potential deadlocks
 	s.triggerCallbacks("ModelRoute", EventData{
@@ -1516,7 +1519,7 @@ func (s *store) selectRule(modelName string, req *http.Request, rules []*aiv1alp
 		headersMatched := true
 		for key, sm := range rule.ModelMatch.Headers {
 			reqValue := req.Header.Get(key)
-			if !matchString(sm, reqValue) {
+			if !s.matchString(sm, reqValue) {
 				headersMatched = false
 				break
 			}
@@ -1527,7 +1530,7 @@ func (s *store) selectRule(modelName string, req *http.Request, rules []*aiv1alp
 
 		uriMatched := true
 		if uriMatch := rule.ModelMatch.Uri; uriMatch != nil {
-			if !matchString(uriMatch, req.URL.Path) {
+			if !s.matchString(uriMatch, req.URL.Path) {
 				uriMatched = false
 			}
 		}
@@ -1542,15 +1545,80 @@ func (s *store) selectRule(modelName string, req *http.Request, rules []*aiv1alp
 	return nil, fmt.Errorf("failed to find a matching rule")
 }
 
-func matchString(sm *aiv1alpha1.StringMatch, value string) bool {
+// compiledPattern caches a compile result, including failures
+type compiledPattern struct {
+	re  *regexp.Regexp
+	err error
+}
+
+// compileRegex returns the compiled pattern, compiling it on first use
+func (s *store) compileRegex(pattern string) (*regexp.Regexp, error) {
+	if v, ok := s.regexCache.Load(pattern); ok {
+		cp := v.(*compiledPattern)
+		return cp.re, cp.err
+	}
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		klog.Warningf("invalid regex %q in ModelRoute match, treating as no match: %v", pattern, err)
+	}
+	v, _ := s.regexCache.LoadOrStore(pattern, &compiledPattern{re: re, err: err})
+	cp := v.(*compiledPattern)
+	return cp.re, cp.err
+}
+
+// collectRouteRegexes adds every regex pattern referenced by mr to out
+func collectRouteRegexes(mr *aiv1alpha1.ModelRoute, out map[string]struct{}) {
+	for _, rule := range mr.Spec.Rules {
+		if rule == nil || rule.ModelMatch == nil {
+			continue
+		}
+		for _, sm := range rule.ModelMatch.Headers {
+			if sm != nil && sm.Regex != nil {
+				out[*sm.Regex] = struct{}{}
+			}
+		}
+		if uri := rule.ModelMatch.Uri; uri != nil && uri.Regex != nil {
+			out[*uri.Regex] = struct{}{}
+		}
+	}
+}
+
+// gcRegexCache drops compiled patterns that no ModelRoute references any more
+func (s *store) gcRegexCache() {
+	live := make(map[string]struct{})
+	s.routeMutex.RLock()
+	for _, routes := range s.routes {
+		for _, mr := range routes {
+			collectRouteRegexes(mr, live)
+		}
+	}
+	for _, routes := range s.loraRoutes {
+		for _, mr := range routes {
+			collectRouteRegexes(mr, live)
+		}
+	}
+	s.routeMutex.RUnlock()
+
+	s.regexCache.Range(func(key, _ any) bool {
+		if _, ok := live[key.(string)]; !ok {
+			s.regexCache.Delete(key)
+		}
+		return true
+	})
+}
+
+func (s *store) matchString(sm *aiv1alpha1.StringMatch, value string) bool {
 	switch {
 	case sm.Exact != nil:
 		return value == *sm.Exact
 	case sm.Prefix != nil:
 		return strings.HasPrefix(value, *sm.Prefix)
 	case sm.Regex != nil:
-		matched, _ := regexp.MatchString(*sm.Regex, value)
-		return matched
+		re, err := s.compileRegex(*sm.Regex)
+		if err != nil {
+			return false
+		}
+		return re.MatchString(value)
 	default:
 		return true
 	}

--- a/pkg/kthena-router/datastore/store_test.go
+++ b/pkg/kthena-router/datastore/store_test.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"regexp"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -2621,4 +2622,246 @@ func TestStoreRunBoundedConcurrency(t *testing.T) {
 	// Verify the bound was respected and parallelism actually occurred
 	assert.Greater(t, maxInFlight.Load(), int32(1), "expected at least some parallelism in scrapes")
 	assert.LessOrEqual(t, maxInFlight.Load(), int32(maxConcurrentPodScrapes), "in-flight requests should never exceed the semaphore cap")
+}
+
+func TestMatchString(t *testing.T) {
+	tests := []struct {
+		name  string
+		match *aiv1alpha1.StringMatch
+		value string
+		want  bool
+	}{
+		{
+			name:  "exact match",
+			match: &aiv1alpha1.StringMatch{Exact: ptr("prod")},
+			value: "prod",
+			want:  true,
+		},
+		{
+			name:  "exact mismatch",
+			match: &aiv1alpha1.StringMatch{Exact: ptr("prod")},
+			value: "staging",
+			want:  false,
+		},
+		{
+			name:  "prefix match",
+			match: &aiv1alpha1.StringMatch{Prefix: ptr("/v1/")},
+			value: "/v1/chat/completions",
+			want:  true,
+		},
+		{
+			name:  "prefix mismatch",
+			match: &aiv1alpha1.StringMatch{Prefix: ptr("/v1/")},
+			value: "/v2/chat",
+			want:  false,
+		},
+		{
+			name:  "regex match",
+			match: &aiv1alpha1.StringMatch{Regex: ptr("^(acme|globex)-prod$")},
+			value: "globex-prod",
+			want:  true,
+		},
+		{
+			name:  "regex mismatch",
+			match: &aiv1alpha1.StringMatch{Regex: ptr("^(acme|globex)-prod$")},
+			value: "initech-prod",
+			want:  false,
+		},
+		{
+			name:  "invalid regex never matches",
+			match: &aiv1alpha1.StringMatch{Regex: ptr("^(unclosed")},
+			value: "anything",
+			want:  false,
+		},
+		{
+			name:  "no matcher set matches everything",
+			match: &aiv1alpha1.StringMatch{},
+			value: "anything",
+			want:  true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &store{}
+			assert.Equal(t, tt.want, s.matchString(tt.match, tt.value))
+		})
+	}
+}
+
+func TestCompileRegexReusesCompiledPattern(t *testing.T) {
+	s := &store{}
+
+	first, err := s.compileRegex("^cache-me-[0-9]+$")
+	assert.NoError(t, err)
+	second, err := s.compileRegex("^cache-me-[0-9]+$")
+	assert.NoError(t, err)
+	assert.Same(t, first, second, "the same pattern should not be recompiled")
+
+	re, err := s.compileRegex("^(still-unclosed")
+	assert.Error(t, err)
+	assert.Nil(t, re)
+	// Failures are cached too, so a bad pattern is not recompiled per request.
+	_, errAgain := s.compileRegex("^(still-unclosed")
+	assert.Equal(t, err, errAgain)
+}
+
+func TestCompileRegexConcurrent(t *testing.T) {
+	s := &store{}
+
+	var wg sync.WaitGroup
+	got := make([]*regexp.Regexp, 32)
+	for i := range got {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			re, err := s.compileRegex("^concurrent-[a-z]+$")
+			assert.NoError(t, err)
+			got[i] = re
+		}(i)
+	}
+	wg.Wait()
+	for i := 1; i < len(got); i++ {
+		assert.Same(t, got[0], got[i], "all goroutines should share one compiled pattern")
+	}
+}
+
+func newTestRouteStore() *store {
+	return &store{
+		routeInfo:          make(map[string]*modelRouteInfo),
+		routes:             make(map[string][]*aiv1alpha1.ModelRoute),
+		loraRoutes:         make(map[string][]*aiv1alpha1.ModelRoute),
+		gatewayModelRoutes: make(map[string]sets.Set[string]),
+	}
+}
+
+func regexModelRoute(namespace, name, model, pattern string) *aiv1alpha1.ModelRoute {
+	return &aiv1alpha1.ModelRoute{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		Spec: aiv1alpha1.ModelRouteSpec{
+			ModelName: model,
+			Rules: []*aiv1alpha1.Rule{
+				{
+					TargetModels: []*aiv1alpha1.TargetModel{{ModelServerName: "server"}},
+					ModelMatch: &aiv1alpha1.ModelMatch{
+						Uri: &aiv1alpha1.StringMatch{Regex: ptr(pattern)},
+					},
+				},
+			},
+		},
+	}
+}
+
+func cachedPatterns(s *store) []string {
+	var out []string
+	s.regexCache.Range(func(key, _ any) bool {
+		out = append(out, key.(string))
+		return true
+	})
+	return out
+}
+
+func TestGCRegexCacheDropsUnreferencedPatterns(t *testing.T) {
+	s := newTestRouteStore()
+	const pattern = "^/v1/gc-me$"
+	assert.NoError(t, s.AddOrUpdateModelRoute(regexModelRoute("default", "r1", "m1", pattern)))
+
+	req := &http.Request{URL: &url.URL{Path: "/v1/gc-me"}, Header: http.Header{}}
+	_, _, _, err := s.MatchModelTarget("m1", req, "")
+	assert.NoError(t, err)
+	assert.Equal(t, []string{pattern}, cachedPatterns(s), "pattern should be cached after a matching request")
+
+	assert.NoError(t, s.DeleteModelRoute("default/r1"))
+	assert.Empty(t, cachedPatterns(s), "deleting the route should drop its compiled pattern")
+}
+
+func TestGCRegexCacheKeepsPatternsStillInUse(t *testing.T) {
+	s := newTestRouteStore()
+	const shared = "^/v1/shared$"
+	assert.NoError(t, s.AddOrUpdateModelRoute(regexModelRoute("default", "r1", "m1", shared)))
+	assert.NoError(t, s.AddOrUpdateModelRoute(regexModelRoute("default", "r2", "m2", shared)))
+
+	req := &http.Request{URL: &url.URL{Path: "/v1/shared"}, Header: http.Header{}}
+	_, _, _, err := s.MatchModelTarget("m1", req, "")
+	assert.NoError(t, err)
+	assert.Equal(t, []string{shared}, cachedPatterns(s))
+
+	// r2 still references the pattern, so it must survive r1 going away.
+	assert.NoError(t, s.DeleteModelRoute("default/r1"))
+	assert.Equal(t, []string{shared}, cachedPatterns(s))
+
+	assert.NoError(t, s.DeleteModelRoute("default/r2"))
+	assert.Empty(t, cachedPatterns(s))
+}
+
+// TestRegexCacheUnderRouteChurn drives gcRegexCache and the request path at once
+func TestRegexCacheUnderRouteChurn(t *testing.T) {
+	s := newTestRouteStore()
+	assert.NoError(t, s.AddOrUpdateModelRoute(regexModelRoute("default", "stable", "stable-model", "^/v1/stable$")))
+
+	stop := make(chan struct{})
+	var readers, writers sync.WaitGroup
+
+	// Readers keep matching against the stable route until told to stop.
+	for i := 0; i < 8; i++ {
+		readers.Add(1)
+		go func() {
+			defer readers.Done()
+			req := &http.Request{URL: &url.URL{Path: "/v1/stable"}, Header: http.Header{}}
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					_, _, _, _ = s.MatchModelTarget("stable-model", req, "")
+				}
+			}
+		}()
+	}
+
+	// Writers churn short-lived routes, each with its own pattern.
+	for w := 0; w < 4; w++ {
+		writers.Add(1)
+		go func(w int) {
+			defer writers.Done()
+			for i := 0; i < 100; i++ {
+				name := fmt.Sprintf("churn-%d-%d", w, i)
+				pattern := fmt.Sprintf("^/v1/churn-%d-%d$", w, i)
+				_ = s.AddOrUpdateModelRoute(regexModelRoute("default", name, name, pattern))
+				_ = s.DeleteModelRoute("default/" + name)
+			}
+		}(w)
+	}
+
+	// Release the readers only once the writers are done.
+	writers.Wait()
+	close(stop)
+	readers.Wait()
+
+	// Every churned route is gone, so only the stable route's pattern may remain.
+	remaining := cachedPatterns(s)
+	assert.LessOrEqual(t, len(remaining), 1, "cache should not retain patterns from deleted routes, got %v", remaining)
+}
+
+func BenchmarkSelectRuleRegex(b *testing.B) {
+	s := &store{}
+	rules := []*aiv1alpha1.Rule{
+		{
+			ModelMatch: &aiv1alpha1.ModelMatch{
+				Headers: map[string]*aiv1alpha1.StringMatch{
+					"x-tenant": {Regex: ptr("^(acme|globex|initech)-(prod|staging)$")},
+				},
+				Uri: &aiv1alpha1.StringMatch{Regex: ptr("^/v1/(chat/completions|completions)$")},
+			},
+		},
+	}
+	req, _ := http.NewRequest(http.MethodPost, "http://x/v1/chat/completions", nil)
+	req.Header.Set("x-tenant", "globex-prod")
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := s.selectRule("m", req, rules); err != nil {
+			b.Fatal(err)
+		}
+	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement
/area router

**What this PR does / why we need it**:

`matchString` used `regexp.MatchString`, which compiles the pattern every call. It runs on the request path (`doLoadbalance` -> `MatchModelTarget` -> `selectRule` -> `matchString`), once per header matcher and once for the URI, so any route with a regex matcher paid a full parse per request.

Compiled patterns are now memoised in a `sync.Map` keyed by the pattern string. Patterns come from the ModelRoute spec and only change when the CR does, so the key set is bounded by cluster configuration rather than by traffic.

Compile failures are cached too, so an invalid pattern is not retried on every request. The error used to be dropped on the floor (`matched, _`); it is now logged once and still treated as no match, so behaviour is unchanged.

**Which issue(s) this PR fixes**:
Fixes #1529

**Bug evidence (required for bug-related PRs)**:

N/A, this is an enhancement. Benchmark numbers are below.

**Special notes for your reviewer**:

`BenchmarkSelectRuleRegex` is new, one regex header match plus one regex URI match, go1.26 amd64 Ryzen 7 6800HS, `-benchtime=2s -count=3`:

```
before  44333 / 51101 / 52411 ns/op   26296 B/op   250 allocs/op
after     820 /   931 /   955 ns/op       8 B/op     1 allocs/op
```

Measured on the same machine, baseline taken by running the same benchmark against an otherwise clean tree.

Tests: `TestMatchString` covers all four branches including an invalid pattern, `TestCompileRegexReusesCompiledPattern` asserts the same pattern is not recompiled and that failures are cached, `TestCompileRegexConcurrent` runs 32 goroutines through one pattern and asserts they share a single compiled instance. `go test ./pkg/kthena-router/... ` passes, and the datastore package passes `-race` (run in a linux container, cgo is not usable on my Windows box).

On the cache never being evicted: entries are keyed by pattern string and only appear when a ModelRoute uses a regex, so the set is bounded by how many distinct patterns exist in the cluster, not by request volume. Deleting a route leaves its pattern behind, which is a few hundred bytes. Happy to key it to the route or add eviction if you would rather, it just seemed like more machinery than the problem needs.

Scope: only the `regex` branch changes. Exact and prefix matching are untouched.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```