### PR TITLE
perf: compile HTTPRoute regex path matchers once

### DIFF
--- a/pkg/kthena-router/datastore/store.go
+++ b/pkg/kthena-router/datastore/store.go
@@ -278,6 +278,9 @@ type Store interface {
 	GetHTTPRoute(key string) *gatewayv1.HTTPRoute
 	GetAllHTTPRoutes() []*gatewayv1.HTTPRoute
 	GetHTTPRoutesByGateway(gatewayKey string) []*gatewayv1.HTTPRoute
+	// CompileHTTPRouteRegex compiles an HTTPRoute regex path pattern, reusing
+	// the compiled result on subsequent calls for the same pattern.
+	CompileHTTPRouteRegex(pattern string) (*regexp.Regexp, error)
 
 	// GetModelNames returns all model names registered via ModelRoutes,
 	// including both base model names and LoRA adapter names.
@@ -388,9 +391,10 @@ type store struct {
 	inferencePools     map[string]*inferencev1.InferencePool // key: namespace/name, value: *inferencev1.InferencePool
 
 	// HTTPRoute fields (using standard Gateway API)
-	httpRouteMutex sync.RWMutex
-	httpRoutes     map[string]*gatewayv1.HTTPRoute // key: namespace/name, value: *gatewayv1.HTTPRoute
-	gatewayRoutes  map[string]sets.Set[string]     // key: gateway key (namespace/name), value: set of HTTPRoute keys
+	httpRouteMutex      sync.RWMutex
+	httpRoutes          map[string]*gatewayv1.HTTPRoute // key: namespace/name, value: *gatewayv1.HTTPRoute
+	gatewayRoutes       map[string]sets.Set[string]     // key: gateway key (namespace/name), value: set of HTTPRoute keys
+	httpRouteRegexCache sync.Map                        // key: regex pattern, value: *compiledPattern
 	// New fields for callback management
 	callbacks map[string][]CallbackFunc
 
@@ -2420,6 +2424,8 @@ func (s *store) AddOrUpdateHTTPRoute(httpRoute *gatewayv1.HTTPRoute) error {
 
 	s.httpRouteMutex.Unlock()
 
+	s.gcHTTPRouteRegexCache()
+
 	klog.V(4).Infof("Added or updated HTTPRoute: %s", key)
 	return nil
 }
@@ -2445,6 +2451,8 @@ func (s *store) DeleteHTTPRoute(key string) error {
 		delete(s.httpRoutes, key)
 	}
 	s.httpRouteMutex.Unlock()
+
+	s.gcHTTPRouteRegexCache()
 
 	if exists {
 		klog.V(4).Infof("Deleted HTTPRoute: %s", key)
@@ -2483,4 +2491,56 @@ func (s *store) GetHTTPRoutesByGateway(gatewayKey string) []*gatewayv1.HTTPRoute
 		}
 	}
 	return result
+}
+
+// CompileHTTPRouteRegex returns the compiled HTTPRoute regex path pattern,
+// compiling it on first use. Compile failures are cached too, so an invalid
+// pattern is not retried on every request.
+func (s *store) CompileHTTPRouteRegex(pattern string) (*regexp.Regexp, error) {
+	if v, ok := s.httpRouteRegexCache.Load(pattern); ok {
+		cp := v.(*compiledPattern)
+		return cp.re, cp.err
+	}
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		klog.Warningf("invalid regex %q in HTTPRoute match, treating as no match: %v", pattern, err)
+	}
+	v, _ := s.httpRouteRegexCache.LoadOrStore(pattern, &compiledPattern{re: re, err: err})
+	cp := v.(*compiledPattern)
+	return cp.re, cp.err
+}
+
+// collectHTTPRouteRegexes adds every regex path pattern referenced by route to out
+func collectHTTPRouteRegexes(route *gatewayv1.HTTPRoute, out map[string]struct{}) {
+	for _, rule := range route.Spec.Rules {
+		for _, match := range rule.Matches {
+			if match.Path == nil || match.Path.Type == nil || *match.Path.Type != gatewayv1.PathMatchRegularExpression {
+				continue
+			}
+			value := "/"
+			if match.Path.Value != nil {
+				value = *match.Path.Value
+			}
+			out[value] = struct{}{}
+		}
+	}
+}
+
+// gcHTTPRouteRegexCache drops compiled patterns that no HTTPRoute references any more
+func (s *store) gcHTTPRouteRegexCache() {
+	live := make(map[string]struct{})
+	s.httpRouteMutex.RLock()
+	for _, route := range s.httpRoutes {
+		if route != nil {
+			collectHTTPRouteRegexes(route, live)
+		}
+	}
+	s.httpRouteMutex.RUnlock()
+
+	s.httpRouteRegexCache.Range(func(key, _ any) bool {
+		if _, ok := live[key.(string)]; !ok {
+			s.httpRouteRegexCache.Delete(key)
+		}
+		return true
+	})
 }

--- a/pkg/kthena-router/datastore/store.go
+++ b/pkg/kthena-router/datastore/store.go
@@ -395,6 +395,7 @@ type store struct {
 	httpRoutes          map[string]*gatewayv1.HTTPRoute // key: namespace/name, value: *gatewayv1.HTTPRoute
 	gatewayRoutes       map[string]sets.Set[string]     // key: gateway key (namespace/name), value: set of HTTPRoute keys
 	httpRouteRegexCache sync.Map                        // key: regex pattern, value: *compiledPattern
+	httpRouteRegexRefs  map[string]int                  // key: regex pattern, value: number of HTTPRoutes referencing it
 	// New fields for callback management
 	callbacks map[string][]CallbackFunc
 
@@ -421,6 +422,7 @@ func New(opts ...Option) Store {
 		inferencePools:      make(map[string]*inferencev1.InferencePool),
 		httpRoutes:          make(map[string]*gatewayv1.HTTPRoute),
 		gatewayRoutes:       make(map[string]sets.Set[string]),
+		httpRouteRegexRefs:  make(map[string]int),
 		callbacks:           make(map[string][]CallbackFunc),
 		initialSynced:       &atomic.Bool{},
 		requestWaitingQueue: sync.Map{},
@@ -2384,6 +2386,7 @@ func (s *store) AddOrUpdateHTTPRoute(httpRoute *gatewayv1.HTTPRoute) error {
 
 	s.httpRouteMutex.Lock()
 	oldRoute := s.httpRoutes[key]
+	s.updateHTTPRouteRegexRefs(oldRoute, httpRoute)
 	s.httpRoutes[key] = httpRoute
 
 	// Update gateway routes mapping
@@ -2424,8 +2427,6 @@ func (s *store) AddOrUpdateHTTPRoute(httpRoute *gatewayv1.HTTPRoute) error {
 
 	s.httpRouteMutex.Unlock()
 
-	s.gcHTTPRouteRegexCache()
-
 	klog.V(4).Infof("Added or updated HTTPRoute: %s", key)
 	return nil
 }
@@ -2439,8 +2440,9 @@ func isGatewayParentRef(parentRef gatewayv1.ParentReference) bool {
 
 func (s *store) DeleteHTTPRoute(key string) error {
 	s.httpRouteMutex.Lock()
-	_, exists := s.httpRoutes[key]
+	oldRoute, exists := s.httpRoutes[key]
 	if exists {
+		s.updateHTTPRouteRegexRefs(oldRoute, nil)
 		// Remove from gateway routes mapping
 		for gatewayKey, routeSet := range s.gatewayRoutes {
 			routeSet.Delete(key)
@@ -2451,8 +2453,6 @@ func (s *store) DeleteHTTPRoute(key string) error {
 		delete(s.httpRoutes, key)
 	}
 	s.httpRouteMutex.Unlock()
-
-	s.gcHTTPRouteRegexCache()
 
 	if exists {
 		klog.V(4).Infof("Deleted HTTPRoute: %s", key)
@@ -2510,8 +2510,13 @@ func (s *store) CompileHTTPRouteRegex(pattern string) (*regexp.Regexp, error) {
 	return cp.re, cp.err
 }
 
-// collectHTTPRouteRegexes adds every regex path pattern referenced by route to out
-func collectHTTPRouteRegexes(route *gatewayv1.HTTPRoute, out map[string]struct{}) {
+// collectHTTPRouteRegexes returns every regex path pattern referenced by route.
+func collectHTTPRouteRegexes(route *gatewayv1.HTTPRoute) map[string]struct{} {
+	patterns := make(map[string]struct{})
+	if route == nil {
+		return patterns
+	}
+
 	for _, rule := range route.Spec.Rules {
 		for _, match := range rule.Matches {
 			if match.Path == nil || match.Path.Type == nil || *match.Path.Type != gatewayv1.PathMatchRegularExpression {
@@ -2521,26 +2526,40 @@ func collectHTTPRouteRegexes(route *gatewayv1.HTTPRoute, out map[string]struct{}
 			if match.Path.Value != nil {
 				value = *match.Path.Value
 			}
-			out[value] = struct{}{}
+			patterns[value] = struct{}{}
 		}
 	}
+	return patterns
 }
 
-// gcHTTPRouteRegexCache drops compiled patterns that no HTTPRoute references any more
-func (s *store) gcHTTPRouteRegexCache() {
-	live := make(map[string]struct{})
-	s.httpRouteMutex.RLock()
-	for _, route := range s.httpRoutes {
-		if route != nil {
-			collectHTTPRouteRegexes(route, live)
-		}
+// updateHTTPRouteRegexRefs updates cache references for one HTTPRoute mutation.
+// The caller must hold httpRouteMutex.
+func (s *store) updateHTTPRouteRegexRefs(oldRoute, newRoute *gatewayv1.HTTPRoute) {
+	if s.httpRouteRegexRefs == nil {
+		s.httpRouteRegexRefs = make(map[string]int)
 	}
-	s.httpRouteMutex.RUnlock()
 
-	s.httpRouteRegexCache.Range(func(key, _ any) bool {
-		if _, ok := live[key.(string)]; !ok {
-			s.httpRouteRegexCache.Delete(key)
+	oldPatterns := collectHTTPRouteRegexes(oldRoute)
+	newPatterns := collectHTTPRouteRegexes(newRoute)
+
+	for pattern := range oldPatterns {
+		if _, stillReferenced := newPatterns[pattern]; stillReferenced {
+			continue
 		}
-		return true
-	})
+
+		refs := s.httpRouteRegexRefs[pattern]
+		if refs <= 1 {
+			delete(s.httpRouteRegexRefs, pattern)
+			s.httpRouteRegexCache.Delete(pattern)
+			continue
+		}
+		s.httpRouteRegexRefs[pattern] = refs - 1
+	}
+
+	for pattern := range newPatterns {
+		if _, wasReferenced := oldPatterns[pattern]; wasReferenced {
+			continue
+		}
+		s.httpRouteRegexRefs[pattern]++
+	}
 }

--- a/pkg/kthena-router/datastore/store_test.go
+++ b/pkg/kthena-router/datastore/store_test.go
@@ -1792,8 +1792,9 @@ func TestAddOrUpdateHTTPRoute_UpdatesGatewayRoutes(t *testing.T) {
 
 func newTestHTTPRouteStore() *store {
 	return &store{
-		httpRoutes:    make(map[string]*gatewayv1.HTTPRoute),
-		gatewayRoutes: make(map[string]sets.Set[string]),
+		httpRoutes:         make(map[string]*gatewayv1.HTTPRoute),
+		gatewayRoutes:      make(map[string]sets.Set[string]),
+		httpRouteRegexRefs: make(map[string]int),
 	}
 }
 

--- a/pkg/kthena-router/datastore/store_test.go
+++ b/pkg/kthena-router/datastore/store_test.go
@@ -1790,6 +1790,121 @@ func TestAddOrUpdateHTTPRoute_UpdatesGatewayRoutes(t *testing.T) {
 	assert.Len(t, s.GetHTTPRoutesByGateway("default/gateway-b"), 1)
 }
 
+func newTestHTTPRouteStore() *store {
+	return &store{
+		httpRoutes:    make(map[string]*gatewayv1.HTTPRoute),
+		gatewayRoutes: make(map[string]sets.Set[string]),
+	}
+}
+
+func regexHTTPRoute(namespace, name, pattern string) *gatewayv1.HTTPRoute {
+	regexType := gatewayv1.PathMatchRegularExpression
+	return &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		Spec: gatewayv1.HTTPRouteSpec{
+			Rules: []gatewayv1.HTTPRouteRule{
+				{
+					Matches: []gatewayv1.HTTPRouteMatch{
+						{
+							Path: &gatewayv1.HTTPPathMatch{Type: &regexType, Value: &pattern},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func cachedHTTPRoutePatterns(s *store) []string {
+	var out []string
+	s.httpRouteRegexCache.Range(func(key, _ any) bool {
+		out = append(out, key.(string))
+		return true
+	})
+	return out
+}
+
+func TestCompileHTTPRouteRegexReusesCompiledPattern(t *testing.T) {
+	s := &store{}
+
+	first, err := s.CompileHTTPRouteRegex("^/v1/cache-me$")
+	assert.NoError(t, err)
+	second, err := s.CompileHTTPRouteRegex("^/v1/cache-me$")
+	assert.NoError(t, err)
+	assert.Same(t, first, second, "the same pattern should not be recompiled")
+
+	re, err := s.CompileHTTPRouteRegex("^(unclosed")
+	assert.Error(t, err)
+	assert.Nil(t, re)
+	// Failures are cached too, so a bad pattern is not recompiled per request.
+	_, errAgain := s.CompileHTTPRouteRegex("^(unclosed")
+	assert.Equal(t, err, errAgain)
+}
+
+func TestCompileHTTPRouteRegexConcurrent(t *testing.T) {
+	s := &store{}
+
+	var wg sync.WaitGroup
+	got := make([]*regexp.Regexp, 32)
+	for i := range got {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			re, err := s.CompileHTTPRouteRegex("^/v1/concurrent-[a-z]+$")
+			assert.NoError(t, err)
+			got[i] = re
+		}(i)
+	}
+	wg.Wait()
+	for i := 1; i < len(got); i++ {
+		assert.Same(t, got[0], got[i], "all goroutines should share one compiled pattern")
+	}
+}
+
+func TestGCHTTPRouteRegexCacheDropsUnreferencedPatterns(t *testing.T) {
+	s := newTestHTTPRouteStore()
+	const pattern = "^/v1/gc-me$"
+	assert.NoError(t, s.AddOrUpdateHTTPRoute(regexHTTPRoute("default", "r1", pattern)))
+
+	_, err := s.CompileHTTPRouteRegex(pattern)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{pattern}, cachedHTTPRoutePatterns(s), "pattern should be cached after first compile")
+
+	assert.NoError(t, s.DeleteHTTPRoute("default/r1"))
+	assert.Empty(t, cachedHTTPRoutePatterns(s), "deleting the route should drop its compiled pattern")
+}
+
+func TestGCHTTPRouteRegexCacheDropsPatternsRemovedByUpdate(t *testing.T) {
+	s := newTestHTTPRouteStore()
+	const oldPattern = "^/v1/old-regex$"
+	assert.NoError(t, s.AddOrUpdateHTTPRoute(regexHTTPRoute("default", "r1", oldPattern)))
+
+	_, err := s.CompileHTTPRouteRegex(oldPattern)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{oldPattern}, cachedHTTPRoutePatterns(s))
+
+	assert.NoError(t, s.AddOrUpdateHTTPRoute(regexHTTPRoute("default", "r1", "^/v1/new-regex$")))
+	assert.Empty(t, cachedHTTPRoutePatterns(s), "updating a route away from a regex should drop its compiled pattern")
+}
+
+func TestGCHTTPRouteRegexCacheKeepsPatternsStillInUse(t *testing.T) {
+	s := newTestHTTPRouteStore()
+	const shared = "^/v1/shared$"
+	assert.NoError(t, s.AddOrUpdateHTTPRoute(regexHTTPRoute("default", "r1", shared)))
+	assert.NoError(t, s.AddOrUpdateHTTPRoute(regexHTTPRoute("default", "r2", shared)))
+
+	_, err := s.CompileHTTPRouteRegex(shared)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{shared}, cachedHTTPRoutePatterns(s))
+
+	// r2 still references the pattern, so it must survive r1 going away.
+	assert.NoError(t, s.DeleteHTTPRoute("default/r1"))
+	assert.Equal(t, []string{shared}, cachedHTTPRoutePatterns(s))
+
+	assert.NoError(t, s.DeleteHTTPRoute("default/r2"))
+	assert.Empty(t, cachedHTTPRoutePatterns(s))
+}
+
 func TestAddOrUpdatePod_MetricsPreservedOnUpdate(t *testing.T) {
 	sampleCount := uint64(100)
 	sampleSum := 0.42

--- a/pkg/kthena-router/debug/handlers_test.go
+++ b/pkg/kthena-router/debug/handlers_test.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"regexp"
 	"testing"
 	"time"
 
@@ -310,6 +311,10 @@ func (m *MockStore) GetAllHTTPRoutes() []*gatewayv1.HTTPRoute {
 		return nil
 	}
 	return args.Get(0).([]*gatewayv1.HTTPRoute)
+}
+
+func (m *MockStore) CompileHTTPRouteRegex(pattern string) (*regexp.Regexp, error) {
+	return regexp.Compile(pattern)
 }
 
 func (m *MockStore) GetAllInferencePools() []*inferencev1.InferencePool {

--- a/pkg/kthena-router/router/httproute_match.go
+++ b/pkg/kthena-router/router/httproute_match.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/klog/v2"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
@@ -108,7 +107,7 @@ func (r *Router) findHTTPRouteMatch(c *gin.Context, gatewayKey string) (httpRout
 		if !hostnameMatched {
 			continue
 		}
-		result, matched := findBestHTTPRouteRuleMatch(route, c.Request.URL.Path)
+		result, matched := findBestHTTPRouteRuleMatch(route, c.Request.URL.Path, r.store.CompileHTTPRouteRegex)
 		if matched {
 			result.hostname = hostnamePrecedence
 			if !found || compareHTTPRouteMatchPrecedence(result, best) < 0 {
@@ -150,7 +149,7 @@ func isGatewayParentRef(parentRef gatewayv1.ParentReference) bool {
 	return parentRef.Kind == nil || *parentRef.Kind == "Gateway"
 }
 
-func findBestHTTPRouteRuleMatch(route *gatewayv1.HTTPRoute, requestPath string) (httpRouteMatchResult, bool) {
+func findBestHTTPRouteRuleMatch(route *gatewayv1.HTTPRoute, requestPath string, compileRegex func(string) (*regexp.Regexp, error)) (httpRouteMatchResult, bool) {
 	var best httpRouteMatchResult
 	found := false
 	for i := range route.Spec.Rules {
@@ -182,7 +181,7 @@ func findBestHTTPRouteRuleMatch(route *gatewayv1.HTTPRoute, requestPath string) 
 				// into a path-only match and could select the wrong backend.
 				continue
 			}
-			matched, matchedPrefix, pathPrecedence := matchHTTPRoutePath(match.Path, requestPath, route)
+			matched, matchedPrefix, pathPrecedence := matchHTTPRoutePath(match.Path, requestPath, route, compileRegex)
 			if !matched {
 				continue
 			}
@@ -372,7 +371,7 @@ const (
 // matchHTTPRoutePath checks only the path predicate. It returns the matched
 // prefix needed by ReplacePrefixMatch URLRewrite and the path score used to
 // compare rules inside one HTTPRoute.
-func matchHTTPRoutePath(path *gatewayv1.HTTPPathMatch, requestPath string, route *gatewayv1.HTTPRoute) (bool, string, httpRoutePathPrecedence) {
+func matchHTTPRoutePath(path *gatewayv1.HTTPPathMatch, requestPath string, route *gatewayv1.HTTPRoute, compileRegex func(string) (*regexp.Regexp, error)) (bool, string, httpRoutePathPrecedence) {
 	if path == nil {
 		return true, "/", httpRoutePathPrecedence{matchType: httpPathPrefixPrecedence, characters: 1}
 	}
@@ -389,9 +388,8 @@ func matchHTTPRoutePath(path *gatewayv1.HTTPPathMatch, requestPath string, route
 		}
 		return true, matchedPrefix, httpRoutePathPrecedence{matchType: httpPathPrefixPrecedence, characters: len(matchedPrefix)}
 	case gatewayv1.PathMatchRegularExpression:
-		expression, err := regexp.Compile(pathValue)
+		expression, err := compileRegex(pathValue)
 		if err != nil {
-			klog.Warningf("Invalid regex pattern '%s' in HTTPRoute %s/%s: %v", pathValue, route.Namespace, route.Name, err)
 			return false, "", httpRoutePathPrecedence{}
 		}
 		return expression.MatchString(requestPath), "", httpRoutePathPrecedence{matchType: httpPathRegularExpressionPrecedence}

--- a/pkg/kthena-router/router/httproute_match_test.go
+++ b/pkg/kthena-router/router/httproute_match_test.go
@@ -19,6 +19,7 @@ package router
 import (
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"testing"
 	"time"
 
@@ -468,6 +469,49 @@ func TestMatchHTTPRouteHostname(t *testing.T) {
 	}
 }
 
+func TestMatchHTTPRoutePathRegularExpression(t *testing.T) {
+	regexType := gatewayv1.PathMatchRegularExpression
+	regexMatch := func(pattern string) *gatewayv1.HTTPPathMatch {
+		return &gatewayv1.HTTPPathMatch{Type: &regexType, Value: &pattern}
+	}
+	route := &gatewayv1.HTTPRoute{ObjectMeta: v1.ObjectMeta{Namespace: "default", Name: "regex-route"}}
+	compile := func(pattern string) (*regexp.Regexp, error) {
+		return regexp.Compile(pattern)
+	}
+
+	t.Run("matches request path", func(t *testing.T) {
+		matched, matchedPrefix, precedence := matchHTTPRoutePath(regexMatch("^/v1/chat/completions$"), "/v1/chat/completions", route, compile)
+		assert.True(t, matched)
+		assert.Empty(t, matchedPrefix)
+		assert.Equal(t, httpPathRegularExpressionPrecedence, precedence.matchType)
+	})
+
+	t.Run("does not match request path", func(t *testing.T) {
+		matched, _, _ := matchHTTPRoutePath(regexMatch("^/v1/chat/completions$"), "/v1/models", route, compile)
+		assert.False(t, matched)
+	})
+
+	t.Run("invalid regex returns no match without panicking", func(t *testing.T) {
+		matched, _, _ := matchHTTPRoutePath(regexMatch("^(unclosed"), "/v1/chat/completions", route, compile)
+		assert.False(t, matched)
+	})
+
+	t.Run("does not compile regexes for other match types", func(t *testing.T) {
+		compileCount := 0
+		countingCompile := func(pattern string) (*regexp.Regexp, error) {
+			compileCount++
+			return regexp.Compile(pattern)
+		}
+		prefixType := gatewayv1.PathMatchPathPrefix
+		prefix := "/v1"
+		pathMatch := &gatewayv1.HTTPPathMatch{Type: &prefixType, Value: &prefix}
+
+		matched, _, _ := matchHTTPRoutePath(pathMatch, "/v1/chat/completions", route, countingCompile)
+		assert.True(t, matched)
+		assert.Zero(t, compileCount)
+	})
+}
+
 func TestInferencePoolFromHTTPRouteRuleWeights(t *testing.T) {
 	group := inferencePoolBackendGroup
 	kind := inferencePoolBackendKind
@@ -554,4 +598,35 @@ func TestSelectWeightedInferencePool(t *testing.T) {
 			assert.Equal(t, tt.expected, pool.Name)
 		})
 	}
+}
+
+func BenchmarkMatchHTTPRoutePathRegex(b *testing.B) {
+	regexType := gatewayv1.PathMatchRegularExpression
+	value := "^/v1/chat/completions$"
+	pathMatch := &gatewayv1.HTTPPathMatch{Type: &regexType, Value: &value}
+	route := &gatewayv1.HTTPRoute{}
+
+	b.Run("compile-every-request", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			matched, _, _ := matchHTTPRoutePath(pathMatch, "/v1/chat/completions", route, regexp.Compile)
+			if !matched {
+				b.Fatal("expected match")
+			}
+		}
+	})
+
+	b.Run("precompiled", func(b *testing.B) {
+		b.ReportAllocs()
+		cached := regexp.MustCompile(value)
+		compile := func(string) (*regexp.Regexp, error) {
+			return cached, nil
+		}
+		for i := 0; i < b.N; i++ {
+			matched, _, _ := matchHTTPRoutePath(pathMatch, "/v1/chat/completions", route, compile)
+			if !matched {
+				b.Fatal("expected match")
+			}
+		}
+	})
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement

**What this PR does / why we need it**:

`matchHTTPRoutePath` used `regexp.Compile` on every request, so any HTTPRoute using a regular expression path match paid a full parse per request in the request hot path.

This change caches compiled patterns per store, keyed by the pattern string. `gcHTTPRouteRegexCache` runs after an HTTPRoute is added, updated or deleted and drops any pattern no route references any more. Compile failures are cached as well, so an invalid pattern is not retried per request and the warning is logged once per pattern instead of on every request.

**Which issue(s) this PR fixes**:

Fixes #1573

**Bug evidence (required for bug-related PRs)**:

N/A

**Special notes for your reviewer**:

This PR was written in part with the assistance of generative AI.

- Tests: `go test ./pkg/kthena-router/... -count=1` passes.
- Benchmark `BenchmarkMatchHTTPRoutePathRegex` (one regex path match, go1.26.1 amd64):
  - before: 4.85us/op, 7329 B/op, 86 allocs/op
  - after: 0.27us/op, 0 B/op, 0 allocs/op

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```