### PR TITLE
logging: add resource context to remaining controller error logs

### DIFF
--- a/pkg/autoscaler/controller/autoscale_controller.go
+++ b/pkg/autoscaler/controller/autoscale_controller.go
@@ -171,7 +171,7 @@ func (ac *AutoscaleController) Reconcile(ctx context.Context) {
 	for _, policy := range policies {
 		err := ac.schedule(ctx, policy)
 		if err != nil {
-			klog.Errorf("failed to process autoscale,err: %v", err)
+			klog.Errorf("failed to process autoscale for policy %s: %v", klog.KObj(policy), err)
 			continue
 		}
 	}

--- a/pkg/model-serving-controller/controller/model_serving_controller.go
+++ b/pkg/model-serving-controller/controller/model_serving_controller.go
@@ -346,7 +346,7 @@ func (c *ModelServingController) updatePod(_, newObj interface{}) {
 		if apierrors.IsNotFound(err) {
 			klog.V(4).Infof("modelServing of pod %s has been deleted", newPod.Name)
 		} else {
-			klog.Errorf("get model Serving failed when update pod: %v", err)
+			klog.Errorf("get model Serving failed when update pod %s/%s: %v", newPod.Namespace, newPod.Name, err)
 		}
 		return
 	}
@@ -361,13 +361,13 @@ func (c *ModelServingController) updatePod(_, newObj interface{}) {
 		// The pod is available, that is, the state is running, and the container is ready
 		err = c.handleReadyPod(ms, servingGroupName, newPod)
 		if err != nil {
-			klog.Errorf("handle running pod failed: %v", err)
+			klog.Errorf("handle running pod %s/%s failed for ModelServing %s/%s: %v", newPod.Namespace, newPod.Name, ms.Namespace, ms.Name, err)
 		}
 	case utils.IsPodFailed(newPod) || utils.ContainerRestarted(newPod):
 		klog.V(4).Infof("handleErrorPod: %s/%s", newPod.Namespace, newPod.Name)
 		err = c.handleErrorPod(ms, servingGroupName, newPod)
 		if err != nil {
-			klog.Errorf("handle error pod failed: %v", err)
+			klog.Errorf("handle error pod %s/%s failed for ModelServing %s/%s: %v", newPod.Namespace, newPod.Name, ms.Namespace, ms.Name, err)
 		}
 	default:
 		klog.V(4).Infof("handleDefault: %s/%s", newPod.Namespace, newPod.Name)
@@ -420,7 +420,7 @@ func (c *ModelServingController) deletePod(obj interface{}) {
 
 	err := c.handleDeletedPod(ms, servingGroupName, pod)
 	if err != nil {
-		klog.Errorf("handle deleted pod failed: %v", err)
+		klog.Errorf("handle deleted pod %s/%s failed in ServingGroup %s of ModelServing %s/%s: %v", pod.Namespace, pod.Name, servingGroupName, ms.Namespace, ms.Name, err)
 	}
 }
 
@@ -1885,7 +1885,7 @@ func (c *ModelServingController) isServingGroupOutdated(group datastore.ServingG
 	groupNameValue := fmt.Sprintf("%s/%s", namespace, group.Name)
 	pods, err := c.getPodsByIndex(GroupNameKey, groupNameValue)
 	if err != nil {
-		klog.Errorf("cannot list pod when check group updated,err: %v", err)
+		klog.Errorf("cannot list pod when check ServingGroup %s/%s updated: %v", namespace, group.Name, err)
 		return false
 	}
 	// Check all pods match the newHash
@@ -1987,19 +1987,19 @@ func (c *ModelServingController) isServingGroupDeleted(ms *workloadv1alpha1.Mode
 	groupNameValue := fmt.Sprintf("%s/%s", ms.Namespace, servingGroupName)
 	pods, err := c.getPodsByIndex(GroupNameKey, groupNameValue)
 	if err != nil {
-		klog.Errorf("failed to get pod, err: %v", err)
+		klog.Errorf("failed to get pods for ServingGroup %s of ModelServing %s/%s: %v", servingGroupName, ms.Namespace, ms.Name, err)
 		return false
 	}
 	services, err := c.getServicesByIndex(GroupNameKey, groupNameValue)
 	if err != nil {
-		klog.Errorf("failed to get service, err:%v", err)
+		klog.Errorf("failed to get services for ServingGroup %s of ModelServing %s/%s: %v", servingGroupName, ms.Namespace, ms.Name, err)
 		return false
 	}
 	pgs := []*schedulingv1beta1.PodGroup{}
 	if c.podGroupManager.HasPodGroupCRD() {
 		pgs, err = c.getPodGroupsByIndex(GroupNameKey, groupNameValue)
 		if err != nil {
-			klog.Errorf("failed to get podGroup, err: %v", err)
+			klog.Errorf("failed to get podGroups for ServingGroup %s of ModelServing %s/%s: %v", servingGroupName, ms.Namespace, ms.Name, err)
 			return false
 		}
 	}
@@ -2015,12 +2015,12 @@ func (c *ModelServingController) isRoleDeleted(ms *workloadv1alpha1.ModelServing
 	// check whether the role deletion has been completed
 	pods, err := c.getPodsByIndex(RoleIDKey, roleIDValue)
 	if err != nil {
-		klog.Errorf("failed to get pod, err: %v", err)
+		klog.Errorf("failed to get pods for role %s/%s in ServingGroup %s of ModelServing %s/%s: %v", roleName, roleID, servingGroupName, ms.Namespace, ms.Name, err)
 		return false
 	}
 	services, err := c.getServicesByIndex(RoleIDKey, roleIDValue)
 	if err != nil {
-		klog.Errorf("failed to get service, err:%v", err)
+		klog.Errorf("failed to get services for role %s/%s in ServingGroup %s of ModelServing %s/%s: %v", roleName, roleID, servingGroupName, ms.Namespace, ms.Name, err)
 		return false
 	}
 	return len(pods) == 0 && len(services) == 0


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it

PR #1362 added contextual fields to several controller error logs, but some similar error paths in the same areas were still missing the Kubernetes resource identity.

This PR adds the available context to the remaining error logs:

ModelServing Pod update/delete failures include Pod and ModelServing namespace/name.
ServingGroup and Role-related failures include the relevant ServingGroup, Role, and ModelServing context.
Autoscaler Reconcile errors include the affected AutoscalingPolicy identity.

This allows operators to identify which Kubernetes resource caused an error directly from the controller logs.

The changes are logging-only. There are no changes to control flow, error handling, retry/requeue behavior, or log levels.

## Which issue(s) this PR fixes

Fixes #1564

## Bug evidence (required for bug-related PRs)

N/A — this PR does not change the underlying failure behavior. It only adds missing resource context to existing error logs.

## Special notes for your reviewer
This is a follow-up to the contextual logging work introduced by PR #1362.
The branch was created from the latest upstream/main and contains only the two-file logging change.
No unrelated controller behavior was modified.
e2e.log was pre-existing and was not modified or included.
gofmt, go build ./..., go vet, make lint, and the affected controller test suites all pass.
## Does this PR introduce a user-facing change?

No. This only improves controller log context; there is no API or runtime behavior change.

NONE