### PR TITLE
runtime: name the mapping key TTL

### DIFF
--- a/python/kthena/runtime/kv_cache_manager.py
+++ b/python/kthena/runtime/kv_cache_manager.py
@@ -39,6 +39,11 @@ def get_sglang_mapping_key_prefix() -> str:
     return "sglang:kv:block"
 
 
+# 24h, kept equal by hand to kvCacheFieldFreshDuration in
+# pkg/kthena-router/scheduler/plugins/kvcache_aware.go; change both together.
+MAPPING_KEY_TTL_SECONDS = 86400
+
+
 def compute_standardized_hash(token_ids: List[int]) -> int:
     if not token_ids:
         return 0
@@ -119,7 +124,7 @@ class VLLMKVCacheRedisManager:
             self.hash_mapping[engine_hash] = std_hash
             mapping_key = self._get_hash_mapping_key(engine_hash, pod_identifier)
             pipe.set(mapping_key, str(std_hash))
-            pipe.expire(mapping_key, 86400)
+            pipe.expire(mapping_key, MAPPING_KEY_TTL_SECONDS)
             pipe.hset(matrix_block_key, pod_identifier, timestamp)
         return True
 


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:

The 24 hour mapping key TTL is one contract encoded twice: a bare `86400` on the runtime side, and `kvCacheFieldFreshDuration = 24 * time.Hour` on the router side whose comment says it "matches the runtime mapping key expiry". Nothing links the two; they agree by hand:

https://github.com/volcano-sh/kthena/blob/42ca6557652adbb3e6fe90bece4f3f161536246d/python/kthena/runtime/kv_cache_manager.py#L122

https://github.com/volcano-sh/kthena/blob/42ca6557652adbb3e6fe90bece4f3f161536246d/pkg/kthena-router/scheduler/plugins/kvcache_aware.go#L73-L74

This names the runtime side and points each half at the other, so whoever changes one finds the other. No behavior change.

Context: https://github.com/volcano-sh/kthena/issues/1328#issuecomment-5244437245 asked whether the 24h should live in one place both sides read. A genuinely shared source needs cross language plumbing that is not worth the weight; naming both halves and cross referencing them is the cheap version.

**Special notes for your reviewer**:

No issue attached, a two line naming cleanup did not seem to warrant one; the discussion lives on #1328.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
