### PR TITLE
router: reject cross-namespace HTTPRoute backends

### DIFF
--- a/pkg/kthena-router/router/httproute_match.go
+++ b/pkg/kthena-router/router/httproute_match.go
@@ -221,6 +221,9 @@ func inferencePoolFromHTTPRouteRule(route *gatewayv1.HTTPRoute, rule *gatewayv1.
 	for _, backendRef := range rule.BackendRefs {
 		if backendRef.Group != nil && *backendRef.Group == inferencePoolBackendGroup &&
 			backendRef.Kind != nil && *backendRef.Kind == inferencePoolBackendKind {
+			if backendRef.Namespace != nil && string(*backendRef.Namespace) != route.Namespace {
+				continue
+			}
 			weight := 1
 			if backendRef.Weight != nil {
 				weight = int(*backendRef.Weight)

--- a/pkg/kthena-router/router/httproute_match_test.go
+++ b/pkg/kthena-router/router/httproute_match_test.go
@@ -363,19 +363,22 @@ func TestMatchHTTPRouteHostname(t *testing.T) {
 	}
 }
 
-func TestInferencePoolFromHTTPRouteRuleWeights(t *testing.T) {
+func TestInferencePoolFromHTTPRouteRule(t *testing.T) {
 	group := inferencePoolBackendGroup
 	kind := inferencePoolBackendKind
+	defaultNamespace := gatewayv1.Namespace("default")
+	otherNamespace := gatewayv1.Namespace("other")
 	zero := int32(0)
 	one := int32(1)
 
-	backendRef := func(name string, weight *int32) gatewayv1.HTTPBackendRef {
+	backendRef := func(name string, namespace *gatewayv1.Namespace, weight *int32) gatewayv1.HTTPBackendRef {
 		return gatewayv1.HTTPBackendRef{
 			BackendRef: gatewayv1.BackendRef{
 				BackendObjectReference: gatewayv1.BackendObjectReference{
-					Group: &group,
-					Kind:  &kind,
-					Name:  gatewayv1.ObjectName(name),
+					Group:     &group,
+					Kind:      &kind,
+					Name:      gatewayv1.ObjectName(name),
+					Namespace: namespace,
 				},
 				Weight: weight,
 			},
@@ -391,8 +394,8 @@ func TestInferencePoolFromHTTPRouteRuleWeights(t *testing.T) {
 		{
 			name: "skips a zero-weight backend",
 			backendRefs: []gatewayv1.HTTPBackendRef{
-				backendRef("pool-zero", &zero),
-				backendRef("pool-live", &one),
+				backendRef("pool-zero", nil, &zero),
+				backendRef("pool-live", nil, &one),
 			},
 			expected: types.NamespacedName{Namespace: "default", Name: "pool-live"},
 			found:    true,
@@ -400,7 +403,7 @@ func TestInferencePoolFromHTTPRouteRuleWeights(t *testing.T) {
 		{
 			name: "uses the default weight when omitted",
 			backendRefs: []gatewayv1.HTTPBackendRef{
-				backendRef("pool-default", nil),
+				backendRef("pool-default", nil, nil),
 			},
 			expected: types.NamespacedName{Namespace: "default", Name: "pool-default"},
 			found:    true,
@@ -408,9 +411,33 @@ func TestInferencePoolFromHTTPRouteRuleWeights(t *testing.T) {
 		{
 			name: "returns no backend when all weights are zero",
 			backendRefs: []gatewayv1.HTTPBackendRef{
-				backendRef("pool-zero", &zero),
+				backendRef("pool-zero", nil, &zero),
 			},
 			found: false,
+		},
+		{
+			name: "allows an explicit route namespace",
+			backendRefs: []gatewayv1.HTTPBackendRef{
+				backendRef("pool-default", &defaultNamespace, nil),
+			},
+			expected: types.NamespacedName{Namespace: "default", Name: "pool-default"},
+			found:    true,
+		},
+		{
+			name: "rejects a cross-namespace backend",
+			backendRefs: []gatewayv1.HTTPBackendRef{
+				backendRef("pool-other", &otherNamespace, nil),
+			},
+			found: false,
+		},
+		{
+			name: "skips a cross-namespace backend",
+			backendRefs: []gatewayv1.HTTPBackendRef{
+				backendRef("pool-other", &otherNamespace, nil),
+				backendRef("pool-default", nil, nil),
+			},
+			expected: types.NamespacedName{Namespace: "default", Name: "pool-default"},
+			found:    true,
 		},
 	}
 

--- a/pkg/kthena-router/router/router_test.go
+++ b/pkg/kthena-router/router/router_test.go
@@ -312,6 +312,47 @@ func TestRouter_HandleHTTPRoute_PathPrefix(t *testing.T) {
 	}
 }
 
+func TestRouter_HandleHTTPRoute_RejectsCrossNamespaceBackend(t *testing.T) {
+	store := datastore.New()
+	router := &Router{store: store}
+	gatewayKind := gatewayv1.Kind("Gateway")
+	poolGroup := inferencePoolBackendGroup
+	poolKind := inferencePoolBackendKind
+	poolNamespace := gatewayv1.Namespace("other")
+
+	route := &gatewayv1.HTTPRoute{
+		ObjectMeta: v1.ObjectMeta{Name: "route", Namespace: "default"},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{{Name: "gw", Kind: &gatewayKind}},
+			},
+			Rules: []gatewayv1.HTTPRouteRule{{
+				BackendRefs: []gatewayv1.HTTPBackendRef{{
+					BackendRef: gatewayv1.BackendRef{
+						BackendObjectReference: gatewayv1.BackendObjectReference{
+							Group:     &poolGroup,
+							Kind:      &poolKind,
+							Name:      "pool",
+							Namespace: &poolNamespace,
+						},
+					},
+				}},
+			}},
+		},
+	}
+	assert.NoError(t, store.AddOrUpdateHTTPRoute(route))
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request, _ = http.NewRequest(http.MethodPost, "/custom", nil)
+
+	matched, pool, err := router.handleHTTPRoute(c, "default/gw")
+
+	assert.True(t, matched)
+	assert.Equal(t, types.NamespacedName{}, pool)
+	assert.EqualError(t, err, "matched HTTPRoute default/route has no eligible InferencePool backend")
+}
+
 func TestRouter_HandleHTTPRoute_UsesMatchedRuleBackend(t *testing.T) {
 	pathType := gatewayv1.PathMatchPathPrefix
 	kind := gatewayv1.Kind("Gateway")


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Rejects cross-namespace InferencePool backend references during HTTPRoute backend selection. Kthena does not support ReferenceGrant here, so these references must not receive traffic.

**Which issue(s) this PR fixes**:

Fixes #1544

**Bug evidence (required for bug-related PRs)**:

Create an HTTPRoute in `tenant-a` with an InferencePool backend in `tenant-b`, without a ReferenceGrant. A matching request previously selected `tenant-b/private-pool` because the backend namespace was copied directly into the pool lookup:

https://github.com/volcano-sh/kthena/blob/b8c3d6cb1d3f6970f8d96cfea83ff80d4f744eff/pkg/kthena-router/router/httproute_match.go#L221-L240

The request path now ignores that backend and returns no eligible InferencePool. Same-namespace backends continue to work.

**Special notes for your reviewer**:

Tested with:

```text
go test ./pkg/kthena-router/router -count=1
go test ./pkg/kthena-router/... -count=1
go vet ./pkg/kthena-router/...
```
ReferenceGrant support is intentionally not added.

**Does this PR introduce a user-facing change?**:

```release-note
Kthena no longer routes HTTPRoute traffic to cross-namespace InferencePool backends.
```