### PR TITLE
router: size score result maps and drop an intermediate map

### DIFF
--- a/pkg/kthena-router/scheduler/plugins/gpu.go
+++ b/pkg/kthena-router/scheduler/plugins/gpu.go
@@ -39,7 +39,7 @@ func (g *GPUCacheUsage) Name() string {
 	return g.name
 }
 func (g *GPUCacheUsage) Score(ctx *framework.Context, pods []*datastore.PodInfo) map[*datastore.PodInfo]int {
-	scoreResults := make(map[*datastore.PodInfo]int)
+	scoreResults := make(map[*datastore.PodInfo]int, len(pods))
 	for _, info := range pods {
 		score := int((1.0 - info.GetGPUCacheUsage()) * 100)
 		scoreResults[info] = score

--- a/pkg/kthena-router/scheduler/plugins/least_latency.go
+++ b/pkg/kthena-router/scheduler/plugins/least_latency.go
@@ -106,7 +106,7 @@ func (l *LeastLatency) Name() string {
 // Score calculates a score for each pod based on their inference latency:
 func (l *LeastLatency) Score(ctx *framework.Context, pods []*datastore.PodInfo) map[*datastore.PodInfo]int {
 	// Stores the computed score for each pod
-	scoreResults := make(map[*datastore.PodInfo]int)
+	scoreResults := make(map[*datastore.PodInfo]int, len(pods))
 	// Handle edge case: empty pod list
 	if len(pods) == 0 {
 		return scoreResults

--- a/pkg/kthena-router/scheduler/plugins/least_request.go
+++ b/pkg/kthena-router/scheduler/plugins/least_request.go
@@ -76,7 +76,7 @@ func (l *LeastRequest) Filter(ctx *framework.Context, pods []*datastore.PodInfo)
 }
 
 func (l *LeastRequest) Score(ctx *framework.Context, pods []*datastore.PodInfo) map[*datastore.PodInfo]int {
-	scoreResults := make(map[*datastore.PodInfo]int)
+	scoreResults := make(map[*datastore.PodInfo]int, len(pods))
 	if len(pods) == 0 {
 		return scoreResults
 	}
@@ -90,24 +90,24 @@ func (l *LeastRequest) Score(ctx *framework.Context, pods []*datastore.PodInfo) 
 	//     router has dispatched but the engine has not yet started executing
 	//     (i.e. likely queued inside the engine). Weighted ×100 to strongly
 	//     penalise pods whose queue is building up.
-	baseScores := make(map[*datastore.PodInfo]float64)
+	baseScores := make([]float64, len(pods))
 	maxScore := 0.0
-	for _, info := range pods {
+	for i, info := range pods {
 		// Estimate queued requests as max(onFlight - running, 0). The engine-reported
 		// running count has a poll lag (~1 s), so this may briefly over-count, but
 		// it provides a leading indicator of queue build-up at the pod.
 		base := float64(info.GetOnFlightRequestNum()) + 100*math.Max(float64(info.GetOnFlightRequestNum())-float64(info.GetRequestRunningNum()), 0)
-		baseScores[info] = base
+		baseScores[i] = base
 		if base > maxScore {
 			maxScore = base
 		}
 	}
 
 	// Normalise to [0, 100]: the least-loaded pod gets 100.
-	for _, info := range pods {
+	for i, info := range pods {
 		score := 100.0
 		if maxScore > 0 {
-			score = ((maxScore - baseScores[info]) / maxScore) * 100
+			score = ((maxScore - baseScores[i]) / maxScore) * 100
 		}
 		scoreResults[info] = int(score)
 	}

--- a/pkg/kthena-router/scheduler/plugins/random.go
+++ b/pkg/kthena-router/scheduler/plugins/random.go
@@ -57,7 +57,7 @@ func (r *Random) Name() string {
 
 // Score assigns random scores to pods within the range [0, 100]
 func (r *Random) Score(ctx *framework.Context, pods []*datastore.PodInfo) map[*datastore.PodInfo]int {
-	scoreResults := make(map[*datastore.PodInfo]int)
+	scoreResults := make(map[*datastore.PodInfo]int, len(pods))
 
 	if len(pods) == 0 {
 		return scoreResults

--- a/pkg/kthena-router/scheduler/scheduler_impl.go
+++ b/pkg/kthena-router/scheduler/scheduler_impl.go
@@ -223,7 +223,7 @@ func (s *SchedulerImpl) RunFilterPlugins(pods []*datastore.PodInfo, ctx *framewo
 }
 
 func (s *SchedulerImpl) RunScorePlugins(pods []*datastore.PodInfo, ctx *framework.Context) map[*datastore.PodInfo]int {
-	res := make(map[*datastore.PodInfo]int)
+	res := make(map[*datastore.PodInfo]int, len(pods))
 	// Checked once: V(4) arguments are boxed before klog can discard them
 	logScores := klog.V(4).Enabled()
 	for _, scorePlugin := range s.scorePlugins {


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement
/area router

**What this PR does / why we need it**:

`least-request` built a second map just to carry base scores between its two passes. Both loops walk `pods` in order, so it is now a `[]float64` indexed by position, which drops a map allocation per request plus the hashing on every read and write.

The result maps are also built without a size hint even though the pod count is known up front. `prefix-cache` and `kvcache-aware` already pass `len(pods)`; `gpu`, `least-latency`, `least-request`, `random` and the accumulator in `RunScorePlugins` did not, so they now do.

Results are unchanged, the maps hold the same keys and values.

**Which issue(s) this PR fixes**:
Fixes #1591

**Bug evidence (required for bug-related PRs)**:

N/A, enhancement. Numbers below.

**Special notes for your reviewer**:

Default plugin set, 16 pods, go1.26.5 linux/amd64, `-benchtime=3s -count=3`:

```
score stage    before  11561 ns/op   5608 B/op   38 allocs/op
               after    7347 ns/op   3408 B/op   25 allocs/op

full Schedule  before  14127 ns/op   6512 B/op   50 allocs/op
               after   10315 ns/op   4312 B/op   37 allocs/op
```

An allocation profile put `LeastRequest.Score` at 33% of allocated objects in the scoring stage, which is why the intermediate map is the part that matters. In absolute terms this is about 3.8us per request, so it is allocation churn at load rather than single request latency.

No new tests, the existing plugin tests already cover the scoring results and this does not change them. Happy to add a benchmark to the tree if you would rather have the numbers reproducible in CI.

`go test ./pkg/kthena-router/...` passes, `scheduler` and `scheduler/plugins` pass `-race`, gofmt and vet clean.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```