### PR TITLE
Fix vLLM ZMQ topic filter

### DIFF
--- a/python/kthena/runtime/zmq_subscriber.py
+++ b/python/kthena/runtime/zmq_subscriber.py
@@ -143,6 +143,8 @@ class VLLMZMQSubscriber:
 
             logger.info(f"Connected to ZMQ endpoint: {self.config.zmq_endpoint}")
 
+            expected_topic = self.config.zmq_topic_filter
+
             while self.running:
                 try:
                     parts = await self.socket.recv_multipart(zmq.NOBLOCK)
@@ -151,7 +153,7 @@ class VLLMZMQSubscriber:
                         continue
 
                     topic, payload = self._extract_message_data(parts)
-                    if not topic or topic != "kv-events":
+                    if expected_topic and topic != expected_topic:
                         continue
 
                     await self._process_message(payload, self.config.pod_identifier, self.config.model_name)

--- a/python/kthena/tests/test_zmq_subscriber.py
+++ b/python/kthena/tests/test_zmq_subscriber.py
@@ -1,0 +1,68 @@
+# Copyright The Volcano Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from dataclasses import replace
+
+import pytest
+
+from kthena.runtime import zmq_subscriber
+from kthena.runtime.zmq_subscriber import VLLMZMQSubscriber
+
+
+@pytest.mark.asyncio
+async def test_vllm_subscriber_honors_configured_topic_filter(monkeypatch):
+    sub = VLLMZMQSubscriber(pod_identifier="pod-a", model_name="m")
+    sub.config = replace(sub.config, zmq_topic_filter="test-topic")
+    processed_payloads = []
+
+    class _FakeZMQ:
+        def __init__(self):
+            self.messages = [
+                [b"wrong-topic", b"seq", b"wrong"],
+                [b"test-topic", b"seq", b"right"],
+            ]
+
+        def socket(self, socket_type):
+            return self
+
+        def connect(self, endpoint):
+            pass
+
+        def setsockopt_string(self, option, value):
+            pass
+
+        def setsockopt(self, option, value):
+            pass
+
+        async def recv_multipart(self, flags):
+            return self.messages.pop(0)
+
+        def close(self):
+            pass
+
+        def term(self):
+            pass
+
+    fake_zmq = _FakeZMQ()
+    monkeypatch.setattr(zmq_subscriber.zmq.asyncio, "Context", lambda: fake_zmq)
+
+    async def process_message(payload, pod_identifier, model_name):
+        processed_payloads.append(payload)
+        sub.running = False
+
+    sub._process_message = process_message
+    sub.running = True
+
+    await sub._run_subscriber()
+
+    assert processed_payloads == [b"right"]


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The vLLM ZMQ subscriber already subscribes to the topic configured by `VLLM_ZMQ_TOPIC_FILTER`, but the message filtering path still compared incoming topics against the hardcoded `kv-events` topic.

That made non-default topic filters silently drop valid messages after they were received from ZMQ.

This PR makes the vLLM subscriber use the configured topic for the application-level topic check, matching the existing SGLang subscriber behavior.

**Which issue(s) this PR fixes**:
Fixes #1527

**Bug evidence (required for bug-related PRs)**:

Set `VLLM_ZMQ_TOPIC_FILTER=test-topic` and publish a normal 3-part vLLM ZMQ message with topic `test-topic`.

Before this change:
- the SUB socket subscribes to `test-topic`
- the frame is received from ZMQ
- the application-level check drops it because the code compares the topic with hardcoded `kv-events`
- the event is never processed

The broken path was:

```python
topic, payload = self._extract_message_data(parts)
if not topic or topic != "kv-events":
    continue
```
After this change, the same application-level check uses self.config.zmq_topic_filter, so the topic used by the SUB socket and the topic accepted by the subscriber stay consistent.

A regression test covers the non-default topic case and verifies that a message on the configured topic is processed while a different topic is ignored.

**Special notes for your reviewer:**
The change intentionally mirrors the existing SGLang ZMQ subscriber topic-filter handling.

Does this PR introduce a user-facing change?:
```
Fixed vLLM ZMQ event subscriber topic filtering to honor VLLM_ZMQ_TOPIC_FILTER during message processing.
```