### PR TITLE
fix(router): apply Gateway API precedence across matching HTTPRoutes

### DIFF
--- a/pkg/kthena-router/router/httproute_match.go
+++ b/pkg/kthena-router/router/httproute_match.go
@@ -48,7 +48,25 @@ type httpRouteMatchResult struct {
 	// path stores the path specificity used to choose the best rule within one
 	// HTTPRoute and then the best match across all applicable HTTPRoutes.
 	path httpRoutePathPrecedence
+	// hostname stores the matching hostname specificity used to choose between
+	// HTTPRoutes before applying path precedence.
+	hostname httpRouteHostnamePrecedence
 }
+
+type httpRouteHostnamePrecedence struct {
+	// matchType ranks hostname matches. Exact hostnames are more specific than
+	// wildcard hostnames, which are more specific than routes without hostnames.
+	matchType int
+	// characters is the length of the matching hostname pattern. It resolves
+	// ties between wildcard hostnames with different suffix lengths.
+	characters int
+}
+
+const (
+	httpRouteHostnameAnyPrecedence = iota
+	httpRouteHostnameWildcardPrecedence
+	httpRouteHostnameExactPrecedence
+)
 
 type httpRoutePathPrecedence struct {
 	// matchType ranks path match kinds. Higher values are more specific:
@@ -86,11 +104,13 @@ func (r *Router) findHTTPRouteMatch(c *gin.Context, gatewayKey string) (httpRout
 		if !httpRouteMatchesGatewayListener(route, gatewayKey, listenerName, listenerPort) {
 			continue
 		}
-		if !matchHTTPRouteHostnames(route.Spec.Hostnames, c.Request.Host) {
+		hostnamePrecedence, hostnameMatched := matchHTTPRouteHostnamePrecedence(route.Spec.Hostnames, c.Request.Host)
+		if !hostnameMatched {
 			continue
 		}
 		result, matched := findBestHTTPRouteRuleMatch(route, c.Request.URL.Path)
 		if matched {
+			result.hostname = hostnamePrecedence
 			if !found || compareHTTPRouteMatchPrecedence(result, best) < 0 {
 				best = result
 				found = true
@@ -224,9 +244,13 @@ func compareHTTPRoutePathSpecificity(a, b httpRoutePathPrecedence) int {
 }
 
 // compareHTTPRouteMatchPrecedence compares the best matches from two different
-// HTTPRoutes. Path specificity wins first. Gateway API then resolves ties using
-// the oldest route creation timestamp and lexical namespace/name order.
+// HTTPRoutes. Gateway API ranks hostname specificity before path specificity,
+// then resolves ties using the oldest route creation timestamp and lexical
+// namespace/name order.
 func compareHTTPRouteMatchPrecedence(a, b httpRouteMatchResult) int {
+	if result := compareHTTPRouteHostnamePrecedence(a.hostname, b.hostname); result != 0 {
+		return result
+	}
 	if result := compareHTTPRoutePathSpecificity(a.path, b.path); result != 0 {
 		return result
 	}
@@ -246,6 +270,22 @@ func compareHTTPRouteMatchPrecedence(a, b httpRouteMatchResult) int {
 		return -1
 	}
 	if a.route.Name > b.route.Name {
+		return 1
+	}
+	return 0
+}
+
+func compareHTTPRouteHostnamePrecedence(a, b httpRouteHostnamePrecedence) int {
+	if a.matchType != b.matchType {
+		if a.matchType > b.matchType {
+			return -1
+		}
+		return 1
+	}
+	if a.characters != b.characters {
+		if a.characters > b.characters {
+			return -1
+		}
 		return 1
 	}
 	return 0
@@ -370,22 +410,27 @@ func matchHTTPPathPrefix(path, prefix string) (bool, string) {
 	return path == normalizedPrefix || strings.HasPrefix(path, normalizedPrefix+"/"), normalizedPrefix
 }
 
-// matchHTTPRouteHostnames matches the request Host header against route
-// hostnames. Empty hostnames means the route matches all hosts.
-func matchHTTPRouteHostnames(hostnames []gatewayv1.Hostname, requestHost string) bool {
+// matchHTTPRouteHostnamePrecedence returns the most specific hostname pattern
+// matched by the route. Empty hostnames match every host with the lowest
+// specificity.
+func matchHTTPRouteHostnamePrecedence(hostnames []gatewayv1.Hostname, requestHost string) (httpRouteHostnamePrecedence, bool) {
 	if len(hostnames) == 0 {
-		return true
+		return httpRouteHostnamePrecedence{matchType: httpRouteHostnameAnyPrecedence}, true
 	}
 	normalizedHost := normalizeHTTPRouteHost(requestHost)
 	if normalizedHost == "" {
-		return false
+		return httpRouteHostnamePrecedence{}, false
 	}
+	var best httpRouteHostnamePrecedence
+	found := false
 	for _, hostname := range hostnames {
-		if matchHTTPRouteHostname(string(hostname), normalizedHost) {
-			return true
+		precedence, matched := matchHTTPRouteHostnamePattern(string(hostname), normalizedHost)
+		if matched && (!found || compareHTTPRouteHostnamePrecedence(precedence, best) < 0) {
+			best = precedence
+			found = true
 		}
 	}
-	return false
+	return best, found
 }
 
 // normalizeHTTPRouteHost removes the optional Host header port and normalizes
@@ -410,17 +455,31 @@ func normalizeHTTPRouteHost(host string) string {
 // suffix hostnames. A wildcard such as "*.example.com" matches
 // "api.example.com" and "v1.api.example.com", but not "example.com".
 func matchHTTPRouteHostname(pattern, host string) bool {
+	_, matched := matchHTTPRouteHostnamePattern(pattern, host)
+	return matched
+}
+
+func matchHTTPRouteHostnamePattern(pattern, host string) (httpRouteHostnamePrecedence, bool) {
 	pattern = strings.ToLower(strings.TrimSuffix(pattern, "."))
 	if pattern == host {
-		return true
+		return httpRouteHostnamePrecedence{
+			matchType:  httpRouteHostnameExactPrecedence,
+			characters: len(pattern),
+		}, true
 	}
 	if !strings.HasPrefix(pattern, "*.") {
-		return false
+		return httpRouteHostnamePrecedence{}, false
 	}
 	suffix := strings.TrimPrefix(pattern, "*")
 	if !strings.HasSuffix(host, suffix) {
-		return false
+		return httpRouteHostnamePrecedence{}, false
 	}
 	prefix := strings.TrimSuffix(host, suffix)
-	return prefix != ""
+	if prefix == "" {
+		return httpRouteHostnamePrecedence{}, false
+	}
+	return httpRouteHostnamePrecedence{
+		matchType:  httpRouteHostnameWildcardPrecedence,
+		characters: len(suffix),
+	}, true
 }

--- a/pkg/kthena-router/router/httproute_match.go
+++ b/pkg/kthena-router/router/httproute_match.go
@@ -45,8 +45,8 @@ type httpRouteMatchResult struct {
 	// stored in gin.Context so ReplacePrefixMatch URLRewrite can replace exactly
 	// the prefix that made this rule match.
 	matchedPrefix string
-	// path stores the path specificity used only to choose the best rule within
-	// this HTTPRoute.
+	// path stores the path specificity used to choose the best rule within one
+	// HTTPRoute and then the best match across all applicable HTTPRoutes.
 	path httpRoutePathPrecedence
 }
 
@@ -66,10 +66,9 @@ type httpRoutePathPrecedence struct {
 }
 
 // findHTTPRouteMatch keeps Kthena's lightweight HTTPRoute matching model. It
-// checks hostnames at the route level, then picks the best path match within the
-// first matching HTTPRoute and preserves that rule for backend/filter lookup. It
-// intentionally does not implement full Gateway API method/header/query matching
-// or cross-route precedence.
+// checks hostnames at the route level, finds the best path match in every
+// applicable HTTPRoute, then applies cross-route precedence. It intentionally
+// does not implement full Gateway API method/header/query matching.
 func (r *Router) findHTTPRouteMatch(c *gin.Context, gatewayKey string) (httpRouteMatchResult, bool) {
 	httpRoutes := r.store.GetHTTPRoutesByGateway(gatewayKey)
 	if len(httpRoutes) == 0 {
@@ -78,6 +77,8 @@ func (r *Router) findHTTPRouteMatch(c *gin.Context, gatewayKey string) (httpRout
 	listenerName := c.GetString(GatewayListenerNameKey)
 	listenerPort := c.GetInt(GatewayListenerPortKey)
 
+	var best httpRouteMatchResult
+	found := false
 	for _, route := range httpRoutes {
 		if route == nil {
 			continue
@@ -90,10 +91,13 @@ func (r *Router) findHTTPRouteMatch(c *gin.Context, gatewayKey string) (httpRout
 		}
 		result, matched := findBestHTTPRouteRuleMatch(route, c.Request.URL.Path)
 		if matched {
-			return result, true
+			if !found || compareHTTPRouteMatchPrecedence(result, best) < 0 {
+				best = result
+				found = true
+			}
 		}
 	}
-	return httpRouteMatchResult{}, false
+	return best, found
 }
 
 func httpRouteMatchesGatewayListener(route *gatewayv1.HTTPRoute, gatewayKey, listenerName string, listenerPort int) bool {
@@ -184,17 +188,8 @@ func hasUnsupportedHTTPRouteMatchPredicates(match gatewayv1.HTTPRouteMatch) bool
 }
 
 func compareHTTPRoutePathPrecedence(a, b httpRoutePathPrecedence) int {
-	if a.matchType != b.matchType {
-		if a.matchType > b.matchType {
-			return -1
-		}
-		return 1
-	}
-	if a.characters != b.characters {
-		if a.characters > b.characters {
-			return -1
-		}
-		return 1
+	if result := compareHTTPRoutePathSpecificity(a, b); result != 0 {
+		return result
 	}
 	if a.ruleIndex != b.ruleIndex {
 		// When path specificity is equal, keep the HTTPRoute's rule order.
@@ -207,6 +202,50 @@ func compareHTTPRoutePathPrecedence(a, b httpRoutePathPrecedence) int {
 		return -1
 	}
 	if a.matchIndex > b.matchIndex {
+		return 1
+	}
+	return 0
+}
+
+func compareHTTPRoutePathSpecificity(a, b httpRoutePathPrecedence) int {
+	if a.matchType != b.matchType {
+		if a.matchType > b.matchType {
+			return -1
+		}
+		return 1
+	}
+	if a.characters != b.characters {
+		if a.characters > b.characters {
+			return -1
+		}
+		return 1
+	}
+	return 0
+}
+
+// compareHTTPRouteMatchPrecedence compares the best matches from two different
+// HTTPRoutes. Path specificity wins first. Gateway API then resolves ties using
+// the oldest route creation timestamp and lexical namespace/name order.
+func compareHTTPRouteMatchPrecedence(a, b httpRouteMatchResult) int {
+	if result := compareHTTPRoutePathSpecificity(a.path, b.path); result != 0 {
+		return result
+	}
+	if !a.route.CreationTimestamp.Equal(&b.route.CreationTimestamp) {
+		if a.route.CreationTimestamp.Before(&b.route.CreationTimestamp) {
+			return -1
+		}
+		return 1
+	}
+	if a.route.Namespace != b.route.Namespace {
+		if a.route.Namespace < b.route.Namespace {
+			return -1
+		}
+		return 1
+	}
+	if a.route.Name < b.route.Name {
+		return -1
+	}
+	if a.route.Name > b.route.Name {
 		return 1
 	}
 	return 0

--- a/pkg/kthena-router/router/httproute_match_test.go
+++ b/pkg/kthena-router/router/httproute_match_test.go
@@ -316,6 +316,8 @@ func TestRouter_FindHTTPRouteMatch(t *testing.T) {
 
 func TestRouter_FindHTTPRouteMatchCrossRoutePrecedence(t *testing.T) {
 	pathType := gatewayv1.PathMatchPathPrefix
+	gatewayKind := gatewayv1.Kind("Gateway")
+	gatewayNamespace := gatewayv1.Namespace("default")
 	route := func(namespace, name, prefix string, createdAt time.Time) *gatewayv1.HTTPRoute {
 		return &gatewayv1.HTTPRoute{
 			ObjectMeta: v1.ObjectMeta{
@@ -324,6 +326,13 @@ func TestRouter_FindHTTPRouteMatchCrossRoutePrecedence(t *testing.T) {
 				CreationTimestamp: v1.NewTime(createdAt),
 			},
 			Spec: gatewayv1.HTTPRouteSpec{
+				CommonRouteSpec: gatewayv1.CommonRouteSpec{
+					ParentRefs: []gatewayv1.ParentReference{{
+						Name:      "gateway",
+						Namespace: &gatewayNamespace,
+						Kind:      &gatewayKind,
+					}},
+				},
 				Rules: []gatewayv1.HTTPRouteRule{{
 					Matches: []gatewayv1.HTTPRouteMatch{{
 						Path: &gatewayv1.HTTPPathMatch{Type: &pathType, Value: &prefix},

--- a/pkg/kthena-router/router/httproute_match_test.go
+++ b/pkg/kthena-router/router/httproute_match_test.go
@@ -341,12 +341,17 @@ func TestRouter_FindHTTPRouteMatchCrossRoutePrecedence(t *testing.T) {
 			},
 		}
 	}
+	withHostname := func(httpRoute *gatewayv1.HTTPRoute, hostname gatewayv1.Hostname) *gatewayv1.HTTPRoute {
+		httpRoute.Spec.Hostnames = []gatewayv1.Hostname{hostname}
+		return httpRoute
+	}
 	newer := time.Date(2026, time.January, 2, 0, 0, 0, 0, time.UTC)
 	older := newer.Add(-time.Hour)
 
 	tests := []struct {
 		name          string
 		routes        []*gatewayv1.HTTPRoute
+		host          string
 		expectedRoute types.NamespacedName
 	}{
 		{
@@ -356,6 +361,15 @@ func TestRouter_FindHTTPRouteMatchCrossRoutePrecedence(t *testing.T) {
 				route("default", "chat-route", "/chat", newer),
 			},
 			expectedRoute: types.NamespacedName{Namespace: "default", Name: "chat-route"},
+		},
+		{
+			name: "exact hostname wins before path specificity",
+			routes: []*gatewayv1.HTTPRoute{
+				withHostname(route("default", "wildcard-route", "/chat", newer), "*.example.com"),
+				withHostname(route("default", "exact-route", "/", older), "api.example.com"),
+			},
+			host:          "api.example.com",
+			expectedRoute: types.NamespacedName{Namespace: "default", Name: "exact-route"},
 		},
 		{
 			name: "oldest route wins equal path specificity regardless of route order",
@@ -381,6 +395,7 @@ func TestRouter_FindHTTPRouteMatchCrossRoutePrecedence(t *testing.T) {
 			w := httptest.NewRecorder()
 			c, _ := gin.CreateTestContext(w)
 			c.Request, _ = http.NewRequest(http.MethodPost, "/chat/completions", nil)
+			c.Request.Host = tt.host
 
 			match, found := router.findHTTPRouteMatch(c, "default/gateway")
 			if !found {

--- a/pkg/kthena-router/router/httproute_match_test.go
+++ b/pkg/kthena-router/router/httproute_match_test.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
@@ -29,6 +30,15 @@ import (
 
 	"github.com/volcano-sh/kthena/pkg/kthena-router/datastore"
 )
+
+type orderedHTTPRouteStore struct {
+	datastore.Store
+	routes []*gatewayv1.HTTPRoute
+}
+
+func (s *orderedHTTPRouteStore) GetHTTPRoutesByGateway(string) []*gatewayv1.HTTPRoute {
+	return s.routes
+}
 
 func TestRouter_FindHTTPRouteMatch(t *testing.T) {
 	pathType := gatewayv1.PathMatchPathPrefix
@@ -300,6 +310,77 @@ func TestRouter_FindHTTPRouteMatch(t *testing.T) {
 			pool, found := inferencePoolFromHTTPRouteRule(result.route, result.rule)
 			assert.True(t, found)
 			assert.Equal(t, types.NamespacedName{Namespace: "default", Name: tt.expectedPool}, pool)
+		})
+	}
+}
+
+func TestRouter_FindHTTPRouteMatchCrossRoutePrecedence(t *testing.T) {
+	pathType := gatewayv1.PathMatchPathPrefix
+	route := func(namespace, name, prefix string, createdAt time.Time) *gatewayv1.HTTPRoute {
+		return &gatewayv1.HTTPRoute{
+			ObjectMeta: v1.ObjectMeta{
+				Namespace:         namespace,
+				Name:              name,
+				CreationTimestamp: v1.NewTime(createdAt),
+			},
+			Spec: gatewayv1.HTTPRouteSpec{
+				Rules: []gatewayv1.HTTPRouteRule{{
+					Matches: []gatewayv1.HTTPRouteMatch{{
+						Path: &gatewayv1.HTTPPathMatch{Type: &pathType, Value: &prefix},
+					}},
+				}},
+			},
+		}
+	}
+	newer := time.Date(2026, time.January, 2, 0, 0, 0, 0, time.UTC)
+	older := newer.Add(-time.Hour)
+
+	tests := []struct {
+		name          string
+		routes        []*gatewayv1.HTTPRoute
+		expectedRoute types.NamespacedName
+	}{
+		{
+			name: "longest matching prefix wins regardless of route order",
+			routes: []*gatewayv1.HTTPRoute{
+				route("default", "root-route", "/", older),
+				route("default", "chat-route", "/chat", newer),
+			},
+			expectedRoute: types.NamespacedName{Namespace: "default", Name: "chat-route"},
+		},
+		{
+			name: "oldest route wins equal path specificity regardless of route order",
+			routes: []*gatewayv1.HTTPRoute{
+				route("default", "new-route", "/chat", newer),
+				route("default", "old-route", "/chat", older),
+			},
+			expectedRoute: types.NamespacedName{Namespace: "default", Name: "old-route"},
+		},
+		{
+			name: "namespace and name resolve equal timestamp ties",
+			routes: []*gatewayv1.HTTPRoute{
+				route("team-b", "a-route", "/chat", older),
+				route("team-a", "z-route", "/chat", older),
+			},
+			expectedRoute: types.NamespacedName{Namespace: "team-a", Name: "z-route"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			router := &Router{store: &orderedHTTPRouteStore{routes: tt.routes}}
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request, _ = http.NewRequest(http.MethodPost, "/chat/completions", nil)
+
+			match, found := router.findHTTPRouteMatch(c, "default/gateway")
+			if !found {
+				t.Fatal("expected a matching HTTPRoute")
+			}
+			assert.Equal(t, tt.expectedRoute, types.NamespacedName{
+				Namespace: match.route.Namespace,
+				Name:      match.route.Name,
+			})
 		})
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR makes HTTPRoute selection deterministic when multiple routes attached to the same Gateway match one request.

Previously, the router returned the first matching HTTPRoute from the datastore. Since the datastore builds this route list from a Go map, route selection depended on map iteration order. A broad `/` route could win over a more specific `/chat` route.

The router now evaluates every applicable HTTPRoute and applies precedence in this order:

1. Most specific path match.
2. Oldest HTTPRoute creation timestamp for equal path specificity.
3. Lexical namespace and name order for equal timestamps.

This aligns route selection with Gateway API HTTPRoute precedence for the supported path matching model.

**Which issue(s) this PR fixes**:

Fixes #1528

**Bug evidence (required for bug-related PRs)**:

A router test reproduces the failure with two matching routes returned in this order:

```text
root-route: /
chat-route: /chat
```

For a request to `/chat/completions`, the previous implementation selected `root-route` because it returned after the first route match.

The new regression coverage verifies:

- `/chat` wins over `/` regardless of route order.
- The older route wins when path specificity is equal.
- Namespace and name provide a deterministic final tie breaker.

**Special notes for your reviewer**:

Kthena still skips HTTPRoute matches with method, header, or query predicates because the router does not evaluate those predicates. This PR changes cross route precedence only for the supported hostname and path matching model.

**Does this PR introduce a user-facing change?**:

```release-note
HTTPRoute selection now consistently prefers the most specific matching route across routes attached to the same Gateway.
```