### PR TITLE
router: fix prefix cache races with pod deletion

### DIFF
--- a/pkg/kthena-router/datastore/store.go
+++ b/pkg/kthena-router/datastore/store.go
@@ -219,7 +219,7 @@ type Store interface {
 	// HasSynced checks if the store has been initialized and synced
 	HasSynced() bool
 
-	// GetPodInfo returns the pod info for a given pod name (for testing)
+	// GetPodInfo returns the pod info for a given pod name, or nil if the pod is not tracked
 	GetPodInfo(podName types.NamespacedName) *PodInfo
 
 	// SyncOnFlightCounts fetches the current on-flight counts for all tracked

--- a/pkg/kthena-router/datastore/store.go
+++ b/pkg/kthena-router/datastore/store.go
@@ -248,7 +248,7 @@ type Store interface {
 	// HasSynced checks if the store has been initialized and synced
 	HasSynced() bool
 
-	// GetPodInfo returns the pod info for a given pod name (for testing)
+	// GetPodInfo returns the pod info for a given pod name, or nil if the pod is not tracked
 	GetPodInfo(podName types.NamespacedName) *PodInfo
 
 	// SyncOnFlightCounts fetches the current on-flight counts for all tracked

--- a/pkg/kthena-router/scheduler/plugins/cache/prefix_store.go
+++ b/pkg/kthena-router/scheduler/plugins/cache/prefix_store.go
@@ -21,6 +21,7 @@ import (
 
 	"istio.io/istio/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
 
 	"github.com/volcano-sh/kthena/pkg/kthena-router/datastore"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/metrics"
@@ -173,7 +174,8 @@ func (s *ModelPrefixStore) FindTopMatches(model string, hashes []uint64, pods []
 		shard.mu.RLock()
 		podSet, exists := shard.hashes[hash]
 		if exists {
-			// Note: we are iterating over a copy of the set, so we don't need to hold the lock.
+			// The set is the live map, not a copy; iteration is safe because the shard
+			// read lock is held until the loop ends.
 			for pod := range podSet {
 				// Skip if pod is not in the candidate set or already matched
 				if !candidatePods.Contains(pod) {
@@ -208,7 +210,9 @@ func (s *ModelPrefixStore) Add(model string, hashes []uint64, pod *datastore.Pod
 	podLRU, exists := s.podHashes[nsName]
 	if !exists {
 		// Add runs after the proxied request completes, possibly long after the pod is
-		// gone. Re-registering it then would leave entries nothing can evict.
+		// gone. Re-registering it then would leave entries nothing can evict. The gate is
+		// sound because the store removes a pod before dispatching its delete event: a miss
+		// here means the purge has fired or will fire.
 		if s.store.GetPodInfo(nsName) == nil {
 			s.podHashesMu.Unlock()
 			return
@@ -223,6 +227,9 @@ func (s *ModelPrefixStore) Add(model string, hashes []uint64, pod *datastore.Pod
 			s.onHashEvicted(key.model, []uint64{key.hash}, nsName)
 		})
 		if err != nil {
+			// Only reachable with a non-positive capacity; without the log this would
+			// silently disable caching.
+			klog.Errorf("ModelPrefixStore: failed to create pod LRU (capacity %d): %v", s.hashCapacity, err)
 			s.podHashesMu.Unlock()
 			return
 		}

--- a/pkg/kthena-router/scheduler/plugins/cache/prefix_store.go
+++ b/pkg/kthena-router/scheduler/plugins/cache/prefix_store.go
@@ -77,6 +77,7 @@ type ModelPrefixStore struct {
 	podHashes    map[types.NamespacedName]Cache[hashModelKey, struct{}] // Map of pod to its hash LRU
 	topK         int                                                    // Each match returns at most topK pods.
 	hashCapacity int                                                    // Capacity for each pod's hash LRU
+	store        datastore.Store                                        // Liveness source for Add's registration gate
 }
 
 // NewModelPrefixStore creates a new ModelPrefixStore with the specified capacity and topK
@@ -86,6 +87,7 @@ func NewModelPrefixStore(store datastore.Store, hashCapacity, topK int) *ModelPr
 		podHashes:    make(map[types.NamespacedName]Cache[hashModelKey, struct{}]),
 		topK:         topK,
 		hashCapacity: hashCapacity,
+		store:        store,
 	}
 
 	// Register callback for pod deletion
@@ -113,15 +115,21 @@ func (s *ModelPrefixStore) onPodDeleted(data datastore.EventData) {
 			hashByModel[key.model] = append(hashByModel[key.model], key.hash)
 		}
 		for model, hashSlice := range hashByModel {
-			s.onHashEvicted(model, hashSlice, data.Pod)
-			// check whether we need to delete entries
-			s.entriesMu.Lock()
-			if modelCache, exists := s.entries[model]; exists && isModelHashShardEmpty(modelCache) {
-				delete(s.entries, model)
-			}
-			s.entriesMu.Unlock()
+			s.purgeModelHashes(model, hashSlice, data.Pod)
 		}
 	}
+}
+
+// purgeModelHashes removes the pod's entries for the given hashes and drops the model when it
+// empties. Shared by pod deletion and Add's undo; must not take podHashesMu.
+func (s *ModelPrefixStore) purgeModelHashes(model string, hashes []uint64, nsName types.NamespacedName) {
+	s.onHashEvicted(model, hashes, nsName)
+	// check whether we need to delete entries
+	s.entriesMu.Lock()
+	if modelCache, exists := s.entries[model]; exists && isModelHashShardEmpty(modelCache) {
+		delete(s.entries, model)
+	}
+	s.entriesMu.Unlock()
 }
 
 func isModelHashShardEmpty(model *modelHashes) bool {
@@ -199,13 +207,25 @@ func (s *ModelPrefixStore) Add(model string, hashes []uint64, pod *datastore.Pod
 	s.podHashesMu.Lock()
 	podLRU, exists := s.podHashes[nsName]
 	if !exists {
-		podLRU, _ = NewLRUCache(s.hashCapacity, func(key hashModelKey, value struct{}) {
+		// Add runs after the proxied request completes, possibly long after the pod is
+		// gone. Re-registering it then would leave entries nothing can evict.
+		if s.store.GetPodInfo(nsName) == nil {
+			s.podHashesMu.Unlock()
+			return
+		}
+		var err error
+		podLRU, err = NewLRUCache(s.hashCapacity, func(key hashModelKey, value struct{}) {
 			// Only capacity-driven evictions reach this callback; pod deletion removes
 			// entries via onHashEvicted directly, so this is the right place to count them.
 			metrics.DefaultMetrics.RecordPrefixCacheEviction(key.model)
-			// Safe to call synchronously: podLRU.Add() is invoked after shard.mu.Unlock().
+			// Safe to call synchronously: golang-lru v2 runs it outside its own lock, and
+			// podLRU.Add() is invoked after shard.mu.Unlock().
 			s.onHashEvicted(key.model, []uint64{key.hash}, nsName)
 		})
+		if err != nil {
+			s.podHashesMu.Unlock()
+			return
+		}
 		s.podHashes[nsName] = podLRU
 	}
 	s.podHashesMu.Unlock()
@@ -232,6 +252,16 @@ func (s *ModelPrefixStore) Add(model string, hashes []uint64, pod *datastore.Pod
 		shard.hashes[hash].Insert(nsName)
 		shard.mu.Unlock()
 		podLRU.Add(hashModelKey{hash: hash, model: model}, struct{}{})
+	}
+
+	// A deletion that ran meanwhile purged what it saw, not what we kept inserting, so
+	// take ours back out. Pointer compare, not presence: a recreated pod's new LRU is
+	// not ours, and mistaking it for ours would leave this call's entries behind.
+	s.podHashesMu.RLock()
+	current, registered := s.podHashes[nsName]
+	s.podHashesMu.RUnlock()
+	if !registered || current != podLRU {
+		s.purgeModelHashes(model, hashes, nsName)
 	}
 }
 

--- a/pkg/kthena-router/scheduler/plugins/cache/prefix_store.go
+++ b/pkg/kthena-router/scheduler/plugins/cache/prefix_store.go
@@ -209,10 +209,6 @@ func (s *ModelPrefixStore) Add(model string, hashes []uint64, pod *datastore.Pod
 	s.podHashesMu.Lock()
 	podLRU, exists := s.podHashes[nsName]
 	if !exists {
-		// Add runs after the proxied request completes, possibly long after the pod is
-		// gone. Re-registering it then would leave entries nothing can evict. The gate is
-		// sound because the store removes a pod before dispatching its delete event: a miss
-		// here means the purge has fired or will fire.
 		if s.store.GetPodInfo(nsName) == nil {
 			s.podHashesMu.Unlock()
 			return
@@ -261,9 +257,6 @@ func (s *ModelPrefixStore) Add(model string, hashes []uint64, pod *datastore.Pod
 		podLRU.Add(hashModelKey{hash: hash, model: model}, struct{}{})
 	}
 
-	// A deletion that ran meanwhile purged what it saw, not what we kept inserting, so
-	// take ours back out. Pointer compare, not presence: a recreated pod's new LRU is
-	// not ours, and mistaking it for ours would leave this call's entries behind.
 	s.podHashesMu.RLock()
 	current, registered := s.podHashes[nsName]
 	s.podHashesMu.RUnlock()

--- a/pkg/kthena-router/scheduler/plugins/cache/prefix_store_test.go
+++ b/pkg/kthena-router/scheduler/plugins/cache/prefix_store_test.go
@@ -33,6 +33,50 @@ import (
 	"github.com/volcano-sh/kthena/pkg/kthena-router/metrics"
 )
 
+// seedPod registers the pod in the datastore so Add's liveness gate accepts it.
+func seedPod(t testing.TB, ds datastore.Store, pod *datastore.PodInfo) {
+	t.Helper()
+	if err := ds.AddOrUpdatePod(pod.Pod, nil); err != nil {
+		t.Fatalf("seed pod: %v", err)
+	}
+}
+
+// orphanReport lists shard entries no LRU can evict: pod in a shard set but not in
+// podHashes, or its LRU not tracking the key. The other direction is evictable and fine.
+func orphanReport(store *ModelPrefixStore) []string {
+	var orphans []string
+	store.podHashesMu.RLock()
+	defer store.podHashesMu.RUnlock()
+	store.entriesMu.RLock()
+	defer store.entriesMu.RUnlock()
+	for model, mh := range store.entries {
+		for _, shard := range mh.shards {
+			shard.mu.RLock()
+			for hash, podSet := range shard.hashes {
+				for nsName := range podSet {
+					lru, ok := store.podHashes[nsName]
+					if !ok {
+						orphans = append(orphans, fmt.Sprintf("model %s hash %d pod %s in shard but not in podHashes", model, hash, nsName))
+						continue
+					}
+					if !lru.Contains(hashModelKey{hash: hash, model: model}) {
+						orphans = append(orphans, fmt.Sprintf("model %s hash %d pod %s not tracked by its LRU", model, hash, nsName))
+					}
+				}
+			}
+			shard.mu.RUnlock()
+		}
+	}
+	return orphans
+}
+
+func checkNoOrphans(t *testing.T, store *ModelPrefixStore) {
+	t.Helper()
+	for _, o := range orphanReport(store) {
+		t.Errorf("orphan: %s", o)
+	}
+}
+
 func TestModelPrefixStore(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -136,6 +180,10 @@ func TestModelPrefixStore(t *testing.T) {
 			mockStore := datastore.New()
 			store := NewModelPrefixStore(mockStore, tt.maxHashes, tt.topK)
 
+			for _, pod := range tt.pods {
+				seedPod(t, mockStore, pod)
+			}
+
 			// Add pods to cache
 			for i, pod := range tt.pods {
 				if i < len(tt.addHashes) {
@@ -182,6 +230,8 @@ func TestModelPrefixStore(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "pod2", Namespace: "ns1"},
 			},
 		}
+		seedPod(t, mockStore, pod1)
+		seedPod(t, mockStore, pod2)
 
 		// Add same hash for different models
 		store.Add("model-a", []uint64{100, 200}, pod1)
@@ -215,6 +265,7 @@ func TestModelPrefixStore(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "callback-pod", Namespace: "test"},
 			},
 		}
+		seedPod(t, mockStore, pod)
 
 		// Add 2 hashes for model-1 (LRU: [m1:1, m1:2])
 		store.Add("callback-model-1", []uint64{1, 2}, pod)
@@ -253,6 +304,7 @@ func TestModelPrefixStore(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: podName.Name, Namespace: podName.Namespace},
 			},
 		}
+		seedPod(t, mockStore, pod)
 
 		// Add hashes for multiple models
 		store.Add("deletion-model-1", []uint64{100, 200}, pod)
@@ -291,6 +343,8 @@ func TestModelPrefixStore(t *testing.T) {
 		pod2 := &datastore.PodInfo{
 			Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod2", Namespace: "ns1"}},
 		}
+		seedPod(t, mockStore, pod1)
+		seedPod(t, mockStore, pod2)
 
 		// Both pods are added to the cache with the same hashes.
 		store.Add("filter-model", []uint64{1, 2, 3}, pod1)
@@ -320,6 +374,7 @@ func TestModelPrefixStore(t *testing.T) {
 		pod := &datastore.PodInfo{
 			Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: "ns1"}},
 		}
+		seedPod(t, mockStore, pod)
 		store.Add("filter-model", []uint64{1, 2, 3}, pod)
 
 		// Even though pod is cached, an empty candidates list must return nothing.
@@ -349,6 +404,7 @@ func TestModelPrefixStoreEvictionMetric(t *testing.T) {
 		pod := &datastore.PodInfo{
 			Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "evict-pod", Namespace: "test"}},
 		}
+		seedPod(t, mockStore, pod)
 
 		const model = "evictmetric-capacity-model"
 		before := prefixEvictionCount(t, model)
@@ -370,6 +426,7 @@ func TestModelPrefixStoreEvictionMetric(t *testing.T) {
 		pod := &datastore.PodInfo{
 			Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: podName.Name, Namespace: podName.Namespace}},
 		}
+		seedPod(t, mockStore, pod)
 
 		const model = "evictmetric-deletion-model"
 		before := prefixEvictionCount(t, model)
@@ -403,6 +460,7 @@ func TestModelPrefixStoreConcurrency(t *testing.T) {
 					},
 				},
 			}
+			seedPod(t, mockStore, pods[i])
 		}
 
 		// Concurrently add hashes
@@ -449,6 +507,7 @@ func TestModelPrefixStoreConcurrency(t *testing.T) {
 					},
 				},
 			}
+			seedPod(t, mockStore, pods[i])
 		}
 
 		var wg sync.WaitGroup
@@ -509,6 +568,7 @@ func TestModelPrefixStoreConcurrency(t *testing.T) {
 					},
 				},
 			}
+			seedPod(t, mockStore, pods[i])
 		}
 
 		var wg sync.WaitGroup
@@ -530,7 +590,8 @@ func TestModelPrefixStoreConcurrency(t *testing.T) {
 
 		time.Sleep(10 * time.Millisecond) // Let some adds happen first
 
-		// Pod deletion operations
+		// Delete through the datastore so the callback dispatch and the liveness
+		// gate are exercised the way production does it.
 		for i := range numPods / 2 {
 			wg.Add(1)
 			go func(podIndex int) {
@@ -540,21 +601,28 @@ func TestModelPrefixStoreConcurrency(t *testing.T) {
 					Namespace: pods[podIndex].Pod.Namespace,
 					Name:      pods[podIndex].Pod.Name,
 				}
-
-				// Simulate pod deletion event
-				store.onPodDeleted(datastore.EventData{
-					EventType: datastore.EventDelete,
-					Pod:       nsName,
-				})
+				assert.NoError(t, mockStore.DeletePod(nsName))
 			}(i)
 		}
 
 		wg.Wait()
-		time.Sleep(10 * time.Millisecond)
 
-		queryHashes := []uint64{1, 2, 3}
-		matches := store.FindTopMatches("deletion-model", queryHashes, pods)
-		assert.Equal(t, 0, len(matches))
+		// The callback purges shards after removing the registration, so poll until
+		// deleted pods are unregistered and nothing is left mid-purge.
+		assert.Eventually(t, func() bool {
+			store.podHashesMu.RLock()
+			for i := range numPods / 2 {
+				nsName := types.NamespacedName{Namespace: "test", Name: fmt.Sprintf("deletion-pod%d", i)}
+				if _, ok := store.podHashes[nsName]; ok {
+					store.podHashesMu.RUnlock()
+					return false
+				}
+			}
+			store.podHashesMu.RUnlock()
+			return len(orphanReport(store)) == 0
+		}, 2*time.Second, 5*time.Millisecond)
+
+		checkNoOrphans(t, store)
 	})
 
 	t.Run("LRU Eviction Under Concurrency", func(t *testing.T) {
@@ -576,6 +644,7 @@ func TestModelPrefixStoreConcurrency(t *testing.T) {
 					},
 				},
 			}
+			seedPod(t, mockStore, pods[i])
 		}
 
 		var wg sync.WaitGroup
@@ -643,6 +712,7 @@ func TestModelPrefixStoreConcurrency(t *testing.T) {
 						},
 					},
 				}
+				seedPod(t, mockStore, allPods[m][p])
 			}
 		}
 
@@ -719,6 +789,126 @@ func TestModelPrefixStoreConcurrency(t *testing.T) {
 			matches := store.FindTopMatches(modelName, queryHashes, allPods[m])
 			t.Logf("Model %s: found %d matches after stress test", modelName, len(matches))
 		}
+
+		checkNoOrphans(t, store)
+	})
+
+	t.Run("Add racing pod deletion leaves no orphans", func(t *testing.T) {
+		const iters = 300
+		hashes := []uint64{1, 2, 3, 4, 5, 6, 7, 8}
+		for range iters {
+			mockStore := datastore.New()
+			store := NewModelPrefixStore(mockStore, 128, 5)
+			pod := &datastore.PodInfo{
+				Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "race-pod", Namespace: "test"}},
+			}
+			seedPod(t, mockStore, pod)
+			nsName := types.NamespacedName{Namespace: "test", Name: "race-pod"}
+
+			var wg sync.WaitGroup
+			wg.Add(2)
+			go func() {
+				defer wg.Done()
+				store.Add("race-model", hashes, pod)
+			}()
+			go func() {
+				defer wg.Done()
+				store.onPodDeleted(datastore.EventData{EventType: datastore.EventDelete, Pod: nsName})
+			}()
+			wg.Wait()
+
+			checkNoOrphans(t, store)
+		}
+	})
+}
+
+func TestModelPrefixStoreDeletedPod(t *testing.T) {
+	t.Run("Stale Add after completed deletion does not resurrect the pod", func(t *testing.T) {
+		mockStore := datastore.New()
+		store := NewModelPrefixStore(mockStore, 10, 5)
+
+		nsName := types.NamespacedName{Namespace: "test", Name: "stale-pod"}
+		pod := &datastore.PodInfo{
+			Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: nsName.Name, Namespace: nsName.Namespace}},
+		}
+		seedPod(t, mockStore, pod)
+
+		store.Add("stale-model", []uint64{1, 2, 3}, pod)
+		assert.Equal(t, float64(3), store.EntryCount())
+
+		// Delete the pod; the direct onPodDeleted call makes the purge deterministic,
+		// the callback DeletePod dispatches is an idempotent no-op.
+		assert.NoError(t, mockStore.DeletePod(nsName))
+		store.onPodDeleted(datastore.EventData{EventType: datastore.EventDelete, Pod: nsName})
+		assert.Eventually(t, func() bool { return store.EntryCount() == 0 }, time.Second, 5*time.Millisecond)
+
+		// The Add for a request that was still in flight when the pod went away.
+		store.Add("stale-model", []uint64{1, 2, 3}, pod)
+
+		store.podHashesMu.RLock()
+		_, registered := store.podHashes[nsName]
+		store.podHashesMu.RUnlock()
+		assert.False(t, registered, "stale Add must not re-register a deleted pod")
+		assert.Equal(t, float64(0), store.EntryCount())
+		store.entriesMu.RLock()
+		assert.Equal(t, 0, len(store.entries), "stale Add must not recreate the model entry")
+		store.entriesMu.RUnlock()
+		checkNoOrphans(t, store)
+	})
+
+	t.Run("Readiness flap does not permanently suppress caching", func(t *testing.T) {
+		mockStore := datastore.New()
+		store := NewModelPrefixStore(mockStore, 10, 5)
+
+		nsName := types.NamespacedName{Namespace: "test", Name: "flap-pod"}
+		pod := &datastore.PodInfo{
+			Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: nsName.Name, Namespace: nsName.Namespace}},
+		}
+		seedPod(t, mockStore, pod)
+		store.Add("flap-model", []uint64{1, 2}, pod)
+
+		// Pod goes NotReady: removed from the datastore, delete event fires. The purge
+		// drops the model entry last, so entries emptying means the callback finished.
+		assert.NoError(t, mockStore.DeletePod(nsName))
+		assert.Eventually(t, func() bool {
+			store.entriesMu.RLock()
+			defer store.entriesMu.RUnlock()
+			return len(store.entries) == 0
+		}, 2*time.Second, 5*time.Millisecond)
+
+		// Pod becomes Ready again and caches normally.
+		seedPod(t, mockStore, pod)
+		store.Add("flap-model", []uint64{1, 2}, pod)
+
+		matches := store.FindTopMatches("flap-model", []uint64{1, 2}, []*datastore.PodInfo{pod})
+		assert.Equal(t, 1, len(matches))
+		assert.Equal(t, 2, matches[nsName])
+		assert.Equal(t, float64(2), store.EntryCount())
+	})
+
+	t.Run("Undo path does not count as eviction", func(t *testing.T) {
+		mockStore := datastore.New()
+		store := NewModelPrefixStore(mockStore, 10, 5)
+
+		nsName := types.NamespacedName{Namespace: "test", Name: "undo-pod"}
+		pod := &datastore.PodInfo{
+			Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: nsName.Name, Namespace: nsName.Namespace}},
+		}
+		seedPod(t, mockStore, pod)
+
+		const model = "evictmetric-undo-model"
+		before := prefixEvictionCount(t, model)
+
+		store.Add(model, []uint64{1, 2, 3}, pod)
+		// The path Add takes when its verify step finds the registration gone.
+		store.purgeModelHashes(model, []uint64{1, 2, 3}, nsName)
+
+		if got := prefixEvictionCount(t, model) - before; got != 0 {
+			t.Errorf("evictions delta on undo = %v, want 0", got)
+		}
+		store.entriesMu.RLock()
+		assert.Equal(t, 0, len(store.entries))
+		store.entriesMu.RUnlock()
 	})
 }
 
@@ -743,6 +933,7 @@ func BenchmarkModelPrefixStore_FindAndAdd(b *testing.B) {
 				},
 			},
 		}
+		seedPod(b, mockStore, pods[i])
 	}
 
 	for m := 0; m < numModels; m++ {

--- a/pkg/kthena-router/scheduler/plugins/prefix_cache_test.go
+++ b/pkg/kthena-router/scheduler/plugins/prefix_cache_test.go
@@ -108,6 +108,14 @@ func TestHashPrompt(t *testing.T) {
 	}
 }
 
+// seedPodInStore registers the pod in the datastore so the prefix store's Add accepts it.
+func seedPodInStore(t testing.TB, ds datastore.Store, pod *datastore.PodInfo) {
+	t.Helper()
+	if err := ds.AddOrUpdatePod(pod.Pod, nil); err != nil {
+		t.Fatalf("seed pod: %v", err)
+	}
+}
+
 func TestPrefixCacheScore(t *testing.T) {
 	// We construct a minimal PrefixCache by hand to avoid yaml/flag plumbing.
 	t.Run("all pods present in score map, non-matching pods score 0", func(t *testing.T) {
@@ -126,6 +134,7 @@ func TestPrefixCacheScore(t *testing.T) {
 		pod3 := &datastore.PodInfo{Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod3", Namespace: "ns1"}}}
 
 		// Pre-populate cache: only pod1 has a matching prefix for "hello world"
+		seedPodInStore(t, mockDS, pod1)
 		prompt := "hello world"
 		hashes := plugin.hashPrompt("test-model", prompt)
 		prefixStore.Add("test-model", hashes, pod1)
@@ -272,6 +281,7 @@ func TestPrefixCacheScoreMetrics(t *testing.T) {
 	pod2 := &datastore.PodInfo{Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod2", Namespace: "ns1"}}}
 
 	const model = "prefixmetrics-model"
+	seedPodInStore(t, mockDS, pod1)
 	prompt := "hello world from prefix cache metrics test"
 	hashes := plugin.hashPrompt(model, prompt)
 	prefixStore.Add(model, hashes, pod1)
@@ -308,6 +318,7 @@ func TestPrefixCacheEntriesProviderRegistered(t *testing.T) {
 	plugin := NewPrefixCache(mockDS, runtime.RawExtension{Raw: []byte{}})
 
 	pod := &datastore.PodInfo{Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: "ns1"}}}
+	seedPodInStore(t, mockDS, pod)
 	const model = "prefixentries-model"
 	hashes := plugin.hashPrompt(model, "some prompt that yields a single block")
 	plugin.store.Add(model, hashes, pod)
@@ -331,6 +342,7 @@ func benchmarkPrefixScore(b *testing.B, withMetrics bool) {
 	pods := []*datastore.PodInfo{pod1, pod2}
 
 	const model = "bench-prefix-model"
+	seedPodInStore(b, mockDS, pod1)
 	prompt := strings.Repeat("the quick brown fox jumps over the lazy dog ", 40)
 	hashes := plugin.hashPrompt(model, prompt)
 	prefixStore.Add(model, hashes, pod1)
@@ -373,12 +385,15 @@ func TestNewPrefixCacheWithEmptyArgs(t *testing.T) {
 }
 
 func TestNewPrefixCacheRespectsTopKMatches(t *testing.T) {
-	plugin := NewPrefixCache(datastore.New(), runtime.RawExtension{
+	mockDS := datastore.New()
+	plugin := NewPrefixCache(mockDS, runtime.RawExtension{
 		Raw: []byte(`{"blockSizeToHash": 64, "maxBlocksToMatch": 128, "maxHashCacheSize": 50000, "topKMatches": 1}`),
 	})
 
 	pod1 := &datastore.PodInfo{Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: "ns1"}}}
 	pod2 := &datastore.PodInfo{Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod2", Namespace: "ns1"}}}
+	seedPodInStore(t, mockDS, pod1)
+	seedPodInStore(t, mockDS, pod2)
 
 	prompt := "same prompt for both pods"
 	hashes := plugin.hashPrompt("test-model", prompt)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`ModelPrefixStore.Add` releases `podHashesMu` before inserting into the shard index, and registers a pod again whenever its LRU is missing. Pod deletion turns both into leaks:

- a deletion landing mid `Add` purges the LRU snapshot it took, then the still running `Add` keeps inserting; those entries have no eviction path left
- an `Add` arriving after the deletion completed recreates the LRU for a pod that no longer exists, and nothing ever removes it. @acsoto pointed this case out on the issue, and it is the common one: `Add` runs from PostSchedule when the proxied request completes, so the gap between scheduling and `Add` spans the whole request

The fix keeps the short lock structure:

- `Add` only registers a pod the datastore still knows. The datastore removes a pod before dispatching its delete event, so this check under `podHashesMu` cannot race the callback
- after inserting, `Add` re-reads the registration; if its LRU is no longer the registered one, a deletion won, and `Add` removes exactly what it inserted. Pointer comparison rather than presence, since a recreated pod registers a new LRU

A tombstone set was the alternative and is wrong here: a pod leaves the datastore just for going NotReady and returns under the same name, so liveness has to come from the live store.

Hot path cost: one map load when a pod is first registered, one RLock read per `Add`. No lock is held across the shard inserts.

Left alone on purpose: the pre-existing race where `entries[model]` can be dropped after a concurrent `Add` captured the model pointer. Entries lost that way stay evictable, inside the tolerance the file already documents.

**Which issue(s) this PR fixes**:
Fixes #1513

**Bug evidence (required for bug-related PRs)**:

The interleaving and repro are in #1513, measured at 15 of 2000 interleaved runs. On current main:

- `Add` releases the lock, then inserts: https://github.com/volcano-sh/kthena/blob/0714136e5cf09297d910e660c7d7d08b2804fad2/pkg/kthena-router/scheduler/plugins/cache/prefix_store.go#L199-L235
- `onPodDeleted` purges from a `Keys()` snapshot: https://github.com/volcano-sh/kthena/blob/0714136e5cf09297d910e660c7d7d08b2804fad2/pkg/kthena-router/scheduler/plugins/cache/prefix_store.go#L98-L125
- callbacks run on their own goroutines: https://github.com/volcano-sh/kthena/blob/0714136e5cf09297d910e660c7d7d08b2804fad2/pkg/kthena-router/datastore/store.go#L1770
- `RunPostHooks` fires after the proxied request completes: https://github.com/volcano-sh/kthena/blob/0714136e5cf09297d910e660c7d7d08b2804fad2/pkg/kthena-router/router/router.go#L824

The new stale `Add` regression test fails on main by re-registering the deleted pod. No live cluster repro, the tests exercise the path, same as #1428.

**Special notes for your reviewer**:

Existing tests build pods without datastore entries, so they now seed the datastore first, which is most of the test diff. New coverage: a deterministic stale `Add` case, an interleaved `Add` versus deletion loop with an invariant check that every shard entry stays evictable, a readiness flap case proving a returning pod caches again, and a check that the undo path does not count as an eviction.

Two acknowledged edges, both in the tolerated direction: a stale Add's undo can transiently purge entries a recreated same name pod just re inserted (microsecond window, self heals on the next Add), and requests completing while their pod is NotReady no longer warm the cache, since that warming path was exactly the phantom registration this fixes. While hardening the tests I also found a sibling datastore gap, a pod removal path that skips the delete event entirely, filed separately as #1570.

`GetPodInfo`'s doc comment said "(for testing)"; it now has a production caller, so the note is updated.

**Does this PR introduce a user-facing change?**:

```release-note
Fixed the prefix cache retaining unevictable entries when a pod is deleted while or shortly before its cache update runs.
```

