### PR TITLE
router: ignore runtime sidecar restarts in kvcache freshness

### DIFF
--- a/docs/kthena/docs/user-guide/config-router.md
+++ b/docs/kthena/docs/user-guide/config-router.md
@@ -19,7 +19,7 @@ Plugin Configuration (PluginConfig):
 | least-request | maxWaitingRequests                                          | Sets the maximum number of waiting requests                                                               |
 | least-latency | TTFTTPOTWeightFactor                                        | Sets the weight factor for TTFT and TPOT                                                                  |
 | prefix-cache  | blockSizeToHash<br />maxBlocksToMatch<br />maxHashCacheSize | Configures prefix cache parameters                                                                        |
-| kvcache-aware | blockSizeToHash<br />maxBlocksToMatch                       | Configures KV cache aware token-block matching parameters. Requires Redis and the Kthena Runtime sidecar. |
+| kvcache-aware | blockSizeToHash<br />maxBlocksToMatch<br />runtimeContainerName | Configures KV cache aware token-block matching parameters. Requires Redis and the Kthena Runtime sidecar. `runtimeContainerName`: sidecar excluded from the restart signal (default `runtime`, `""` disables). |
 
 Filter Plugins (Filter):
 

--- a/docs/kthena/docs/user-guide/config-router.md
+++ b/docs/kthena/docs/user-guide/config-router.md
@@ -19,7 +19,7 @@ Plugin Configuration (PluginConfig):
 | least-request | maxWaitingRequests                                          | Sets the maximum number of waiting requests                                                               |
 | least-latency | TTFTTPOTWeightFactor                                        | Sets the TTFT weight factor. Must be between `0.0` and `1.0`.                                             |
 | prefix-cache  | blockSizeToHash<br />maxBlocksToMatch<br />maxHashCacheSize | Configures prefix cache parameters                                                                        |
-| kvcache-aware | blockSizeToHash<br />maxBlocksToMatch                       | Configures KV cache aware token-block matching parameters. Requires Redis and the Kthena Runtime sidecar. |
+| kvcache-aware | blockSizeToHash<br />maxBlocksToMatch<br />runtimeContainerName | Configures KV cache aware token-block matching parameters. Requires Redis and the Kthena Runtime sidecar. `runtimeContainerName`: sidecar excluded from the restart signal (default `runtime`, `""` disables). |
 
 `TTFTTPOTWeightFactor` controls how the least-latency plugin balances Time To First Token (TTFT) and Time Per Output Token (TPOT):
 

--- a/docs/kthena/docs/user-guide/kvcache-aware.md
+++ b/docs/kthena/docs/user-guide/kvcache-aware.md
@@ -17,7 +17,7 @@ Pods with more consecutive matching blocks score higher and are preferred for ro
 ## Prerequisites
 
 - **Redis**: A Redis instance accessible by both the router and the runtime sidecars. Deploy Redis using the provided [redis-standalone.yaml](../assets/examples/redis/redis-standalone.yaml) example.
-- **Kthena Runtime sidecar**: Must be deployed alongside each vLLM pod. The sidecar listens to vLLM's ZMQ `kv-events` stream and writes token block hashes into Redis.
+- **Kthena Runtime sidecar**: Must be deployed alongside each vLLM pod. The sidecar listens to vLLM's ZMQ `kv-events` stream and writes token block hashes into Redis. The container should be named `runtime` (the generated templates and examples do this): the router excludes that container from its cache freshness restart signal, since a sidecar restart leaves the engine's KV cache intact. Deployments that name the sidecar differently can set the plugin's `runtimeContainerName` argument to match (one value for the whole router).
 - **vLLM v1 with KV event support**: The vLLM engine must be running with `VLLM_USE_V1=1` and expose the ZMQ kv-events topic.
 - **Multi-pod inference deployment**: The plugin is meaningful only when multiple pods serve the same model.
 

--- a/pkg/kthena-router/scheduler/plugins/kvcache_aware.go
+++ b/pkg/kthena-router/scheduler/plugins/kvcache_aware.go
@@ -76,9 +76,9 @@ const (
 	kvCacheGCInterval = time.Hour
 	kvCacheGCScanSize = int64(100)
 
-	// runtimeContainerName is the runtime sidecar's name in the generated pod templates
-	// and the examples. Its restarts leave the engine's KV cache intact.
-	runtimeContainerName = "runtime"
+	// defaultRuntimeContainerName is the runtime sidecar's name in the generated pod
+	// templates and the examples. Its restarts leave the engine's KV cache intact.
+	defaultRuntimeContainerName = "runtime"
 )
 
 type KVCacheAwareArgs struct {
@@ -88,16 +88,21 @@ type KVCacheAwareArgs struct {
 	VLLMTokenizerPort int `yaml:"vllmTokenizerPort,omitempty"`
 	// SGLangTokenizerPort overrides the default SGLang tokenizer port (30000).
 	SGLangTokenizerPort int `yaml:"sglangTokenizerPort,omitempty"`
+	// RuntimeContainerName is the sidecar container excluded from the restart signal,
+	// one value for the whole router. Defaults to "runtime", the name used by the
+	// generated pod templates; "" counts every container.
+	RuntimeContainerName *string `yaml:"runtimeContainerName,omitempty"`
 }
 
 type KVCacheAware struct {
-	name             string
-	maxBlocksToMatch int
-	keyPrefix        string
-	redisClient      *redis.Client
-	processor        *TokenBlockProcessor
-	tokenizerManager *tokenization.TokenizerManager
-	gcCursor         uint64
+	name                 string
+	maxBlocksToMatch     int
+	keyPrefix            string
+	redisClient          *redis.Client
+	processor            *TokenBlockProcessor
+	tokenizerManager     *tokenization.TokenizerManager
+	runtimeContainerName string
+	gcCursor             uint64
 }
 
 var _ framework.ScorePlugin = &KVCacheAware{}
@@ -154,9 +159,13 @@ func NewKVCacheAware(pluginArg runtime.RawExtension) *KVCacheAware {
 	if sglangPort <= 0 {
 		sglangPort = defaultSGLangTokenizerPort
 	}
+	runtimeName := defaultRuntimeContainerName
+	if args.RuntimeContainerName != nil {
+		runtimeName = *args.RuntimeContainerName
+	}
 
-	klog.Infof("KVCacheAware: config blockSizeToHash=%d, maxBlocksToMatch=%d, vllmTokenizerPort=%d, sglangTokenizerPort=%d",
-		blockSizeToHash, maxBlocksToMatch, vllmPort, sglangPort)
+	klog.Infof("KVCacheAware: config blockSizeToHash=%d, maxBlocksToMatch=%d, vllmTokenizerPort=%d, sglangTokenizerPort=%d, runtimeContainerName=%q",
+		blockSizeToHash, maxBlocksToMatch, vllmPort, sglangPort, runtimeName)
 
 	managerConfig := tokenization.TokenizerManagerConfig{
 		EndpointPorts: map[string]int{
@@ -174,12 +183,13 @@ func NewKVCacheAware(pluginArg runtime.RawExtension) *KVCacheAware {
 	}
 
 	plugin := &KVCacheAware{
-		name:             KVCacheAwarePluginName,
-		maxBlocksToMatch: maxBlocksToMatch,
-		keyPrefix:        kvCacheKeyPrefix,
-		redisClient:      redisClient,
-		processor:        &TokenBlockProcessor{blockSize: blockSizeToHash},
-		tokenizerManager: manager,
+		name:                 KVCacheAwarePluginName,
+		maxBlocksToMatch:     maxBlocksToMatch,
+		keyPrefix:            kvCacheKeyPrefix,
+		redisClient:          redisClient,
+		processor:            &TokenBlockProcessor{blockSize: blockSizeToHash},
+		tokenizerManager:     manager,
+		runtimeContainerName: runtimeName,
 	}
 	plugin.startGC()
 	return plugin
@@ -245,7 +255,7 @@ func (t *KVCacheAware) Score(ctx *framework.Context, pods []*datastore.PodInfo) 
 	}
 
 	redisStart := time.Now()
-	blockToPods, err := t.queryRedisForBlocks(blockHashes, ctx.Model, ownerStartTimes(pods))
+	blockToPods, err := t.queryRedisForBlocks(blockHashes, ctx.Model, ownerStartTimes(pods, t.runtimeContainerName))
 	redisDuration := time.Since(redisStart)
 	if err != nil {
 		if ctx.MetricsRecorder != nil {
@@ -424,10 +434,10 @@ func (t *KVCacheAware) deleteStaleFields(staleFields map[string][]string) {
 }
 
 // podLastContainerStartUnix reports when the pod's containers last started, or 0 if none are
-// running. The runtime sidecar is excluded: it only relays events, so restarting it says
-// nothing about the cache. Readiness is not used: it also flips on a probe failure, which
-// leaves the cache intact.
-func podLastContainerStartUnix(pod *corev1.Pod) int64 {
+// running. The sidecar named sidecarName is excluded: it only relays events, so restarting
+// it says nothing about the cache; an empty name excludes nothing. Readiness is not used:
+// it also flips on a probe failure, which leaves the cache intact.
+func podLastContainerStartUnix(pod *corev1.Pod, sidecarName string) int64 {
 	if pod == nil {
 		return 0
 	}
@@ -440,7 +450,7 @@ func podLastContainerStartUnix(pod *corev1.Pod) int64 {
 		if started > newestAll {
 			newestAll = started
 		}
-		if cs.Name == runtimeContainerName {
+		if sidecarName != "" && cs.Name == sidecarName {
 			continue
 		}
 		if started > newest {
@@ -456,10 +466,10 @@ func podLastContainerStartUnix(pod *corev1.Pod) int64 {
 
 // ownerStartTimes maps each candidate's cache-owner identifier to its container start time.
 // Keyed on the full name.namespace form so pods sharing a name across namespaces stay distinct.
-func ownerStartTimes(pods []*datastore.PodInfo) map[string]int64 {
+func ownerStartTimes(pods []*datastore.PodInfo, sidecarName string) map[string]int64 {
 	owners := make(map[string]int64, len(pods))
 	for _, p := range pods {
-		if started := podLastContainerStartUnix(p.GetPod()); started > 0 {
+		if started := podLastContainerStartUnix(p.GetPod(), sidecarName); started > 0 {
 			owners[podCacheOwnerIdentifier(p)] = started
 		}
 	}

--- a/pkg/kthena-router/scheduler/plugins/kvcache_aware.go
+++ b/pkg/kthena-router/scheduler/plugins/kvcache_aware.go
@@ -75,6 +75,10 @@ const (
 
 	kvCacheGCInterval = time.Hour
 	kvCacheGCScanSize = int64(100)
+
+	// runtimeContainerName is the runtime sidecar's name in the generated pod templates
+	// and the examples. Its restarts leave the engine's KV cache intact.
+	runtimeContainerName = "runtime"
 )
 
 type KVCacheAwareArgs struct {
@@ -420,19 +424,32 @@ func (t *KVCacheAware) deleteStaleFields(staleFields map[string][]string) {
 }
 
 // podLastContainerStartUnix reports when the pod's containers last started, or 0 if none are
-// running. Readiness is not used: it also flips on a probe failure, which leaves the cache intact.
+// running. The runtime sidecar is excluded: it only relays events, so restarting it says
+// nothing about the cache. Readiness is not used: it also flips on a probe failure, which
+// leaves the cache intact.
 func podLastContainerStartUnix(pod *corev1.Pod) int64 {
 	if pod == nil {
 		return 0
 	}
-	var newest int64
+	var newest, newestAll int64
 	for _, cs := range pod.Status.ContainerStatuses {
 		if cs.State.Running == nil {
 			continue
 		}
-		if started := cs.State.Running.StartedAt.Unix(); started > newest {
+		started := cs.State.Running.StartedAt.Unix()
+		if started > newestAll {
+			newestAll = started
+		}
+		if cs.Name == runtimeContainerName {
+			continue
+		}
+		if started > newest {
 			newest = started
 		}
+	}
+	if newest == 0 {
+		// No container other than the sidecar is running: keep the previous behavior.
+		return newestAll
 	}
 	return newest
 }

--- a/pkg/kthena-router/scheduler/plugins/kvcache_aware.go
+++ b/pkg/kthena-router/scheduler/plugins/kvcache_aware.go
@@ -76,6 +76,10 @@ const (
 
 	kvCacheGCInterval = time.Hour
 	kvCacheGCScanSize = int64(100)
+
+	// runtimeContainerName is the runtime sidecar's name in the generated pod templates
+	// and the examples. Its restarts leave the engine's KV cache intact.
+	runtimeContainerName = "runtime"
 )
 
 type KVCacheAwareArgs struct {
@@ -427,19 +431,32 @@ func (t *KVCacheAware) deleteStaleFields(staleFields map[string][]string) {
 }
 
 // podLastContainerStartUnix reports when the pod's containers last started, or 0 if none are
-// running. Readiness is not used: it also flips on a probe failure, which leaves the cache intact.
+// running. The runtime sidecar is excluded: it only relays events, so restarting it says
+// nothing about the cache. Readiness is not used: it also flips on a probe failure, which
+// leaves the cache intact.
 func podLastContainerStartUnix(pod *corev1.Pod) int64 {
 	if pod == nil {
 		return 0
 	}
-	var newest int64
+	var newest, newestAll int64
 	for _, cs := range pod.Status.ContainerStatuses {
 		if cs.State.Running == nil {
 			continue
 		}
-		if started := cs.State.Running.StartedAt.Unix(); started > newest {
+		started := cs.State.Running.StartedAt.Unix()
+		if started > newestAll {
+			newestAll = started
+		}
+		if cs.Name == runtimeContainerName {
+			continue
+		}
+		if started > newest {
 			newest = started
 		}
+	}
+	if newest == 0 {
+		// No container other than the sidecar is running: keep the previous behavior.
+		return newestAll
 	}
 	return newest
 }

--- a/pkg/kthena-router/scheduler/plugins/kvcache_aware.go
+++ b/pkg/kthena-router/scheduler/plugins/kvcache_aware.go
@@ -77,9 +77,9 @@ const (
 	kvCacheGCInterval = time.Hour
 	kvCacheGCScanSize = int64(100)
 
-	// runtimeContainerName is the runtime sidecar's name in the generated pod templates
-	// and the examples. Its restarts leave the engine's KV cache intact.
-	runtimeContainerName = "runtime"
+	// defaultRuntimeContainerName is the runtime sidecar's name in the generated pod
+	// templates and the examples. Its restarts leave the engine's KV cache intact.
+	defaultRuntimeContainerName = "runtime"
 )
 
 type KVCacheAwareArgs struct {
@@ -89,16 +89,21 @@ type KVCacheAwareArgs struct {
 	VLLMTokenizerPort int `yaml:"vllmTokenizerPort,omitempty"`
 	// SGLangTokenizerPort overrides the default SGLang tokenizer port (30000).
 	SGLangTokenizerPort int `yaml:"sglangTokenizerPort,omitempty"`
+	// RuntimeContainerName is the sidecar container excluded from the restart signal,
+	// one value for the whole router. Defaults to "runtime", the name used by the
+	// generated pod templates; "" counts every container.
+	RuntimeContainerName *string `yaml:"runtimeContainerName,omitempty"`
 }
 
 type KVCacheAware struct {
-	name             string
-	maxBlocksToMatch int
-	keyPrefix        string
-	redisClient      *redis.Client
-	processor        *TokenBlockProcessor
-	tokenizerManager *tokenization.TokenizerManager
-	gcCursor         uint64
+	name                 string
+	maxBlocksToMatch     int
+	keyPrefix            string
+	redisClient          *redis.Client
+	processor            *TokenBlockProcessor
+	tokenizerManager     *tokenization.TokenizerManager
+	runtimeContainerName string
+	gcCursor             uint64
 }
 
 var _ framework.ScorePlugin = &KVCacheAware{}
@@ -149,9 +154,13 @@ func NewKVCacheAware(pluginArg runtime.RawExtension) *KVCacheAware {
 
 	vllmPort := normalizeTokenizerPort(tokenization.EngineVLLM, args.VLLMTokenizerPort, defaultVLLMTokenizerPort)
 	sglangPort := normalizeTokenizerPort(tokenization.EngineSGLang, args.SGLangTokenizerPort, defaultSGLangTokenizerPort)
+	runtimeName := defaultRuntimeContainerName
+	if args.RuntimeContainerName != nil {
+		runtimeName = *args.RuntimeContainerName
+	}
 
-	klog.Infof("KVCacheAware: config blockSizeToHash=%d, maxBlocksToMatch=%d, vllmTokenizerPort=%d, sglangTokenizerPort=%d",
-		blockSizeToHash, maxBlocksToMatch, vllmPort, sglangPort)
+	klog.Infof("KVCacheAware: config blockSizeToHash=%d, maxBlocksToMatch=%d, vllmTokenizerPort=%d, sglangTokenizerPort=%d, runtimeContainerName=%q",
+		blockSizeToHash, maxBlocksToMatch, vllmPort, sglangPort, runtimeName)
 
 	managerConfig := tokenization.TokenizerManagerConfig{
 		EndpointPorts: map[string]int{
@@ -169,12 +178,13 @@ func NewKVCacheAware(pluginArg runtime.RawExtension) *KVCacheAware {
 	}
 
 	plugin := &KVCacheAware{
-		name:             KVCacheAwarePluginName,
-		maxBlocksToMatch: maxBlocksToMatch,
-		keyPrefix:        kvCacheKeyPrefix,
-		redisClient:      redisClient,
-		processor:        &TokenBlockProcessor{blockSize: blockSizeToHash},
-		tokenizerManager: manager,
+		name:                 KVCacheAwarePluginName,
+		maxBlocksToMatch:     maxBlocksToMatch,
+		keyPrefix:            kvCacheKeyPrefix,
+		redisClient:          redisClient,
+		processor:            &TokenBlockProcessor{blockSize: blockSizeToHash},
+		tokenizerManager:     manager,
+		runtimeContainerName: runtimeName,
 	}
 	plugin.startGC()
 	return plugin
@@ -252,7 +262,7 @@ func (t *KVCacheAware) Score(ctx *framework.Context, pods []*datastore.PodInfo) 
 	}
 
 	redisStart := time.Now()
-	blockToPods, err := t.queryRedisForBlocks(blockHashes, ctx.Model, ownerStartTimes(pods))
+	blockToPods, err := t.queryRedisForBlocks(blockHashes, ctx.Model, ownerStartTimes(pods, t.runtimeContainerName))
 	redisDuration := time.Since(redisStart)
 	if err != nil {
 		if ctx.MetricsRecorder != nil {
@@ -431,10 +441,10 @@ func (t *KVCacheAware) deleteStaleFields(staleFields map[string][]string) {
 }
 
 // podLastContainerStartUnix reports when the pod's containers last started, or 0 if none are
-// running. The runtime sidecar is excluded: it only relays events, so restarting it says
-// nothing about the cache. Readiness is not used: it also flips on a probe failure, which
-// leaves the cache intact.
-func podLastContainerStartUnix(pod *corev1.Pod) int64 {
+// running. The sidecar named sidecarName is excluded: it only relays events, so restarting
+// it says nothing about the cache; an empty name excludes nothing. Readiness is not used:
+// it also flips on a probe failure, which leaves the cache intact.
+func podLastContainerStartUnix(pod *corev1.Pod, sidecarName string) int64 {
 	if pod == nil {
 		return 0
 	}
@@ -447,7 +457,7 @@ func podLastContainerStartUnix(pod *corev1.Pod) int64 {
 		if started > newestAll {
 			newestAll = started
 		}
-		if cs.Name == runtimeContainerName {
+		if sidecarName != "" && cs.Name == sidecarName {
 			continue
 		}
 		if started > newest {
@@ -463,10 +473,10 @@ func podLastContainerStartUnix(pod *corev1.Pod) int64 {
 
 // ownerStartTimes maps each candidate's cache-owner identifier to its container start time.
 // Keyed on the full name.namespace form so pods sharing a name across namespaces stay distinct.
-func ownerStartTimes(pods []*datastore.PodInfo) map[string]int64 {
+func ownerStartTimes(pods []*datastore.PodInfo, sidecarName string) map[string]int64 {
 	owners := make(map[string]int64, len(pods))
 	for _, p := range pods {
-		if started := podLastContainerStartUnix(p.GetPod()); started > 0 {
+		if started := podLastContainerStartUnix(p.GetPod(), sidecarName); started > 0 {
 			owners[podCacheOwnerIdentifier(p)] = started
 		}
 	}

--- a/pkg/kthena-router/scheduler/plugins/kvcache_aware_test.go
+++ b/pkg/kthena-router/scheduler/plugins/kvcache_aware_test.go
@@ -2310,7 +2310,8 @@ func TestPodLastContainerStartUnix(t *testing.T) {
 			want: older.Unix(),
 		},
 		{
-			// A sidecar restart moves this forward even though the engine did not restart.
+			// Unnamed containers are all counted; pods without the runtime naming
+			// convention keep this behavior.
 			name: "newest start across containers wins",
 			pod:  startedPod("p", "ns", &older, &newer).Pod,
 			want: newer.Unix(),
@@ -2324,6 +2325,76 @@ func TestPodLastContainerStartUnix(t *testing.T) {
 			name: "no running container",
 			pod:  startedPod("p", "ns", nil).Pod,
 			want: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := podLastContainerStartUnix(tt.pod); got != tt.want {
+				t.Errorf("podLastContainerStartUnix() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+// containerStart names a container and its running start time; nil means not running.
+type containerStart struct {
+	name string
+	at   *time.Time
+}
+
+// startedPodContainers builds a candidate with named container statuses.
+func startedPodContainers(name, namespace string, containers ...containerStart) *datastore.PodInfo {
+	statuses := make([]v1.ContainerStatus, 0, len(containers))
+	for _, c := range containers {
+		cs := v1.ContainerStatus{Name: c.name}
+		if c.at != nil {
+			cs.State.Running = &v1.ContainerStateRunning{StartedAt: metav1.NewTime(*c.at)}
+		}
+		statuses = append(statuses, cs)
+	}
+	return &datastore.PodInfo{
+		Pod: &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+			Status:     v1.PodStatus{ContainerStatuses: statuses},
+		},
+	}
+}
+
+// The runtime sidecar only relays events; restarting it must not move the restart signal,
+// while an engine restart still must.
+func TestPodLastContainerStartUnixIgnoresRuntimeSidecar(t *testing.T) {
+	engineStart := time.Now().Add(-2 * time.Hour).Truncate(time.Second)
+	sidecarRestart := time.Now().Add(-time.Minute).Truncate(time.Second)
+
+	tests := []struct {
+		name string
+		pod  *v1.Pod
+		want int64
+	}{
+		{
+			name: "runtime sidecar restart is ignored",
+			pod: startedPodContainers("p", "ns",
+				containerStart{name: "server", at: &engineStart},
+				containerStart{name: "runtime", at: &sidecarRestart},
+			).Pod,
+			want: engineStart.Unix(),
+		},
+		{
+			name: "engine restart is still detected",
+			pod: startedPodContainers("p", "ns",
+				containerStart{name: "server", at: &sidecarRestart},
+				containerStart{name: "runtime", at: &engineStart},
+			).Pod,
+			want: sidecarRestart.Unix(),
+		},
+		{
+			name: "only the runtime sidecar is running falls back to it",
+			pod: startedPodContainers("p", "ns",
+				containerStart{name: "server", at: nil},
+				containerStart{name: "runtime", at: &sidecarRestart},
+			).Pod,
+			want: sidecarRestart.Unix(),
 		},
 	}
 
@@ -2516,5 +2587,61 @@ func TestKVCacheAware_QueryRedisForBlocks_DropsOldOwnershipAfterLongAgoRestart(t
 
 	if len(result[hash]) != 0 {
 		t.Errorf("stale ownership survived a long-ago restart: got %v, want none", result[hash])
+	}
+}
+
+// A runtime sidecar restart leaves the engine's cache intact, so ownership written while
+// the engine was up must survive it. An engine restart must still drop it.
+func TestKVCacheAware_QueryRedisForBlocks_SidecarRestart(t *testing.T) {
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("failed to start miniredis: %v", err)
+	}
+	defer mr.Close()
+
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer client.Close()
+
+	plugin := &KVCacheAware{keyPrefix: kvCacheKeyPrefix, redisClient: client}
+
+	ctx := context.Background()
+	hash := uint64(444)
+	key := KVCacheAwareBlock{ModelName: "qwen", ChunkHash: hash}.String(kvCacheKeyPrefix)
+
+	now := time.Now()
+	engineStart := now.Add(-2 * time.Hour)
+	writtenAt := now.Add(-time.Hour)
+	sidecarRestart := now.Add(-5 * time.Minute)
+
+	if err := client.HSet(ctx, key, "warm.default", fmt.Sprintf("%d", writtenAt.Unix())).Err(); err != nil {
+		t.Fatalf("failed to seed redis: %v", err)
+	}
+
+	owners := ownerStartTimes([]*datastore.PodInfo{startedPodContainers("warm", "default",
+		containerStart{name: "server", at: &engineStart},
+		containerStart{name: "runtime", at: &sidecarRestart},
+	)})
+
+	result, err := plugin.queryRedisForBlocks([]uint64{hash}, "qwen", owners)
+	if err != nil {
+		t.Fatalf("queryRedisForBlocks returned error: %v", err)
+	}
+	if want := []string{"warm.default"}; !reflect.DeepEqual(result[hash], want) {
+		t.Errorf("sidecar restart dropped valid ownership: got %v, want %v", result[hash], want)
+	}
+
+	// Engine restart after the write: ownership must be dropped.
+	engineRestart := now.Add(-30 * time.Minute)
+	owners = ownerStartTimes([]*datastore.PodInfo{startedPodContainers("warm", "default",
+		containerStart{name: "server", at: &engineRestart},
+		containerStart{name: "runtime", at: &sidecarRestart},
+	)})
+
+	result, err = plugin.queryRedisForBlocks([]uint64{hash}, "qwen", owners)
+	if err != nil {
+		t.Fatalf("queryRedisForBlocks returned error: %v", err)
+	}
+	if len(result[hash]) != 0 {
+		t.Errorf("ownership survived an engine restart: got %v, want none", result[hash])
 	}
 }

--- a/pkg/kthena-router/scheduler/plugins/kvcache_aware_test.go
+++ b/pkg/kthena-router/scheduler/plugins/kvcache_aware_test.go
@@ -2330,7 +2330,7 @@ func TestPodLastContainerStartUnix(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := podLastContainerStartUnix(tt.pod); got != tt.want {
+			if got := podLastContainerStartUnix(tt.pod, "runtime"); got != tt.want {
 				t.Errorf("podLastContainerStartUnix() = %d, want %d", got, tt.want)
 			}
 		})
@@ -2400,7 +2400,7 @@ func TestPodLastContainerStartUnixIgnoresRuntimeSidecar(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := podLastContainerStartUnix(tt.pod); got != tt.want {
+			if got := podLastContainerStartUnix(tt.pod, "runtime"); got != tt.want {
 				t.Errorf("podLastContainerStartUnix() = %d, want %d", got, tt.want)
 			}
 		})
@@ -2420,8 +2420,48 @@ func TestPodLastContainerStartUnixIgnoresReadinessFlap(t *testing.T) {
 		LastTransitionTime: metav1.NewTime(flapped),
 	}}
 
-	if got := podLastContainerStartUnix(pod); got != started.Unix() {
+	if got := podLastContainerStartUnix(pod, "runtime"); got != started.Unix() {
 		t.Errorf("readiness transition leaked into the restart signal: got %d, want %d", got, started.Unix())
+	}
+}
+
+// The arg default must stay "runtime"; an explicit value, including "", wins.
+func TestNewKVCacheAwareRuntimeContainerName(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{name: "unset defaults to runtime", raw: `{}`, want: "runtime"},
+		{name: "explicit name wins", raw: `{"runtimeContainerName":"agent"}`, want: "agent"},
+		{name: "explicit empty disables", raw: `{"runtimeContainerName":""}`, want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plugin := NewKVCacheAware(runtime.RawExtension{Raw: []byte(tt.raw)})
+			if plugin.runtimeContainerName != tt.want {
+				t.Errorf("runtimeContainerName = %q, want %q", plugin.runtimeContainerName, tt.want)
+			}
+		})
+	}
+}
+
+// A pod whose engine container happens to be named runtime can point the exclusion at its
+// real sidecar name, or disable it with "".
+func TestPodLastContainerStartUnixCustomSidecarName(t *testing.T) {
+	sidecarStart := time.Now().Add(-2 * time.Hour).Truncate(time.Second)
+	engineRestart := time.Now().Add(-time.Minute).Truncate(time.Second)
+
+	pod := startedPodContainers("p", "ns",
+		containerStart{name: "runtime", at: &engineRestart},
+		containerStart{name: "agent", at: &sidecarStart},
+	).Pod
+
+	if got := podLastContainerStartUnix(pod, "agent"); got != engineRestart.Unix() {
+		t.Errorf("custom sidecar name missed the engine restart: got %d, want %d", got, engineRestart.Unix())
+	}
+	if got := podLastContainerStartUnix(pod, ""); got != engineRestart.Unix() {
+		t.Errorf("empty sidecar name must count every container: got %d, want %d", got, engineRestart.Unix())
 	}
 }
 
@@ -2434,7 +2474,7 @@ func TestOwnerStartTimes(t *testing.T) {
 		startedPod("pod-1", "ns-a", &at),
 		startedPod("pod-1", "ns-b", &other),
 		startedPod("pod-2", "ns-a", nil),
-	})
+	}, "runtime")
 
 	want := map[string]int64{
 		"pod-1.ns-a": at.Unix(),
@@ -2539,7 +2579,7 @@ func TestKVCacheAware_QueryRedisForBlocks_DropsOwnershipFromBeforeRestart(t *tes
 	owners := ownerStartTimes([]*datastore.PodInfo{
 		startedPod("restarted", "default", &restartedAt),
 		startedPod("stable", "default", &longRunning),
-	})
+	}, "runtime")
 
 	result, err := plugin.queryRedisForBlocks([]uint64{hash}, "qwen", owners)
 	if err != nil {
@@ -2578,7 +2618,7 @@ func TestKVCacheAware_QueryRedisForBlocks_DropsOldOwnershipAfterLongAgoRestart(t
 		t.Fatalf("failed to seed redis: %v", err)
 	}
 
-	owners := ownerStartTimes([]*datastore.PodInfo{startedPod("restarted", "default", &restartedAt)})
+	owners := ownerStartTimes([]*datastore.PodInfo{startedPod("restarted", "default", &restartedAt)}, "runtime")
 
 	result, err := plugin.queryRedisForBlocks([]uint64{hash}, "qwen", owners)
 	if err != nil {
@@ -2620,7 +2660,7 @@ func TestKVCacheAware_QueryRedisForBlocks_SidecarRestart(t *testing.T) {
 	owners := ownerStartTimes([]*datastore.PodInfo{startedPodContainers("warm", "default",
 		containerStart{name: "server", at: &engineStart},
 		containerStart{name: "runtime", at: &sidecarRestart},
-	)})
+	)}, "runtime")
 
 	result, err := plugin.queryRedisForBlocks([]uint64{hash}, "qwen", owners)
 	if err != nil {
@@ -2635,7 +2675,7 @@ func TestKVCacheAware_QueryRedisForBlocks_SidecarRestart(t *testing.T) {
 	owners = ownerStartTimes([]*datastore.PodInfo{startedPodContainers("warm", "default",
 		containerStart{name: "server", at: &engineRestart},
 		containerStart{name: "runtime", at: &sidecarRestart},
-	)})
+	)}, "runtime")
 
 	result, err = plugin.queryRedisForBlocks([]uint64{hash}, "qwen", owners)
 	if err != nil {

--- a/pkg/kthena-router/scheduler/plugins/kvcache_aware_test.go
+++ b/pkg/kthena-router/scheduler/plugins/kvcache_aware_test.go
@@ -2333,7 +2333,8 @@ func TestPodLastContainerStartUnix(t *testing.T) {
 			want: older.Unix(),
 		},
 		{
-			// A sidecar restart moves this forward even though the engine did not restart.
+			// Unnamed containers are all counted; pods without the runtime naming
+			// convention keep this behavior.
 			name: "newest start across containers wins",
 			pod:  startedPod("p", "ns", &older, &newer).Pod,
 			want: newer.Unix(),
@@ -2347,6 +2348,76 @@ func TestPodLastContainerStartUnix(t *testing.T) {
 			name: "no running container",
 			pod:  startedPod("p", "ns", nil).Pod,
 			want: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := podLastContainerStartUnix(tt.pod); got != tt.want {
+				t.Errorf("podLastContainerStartUnix() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+// containerStart names a container and its running start time; nil means not running.
+type containerStart struct {
+	name string
+	at   *time.Time
+}
+
+// startedPodContainers builds a candidate with named container statuses.
+func startedPodContainers(name, namespace string, containers ...containerStart) *datastore.PodInfo {
+	statuses := make([]v1.ContainerStatus, 0, len(containers))
+	for _, c := range containers {
+		cs := v1.ContainerStatus{Name: c.name}
+		if c.at != nil {
+			cs.State.Running = &v1.ContainerStateRunning{StartedAt: metav1.NewTime(*c.at)}
+		}
+		statuses = append(statuses, cs)
+	}
+	return &datastore.PodInfo{
+		Pod: &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+			Status:     v1.PodStatus{ContainerStatuses: statuses},
+		},
+	}
+}
+
+// The runtime sidecar only relays events; restarting it must not move the restart signal,
+// while an engine restart still must.
+func TestPodLastContainerStartUnixIgnoresRuntimeSidecar(t *testing.T) {
+	engineStart := time.Now().Add(-2 * time.Hour).Truncate(time.Second)
+	sidecarRestart := time.Now().Add(-time.Minute).Truncate(time.Second)
+
+	tests := []struct {
+		name string
+		pod  *v1.Pod
+		want int64
+	}{
+		{
+			name: "runtime sidecar restart is ignored",
+			pod: startedPodContainers("p", "ns",
+				containerStart{name: "server", at: &engineStart},
+				containerStart{name: "runtime", at: &sidecarRestart},
+			).Pod,
+			want: engineStart.Unix(),
+		},
+		{
+			name: "engine restart is still detected",
+			pod: startedPodContainers("p", "ns",
+				containerStart{name: "server", at: &sidecarRestart},
+				containerStart{name: "runtime", at: &engineStart},
+			).Pod,
+			want: sidecarRestart.Unix(),
+		},
+		{
+			name: "only the runtime sidecar is running falls back to it",
+			pod: startedPodContainers("p", "ns",
+				containerStart{name: "server", at: nil},
+				containerStart{name: "runtime", at: &sidecarRestart},
+			).Pod,
+			want: sidecarRestart.Unix(),
 		},
 	}
 
@@ -2539,6 +2610,62 @@ func TestKVCacheAware_QueryRedisForBlocks_DropsOldOwnershipAfterLongAgoRestart(t
 
 	if len(result[hash]) != 0 {
 		t.Errorf("stale ownership survived a long-ago restart: got %v, want none", result[hash])
+	}
+}
+
+// A runtime sidecar restart leaves the engine's cache intact, so ownership written while
+// the engine was up must survive it. An engine restart must still drop it.
+func TestKVCacheAware_QueryRedisForBlocks_SidecarRestart(t *testing.T) {
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("failed to start miniredis: %v", err)
+	}
+	defer mr.Close()
+
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer client.Close()
+
+	plugin := &KVCacheAware{keyPrefix: kvCacheKeyPrefix, redisClient: client}
+
+	ctx := context.Background()
+	hash := uint64(444)
+	key := KVCacheAwareBlock{ModelName: "qwen", ChunkHash: hash}.String(kvCacheKeyPrefix)
+
+	now := time.Now()
+	engineStart := now.Add(-2 * time.Hour)
+	writtenAt := now.Add(-time.Hour)
+	sidecarRestart := now.Add(-5 * time.Minute)
+
+	if err := client.HSet(ctx, key, "warm.default", fmt.Sprintf("%d", writtenAt.Unix())).Err(); err != nil {
+		t.Fatalf("failed to seed redis: %v", err)
+	}
+
+	owners := ownerStartTimes([]*datastore.PodInfo{startedPodContainers("warm", "default",
+		containerStart{name: "server", at: &engineStart},
+		containerStart{name: "runtime", at: &sidecarRestart},
+	)})
+
+	result, err := plugin.queryRedisForBlocks([]uint64{hash}, "qwen", owners)
+	if err != nil {
+		t.Fatalf("queryRedisForBlocks returned error: %v", err)
+	}
+	if want := []string{"warm.default"}; !reflect.DeepEqual(result[hash], want) {
+		t.Errorf("sidecar restart dropped valid ownership: got %v, want %v", result[hash], want)
+	}
+
+	// Engine restart after the write: ownership must be dropped.
+	engineRestart := now.Add(-30 * time.Minute)
+	owners = ownerStartTimes([]*datastore.PodInfo{startedPodContainers("warm", "default",
+		containerStart{name: "server", at: &engineRestart},
+		containerStart{name: "runtime", at: &sidecarRestart},
+	)})
+
+	result, err = plugin.queryRedisForBlocks([]uint64{hash}, "qwen", owners)
+	if err != nil {
+		t.Fatalf("queryRedisForBlocks returned error: %v", err)
+	}
+	if len(result[hash]) != 0 {
+		t.Errorf("ownership survived an engine restart: got %v, want none", result[hash])
 	}
 }
 

--- a/pkg/kthena-router/scheduler/plugins/kvcache_aware_test.go
+++ b/pkg/kthena-router/scheduler/plugins/kvcache_aware_test.go
@@ -2353,7 +2353,7 @@ func TestPodLastContainerStartUnix(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := podLastContainerStartUnix(tt.pod); got != tt.want {
+			if got := podLastContainerStartUnix(tt.pod, "runtime"); got != tt.want {
 				t.Errorf("podLastContainerStartUnix() = %d, want %d", got, tt.want)
 			}
 		})
@@ -2423,7 +2423,7 @@ func TestPodLastContainerStartUnixIgnoresRuntimeSidecar(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := podLastContainerStartUnix(tt.pod); got != tt.want {
+			if got := podLastContainerStartUnix(tt.pod, "runtime"); got != tt.want {
 				t.Errorf("podLastContainerStartUnix() = %d, want %d", got, tt.want)
 			}
 		})
@@ -2443,8 +2443,48 @@ func TestPodLastContainerStartUnixIgnoresReadinessFlap(t *testing.T) {
 		LastTransitionTime: metav1.NewTime(flapped),
 	}}
 
-	if got := podLastContainerStartUnix(pod); got != started.Unix() {
+	if got := podLastContainerStartUnix(pod, "runtime"); got != started.Unix() {
 		t.Errorf("readiness transition leaked into the restart signal: got %d, want %d", got, started.Unix())
+	}
+}
+
+// The arg default must stay "runtime"; an explicit value, including "", wins.
+func TestNewKVCacheAwareRuntimeContainerName(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{name: "unset defaults to runtime", raw: `{}`, want: "runtime"},
+		{name: "explicit name wins", raw: `{"runtimeContainerName":"agent"}`, want: "agent"},
+		{name: "explicit empty disables", raw: `{"runtimeContainerName":""}`, want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plugin := NewKVCacheAware(runtime.RawExtension{Raw: []byte(tt.raw)})
+			if plugin.runtimeContainerName != tt.want {
+				t.Errorf("runtimeContainerName = %q, want %q", plugin.runtimeContainerName, tt.want)
+			}
+		})
+	}
+}
+
+// A pod whose engine container happens to be named runtime can point the exclusion at its
+// real sidecar name, or disable it with "".
+func TestPodLastContainerStartUnixCustomSidecarName(t *testing.T) {
+	sidecarStart := time.Now().Add(-2 * time.Hour).Truncate(time.Second)
+	engineRestart := time.Now().Add(-time.Minute).Truncate(time.Second)
+
+	pod := startedPodContainers("p", "ns",
+		containerStart{name: "runtime", at: &engineRestart},
+		containerStart{name: "agent", at: &sidecarStart},
+	).Pod
+
+	if got := podLastContainerStartUnix(pod, "agent"); got != engineRestart.Unix() {
+		t.Errorf("custom sidecar name missed the engine restart: got %d, want %d", got, engineRestart.Unix())
+	}
+	if got := podLastContainerStartUnix(pod, ""); got != engineRestart.Unix() {
+		t.Errorf("empty sidecar name must count every container: got %d, want %d", got, engineRestart.Unix())
 	}
 }
 
@@ -2457,7 +2497,7 @@ func TestOwnerStartTimes(t *testing.T) {
 		startedPod("pod-1", "ns-a", &at),
 		startedPod("pod-1", "ns-b", &other),
 		startedPod("pod-2", "ns-a", nil),
-	})
+	}, "runtime")
 
 	want := map[string]int64{
 		"pod-1.ns-a": at.Unix(),
@@ -2562,7 +2602,7 @@ func TestKVCacheAware_QueryRedisForBlocks_DropsOwnershipFromBeforeRestart(t *tes
 	owners := ownerStartTimes([]*datastore.PodInfo{
 		startedPod("restarted", "default", &restartedAt),
 		startedPod("stable", "default", &longRunning),
-	})
+	}, "runtime")
 
 	result, err := plugin.queryRedisForBlocks([]uint64{hash}, "qwen", owners)
 	if err != nil {
@@ -2601,7 +2641,7 @@ func TestKVCacheAware_QueryRedisForBlocks_DropsOldOwnershipAfterLongAgoRestart(t
 		t.Fatalf("failed to seed redis: %v", err)
 	}
 
-	owners := ownerStartTimes([]*datastore.PodInfo{startedPod("restarted", "default", &restartedAt)})
+	owners := ownerStartTimes([]*datastore.PodInfo{startedPod("restarted", "default", &restartedAt)}, "runtime")
 
 	result, err := plugin.queryRedisForBlocks([]uint64{hash}, "qwen", owners)
 	if err != nil {
@@ -2643,7 +2683,7 @@ func TestKVCacheAware_QueryRedisForBlocks_SidecarRestart(t *testing.T) {
 	owners := ownerStartTimes([]*datastore.PodInfo{startedPodContainers("warm", "default",
 		containerStart{name: "server", at: &engineStart},
 		containerStart{name: "runtime", at: &sidecarRestart},
-	)})
+	)}, "runtime")
 
 	result, err := plugin.queryRedisForBlocks([]uint64{hash}, "qwen", owners)
 	if err != nil {
@@ -2658,7 +2698,7 @@ func TestKVCacheAware_QueryRedisForBlocks_SidecarRestart(t *testing.T) {
 	owners = ownerStartTimes([]*datastore.PodInfo{startedPodContainers("warm", "default",
 		containerStart{name: "server", at: &engineRestart},
 		containerStart{name: "runtime", at: &sidecarRestart},
-	)})
+	)}, "runtime")
 
 	result, err = plugin.queryRedisForBlocks([]uint64{hash}, "qwen", owners)
 	if err != nil {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Since #1463 the kvcache-aware scorer drops ownership written before the newest container start in the pod. The runtime sidecar is one of those containers, so restarting just the sidecar permanently dropped the pod's ownership although the engine cache was intact: the subscriber has no replay or resync, blocks the engine still holds are never re-announced, and the start time only moves forward. @acsoto asked to track this as a follow-up in the #1463 review, filed as #1541.

This excludes the container named `runtime` from the restart signal. That is the sidecar's name in the generated pod templates and in the examples. An agent restart no longer moves the signal; an engine or pod restart still does. When no other container is running the previous behavior is kept, so hand-authored pods with a differently named sidecar lose nothing.

The agent-side engine epoch was designed first and deferred; the analysis is on #1541. Short version: the engines' event sequence numbers reset per process but a restarted engine can publish past the last persisted value while the agent is down, and the engine metrics endpoint does not reliably expose a process start time.

**Which issue(s) this PR fixes**:
Fixes #1541

**Bug evidence (required for bug-related PRs)**:

The mechanism and permalinks are in #1541. The sidecar naming this relies on:

- generated pods: https://github.com/volcano-sh/kthena/blob/b8c3d6cb1d3f6970f8d96cfea83ff80d4f744eff/pkg/model-booster-controller/convert/templates/vllm.yaml#L31-L32
- the kvcache example: https://github.com/volcano-sh/kthena/blob/b8c3d6cb1d3f6970f8d96cfea83ff80d4f744eff/docs/kthena/docs/assets/examples/model-serving/gpu-kvcache-aware.yaml#L82-L83

The new sidecar-restart regression test fails on main: ownership written after the engine started but before a runtime container restart is dropped there and kept here. No live cluster repro, the tests exercise the path, same as #1463.

**Special notes for your reviewer**:

Tests: named-container cases for the start signal (sidecar restart ignored, engine restart detected, sidecar-only fallback), and a miniredis pair asserting ownership survives a sidecar restart and still drops on an engine restart. Existing unnamed-container tests keep passing, they document the fallback for pods outside the naming convention.

**Does this PR introduce a user-facing change?**:

```release-note
Fixed kvcache-aware routing dropping a pod's KV cache ownership when only its runtime sidecar restarts. The excluded sidecar name is configurable via the plugin's runtimeContainerName argument (default runtime).
```

