### PR TITLE
test/e2e: check helm in the e2e preflight

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,12 +89,22 @@ test-docs: ## Run documentation tests (type check and build)
 	cd docs/kthena && npm run typecheck
 	cd docs/kthena && npm run build
 
-.PHONY: test-e2e
-test-e2e: ## Run all e2e tests sequentially (legacy).
-	@command -v kind >/dev/null 2>&1 || { \
-		echo "Kind is not installed. Please install Kind manually."; \
+.PHONY: e2e-preflight
+e2e-preflight: ## Verify the host tools the e2e setup and suites need.
+	@missing=""; \
+	for tool in kind kubectl docker helm; do \
+		command -v $$tool >/dev/null 2>&1 || missing="$$missing $$tool"; \
+	done; \
+	if [ -n "$$missing" ]; then \
+		echo "Missing required tools:$$missing"; \
+		echo ""; \
+		echo "  kind, kubectl, docker   create the cluster and load images"; \
+		echo "  helm                    the e2e harness installs kthena with helm"; \
 		exit 1; \
-	}
+	fi
+
+.PHONY: test-e2e
+test-e2e: e2e-preflight ## Run all e2e tests sequentially (legacy).
 	@echo "Setting up Kind cluster for E2E tests..."
 	@./test/e2e/setup.sh
 	@echo "Running E2E tests sequentially..."
@@ -102,26 +112,22 @@ test-e2e: ## Run all e2e tests sequentially (legacy).
 	@echo "E2E tests completed"
 
 .PHONY: test-e2e-controller-manager
-test-e2e-controller-manager: ## Run controller-manager e2e tests.
-	@command -v kind >/dev/null 2>&1 || { echo "Kind is not installed."; exit 1; }
+test-e2e-controller-manager: e2e-preflight ## Run controller-manager e2e tests.
 	@TEST_CATEGORY=controller-manager ./test/e2e/setup.sh
 	@KUBECONFIG=/tmp/kubeconfig-e2e go test -v -timeout=20m ./test/e2e/controller-manager/...
 
 .PHONY: test-e2e-router
-test-e2e-router: ## Run router e2e tests.
-	@command -v kind >/dev/null 2>&1 || { echo "Kind is not installed."; exit 1; }
+test-e2e-router: e2e-preflight ## Run router e2e tests.
 	@TEST_CATEGORY=router ./test/e2e/setup.sh
 	@KUBECONFIG=/tmp/kubeconfig-e2e go test -v -timeout=18m ./test/e2e/router
 
 .PHONY: test-e2e-gateway-api
-test-e2e-gateway-api: ## Run gateway-api e2e tests.
-	@command -v kind >/dev/null 2>&1 || { echo "Kind is not installed."; exit 1; }
+test-e2e-gateway-api: e2e-preflight ## Run gateway-api e2e tests.
 	@TEST_CATEGORY=gateway-api ./test/e2e/setup.sh
 	@KUBECONFIG=/tmp/kubeconfig-e2e go test -v -timeout=10m ./test/e2e/router/gateway-api/...
 
 .PHONY: test-e2e-gateway-inference-extension
-test-e2e-gateway-inference-extension: ## Run gateway-inference-extension e2e tests.
-	@command -v kind >/dev/null 2>&1 || { echo "Kind is not installed."; exit 1; }
+test-e2e-gateway-inference-extension: e2e-preflight ## Run gateway-inference-extension e2e tests.
 	@TEST_CATEGORY=gateway-inference-extension ./test/e2e/setup.sh
 	@KUBECONFIG=/tmp/kubeconfig-e2e go test -v -timeout=10m ./test/e2e/router/gateway-inference-extension/...
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

`make test-e2e-router` on a host without helm fails after the full image build, roughly 17 minutes in, and nothing in the output names the missing tool. The router harness shells out to `helm install kthena` (`test/e2e/framework/framework.go`), and `e2e-tests.yml` installs helm in its own step, so the local path is the only one that reaches this.

The existing guard checked only kind, and was copy-pasted across five targets with two different messages. This replaces those with one `e2e-preflight` target that checks kind, kubectl, docker and helm, reports every missing tool at once, and says what each is for. kubectl and docker are included because `setup.sh` calls them directly (`kubectl wait`, `kind load docker-image`); in practice they arrive with kind, so that part is defensive.

**Which issue(s) this PR fixes**:

Fixes #

**Bug evidence (required for bug-related PRs)**:

N/A, this is a cleanup PR.

**Special notes for your reviewer**:

Now rebased onto main and reduced to the Makefile change only. Two earlier revisions are worth recording: the first required `sponge` in the preflight, which broke every e2e job because `ensure_sponge` installed it during the build; the second added a `brew` branch to that function, which #1374 has since made obsolete by removing the dependency outright. Both are dropped.

Verified both paths. With every tool present `make e2e-preflight` exits 0 silently. With a stripped PATH it lists what is missing and exits non-zero in under a second, against the 17 minutes the helm failure currently takes to surface.

Keeping the checks in one target is the part most open to debate. Inline per-target checks would also work and would keep each recipe self-contained. Happy to switch if you prefer that.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
