### PR TITLE
perf(router): reuse metric update dispatch tables in datastore

### DIFF
--- a/pkg/kthena-router/datastore/store.go
+++ b/pkg/kthena-router/datastore/store.go
@@ -62,6 +62,34 @@ var (
 	}
 )
 
+// Package-level read-only dispatch tables. Functions take podinfo as a parameter
+// instead of capturing it, so the tables are built once and reused — no per-call
+// map allocation. Concurrent reads of a never-written map are safe. Must stay unexported.
+var (
+	gaugeUpdateFuncs = map[string]func(*PodInfo, float64){
+		utils.KVCacheUsage: func(p *PodInfo, f float64) { p.GPUCacheUsage = f },
+		utils.RequestWaitingNum: func(p *PodInfo, f float64) { p.RequestWaitingNum = f },
+		utils.RequestRunningNum: func(p *PodInfo, f float64) { p.RequestRunningNum = f },
+		utils.TPOT: func(p *PodInfo, f float64) {
+			if f == 0.0 {
+				return
+			}
+			p.TPOT = f
+		},
+		utils.TTFT: func(p *PodInfo, f float64) {
+			if f == 0.0 {
+				return
+			}
+			p.TTFT = f
+		},
+	}
+
+	histogramUpdateFuncs = map[string]func(*PodInfo, *dto.Histogram){
+		utils.TPOT: func(p *PodInfo, h *dto.Histogram) { p.TimePerOutputToken = h },
+		utils.TTFT: func(p *PodInfo, h *dto.Histogram) { p.TimeToFirstToken = h },
+	}
+)
+
 const (
 	// defaultMetricsScrapeInterval is the default polling interval for pod metrics.
 	defaultMetricsScrapeInterval = 1 * time.Second
@@ -1782,33 +1810,10 @@ func getPreviousHistogram(podinfo *PodInfo) map[string]*dto.Histogram {
 func updateGaugeMetricsInfo(podinfo *PodInfo, metricsInfo map[string]float64) {
 	podinfo.mutex.Lock()
 	defer podinfo.mutex.Unlock()
-	updateFuncs := map[string]func(float64){
-		utils.KVCacheUsage: func(f float64) {
-			podinfo.GPUCacheUsage = f
-		},
-		utils.RequestWaitingNum: func(f float64) {
-			podinfo.RequestWaitingNum = f
-		},
-		utils.RequestRunningNum: func(f float64) {
-			podinfo.RequestRunningNum = f
-		},
-		utils.TPOT: func(f float64) {
-			if f == float64(0.0) {
-				return
-			}
-			podinfo.TPOT = f
-		},
-		utils.TTFT: func(f float64) {
-			if f == float64(0.0) {
-				return
-			}
-			podinfo.TTFT = f
-		},
-	}
 
 	for _, name := range metricsName {
-		if updateFunc, exist := updateFuncs[name]; exist {
-			updateFunc(metricsInfo[name])
+		if updateFunc, exist := gaugeUpdateFuncs[name]; exist {
+			updateFunc(podinfo, metricsInfo[name])
 		} else {
 			klog.V(4).Infof("Unknown metric: %s", name)
 		}
@@ -1818,18 +1823,10 @@ func updateGaugeMetricsInfo(podinfo *PodInfo, metricsInfo map[string]float64) {
 func updateHistogramMetrics(podinfo *PodInfo, histogramMetrics map[string]*dto.Histogram) {
 	podinfo.mutex.Lock()
 	defer podinfo.mutex.Unlock()
-	updateFuncs := map[string]func(*dto.Histogram){
-		utils.TPOT: func(h *dto.Histogram) {
-			podinfo.TimePerOutputToken = h
-		},
-		utils.TTFT: func(h *dto.Histogram) {
-			podinfo.TimeToFirstToken = h
-		},
-	}
 
 	for _, name := range histogramMetricsName {
-		if updateFunc, exist := updateFuncs[name]; exist {
-			updateFunc(histogramMetrics[name])
+		if updateFunc, exist := histogramUpdateFuncs[name]; exist {
+			updateFunc(podinfo, histogramMetrics[name])
 		} else {
 			klog.V(4).Infof("Unknown histogram metric: %s", name)
 		}

--- a/pkg/kthena-router/datastore/store.go
+++ b/pkg/kthena-router/datastore/store.go
@@ -65,7 +65,7 @@ var (
 	// instead of capturing it, so the tables are built once and reused — no per-call
 	// map allocation. Concurrent reads of a never-written map are safe. Must stay unexported.
 	gaugeUpdateFuncs = map[string]func(*PodInfo, float64){
-		utils.KVCacheUsage: func(p *PodInfo, f float64) { p.GPUCacheUsage = f },
+		utils.KVCacheUsage:      func(p *PodInfo, f float64) { p.GPUCacheUsage = f },
 		utils.RequestWaitingNum: func(p *PodInfo, f float64) { p.RequestWaitingNum = f },
 		utils.RequestRunningNum: func(p *PodInfo, f float64) { p.RequestRunningNum = f },
 		utils.TPOT: func(p *PodInfo, f float64) {

--- a/pkg/kthena-router/datastore/store.go
+++ b/pkg/kthena-router/datastore/store.go
@@ -60,12 +60,10 @@ var (
 		utils.TPOT,
 		utils.TTFT,
 	}
-)
 
-// Package-level read-only dispatch tables. Functions take podinfo as a parameter
-// instead of capturing it, so the tables are built once and reused — no per-call
-// map allocation. Concurrent reads of a never-written map are safe. Must stay unexported.
-var (
+	// Package-level read-only dispatch tables. Functions take podinfo as a parameter
+	// instead of capturing it, so the tables are built once and reused — no per-call
+	// map allocation. Concurrent reads of a never-written map are safe. Must stay unexported.
 	gaugeUpdateFuncs = map[string]func(*PodInfo, float64){
 		utils.KVCacheUsage: func(p *PodInfo, f float64) { p.GPUCacheUsage = f },
 		utils.RequestWaitingNum: func(p *PodInfo, f float64) { p.RequestWaitingNum = f },

--- a/pkg/kthena-router/datastore/store.go
+++ b/pkg/kthena-router/datastore/store.go
@@ -64,6 +64,8 @@ var (
 	// Package-level read-only dispatch tables. Functions take podinfo as a parameter
 	// instead of capturing it, so the tables are built once and reused — no per-call
 	// map allocation. Concurrent reads of a never-written map are safe. Must stay unexported.
+	// The funcs write PodInfo fields and do not lock podinfo themselves; the caller
+	// must already hold podinfo.mutex (see updateGaugeMetricsInfo/updateHistogramMetrics).
 	gaugeUpdateFuncs = map[string]func(*PodInfo, float64){
 		utils.KVCacheUsage:      func(p *PodInfo, f float64) { p.GPUCacheUsage = f },
 		utils.RequestWaitingNum: func(p *PodInfo, f float64) { p.RequestWaitingNum = f },
@@ -82,6 +84,7 @@ var (
 		},
 	}
 
+	// histogramUpdateFuncs has the same caller-holds-podinfo.mutex precondition as above.
 	histogramUpdateFuncs = map[string]func(*PodInfo, *dto.Histogram){
 		utils.TPOT: func(p *PodInfo, h *dto.Histogram) { p.TimePerOutputToken = h },
 		utils.TTFT: func(p *PodInfo, h *dto.Histogram) { p.TimeToFirstToken = h },

--- a/pkg/kthena-router/datastore/store_test.go
+++ b/pkg/kthena-router/datastore/store_test.go
@@ -258,6 +258,47 @@ func TestGetPreviousHistogram(t *testing.T) {
 	}
 }
 
+func Test_updateGaugeMetricsInfo(t *testing.T) {
+	// Non-zero values are written; TPOT/TTFT zero values are skipped (guard preserved).
+	podinfo := &PodInfo{
+		GPUCacheUsage:    0.5,
+		RequestWaitingNum: 3,
+		RequestRunningNum: 2,
+		TPOT:              0.1,
+		TTFT:              0.2,
+	}
+	metrics := map[string]float64{
+		utils.KVCacheUsage:     0.9,
+		utils.RequestWaitingNum: 10,
+		utils.RequestRunningNum: 7,
+		utils.TPOT:              0.0, // zero → skipped, TPOT unchanged
+		utils.TTFT:              0.4,
+	}
+	updateGaugeMetricsInfo(podinfo, metrics)
+
+	assert.Equal(t, 0.9, podinfo.GPUCacheUsage)
+	assert.Equal(t, float64(10), podinfo.RequestWaitingNum)
+	assert.Equal(t, float64(7), podinfo.RequestRunningNum)
+	assert.Equal(t, 0.1, podinfo.TPOT) // unchanged, zero skipped
+	assert.Equal(t, 0.4, podinfo.TTFT)
+}
+
+func BenchmarkUpdateGaugeMetricsInfo(b *testing.B) {
+	podinfo := &PodInfo{}
+	metrics := map[string]float64{
+		utils.KVCacheUsage:      0.9,
+		utils.RequestWaitingNum: 10,
+		utils.RequestRunningNum: 7,
+		utils.TPOT:              0.1,
+		utils.TTFT:              0.2,
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		updateGaugeMetricsInfo(podinfo, metrics)
+	}
+}
+
 func TestStoreUpdatePodMetrics(t *testing.T) {
 	sum1 := float64(1)
 	count1 := uint64(1)

--- a/pkg/kthena-router/datastore/store_test.go
+++ b/pkg/kthena-router/datastore/store_test.go
@@ -261,14 +261,14 @@ func TestGetPreviousHistogram(t *testing.T) {
 func Test_updateGaugeMetricsInfo(t *testing.T) {
 	// Non-zero values are written; TPOT/TTFT zero values are skipped (guard preserved).
 	podinfo := &PodInfo{
-		GPUCacheUsage:    0.5,
+		GPUCacheUsage:     0.5,
 		RequestWaitingNum: 3,
 		RequestRunningNum: 2,
 		TPOT:              0.1,
 		TTFT:              0.2,
 	}
 	metrics := map[string]float64{
-		utils.KVCacheUsage:     0.9,
+		utils.KVCacheUsage:      0.9,
 		utils.RequestWaitingNum: 10,
 		utils.RequestRunningNum: 7,
 		utils.TPOT:              0.0, // zero → skipped, TPOT unchanged


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it:**

`updateGaugeMetricsInfo` and `updateHistogramMetrics` built a per-call `map[string]func` that captured `podinfo` on every invocation. With the default 1s scrape interval per pod, this allocated a map plus 5 closures
each second per pod on the router data plane.

This PR moves the dispatch tables to package-level read-only vars. Functions now take `podinfo` as a parameter instead of capturing it, so the tables are built once and never reallocated. Concurrent reads of a never-written map are safe in Go; field writes stay guarded by the existing `podinfo.mutex`, so the change is semantically a no-op.

The second commit merges the two package-level `var` blocks into one, since they are all read-only configuration with no semantic grouping.

`getPreviousHistogram` is intentionally left unchanged: its returned map is passed across a function boundary (`GetPodMetrics`) and held by the caller, so it cannot be promoted to a package-level static table or a
sync.Pool without a larger interface change. That belongs in a separate PR.

**Which issue(s) this PR Fixes:**
Fixes #

**Bug evidence (required for bug-related PRs):**
N/A

**Special notes for your reviewer:**

- The dispatch tables are unexported (`gaugeUpdateFuncs` / `histogramUpdateFuncs`). Please keep them 
  unexported — exporting them would allow external writes and break the "never-written → concurrent
  reads safe" invariant.
- TPOT/TTFT zero-value guard is preserved in `Test_updateGaugeMetricsInfo`.
- `getPreviousHistogram`'s 2 allocs/op is a known leftover (map returned to caller); not addressed here to keep 
  this PR focused.

Benchmark (go test -benchmem -count=5, Intel Ultra 7 255H):

| function | before ns/op | after ns/op | before B/op | after B/op | before allocs/op | after allocs/op |
|----------|--------------|-------------|-------------|-------------|------------------|-----------------|
| updateGaugeMetricsInfo | ~370 | ~135 | 80 | 0 | 5 | 0 |

```release-note
NONE