### PR TITLE
test: move Redis e2e fixture into utils

### DIFF
--- a/test/e2e/router/shared.go
+++ b/test/e2e/router/shared.go
@@ -41,14 +41,8 @@ import (
 	"github.com/volcano-sh/kthena/test/e2e/utils"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/discovery/cached/memory"
-	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/restmapper"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
@@ -82,79 +76,7 @@ func WaitForKthenaRouterValidatingWebhook(t *testing.T, ctx context.Context, kth
 
 func ensureRedis(t *testing.T, kubeClient kubernetes.Interface, namespace string) func() {
 	t.Helper()
-	ctx := context.Background()
-
-	config, err := utils.GetKubeConfig()
-	require.NoError(t, err, "Failed to get kubeconfig")
-
-	dynamicClient, err := dynamic.NewForConfig(config)
-	require.NoError(t, err, "Failed to create dynamic client")
-
-	redisManifestPath := filepath.Join(routercontext.TestDataDir, "redis-standalone.yaml")
-
-	redisObjects := utils.LoadUnstructuredYAMLFromFile(redisManifestPath)
-	require.NotEmpty(t, redisObjects, "Redis manifest is empty")
-
-	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(kubeClient.Discovery()))
-	type createdResourceRef struct {
-		gvr       schema.GroupVersionResource
-		namespace string
-		name      string
-	}
-	createdRefs := make([]createdResourceRef, 0, len(redisObjects))
-	var redisDeploymentName string
-
-	for _, obj := range redisObjects {
-		if obj.GetKind() == "Deployment" && redisDeploymentName == "" {
-			redisDeploymentName = obj.GetName()
-		}
-		gvk := obj.GroupVersionKind()
-		mapping, mapErr := mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
-		require.NoError(t, mapErr, "Failed to map GVK %s", gvk.String())
-
-		resourceClient := dynamicClient.Resource(mapping.Resource)
-		namespaceToUse := obj.GetNamespace()
-		resource := func() dynamic.ResourceInterface {
-			if mapping.Scope.Name() == meta.RESTScopeNameNamespace {
-				if namespaceToUse == "" {
-					namespaceToUse = namespace
-					obj.SetNamespace(namespaceToUse)
-				}
-				return resourceClient.Namespace(namespaceToUse)
-			}
-			return resourceClient
-		}()
-
-		_, createErr := resource.Create(ctx, obj, metav1.CreateOptions{})
-		if createErr != nil {
-			require.True(t, apierrors.IsAlreadyExists(createErr), "Failed to create %s/%s: %v", gvk.Kind, obj.GetName(), createErr)
-			continue
-		}
-
-		createdRefs = append(createdRefs, createdResourceRef{
-			gvr:       mapping.Resource,
-			namespace: namespaceToUse,
-			name:      obj.GetName(),
-		})
-	}
-
-	require.NotEmpty(t, redisDeploymentName, "Redis Deployment not found in manifest")
-
-	utils.WaitForDeploymentReady(t, ctx, kubeClient, namespace, redisDeploymentName, 1, 2*time.Minute)
-	t.Log("Redis is ready")
-
-	return func() {
-		cleanupCtx := context.Background()
-		for i := len(createdRefs) - 1; i >= 0; i-- {
-			ref := createdRefs[i]
-			resourceClient := dynamicClient.Resource(ref.gvr)
-			if ref.namespace != "" {
-				_ = resourceClient.Namespace(ref.namespace).Delete(cleanupCtx, ref.name, metav1.DeleteOptions{})
-			} else {
-				_ = resourceClient.Delete(cleanupCtx, ref.name, metav1.DeleteOptions{})
-			}
-		}
-	}
+	return utils.EnsureRedis(t, kubeClient, namespace, filepath.Join(routercontext.TestDataDir, "redis-standalone.yaml"))
 }
 
 func scaleRouterDeployment(t *testing.T, kubeClient kubernetes.Interface, namespace string, replicas int32) func() {

--- a/test/e2e/utils/redis.go
+++ b/test/e2e/utils/redis.go
@@ -1,0 +1,112 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery/cached/memory"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/restmapper"
+)
+
+// EnsureRedis applies the Redis manifest at manifestPath and waits for its Deployment
+// to become ready. Namespaced objects without a namespace land in the given one. The
+// returned cleanup deletes what this call created, newest first; preexisting objects
+// are left in place.
+func EnsureRedis(t *testing.T, kubeClient kubernetes.Interface, namespace, manifestPath string) func() {
+	t.Helper()
+	ctx := context.Background()
+
+	config, err := GetKubeConfig()
+	require.NoError(t, err, "Failed to get kubeconfig")
+
+	dynamicClient, err := dynamic.NewForConfig(config)
+	require.NoError(t, err, "Failed to create dynamic client")
+
+	redisObjects := LoadUnstructuredYAMLFromFile(manifestPath)
+	require.NotEmpty(t, redisObjects, "Redis manifest is empty")
+
+	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(kubeClient.Discovery()))
+	type createdResourceRef struct {
+		gvr       schema.GroupVersionResource
+		namespace string
+		name      string
+	}
+	createdRefs := make([]createdResourceRef, 0, len(redisObjects))
+	var redisDeploymentName string
+
+	for _, obj := range redisObjects {
+		if obj.GetKind() == "Deployment" && redisDeploymentName == "" {
+			redisDeploymentName = obj.GetName()
+		}
+		gvk := obj.GroupVersionKind()
+		mapping, mapErr := mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+		require.NoError(t, mapErr, "Failed to map GVK %s", gvk.String())
+
+		resourceClient := dynamicClient.Resource(mapping.Resource)
+		namespaceToUse := obj.GetNamespace()
+		resource := func() dynamic.ResourceInterface {
+			if mapping.Scope.Name() == meta.RESTScopeNameNamespace {
+				if namespaceToUse == "" {
+					namespaceToUse = namespace
+					obj.SetNamespace(namespaceToUse)
+				}
+				return resourceClient.Namespace(namespaceToUse)
+			}
+			return resourceClient
+		}()
+
+		_, createErr := resource.Create(ctx, obj, metav1.CreateOptions{})
+		if createErr != nil {
+			require.True(t, apierrors.IsAlreadyExists(createErr), "Failed to create %s/%s: %v", gvk.Kind, obj.GetName(), createErr)
+			continue
+		}
+
+		createdRefs = append(createdRefs, createdResourceRef{
+			gvr:       mapping.Resource,
+			namespace: namespaceToUse,
+			name:      obj.GetName(),
+		})
+	}
+
+	require.NotEmpty(t, redisDeploymentName, "Redis Deployment not found in manifest")
+
+	WaitForDeploymentReady(t, ctx, kubeClient, namespace, redisDeploymentName, 1, 2*time.Minute)
+	t.Log("Redis is ready")
+
+	return func() {
+		cleanupCtx := context.Background()
+		for i := len(createdRefs) - 1; i >= 0; i-- {
+			ref := createdRefs[i]
+			resourceClient := dynamicClient.Resource(ref.gvr)
+			if ref.namespace != "" {
+				_ = resourceClient.Namespace(ref.namespace).Delete(cleanupCtx, ref.name, metav1.DeleteOptions{})
+			} else {
+				_ = resourceClient.Delete(cleanupCtx, ref.name, metav1.DeleteOptions{})
+			}
+		}
+	}
+}

--- a/test/e2e/utils/redis.go
+++ b/test/e2e/utils/redis.go
@@ -32,10 +32,10 @@ import (
 	"k8s.io/client-go/restmapper"
 )
 
-// EnsureRedis applies the Redis manifest at manifestPath and waits for its Deployment
-// to become ready. Namespaced objects without a namespace land in the given one. The
-// returned cleanup deletes what this call created, newest first; preexisting objects
-// are left in place.
+// EnsureRedis applies the Redis manifest at manifestPath and waits for every Deployment
+// in it to become ready, each in the namespace it actually lands in. Namespaced objects
+// without a namespace land in the given one. The returned cleanup deletes what this call
+// created, newest first; preexisting objects are left in place.
 func EnsureRedis(t *testing.T, kubeClient kubernetes.Interface, namespace, manifestPath string) func() {
 	t.Helper()
 	ctx := context.Background()
@@ -56,12 +56,13 @@ func EnsureRedis(t *testing.T, kubeClient kubernetes.Interface, namespace, manif
 		name      string
 	}
 	createdRefs := make([]createdResourceRef, 0, len(redisObjects))
-	var redisDeploymentName string
+	type deploymentRef struct {
+		namespace string
+		name      string
+	}
+	deployments := make([]deploymentRef, 0, 1)
 
 	for _, obj := range redisObjects {
-		if obj.GetKind() == "Deployment" && redisDeploymentName == "" {
-			redisDeploymentName = obj.GetName()
-		}
 		gvk := obj.GroupVersionKind()
 		mapping, mapErr := mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
 		require.NoError(t, mapErr, "Failed to map GVK %s", gvk.String())
@@ -79,6 +80,12 @@ func EnsureRedis(t *testing.T, kubeClient kubernetes.Interface, namespace, manif
 			return resourceClient
 		}()
 
+		if obj.GetKind() == "Deployment" {
+			// Captured after the namespace resolves so the wait polls where the object
+			// actually lands, and before Create so preexisting Deployments still get waited on.
+			deployments = append(deployments, deploymentRef{namespace: namespaceToUse, name: obj.GetName()})
+		}
+
 		_, createErr := resource.Create(ctx, obj, metav1.CreateOptions{})
 		if createErr != nil {
 			require.True(t, apierrors.IsAlreadyExists(createErr), "Failed to create %s/%s: %v", gvk.Kind, obj.GetName(), createErr)
@@ -92,9 +99,11 @@ func EnsureRedis(t *testing.T, kubeClient kubernetes.Interface, namespace, manif
 		})
 	}
 
-	require.NotEmpty(t, redisDeploymentName, "Redis Deployment not found in manifest")
+	require.NotEmpty(t, deployments, "Redis Deployment not found in manifest")
 
-	WaitForDeploymentReady(t, ctx, kubeClient, namespace, redisDeploymentName, 1, 2*time.Minute)
+	for _, d := range deployments {
+		WaitForDeploymentReady(t, ctx, kubeClient, d.namespace, d.name, 1, 2*time.Minute)
+	}
 	t.Log("Redis is ready")
 
 	return func() {


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:

Moves the Redis provisioning fixture out of the rate-limit test in `test/e2e/router/shared.go` into `test/e2e/utils`, with the manifest path as a parameter. `ensureRedis` stays as a thin wrapper, so the global rate-limit test behaves exactly as before.

Motivation: the KVCache-aware e2e work discussed in #1328 and drafted in #1222 needs Redis provisioning too; this makes the existing fixture reusable instead of tied to one test. Split out first since it is mechanical and reviewable on its own.

**Special notes for your reviewer**:

Verbatim move, no behavior change. `go build` and `go vet` pass on `./test/e2e/...`.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
