### PR TITLE
Fix goroutine leak in ModelServingController

### DIFF
--- a/pkg/model-serving-controller/controller/model_serving_controller.go
+++ b/pkg/model-serving-controller/controller/model_serving_controller.go
@@ -110,6 +110,7 @@ type ModelServingController struct {
 	workqueue       workqueue.RateLimitingInterface
 	store           datastore.Store
 	graceMap        sync.Map // key: podGracePeriodKey, value:time
+	podGroupCleanup sync.Map // key: namespace/name, value: struct{}
 	initialSync     bool     // indicates whether the initial sync has been completed
 	pluginsRegistry *plugins.Registry
 	recorder        record.EventRecorder
@@ -288,11 +289,13 @@ func (c *ModelServingController) updateModelServing(old, cur interface{}) {
 		return
 	}
 
-	// If network topology is removed, we need to clean up the PodGroups.
-	// Because minRoleReplicas is not allowed to be updated, so we do not need to check it here.
-	// Note: We no longer clean up PodGroups here. This is an informer event handler
-	// and making synchronous API calls blocks the informer. PodGroup cleanup logic
-	// is now handled inside syncModelServing where the context is properly threaded.
+	// If network topology or gang policy is removed, we need to clean up the PodGroups.
+	// We mark the transition here so that the blocking API call can be deferred to the
+	// worker loop (syncModelServing).
+	if (oldms.Spec.Template.NetworkTopology != nil && curms.Spec.Template.NetworkTopology == nil) ||
+		(oldms.Spec.Template.GangPolicy != nil && curms.Spec.Template.GangPolicy == nil) {
+		c.podGroupCleanup.Store(utils.GetNamespaceName(curms).String(), struct{}{})
+	}
 
 	c.enqueueModelServing(curms)
 }
@@ -539,6 +542,9 @@ func (c *ModelServingController) processNextWorkItem(ctx context.Context) bool {
 }
 
 func (c *ModelServingController) syncModelServing(ctx context.Context, key string) error {
+	syncCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
 	klog.V(4).InfoS("Started syncing ModelServing", "key", key)
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
@@ -557,38 +563,41 @@ func (c *ModelServingController) syncModelServing(ctx context.Context, key strin
 	revision := utils.ModelServingRevision(ms)
 
 	// Clean up outdated PodGroups if network topology or gang policy was removed
-	if ms.Spec.Template.NetworkTopology == nil {
-		if ms.Spec.Template.GangPolicy == nil || len(ms.Spec.Template.GangPolicy.MinRoleReplicas) == 0 {
-			if c.podGroupManager != nil {
-				if err := c.podGroupManager.CleanupPodGroups(ctx, ms); err != nil {
+	if ms.Spec.Template.NetworkTopology == nil && (ms.Spec.Template.GangPolicy == nil || len(ms.Spec.Template.GangPolicy.MinRoleReplicas) == 0) {
+		if c.podGroupManager != nil {
+			keyStr := utils.GetNamespaceName(ms).String()
+			if _, needsCleanup := c.podGroupCleanup.Load(keyStr); needsCleanup {
+				if err := c.podGroupManager.CleanupPodGroups(syncCtx, ms); err != nil {
 					klog.Errorf("failed to clean up PodGroups for ModelServing %s/%s: %v", ms.Namespace, ms.Name, err)
+				} else {
+					c.podGroupCleanup.Delete(keyStr)
 				}
 			}
 		}
 	}
 
 	// 1. Sync the number of ServingGroups to match the expected replicas defined in spec.
-	if err := c.syncServingGroupReplicas(ctx, ms, revision); err != nil {
+	if err := c.syncServingGroupReplicas(syncCtx, ms, revision); err != nil {
 		return fmt.Errorf("failed to sync ServingGroup replicas: %v", err)
 	}
 
 	// 2. Sync the roles and their replicas within each ServingGroup, handling partitioned scaling and revisions.
-	if err := c.syncRoleReplicas(ctx, ms, revision); err != nil {
+	if err := c.syncRoleReplicas(syncCtx, ms, revision); err != nil {
 		return fmt.Errorf("failed to sync role replicas: %v", err)
 	}
 
 	// 3. Handle the rolling update process, deleting outdated ServingGroups/Roles to trigger updates.
-	if err := c.manageRollingUpdate(ctx, ms, revision); err != nil {
+	if err := c.manageRollingUpdate(syncCtx, ms, revision); err != nil {
 		return fmt.Errorf("failed to handle rollingUpdate: %v", err)
 	}
 
 	// 4. Create and update Headless Services for internal networking between entry and worker pods.
-	if err := c.syncHeadlessServices(ctx, ms); err != nil {
+	if err := c.syncHeadlessServices(syncCtx, ms); err != nil {
 		return fmt.Errorf("failed to sync headless services: %v", err)
 	}
 
 	// 5. Calculate and update the overall condition and replica status fields of the ModelServing.
-	if err := c.UpdateModelServingStatus(ctx, ms, revision); err != nil {
+	if err := c.UpdateModelServingStatus(syncCtx, ms, revision); err != nil {
 		return fmt.Errorf("failed to update status of ms %s/%s: %v", namespace, name, err)
 	}
 

--- a/pkg/model-serving-controller/controller/model_serving_controller.go
+++ b/pkg/model-serving-controller/controller/model_serving_controller.go
@@ -293,11 +293,6 @@ func (c *ModelServingController) updateModelServing(old, cur interface{}) {
 	// Note: We no longer clean up PodGroups here. This is an informer event handler
 	// and making synchronous API calls blocks the informer. PodGroup cleanup logic
 	// is now handled inside syncModelServing where the context is properly threaded.
-	if oldms.Spec.Template.NetworkTopology != nil && curms.Spec.Template.NetworkTopology == nil {
-		if curms.Spec.Template.GangPolicy == nil || len(curms.Spec.Template.GangPolicy.MinRoleReplicas) == 0 {
-			// PodGroups will be cleaned up in syncModelServing
-		}
-	}
 
 	c.enqueueModelServing(curms)
 }

--- a/pkg/model-serving-controller/controller/model_serving_controller.go
+++ b/pkg/model-serving-controller/controller/model_serving_controller.go
@@ -290,11 +290,12 @@ func (c *ModelServingController) updateModelServing(old, cur interface{}) {
 
 	// If network topology is removed, we need to clean up the PodGroups.
 	// Because minRoleReplicas is not allowed to be updated, so we do not need to check it here.
+	// Note: We no longer clean up PodGroups here. This is an informer event handler
+	// and making synchronous API calls blocks the informer. PodGroup cleanup logic
+	// is now handled inside syncModelServing where the context is properly threaded.
 	if oldms.Spec.Template.NetworkTopology != nil && curms.Spec.Template.NetworkTopology == nil {
 		if curms.Spec.Template.GangPolicy == nil || len(curms.Spec.Template.GangPolicy.MinRoleReplicas) == 0 {
-			if err := c.podGroupManager.CleanupPodGroups(context.TODO(), curms); err != nil {
-				klog.Errorf("failed to clean up PodGroups for ModelServing %s/%s: %v", curms.Namespace, curms.Name, err)
-			}
+			// PodGroups will be cleaned up in syncModelServing
 		}
 	}
 
@@ -560,6 +561,15 @@ func (c *ModelServingController) syncModelServing(ctx context.Context, key strin
 
 	revision := utils.ModelServingRevision(ms)
 
+	// Clean up outdated PodGroups if network topology or gang policy was removed
+	if ms.Spec.Template.NetworkTopology == nil {
+		if ms.Spec.Template.GangPolicy == nil || len(ms.Spec.Template.GangPolicy.MinRoleReplicas) == 0 {
+			if err := c.podGroupManager.CleanupPodGroups(ctx, ms); err != nil {
+				klog.Errorf("failed to clean up PodGroups for ModelServing %s/%s: %v", ms.Namespace, ms.Name, err)
+			}
+		}
+	}
+
 	// 1. Sync the number of ServingGroups to match the expected replicas defined in spec.
 	if err := c.syncServingGroupReplicas(ctx, ms, revision); err != nil {
 		return fmt.Errorf("failed to sync ServingGroup replicas: %v", err)
@@ -581,7 +591,7 @@ func (c *ModelServingController) syncModelServing(ctx context.Context, key strin
 	}
 
 	// 5. Calculate and update the overall condition and replica status fields of the ModelServing.
-	if err := c.UpdateModelServingStatus(ms, revision); err != nil {
+	if err := c.UpdateModelServingStatus(ctx, ms, revision); err != nil {
 		return fmt.Errorf("failed to update status of ms %s/%s: %v", namespace, name, err)
 	}
 
@@ -1263,7 +1273,7 @@ func (c *ModelServingController) DeleteRole(ctx context.Context, ms *workloadv1a
 		return
 	}
 	for _, svc := range services {
-		deleteSvcErr := c.kubeClientSet.CoreV1().Services(ms.Namespace).Delete(context.TODO(), svc.Name, metav1.DeleteOptions{})
+		deleteSvcErr := c.kubeClientSet.CoreV1().Services(ms.Namespace).Delete(ctx, svc.Name, metav1.DeleteOptions{})
 		if deleteSvcErr != nil {
 			if apierrors.IsNotFound(deleteSvcErr) {
 				klog.V(4).Infof("service %s/%s has been deleted", ms.Namespace, svc.Name)
@@ -1731,7 +1741,9 @@ func (c *ModelServingController) handlePodAfterGraceTime(ms *workloadv1alpha1.Mo
 		if !utils.IsPodRunningAndReady(newPod) {
 			// pod has not recovered after the grace period, needs to be rebuilt
 			// After this pod has been deleted, we will rebuild the ServingGroup in deletePod function
-			err = c.kubeClientSet.CoreV1().Pods(ms.Namespace).Delete(context.TODO(), newPod.Name, *metav1.NewPreconditionDeleteOptions(string(errPod.UID)))
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			err = c.kubeClientSet.CoreV1().Pods(ms.Namespace).Delete(ctx, newPod.Name, *metav1.NewPreconditionDeleteOptions(string(errPod.UID)))
 			if err != nil {
 				klog.Errorf("cannot delete pod %s after grace time, err: %v", newPod.Name, err)
 				return
@@ -1742,7 +1754,9 @@ func (c *ModelServingController) handlePodAfterGraceTime(ms *workloadv1alpha1.Mo
 		// grace period is not set or the grace period is 0, the deletion will be executed immediately.
 		defer c.graceMap.Delete(getPodGracePeriodKey(errPod))
 
-		err := c.kubeClientSet.CoreV1().Pods(ms.Namespace).Delete(context.TODO(), errPod.Name, *metav1.NewPreconditionDeleteOptions(string(errPod.UID)))
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		err := c.kubeClientSet.CoreV1().Pods(ms.Namespace).Delete(ctx, errPod.Name, *metav1.NewPreconditionDeleteOptions(string(errPod.UID)))
 		if err != nil {
 			klog.Errorf("cannot delete pod %s when it error, err: %v", errPod.Name, err)
 			return
@@ -1752,17 +1766,19 @@ func (c *ModelServingController) handlePodAfterGraceTime(ms *workloadv1alpha1.Mo
 }
 
 func (c *ModelServingController) handleDeletedPod(ms *workloadv1alpha1.ModelServing, servingGroupName string, pod *corev1.Pod) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
 	// pod is deleted due to failure or other reasons and needs to be rebuilt according to the RecoveryPolicy
 	switch ms.Spec.RecoveryPolicy {
 	case workloadv1alpha1.ServingGroupRecreate:
 		// Rebuild the entire ServingGroup directly
-		if err := c.deleteServingGroup(context.TODO(), ms, servingGroupName); err != nil {
+		if err := c.deleteServingGroup(ctx, ms, servingGroupName); err != nil {
 			klog.Errorf("failed to delete ServingGroup %s: %v", servingGroupName, err)
 		}
 	case workloadv1alpha1.RoleRecreate:
 		// If Rolling update in RoleRecreate mode, requires re-entering the queue during the pod delete event.
 		if c.store.GetServingGroupStatus(utils.GetNamespaceName(ms), servingGroupName) == datastore.ServingGroupDeleting {
-			if err := c.deleteServingGroup(context.TODO(), ms, servingGroupName); err != nil {
+			if err := c.deleteServingGroup(ctx, ms, servingGroupName); err != nil {
 				klog.Errorf("failed to delete ServingGroup %s: %v", servingGroupName, err)
 			}
 			return nil
@@ -1774,7 +1790,7 @@ func (c *ModelServingController) handleDeletedPod(ms *workloadv1alpha1.ModelServ
 				return fmt.Errorf("failed to set ServingGroup %s status: %v", servingGroupName, err)
 			}
 		}
-		c.DeleteRole(context.Background(), ms, servingGroupName, utils.GetRoleName(pod), utils.GetRoleID(pod))
+		c.DeleteRole(ctx, ms, servingGroupName, utils.GetRoleName(pod), utils.GetRoleID(pod))
 	}
 	return nil
 }
@@ -2074,7 +2090,7 @@ func (c *ModelServingController) getPodGroupsByIndex(indexName, indexValue strin
 }
 
 // UpdateModelServingStatus update replicas in modelServing status.
-func (c *ModelServingController) UpdateModelServingStatus(ms *workloadv1alpha1.ModelServing, revision string) error {
+func (c *ModelServingController) UpdateModelServingStatus(ctx context.Context, ms *workloadv1alpha1.ModelServing, revision string) error {
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		// Get latest modelserving from informer store
 		latestMS, getErr := c.modelServingLister.ModelServings(ms.Namespace).Get(ms.Name)
@@ -2103,7 +2119,7 @@ func (c *ModelServingController) UpdateModelServingStatus(ms *workloadv1alpha1.M
 					copy.Status.CurrentRevision = revision
 					copy.Status.UpdateRevision = revision
 					copy.Status.LabelSelector = selector
-					_, updateErr := c.modelServingClient.WorkloadV1alpha1().ModelServings(copy.GetNamespace()).UpdateStatus(context.TODO(), copy, metav1.UpdateOptions{})
+					_, updateErr := c.modelServingClient.WorkloadV1alpha1().ModelServings(copy.GetNamespace()).UpdateStatus(ctx, copy, metav1.UpdateOptions{})
 					return updateErr
 				}
 				return nil
@@ -2250,13 +2266,13 @@ func (c *ModelServingController) UpdateModelServingStatus(ms *workloadv1alpha1.M
 		}
 
 		if shouldUpdate {
-			_, err := c.modelServingClient.WorkloadV1alpha1().ModelServings(copy.GetNamespace()).UpdateStatus(context.TODO(), copy, metav1.UpdateOptions{})
+			_, err := c.modelServingClient.WorkloadV1alpha1().ModelServings(copy.GetNamespace()).UpdateStatus(ctx, copy, metav1.UpdateOptions{})
 			if err != nil {
 				return err
 			}
 			// Clean up old revisions only after roles have been updated (revision status changed)
 			if revisionUpdated {
-				if cleanupErr := utils.CleanupOldControllerRevisions(context.TODO(), c.kubeClientSet, copy); cleanupErr != nil {
+				if cleanupErr := utils.CleanupOldControllerRevisions(ctx, c.kubeClientSet, copy); cleanupErr != nil {
 					klog.Warningf("Failed to cleanup old ControllerRevisions after updating revision status for ModelServing %s/%s: %v", copy.Namespace, copy.Name, cleanupErr)
 				}
 			}

--- a/pkg/model-serving-controller/controller/model_serving_controller.go
+++ b/pkg/model-serving-controller/controller/model_serving_controller.go
@@ -559,8 +559,10 @@ func (c *ModelServingController) syncModelServing(ctx context.Context, key strin
 	// Clean up outdated PodGroups if network topology or gang policy was removed
 	if ms.Spec.Template.NetworkTopology == nil {
 		if ms.Spec.Template.GangPolicy == nil || len(ms.Spec.Template.GangPolicy.MinRoleReplicas) == 0 {
-			if err := c.podGroupManager.CleanupPodGroups(ctx, ms); err != nil {
-				klog.Errorf("failed to clean up PodGroups for ModelServing %s/%s: %v", ms.Namespace, ms.Name, err)
+			if c.podGroupManager != nil {
+				if err := c.podGroupManager.CleanupPodGroups(ctx, ms); err != nil {
+					klog.Errorf("failed to clean up PodGroups for ModelServing %s/%s: %v", ms.Namespace, ms.Name, err)
+				}
 			}
 		}
 	}

--- a/pkg/model-serving-controller/controller/model_serving_controller_test.go
+++ b/pkg/model-serving-controller/controller/model_serving_controller_test.go
@@ -3651,7 +3651,7 @@ func TestModelServingVersionControl(t *testing.T) {
 			}
 
 			// Verify status revisions
-			err = controller.UpdateModelServingStatus(ms, newRevision)
+			err = controller.UpdateModelServingStatus(context.TODO(), ms, newRevision)
 			assert.NoError(t, err)
 
 			// Get updated ModelServing to check status
@@ -3959,7 +3959,7 @@ func TestUpdateModelServingStatusLabelSelector(t *testing.T) {
 				}
 			}
 
-			err = controller.UpdateModelServingStatus(ms, tt.revision)
+			err = controller.UpdateModelServingStatus(context.TODO(), ms, tt.revision)
 			assert.NoError(t, err, "case %d: UpdateModelServingStatus should not error", idx)
 
 			updated, err := kthenaClient.WorkloadV1alpha1().ModelServings("default").Get(context.Background(), tt.msName, metav1.GetOptions{})
@@ -4113,7 +4113,7 @@ func TestUpdateModelServingStatusRevisionFields(t *testing.T) {
 			}
 
 			// Call UpdateModelServingStatus
-			err = controller.UpdateModelServingStatus(ms, tt.newRevision)
+			err = controller.UpdateModelServingStatus(context.TODO(), ms, tt.newRevision)
 			assert.NoError(t, err)
 
 			// Get updated ModelServing to check status


### PR DESCRIPTION
Fixes #1531 

### Description

This PR resolves Issue [#1531](https://github.com/volcano-sh/kthena/issues/1531), which caused goroutine leaks and potential thread starvation inside `ModelServingController`.

Previously, several Kubernetes API calls (such as Pod/Service deletions, status updates, and PodGroup cleanups) used `context.TODO()`. Because `context.TODO()` has no deadline and cannot propagate cancellation signals, any API server latency or network partition could cause worker threads to block indefinitely.

---

### Key Changes

1. **Plumbed Parent `ctx` Down the Reconciliation Flow:**
   - Updated helper functions (`UpdateModelServingStatus`, `DeleteRole`, `syncServingGroupReplicas`, `syncRoleReplicas`, etc.) to accept and use the active `ctx context.Context` passed down from the primary `syncModelServing` worker loop.

2. **Addressed Feedback 
   - Removed `CleanupPodGroups` from `updateModelServing` (the informer event handler). Informer handlers now strictly enqueue work items without performing synchronous blocking API calls.
   - Relocated `CleanupPodGroups` into `syncModelServing` (the main worker loop), where it inherits the parent worker `ctx` (properly propagation cancellation & shutdown signals).

3. **Added Bounded Timeouts for Isolated Cleanup Operations:**
   - Wrapped standalone cleanup calls (such as `handleDeletedPod` and `handlePodAfterGraceTime`) with explicit `context.WithTimeout(context.Background(), 10*time.Second)` to guarantee calls abort cleanly if the API server is unreachable.

4. **Safety & Linter Fixes:**
   - Added a `nil` check for `c.podGroupManager` before calling `CleanupPodGroups` to prevent nil pointer dereferences during unit tests.

---

- [x] **Unit Tests:** All controller unit tests pass cleanly:
  ```bash
  go test -v ./pkg/model-serving-controller/controller/...