### PR TITLE
cli: fix template directory path in README

### DIFF
--- a/cli/kthena/README.md
+++ b/cli/kthena/README.md
@@ -167,7 +167,7 @@ The CLI uses your local kubectl configuration. Ensure you have:
 
 To add new manifest templates:
 
-1. Create a new `.yaml` file in the `templates/` directory
+1. Create a new `.yaml` file under `helm/templates/<vendor>/` (templates are embedded into the binary at build time, so rebuild the CLI to pick it up)
 2. Use Go template syntax with variables: `{{.variable_name}}`
 3. Add a description comment at the top: `# Description: Your template description`
 4. Test with `kthena describe template your-template`


### PR DESCRIPTION
/kind documentation

The Contributing section told contributors to add templates "in the `templates/` directory", which the CLI never reads. Templates are embedded at build time from `helm/templates/<vendor>/` only: the embed pattern `helm/templates/**/*.yaml` matches a single path element per `**`, and both listing and lookup walk the vendor subdirectories:

https://github.com/volcano-sh/kthena/blob/a71f5bfd48fd19c3d9053212ef27b779fc3d612e/cli/kthena/main.go#L28

https://github.com/volcano-sh/kthena/blob/a71f5bfd48fd19c3d9053212ef27b779fc3d612e/cli/kthena/cmd/templates.go#L50-L66

One line: step 1 now names the real location and notes the rebuild, since a file added per the old instruction silently never appears in `kthena get templates`.

Fixes #1574
