### PR TITLE
Fix CI failures: GHCR owner casing and Python liccheck SPDX expressions

### DIFF
--- a/.github/workflows/build-push-release.yml
+++ b/.github/workflows/build-push-release.yml
@@ -22,6 +22,7 @@ on:
     paths:
       - "docker/**"
       - 'python/Dockerfile'
+      - '.github/workflows/build-push-release.yml'
 
 jobs:
   setup:
@@ -30,6 +31,7 @@ jobs:
       version: ${{ steps.version.outputs.version }}
       is_tag: ${{ steps.version.outputs.is_tag }}
       prerelease: ${{ steps.is_prerelease.outputs.prerelease }}
+      repo_owner: ${{ steps.owner.outputs.repo_owner }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -57,6 +59,11 @@ jobs:
           else
             echo "prerelease=false" >> $GITHUB_OUTPUT
           fi
+
+      - name: Set lower case owner name
+        id: owner
+        run: |
+          echo "repo_owner=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_OUTPUT
 
   build_images:
     needs: setup
@@ -128,7 +135,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ github.repository_owner }}/${{ matrix.service }}
+          images: ghcr.io/${{ needs.setup.outputs.repo_owner }}/${{ matrix.service }}
           tags: |
             type=raw,value=${{ needs.setup.outputs.version }}
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
@@ -145,7 +152,7 @@ jobs:
           target: ${{ matrix.target }}
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=ghcr.io/${{ github.repository_owner }}/${{ matrix.service }},push-by-digest=${{ github.event_name != 'pull_request' }},name-canonical=true,push=${{ github.event_name != 'pull_request' }}
+          outputs: type=image,name=ghcr.io/${{ needs.setup.outputs.repo_owner }}/${{ matrix.service }},push-by-digest=${{ github.event_name != 'pull_request' }},name-canonical=true,push=${{ github.event_name != 'pull_request' }}
 
       - name: Export digest
         if: ${{ github.event_name != 'pull_request' }}
@@ -197,7 +204,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ github.repository_owner }}/${{ matrix.service }}
+          images: ghcr.io/${{ needs.setup.outputs.repo_owner }}/${{ matrix.service }}
           tags: |
             type=raw,value=${{ needs.setup.outputs.version }}
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
@@ -208,11 +215,11 @@ jobs:
           DOCKER_METADATA_OUTPUT_JSON: ${{ steps.meta.outputs.json }}
         run: |
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-          $(printf 'ghcr.io/${{ github.repository_owner }}/${{ matrix.service }}@sha256:%s ' *)
+          $(printf 'ghcr.io/${{ needs.setup.outputs.repo_owner }}/${{ matrix.service }}@sha256:%s ' *)
 
       - name: Inspect image
         run: |
-          docker buildx imagetools inspect ghcr.io/${{ github.repository_owner }}/${{ matrix.service }}:${{ needs.setup.outputs.version }}
+          docker buildx imagetools inspect ghcr.io/${{ needs.setup.outputs.repo_owner }}/${{ matrix.service }}:${{ needs.setup.outputs.version }}
 
   build_cli:
     needs: setup
@@ -327,10 +334,9 @@ jobs:
         if: github.event_name != 'pull_request'
         env:
           VERSION: ${{ needs.setup.outputs.version }}
-          REPO_OWNER: ${{ github.repository_owner }}
+          REPO_OWNER: ${{ needs.setup.outputs.repo_owner }}
         run: |
-          LOWER_REPO_OWNER=$(echo "$REPO_OWNER" | tr '[:upper:]' '[:lower:]')
-          helm push kthena.tgz oci://ghcr.io/$LOWER_REPO_OWNER/charts
+          helm push kthena.tgz oci://ghcr.io/$REPO_OWNER/charts
 
       - name: Prepare Helm Release Artifacts
         if: needs.setup.outputs.is_tag == 'true'


### PR DESCRIPTION
## Problem
This PR resolves two CI issues that occur when opening a PR from a fork, as described in #834:
1. **GHCR owner casing:** The `build-push-release.yml` workflow failed to push images when the repository owner's username contained uppercase characters.
2. **Python license check:** The `liccheck` linter failed on `huggingface-hub` transitive dependencies (`packaging` and `tqdm`) because their SPDX license expressions were not authorized in the current allowlist.

## Solution
* Normalized `github.repository_owner` to lowercase in the `setup` job and reused the unified lowercase output (`${{ needs.setup.outputs.repo_owner }}`) across all GHCR image definitions.
* Extended `config/python-licenses-lint.ini` to explicitly allow `apache-2.0 or bsd-2-clause` to satisfy `liccheck` for the required dependencies.

## Fixes Issue
Fixes #834 