### PR TITLE
logging: clean up remaining error log messages

### DIFF
--- a/pkg/autoscaler/util/client.go
+++ b/pkg/autoscaler/util/client.go
@@ -67,11 +67,11 @@ func UpdateModelServing(ctx context.Context, client clientset.Interface, modelIn
 	if oldModelInfer, err := client.WorkloadV1alpha1().ModelServings(modelInfer.Namespace).Get(modelInferCtx, modelInfer.Name, metav1.GetOptions{}); err == nil {
 		modelInfer.ResourceVersion = oldModelInfer.ResourceVersion
 		if _, updateErr := client.WorkloadV1alpha1().ModelServings(modelInfer.Namespace).Update(modelInferCtx, modelInfer, metav1.UpdateOptions{}); updateErr != nil {
-			klog.Errorf("failed to update modelInfer,err: %v", updateErr)
+			klog.Errorf("failed to update ModelServing %s/%s: %v", modelInfer.Namespace, modelInfer.Name, updateErr)
 			return updateErr
 		}
 	} else {
-		klog.Errorf("failed to get old modelInfer,err: %v", err)
+		klog.Errorf("failed to get old ModelServing %s/%s: %v", modelInfer.Namespace, modelInfer.Name, err)
 		return err
 	}
 	return nil

--- a/pkg/model-serving-controller/controller/model_serving_controller.go
+++ b/pkg/model-serving-controller/controller/model_serving_controller.go
@@ -272,12 +272,12 @@ func (c *ModelServingController) addModelServing(obj interface{}) {
 func (c *ModelServingController) updateModelServing(old, cur interface{}) {
 	curms, ok := cur.(*workloadv1alpha1.ModelServing)
 	if !ok {
-		klog.Error("failed to parse ModelServing type when updatems")
+		klog.Errorf("failed to parse new ModelServing type when update %#v", cur)
 		return
 	}
 	oldms, ok := old.(*workloadv1alpha1.ModelServing)
 	if !ok {
-		klog.Error("failed to parse ModelServing type when updatems")
+		klog.Errorf("failed to parse old ModelServing type when update %#v", old)
 		return
 	}
 
@@ -306,7 +306,7 @@ func (c *ModelServingController) deleteModelServing(obj interface{}) {
 		// If the object is not a ModelServing, it might be a tombstone object.
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
-			klog.Errorf("failed to parse ModelServing type when deletems %#v", obj)
+			klog.Errorf("failed to parse ModelServing type when delete %#v", obj)
 			return
 		}
 		ms, ok = tombstone.Obj.(*workloadv1alpha1.ModelServing)
@@ -1296,7 +1296,7 @@ func (c *ModelServingController) DeleteRole(ctx context.Context, ms *workloadv1a
 	services, err := c.getServicesByIndex(RoleIDKey, roleIDValue)
 	if err != nil {
 		deleteErr = err
-		klog.Errorf("failed to get service %v", err)
+		klog.Errorf("failed to get services of role %s/%s: %v", groupName, roleID, err)
 		return
 	}
 	for _, svc := range services {


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:

#1566 added resource context to the remaining controller error logs, but a few residuals survived the sweep:

- `pkg/autoscaler/util/client.go` still logs `modelInfer`, a leftover from the ModelInfer to ModelServing rename, with no namespace or name and the old `,err:` format. Both messages now name the ModelServing and use the `: %v` style the sweep established.
- `updateModelServing` logs the identical `updatems` message for two different type assertion failures, so the log cannot tell which object failed to parse. The two messages now say new/old, spell out update, and include the object the way the add and delete paths already do.
- The `deletems` shorthand in `deleteModelServing` is spelled out.
- The service lookup in role deletion logs `failed to get service %v` with no role context, while the pod deletion right above it names the role. It now matches.

Log messages only, no behavior change. Sent as a direct PR since it finishes the sweep #1566 already scoped.

**Which issue(s) this PR fixes**:
None, follow-up to #1566.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
