### PR TITLE
cli: replace ModelInfer with ModelServing in README

### DIFF
--- a/cli/kthena/README.md
+++ b/cli/kthena/README.md
@@ -24,7 +24,7 @@ package "kthena CLI" {
     
     rectangle "Kubernetes Resources" as KubernetesResources {
        usecase "Model(s)" as ModelResource
-       usecase "ModelInfer(s)" as ModelInferResource
+       usecase "ModelServing(s)" as ModelServingResource
        usecase "Policy(s)" as PolicyResource
        usecase "PolicyBinding(s)" as PolicyBindingResource
     }
@@ -60,7 +60,7 @@ end note
 
 ' layout
 GetVerb -[hidden]-> ModelResource
-GetVerb -[hidden]-> ModelInferResource
+GetVerb -[hidden]-> ModelServingResource
 GetVerb -[hidden]-> PolicyResource
 GetVerb -[hidden]-> PolicyBindingResource
 
@@ -178,7 +178,7 @@ Example template structure:
 # Variables: var1, var2, var3
 ---
 apiVersion: workload.serving.volcano.sh/v1alpha1
-kind: ModelInfer
+kind: ModelServing
 metadata:
   name: {{.name}}
   namespace: {{.namespace}}


### PR DESCRIPTION
/kind documentation

The custom template guide documents `kind: ModelInfer`, but `kthena create manifest` dispatches on kind and only accepts ModelServing, ModelBooster and AutoscalingPolicy, so a template written from the example fails with `unsupported resource type: ModelInfer`:

https://github.com/volcano-sh/kthena/blob/aa6ab1fe19ea86377d406e079331403411b77a1c/cli/kthena/cmd/create.go#L288-L330

The use case diagram at the top of the README had the same stale name, so all three references become ModelServing. The `apiVersion` in the example is already correct, `workload.serving.volcano.sh/v1alpha1` matches the registered group.

Fixes #1543
