### PR TITLE
router: skip score debug logging work when V(4) is off

### DIFF
--- a/pkg/kthena-router/scheduler/plugins/kvcache_aware.go
+++ b/pkg/kthena-router/scheduler/plugins/kvcache_aware.go
@@ -199,12 +199,14 @@ func (t *KVCacheAware) Score(ctx *framework.Context, pods []*datastore.PodInfo) 
 		return nil
 	}
 
-	podNames := make([]string, 0, len(pods))
-	for _, p := range pods {
-		podNames = append(podNames, p.GetPodNamespacedName().Name)
+	if klog.V(4).Enabled() {
+		podNames := make([]string, 0, len(pods))
+		for _, p := range pods {
+			podNames = append(podNames, p.GetPodNamespacedName().Name)
+		}
+		klog.Infof("KVCacheAware.Score: called for model=%q, pods=%v, promptTextLen=%d, messagesLen=%d",
+			ctx.Model, podNames, len(ctx.Prompt.Text), len(ctx.Prompt.Messages))
 	}
-	klog.V(4).Infof("KVCacheAware.Score: called for model=%q, pods=%v, promptTextLen=%d, messagesLen=%d",
-		ctx.Model, podNames, len(ctx.Prompt.Text), len(ctx.Prompt.Messages))
 
 	if (ctx.Prompt.Text == "" && len(ctx.Prompt.Messages) == 0) || ctx.Model == "" {
 		klog.V(4).Infof("KVCacheAware.Score: early return — empty prompt or model (model=%q, textLen=%d, messagesLen=%d)",

--- a/pkg/kthena-router/scheduler/scheduler_impl.go
+++ b/pkg/kthena-router/scheduler/scheduler_impl.go
@@ -224,6 +224,8 @@ func (s *SchedulerImpl) RunFilterPlugins(pods []*datastore.PodInfo, ctx *framewo
 
 func (s *SchedulerImpl) RunScorePlugins(pods []*datastore.PodInfo, ctx *framework.Context) map[*datastore.PodInfo]int {
 	res := make(map[*datastore.PodInfo]int)
+	// Checked once: V(4) arguments are boxed before klog can discard them
+	logScores := klog.V(4).Enabled()
 	for _, scorePlugin := range s.scorePlugins {
 		// Record score plugin execution time
 		startTime := time.Now()
@@ -235,10 +237,14 @@ func (s *SchedulerImpl) RunScorePlugins(pods []*datastore.PodInfo, ctx *framewor
 			ctx.MetricsRecorder.RecordSchedulerPluginDuration(scorePlugin.plugin.Name(), metrics.PluginTypeScore, duration)
 		}
 
-		klog.V(4).Infof("ScorePlugin: %s", scorePlugin.plugin.Name())
+		if logScores {
+			klog.Infof("ScorePlugin: %s", scorePlugin.plugin.Name())
+		}
 		for k, v := range scores {
-			if podName := k.GetPodNamespacedName(); podName.Name != "" {
-				klog.V(4).Infof("Pod: %s/%s, Score: %d", podName.Namespace, podName.Name, v)
+			if logScores {
+				if podName := k.GetPodNamespacedName(); podName.Name != "" {
+					klog.Infof("Pod: %s/%s, Score: %d", podName.Namespace, podName.Name, v)
+				}
 			}
 			if _, ok := res[k]; !ok {
 				res[k] = v * scorePlugin.weight
@@ -248,7 +254,7 @@ func (s *SchedulerImpl) RunScorePlugins(pods []*datastore.PodInfo, ctx *framewor
 		}
 	}
 
-	if klog.V(4).Enabled() {
+	if logScores {
 		klog.Info("Final Pod Scores:")
 		for k, v := range res {
 			if podName := k.GetPodNamespacedName(); podName.Name != "" {

--- a/pkg/kthena-router/scheduler/scheduler_impl_test.go
+++ b/pkg/kthena-router/scheduler/scheduler_impl_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package scheduler
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -370,4 +372,29 @@ func TestPDSchedulerFiltersOverloadedDecodePod(t *testing.T) {
 	// 10 and must be filtered out before PD pairing.
 	err = NewScheduler(store, nil).Schedule(ctx, pods)
 	require.Error(t, err)
+}
+
+// BenchmarkRunScorePlugins measures the scoring loop at default verbosity
+func BenchmarkRunScorePlugins(b *testing.B) {
+	for _, podCount := range []int{8, 32} {
+		b.Run(fmt.Sprintf("pods=%d", podCount), func(b *testing.B) {
+			scheduler := NewScheduler(datastore.New(), nil).(*SchedulerImpl)
+			pods := make([]*datastore.PodInfo, podCount)
+			for i := range pods {
+				pods[i] = createTestPodInfo(fmt.Sprintf("pod-%d", i))
+				pods[i].TTFT = float64(10 + i)
+				pods[i].TPOT = float64(20 + i)
+			}
+			ctx := &framework.Context{
+				Model:  "model",
+				Prompt: &common.ChatMessage{Text: strings.Repeat("token ", 128)},
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_ = scheduler.RunScorePlugins(pods, ctx)
+			}
+		})
+	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement
/area router

**What this PR does / why we need it**:

`RunScorePlugins` called `klog.V(4).Infof` once per pod per score plugin. `Infof` is a no-op at default verbosity, but the arguments are evaluated and boxed into `...interface{}` before klog gets to discard them, so the allocations happened either way. The kvcache-aware plugin did the same thing, building a `[]string` of pod names just to pass it to a V(4) log.

I hoisted the verbosity check, which is the same guard already used for the final-scores dump further down that function. Output is unchanged when the level is on, I compared both forms with `-v=4` set and the emitted lines are identical.

**Which issue(s) this PR fixes**:
Fixes #1560

**Bug evidence (required for bug-related PRs)**:

N/A, enhancement. Numbers below.

**Special notes for your reviewer**:

Added `BenchmarkRunScorePlugins` so this is reproducible. Default plugin set, default verbosity, so none of these lines actually print:

```
8 pods    before   6645 ns/op   3480 B/op   96 allocs/op
          after    3617 ns/op   1464 B/op   18 allocs/op
32 pods   before  31905 ns/op  18440 B/op  339 allocs/op
          after   19730 ns/op  10664 B/op   45 allocs/op
```

Worth being clear that it is the boxing and not the `GetPodNamespacedName` lock. I measured a variant that keeps the `RLock` and only drops the log call and it came out within noise of the fully guarded version, so the read lock is effectively free here.

In absolute terms this is about 3us per request at 8 pods, so it is a CPU and allocation story at load rather than something one request would notice.

`go test ./pkg/kthena-router/...` passes, and the two packages I touched pass `-race`.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```