### PR TITLE
docs: use the routable model name in inference examples

### DIFF
--- a/docs/kthena/docs/getting-started/quick-start.md
+++ b/docs/kthena/docs/getting-started/quick-start.md
@@ -135,7 +135,7 @@ You can now perform inference using the model. Here's an example of how to send 
 curl -X POST http://<model-route-ip>/v1/chat/completions \
 -H "Content-Type: application/json" \
 -d '{
-  "model": "Qwen2.5-0.5B-Instruct",
+  "model": "demo",
   "messages": [
     {
       "role": "user",
@@ -149,7 +149,7 @@ curl -X POST http://<model-route-ip>/v1/chat/completions \
 Use the following command to get the `<model-route-ip>`:
 
 ```bash
-kubectl get svc kthena-router -o jsonpath='{.spec.clusterIP}' -n <your-namespace>
+kubectl get svc kthena-router -o jsonpath='{.spec.clusterIP}' -n kthena-system
 ```
 
 This IP can only be used inside the cluster. If you want to chat from outside the cluster, you can use the `EXTERNAL-IP`

--- a/docs/kthena/docs/user-guide/prefill-decode-disaggregation/modelbooster-vllm-pd-disaggregation.md
+++ b/docs/kthena/docs/user-guide/prefill-decode-disaggregation/modelbooster-vllm-pd-disaggregation.md
@@ -218,7 +218,7 @@ Send a test request through the router:
 ```sh
 curl -X POST http://<ROUTER_IP>:80/v1/chat/completions \
   -H 'Content-Type: application/json' \
-  -d '{"model":"Qwen/Qwen3-0.6B","messages":[{"role":"user","content":"Hello"}],"max_tokens":20}'
+  -d '{"model":"qwen-nixl-pd","messages":[{"role":"user","content":"Hello"}],"max_tokens":20}'
 ```
 
 With NIXL, KV transfer is confirmed by the router log showing prefill and decode

--- a/docs/kthena/versioned_docs/version-v1.0.0/getting-started/quick-start.md
+++ b/docs/kthena/versioned_docs/version-v1.0.0/getting-started/quick-start.md
@@ -135,7 +135,7 @@ You can now perform inference using the model. Here's an example of how to send 
 curl -X POST http://<model-route-ip>/v1/chat/completions \
 -H "Content-Type: application/json" \
 -d '{
-  "model": "Qwen2.5-0.5B-Instruct",
+  "model": "demo",
   "messages": [
     {
       "role": "user",


### PR DESCRIPTION
/kind documentation

**What this PR does / why we need it**:

The Quick Start's final curl and the NIXL guide's verification curl send the vLLM served-model-name, but the generated ModelRoute is keyed on the ModelBooster name, so both documented commands always fail with a routing error (mechanism and permalinks in #1585). The curls now send the routable names, `demo` and `qwen-nixl-pd`; the router rewrites the model field to the served-model-name before proxying, so the requests work end to end. Also fixes the router service lookup namespace in the same Quick Start page (`kthena-system`, matching the install step).

The v1.0.0 versioned Quick Start carries the same curl and was wrong for v1.0.0 as well: at that tag the ModelRoute's `ModelName` is `model.Name` directly, so the fix applies there too.

**Which issue(s) this PR fixes**:
Fixes #1585

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
