### PR TITLE
helm: make router service type configurable

### DIFF
--- a/charts/kthena/charts/networking/templates/kthena-router/component/service.yaml
+++ b/charts/kthena/charts/networking/templates/kthena-router/component/service.yaml
@@ -14,7 +14,7 @@ spec:
     - port: 80
       targetPort: {{ .Values.kthenaRouter.port }}
       name: http
-  type: LoadBalancer
+  type: {{ .Values.kthenaRouter.service.type }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/kthena/charts/networking/values.yaml
+++ b/charts/kthena/charts/networking/values.yaml
@@ -9,6 +9,9 @@ kthenaRouter:
     # exposeOnRouterPort restores the legacy /metrics endpoint on the inference listener.
     # Keep disabled when the inference Service is publicly reachable.
     exposeOnRouterPort: false
+  service:
+    # -- Kubernetes Service type used to expose kthena-router.
+    type: LoadBalancer
   tls:
     enabled: false
     # The DNS name to use for the certificate.

--- a/charts/kthena/values.yaml
+++ b/charts/kthena/values.yaml
@@ -52,6 +52,9 @@ networking:
       exposeOnRouterPort: false
     # -- Debug server port for Kthena Router (localhost only).
     debugPort: 15000
+    service:
+      # -- Kubernetes Service type used to expose Kthena Router.
+      type: LoadBalancer
     image:
       # -- Image repository for Kthena Router.
       repository: ghcr.io/volcano-sh/kthena-router

--- a/docs/kthena/docs/reference/helm-chart-values.md
+++ b/docs/kthena/docs/reference/helm-chart-values.md
@@ -38,6 +38,7 @@ A Helm chart for deploying Kthena
 | networking.kthenaRouter.metrics.port | int | `9090` | Internal Prometheus metrics port for Kthena Router. |
 | networking.kthenaRouter.port | int | `8080` | Container port for Kthena Router. |
 | networking.kthenaRouter.replicas | int | `1` | Number of Kthena Router instances to run. |
+| networking.kthenaRouter.service.type | string | `"LoadBalancer"` | Kubernetes Service type used to expose Kthena Router. |
 | networking.kthenaRouter.sessionBoost.enabled | bool | `false` | Enable session-boost scheduling. Mutually exclusive with fairness. |
 | networking.kthenaRouter.sessionBoost.gracePeriod | string | `"0s"` | Wait time after a request completes for a same-session follow-up.<br/> Disabled by default (`0s`). |
 | networking.kthenaRouter.sessionBoost.header | string | `"X-Session-ID"` | HTTP header used to identify conversation sessions. |


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement

**What this PR does / why we need it**:

Makes the `kthena-router` Kubernetes Service type configurable through `networking.kthenaRouter.service.type`.

The default remains `LoadBalancer` to preserve existing behavior, while users can select `ClusterIP`, `NodePort`, or another supported Service type for local, private, or non-cloud environments.

This limitation was identified while investigating the E2E installation failures addressed by #1536. It is kept as a separate change because #1536 fixes the installation-readiness race, whereas this PR only removes the Helm chart's hard-coded router Service type.

**Which issue(s) this PR fixes**:

Related to #1536.

**Bug evidence (required for bug-related PRs)**:

N/A

**Special notes for your reviewer**:

The generated Helm values reference has been updated.

This PR was written in part with the assistance of generative AI.

Tested with:

```console
helm lint charts/kthena --set networking.kthenaRouter.service.type=LoadBalancer
helm lint charts/kthena --set networking.kthenaRouter.service.type=ClusterIP
helm lint charts/kthena --set networking.kthenaRouter.service.type=NodePort
make lint
make test
make gen-check
```

**Does this PR introduce a user-facing change?**:

```release-note
Allow configuring the kthena-router Kubernetes Service type through `networking.kthenaRouter.service.type`.
```
