### PR TITLE
runtime: decode current vLLM map-shaped KV events

### DIFF
--- a/python/kthena/runtime/zmq_subscriber.py
+++ b/python/kthena/runtime/zmq_subscriber.py
@@ -38,17 +38,17 @@ class EventBatch(msgspec.Struct, array_like=True, omit_defaults=True, gc=False):
 
 
 class KVCacheEvent(
-    msgspec.Struct, array_like=True, omit_defaults=True, gc=False, tag=True
+    msgspec.Struct, omit_defaults=True, gc=False, tag=True
 ):
     pass
 
 
 class BlockStored(KVCacheEvent):
     block_hashes: list[int]
-    parent_block_hash: Optional[int]
     token_ids: list[int]
-    block_size: int
-    lora_id: Optional[int]
+    parent_block_hash: Optional[int] = None
+    block_size: Optional[int] = None
+    lora_id: Optional[int] = None
 
 
 class BlockRemoved(KVCacheEvent):
@@ -63,6 +63,54 @@ class KVEventBatch(EventBatch):
     events: list[Union[BlockStored, BlockRemoved, AllBlocksCleared]]
 
 
+# Legacy positional-array event schema, still emitted by older vLLM and by
+# llm-d-inference-sim with use-vllm-map-event-format=false (its default). The
+# trailing fields after lora_id are omitempty on the wire, so a short array is
+# valid. Kept so the subscriber stays backward compatible with array producers.
+class _LegacyBlockStored(
+    msgspec.Struct, array_like=True, omit_defaults=True, gc=False, tag="BlockStored"
+):
+    block_hashes: list[int]
+    parent_block_hash: Optional[int]
+    token_ids: list[int]
+    block_size: int
+    lora_id: Optional[int] = None
+
+
+class _LegacyBlockRemoved(
+    msgspec.Struct, array_like=True, omit_defaults=True, gc=False, tag="BlockRemoved"
+):
+    block_hashes: list[int]
+
+
+class _LegacyAllBlocksCleared(
+    msgspec.Struct, array_like=True, omit_defaults=True, gc=False, tag="AllBlocksCleared"
+):
+    pass
+
+
+class _LegacyKVEventBatch(EventBatch):
+    events: list[Union[_LegacyBlockStored, _LegacyBlockRemoved, _LegacyAllBlocksCleared]]
+
+
+def _legacy_to_current(event: Any) -> Any:
+    """Normalize a legacy array-shaped event into the current map struct so the
+    rest of the pipeline sees a single representation."""
+    if isinstance(event, _LegacyBlockStored):
+        return BlockStored(
+            block_hashes=event.block_hashes,
+            token_ids=event.token_ids,
+            parent_block_hash=event.parent_block_hash,
+            block_size=event.block_size,
+            lora_id=event.lora_id,
+        )
+    if isinstance(event, _LegacyBlockRemoved):
+        return BlockRemoved(block_hashes=event.block_hashes)
+    if isinstance(event, _LegacyAllBlocksCleared):
+        return AllBlocksCleared()
+    return event
+
+
 class VLLMZMQSubscriber:
 
     def __init__(self, pod_identifier: str, model_name: str):
@@ -72,6 +120,7 @@ class VLLMZMQSubscriber:
         self.running = False
         self.event_publisher = get_event_publisher()
         self.decoder = Decoder(type=KVEventBatch)
+        self._legacy_decoder = Decoder(type=_LegacyKVEventBatch)
         self._connection_lock = asyncio.Lock()
         self._shutdown_event = asyncio.Event()
 
@@ -190,13 +239,33 @@ class VLLMZMQSubscriber:
             logger.warning(f"Error extracting message data: {e}")
             return None, None
 
+    def _decode_legacy(self, payload: bytes) -> KVEventBatch:
+        legacy = self._legacy_decoder.decode(payload)
+        return KVEventBatch(
+            ts=legacy.ts,
+            events=[_legacy_to_current(e) for e in legacy.events],
+            data_parallel_rank=legacy.data_parallel_rank,
+        )
+
+    def _decode_batch(self, payload: bytes) -> KVEventBatch:
+        """Decode a KV-event batch, accepting both the current vLLM map-shaped
+        events and the legacy positional-array events still emitted by older
+        vLLM and by llm-d-inference-sim (use-vllm-map-event-format=false). The
+        outer EventBatch is unchanged; legacy events are normalized to the same
+        structs. Kthena-required block_hashes/token_ids stay required, so a
+        payload missing them is rejected in either shape."""
+        try:
+            return self.decoder.decode(payload)
+        except msgspec.ValidationError:
+            return self._decode_legacy(payload)
+
     async def _process_message(self, payload: bytes, pod_identifier: str, model_name: str) -> None:
         if not payload:
             logger.warning("Empty payload received")
             return
 
         try:
-            event_batch = self.decoder.decode(payload)
+            event_batch = self._decode_batch(payload)
 
             if not event_batch or not hasattr(event_batch, 'events'):
                 logger.warning("Invalid event batch structure")

--- a/python/kthena/tests/test_zmq_subscriber.py
+++ b/python/kthena/tests/test_zmq_subscriber.py
@@ -13,10 +13,16 @@
 # limitations under the License.
 from dataclasses import replace
 
+import msgspec
 import pytest
 
 from kthena.runtime import zmq_subscriber
-from kthena.runtime.zmq_subscriber import VLLMZMQSubscriber
+from kthena.runtime.zmq_subscriber import (
+    AllBlocksCleared,
+    BlockRemoved,
+    BlockStored,
+    VLLMZMQSubscriber,
+)
 
 
 @pytest.mark.asyncio
@@ -66,3 +72,80 @@ async def test_vllm_subscriber_honors_configured_topic_filter(monkeypatch):
     await sub._run_subscriber()
 
     assert processed_payloads == [b"right"]
+
+
+# ---------------------------------------------------------------------------
+# KV-event wire-format compatibility.
+#
+# The subscriber must decode both the current vLLM map-shaped events and the
+# legacy positional-array events still emitted by older vLLM and by
+# llm-d-inference-sim (use-vllm-map-event-format=false, its default). Each
+# fixture is built as raw msgpack so it is the wire itself, not a re-encoding of
+# the runtime's own structs.
+# ---------------------------------------------------------------------------
+
+
+def _decode(*events):
+    payload = msgspec.msgpack.encode([1.0, list(events), None])
+    sub = VLLMZMQSubscriber(pod_identifier="pod-a", model_name="m")
+    return sub._decode_batch(payload).events
+
+
+def test_decodes_current_map_block_stored():
+    (event,) = _decode({"type": "BlockStored", "block_hashes": [10, 11],
+                        "token_ids": [1, 2, 3, 4], "parent_block_hash": None,
+                        "block_size": 2, "lora_id": None})
+    assert isinstance(event, BlockStored)
+    assert event.block_hashes == [10, 11]
+    assert event.token_ids == [1, 2, 3, 4]
+
+
+def test_decodes_current_map_block_removed():
+    (event,) = _decode({"type": "BlockRemoved", "block_hashes": [7]})
+    assert isinstance(event, BlockRemoved)
+    assert event.block_hashes == [7]
+
+
+def test_decodes_current_map_all_blocks_cleared():
+    (event,) = _decode({"type": "AllBlocksCleared"})
+    assert isinstance(event, AllBlocksCleared)
+
+
+def test_decodes_legacy_array_block_stored():
+    # [tag, block_hashes, parent_block_hash, token_ids, block_size, lora_id]
+    (event,) = _decode(["BlockStored", [10, 11], None, [1, 2, 3, 4], 2, None])
+    assert isinstance(event, BlockStored)
+    assert event.block_hashes == [10, 11]
+    assert event.token_ids == [1, 2, 3, 4]
+
+
+def test_decodes_legacy_array_block_removed():
+    (event,) = _decode(["BlockRemoved", [7]])
+    assert isinstance(event, BlockRemoved)
+    assert event.block_hashes == [7]
+
+
+def test_decodes_legacy_array_all_blocks_cleared():
+    (event,) = _decode(["AllBlocksCleared"])
+    assert isinstance(event, AllBlocksCleared)
+
+
+def test_decodes_simulator_array_with_trailing_medium():
+    # Exact llm-d-inference-sim BlockStored wire: a zero parent hash when there
+    # is no parent, and a trailing omitempty `medium` the runtime does not
+    # declare. It must decode with the hashes preserved and `medium` ignored.
+    (event,) = _decode(["BlockStored", [10, 11], 0, [1, 2, 3, 4], 2, 0, "GPU"])
+    assert isinstance(event, BlockStored)
+    assert event.block_hashes == [10, 11]
+    assert event.token_ids == [1, 2, 3, 4]
+    assert event.parent_block_hash == 0
+
+
+def test_rejects_map_missing_block_hashes():
+    with pytest.raises(msgspec.ValidationError):
+        _decode({"type": "BlockStored", "token_ids": [1, 2]})
+
+
+def test_rejects_map_missing_token_ids():
+    with pytest.raises(msgspec.ValidationError):
+        _decode({"type": "BlockStored", "block_hashes": [7]})


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:
The vLLM KV-event subscriber's msgspec decoder declared `KVCacheEvent` with
`array_like=True`, so it expected each event as a tagged array. Current vLLM
emits each KV event as a tagged **map** (only the outer `EventBatch` stays
array-shaped), so real KV events fail to decode (`ValidationError: Expected
array, got object`) and are dropped before reaching Redis — the KVCache-aware
path receives nothing.

This drops `array_like` from `KVCacheEvent` (the outer `EventBatch` is
unchanged) so map-shaped events decode, and relaxes the non-essential
`BlockStored` fields to optional so current and future vLLM fields are
tolerated. Required fields (`block_hashes`, `token_ids`) are still enforced, so
malformed payloads are still rejected; unknown fields are ignored for forward
compatibility.

**Which issue(s) this PR fixes**:
Fixes #1535

**Bug evidence (required for bug-related PRs)**:
Against a KV event captured from a running vLLM 0.26.0 ZMQ publisher, the current
decoder raises `ValidationError: Expected array, got object - at $[1][0]`. The
3-part ZMQ frame and `kv-events` topic pass; the failure is purely the msgspec
typed decode. The added `python/kthena/tests/test_vllm_zmq_wire_compat.py` uses
map-shaped fixtures (BlockStored / BlockRemoved / AllBlocksCleared) that fail to
decode before this change and decode after, plus malformed-rejection and
unknown-field cases.

**Special notes for your reviewer**:
Scope is wire decode for the current vLLM default path. Semantics for
hybrid/multi-group models (group identity), offloaded blocks (medium/locality),
and per-request identity (LoRA / multimodal / cache_salt) are being investigated
separately and are intentionally out of scope here.
This PR was written in part with the assistance of generative AI; the analysis,
experiments, and wording are my own.

**Does this PR introduce a user-facing change?**:
```release-note
Fix vLLM KV-cache event decoding to accept the current vLLM map-shaped wire format.
```
