### PR TITLE
runtime: drop token ids and hash lists from kv cache logs

### DIFF
--- a/python/kthena/runtime/kv_cache_manager.py
+++ b/python/kthena/runtime/kv_cache_manager.py
@@ -46,7 +46,8 @@ def compute_standardized_hash(token_ids: List[int]) -> int:
     hash_obj = hashlib.sha256(token_bytes)
     full_hash = int.from_bytes(hash_obj.digest()[:8], byteorder='big')
     result = full_hash & 0x7FFFFFFFFFFFFFFF
-    logger.info(f"KVCacheManager: compute standardized hash={result}, token_ids={token_ids}")
+    # Token ids are detokenizable prompt content, so they must never reach the logs.
+    logger.debug(f"KVCacheManager: compute standardized hash={result}, tokens={len(token_ids)}")
     return result
 
 
@@ -89,7 +90,7 @@ class VLLMKVCacheRedisManager:
 
             logger.info(
                 f"Runtime Redis Write - Model: {model_name}, Pod: {pod_identifier}, "
-                f"BlockHashes: {block_hashes}, Count: {len(block_hashes)}")
+                f"Count: {len(block_hashes)}")
             return True
 
         except Exception as e:

--- a/python/kthena/tests/test_sglang_kv_cache_handler.py
+++ b/python/kthena/tests/test_sglang_kv_cache_handler.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock
 
@@ -280,3 +281,19 @@ async def test_scan_keys_handles_empty_round_before_cursor_returns_to_zero():
         "matrix:kv:block:qwen@1"
     ]
     assert client._client.cursors == [0, 9]
+
+
+def test_standardized_hash_keeps_token_ids_out_of_info_logs(caplog):
+    """Token ids detokenize back to prompt text, so INFO must never carry them."""
+    with caplog.at_level(logging.INFO, logger="kthena.runtime.kv_cache_manager"):
+        compute_standardized_hash([101, 202, 303])
+    assert caplog.records == []
+
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG, logger="kthena.runtime.kv_cache_manager"):
+        compute_standardized_hash([101, 202, 303])
+    assert len(caplog.records) == 1
+    message = caplog.records[0].getMessage()
+    assert "tokens=3" in message
+    assert "token_ids" not in message
+    assert "101" not in message


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`compute_standardized_hash` logged every block's full token id list at INFO, and token ids detokenize back to prompt text with the model's public tokenizer, so user prompt content landed in container logs at the sidecar's default level:

https://github.com/volcano-sh/kthena/blob/1b3319d0e2023157399c435d07c301cf7b9e8fbf/python/kthena/runtime/kv_cache_manager.py#L49

The write path added a second per-event INFO line with the full block hash list (L90-L92).

The hash line moves to debug and logs a token count instead of the ids, matching the zmq subscribers which already keep per-event detail at debug. The write confirmation stays at INFO with model, pod and count, matching the remove path's count-only line.

**Which issue(s) this PR fixes**:
Fixes #1553

**Special notes for your reviewer**:

The log sits inside `compute_standardized_hash`, so both call sites are covered: the store path, and `get_standardized_hashes`, which currently has no in-repo caller. #1553's body labels that line "the remove path"; that was imprecise, the remove path never computes hashes, and the issue is corrected accordingly. The new test asserts INFO carries no token ids and fails on main.

**Does this PR introduce a user-facing change?**:

```release-note
Runtime sidecar no longer logs prompt token ids or full block hash lists.
```
