### PR TITLE
fix(router): defer quota until backend discovery

### DIFF
--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -267,6 +267,16 @@ func (r *Router) calculateRequestPriority(userID, modelName string) float64 {
 
 type ModelRequest map[string]interface{}
 
+type resolvedBackend struct {
+	pods            []*datastore.PodInfo
+	port            int32
+	modelServerName types.NamespacedName
+	modelRoute      *v1alpha1.ModelRoute
+	modelServer     *v1alpha1.ModelServer
+	provider        *v1alpha1.ExternalModelProvider
+	isLora          bool
+}
+
 func (r *Router) HandlerFunc() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		r.metrics.IncActiveRequests()
@@ -286,7 +296,6 @@ func (r *Router) HandlerFunc() gin.HandlerFunc {
 			return
 		}
 
-		// step 2: Detection of rate limit
 		modelName := modelRequest["model"].(string)
 
 		// Set model name in access log
@@ -341,6 +350,20 @@ func (r *Router) HandlerFunc() gin.HandlerFunc {
 		// Record input tokens immediately
 		metricsRecorder.RecordInputTokens(inputTokens)
 
+		requestID := uuid.New().String()
+		if c.Request.Header.Get("x-request-id") == "" {
+			c.Request.Header.Set("x-request-id", requestID)
+		}
+
+		// Store metrics recorder in context for use in other functions
+		c.Set("metricsRecorder", metricsRecorder)
+
+		backend, err := r.resolveBackend(c, modelRequest)
+		if err != nil {
+			return
+		}
+
+		// step 2: Detection of rate limit
 		// Apply rate limiting using the unified rate limiter
 		if err := r.loadRateLimiter.RateLimit(modelName, promptStr); err != nil {
 			var errorMsg string
@@ -369,24 +392,16 @@ func (r *Router) HandlerFunc() gin.HandlerFunc {
 			return
 		}
 
-		requestID := uuid.New().String()
-		if c.Request.Header.Get("x-request-id") == "" {
-			c.Request.Header.Set("x-request-id", requestID)
-		}
-
-		// Store metrics recorder in context for use in other functions
-		c.Set("metricsRecorder", metricsRecorder)
-
 		// step 3.1: direct load balancing when neither fairness scheduling nor
 		// session boost is enabled.
 		if !EnableFairnessScheduling && !EnableSessionBoost {
-			_ = r.doLoadbalance(c, modelRequest)
+			_ = r.doLoadbalance(c, modelRequest, backend)
 			return
 		}
 
 		// step 3.2: queue scheduling. The queue orders requests by the active
 		// strategy: per-user fairness or session boost (mutually exclusive).
-		if err := r.handleFairnessScheduling(c, modelRequest, requestID, modelName); err != nil {
+		if err := r.handleFairnessScheduling(c, modelRequest, requestID, modelName, backend); err != nil {
 			accesslog.SetError(c, "scheduling", err.Error())
 			c.Set("finishReason", "scheduling")
 			return
@@ -394,7 +409,7 @@ func (r *Router) HandlerFunc() gin.HandlerFunc {
 	}
 }
 
-func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest) error {
+func (r *Router) resolveBackend(c *gin.Context, modelRequest ModelRequest) (*resolvedBackend, error) {
 	modelName := modelRequest["model"].(string)
 
 	// Check if this is an InferencePool request from HTTPRoute
@@ -432,34 +447,9 @@ func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest) error 
 				accesslog.SetError(c, "provider_discovery", fmt.Sprintf("can't find external model provider: %v", modelTarget.Name))
 				c.Set("finishReason", "provider_discovery")
 				c.AbortWithStatusJSON(http.StatusNotFound, fmt.Sprintf("can't find external model provider: %v", modelTarget.Name))
-				return nil
+				return nil, fmt.Errorf("can't find external model provider: %v", modelTarget.Name)
 			}
-
-			modelRouteName := ""
-			if modelRoute != nil {
-				modelRouteName = fmt.Sprintf("%s/%s", modelRoute.Namespace, modelRoute.Name)
-				c.Set("modelRouteName", modelRouteName)
-			}
-			accesslog.SetRequestRouting(c, modelRouteName, "", "")
-			if err := r.proxyExternalProvider(c, c.Request, provider, modelRequest, modelName); err != nil {
-				klog.Errorf("external provider request failed reqID: %s: %v", c.Request.Header.Get("x-request-id"), err)
-				var proxyErr *externalProxyError
-				if errors.As(err, &proxyErr) {
-					accesslog.SetError(c, proxyErr.reason, proxyErr.message)
-					c.Set("finishReason", proxyErr.reason)
-					if !c.Writer.Written() {
-						c.AbortWithStatusJSON(proxyErr.statusCode, proxyErr.message)
-					}
-					return nil
-				}
-
-				accesslog.SetError(c, "external_provider_proxy", "external provider request processing failed")
-				c.Set("finishReason", "external_provider_proxy")
-				if !c.Writer.Written() {
-					c.AbortWithStatusJSON(http.StatusInternalServerError, "request processing failed")
-				}
-			}
-			return nil
+			return &resolvedBackend{modelRoute: modelRoute, provider: provider}, nil
 		}
 
 		modelServerName = modelTarget.Name
@@ -475,18 +465,13 @@ func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest) error 
 			accesslog.SetError(c, "pod_discovery", fmt.Sprintf("can't find model server: %v", modelServerName))
 			c.AbortWithStatusJSON(http.StatusNotFound, fmt.Sprintf("can't find model server: %v", modelServerName))
 			c.Set("finishReason", "pod_discovery")
-			return fmt.Errorf("can't find model server: %v", modelServerName)
+			return nil, fmt.Errorf("can't find model server: %v", modelServerName)
 		}
 		if len(pods) == 0 {
 			accesslog.SetError(c, "pod_discovery", fmt.Sprintf("no available pods for model server: %v", modelServerName))
 			c.AbortWithStatusJSON(http.StatusServiceUnavailable, fmt.Sprintf("no available pods for model server: %v", modelServerName))
 			c.Set("finishReason", "pod_discovery")
-			return fmt.Errorf("no available pods for model server: %v", modelServerName)
-		}
-
-		model := modelServer.Spec.Model
-		if model != nil && !isLora {
-			modelRequest["model"] = *model
+			return nil, fmt.Errorf("no available pods for model server: %v", modelServerName)
 		}
 
 		port = modelServer.Spec.WorkloadPort.Port
@@ -495,7 +480,7 @@ func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest) error 
 		accesslog.SetError(c, "inference_pool_selection", httpRouteErr.Error())
 		c.AbortWithStatusJSON(http.StatusServiceUnavailable, httpRouteErr.Error())
 		c.Set("finishReason", "inference_pool_selection")
-		return httpRouteErr
+		return nil, httpRouteErr
 	} else if matched {
 		// If ModelRoute is not matched, try to match HTTPRoute
 
@@ -507,7 +492,7 @@ func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest) error 
 			accesslog.SetError(c, "inference_pool_discovery", fmt.Sprintf("can't find inference pool: %v", inferencePoolName))
 			c.AbortWithStatusJSON(http.StatusNotFound, fmt.Sprintf("can't find inference pool: %v", inferencePoolName))
 			c.Set("finishReason", "inference_pool_discovery")
-			return fmt.Errorf("can't find inference pool: %v", inferencePoolName)
+			return nil, fmt.Errorf("can't find inference pool: %v", inferencePoolName)
 		}
 
 		// Get pods from InferencePool
@@ -518,19 +503,19 @@ func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest) error 
 				accesslog.SetError(c, "inference_pool_discovery", fmt.Sprintf("can't find inference pool: %v", inferencePoolName))
 				c.AbortWithStatusJSON(http.StatusNotFound, fmt.Sprintf("can't find inference pool: %v", inferencePoolName))
 				c.Set("finishReason", "inference_pool_discovery")
-				return fmt.Errorf("can't find inference pool %v: %w", inferencePoolName, err)
+				return nil, fmt.Errorf("can't find inference pool %v: %w", inferencePoolName, err)
 			}
 			accesslog.SetError(c, "pod_discovery", fmt.Sprintf("failed to get pods for inference pool: %v", inferencePoolName))
 			c.AbortWithStatusJSON(http.StatusInternalServerError, fmt.Sprintf("failed to get pods for inference pool: %v", inferencePoolName))
 			c.Set("finishReason", "pod_discovery")
-			return fmt.Errorf("failed to get pods for inference pool %v: %w", inferencePoolName, err)
+			return nil, fmt.Errorf("failed to get pods for inference pool %v: %w", inferencePoolName, err)
 		}
 		if len(pods) == 0 {
 			klog.Errorf("no available pods for inference pool: %v", inferencePoolName)
 			accesslog.SetError(c, "pod_discovery", fmt.Sprintf("no available pods for inference pool: %v", inferencePoolName))
 			c.AbortWithStatusJSON(http.StatusServiceUnavailable, fmt.Sprintf("no available pods for inference pool: %v", inferencePoolName))
 			c.Set("finishReason", "pod_discovery")
-			return fmt.Errorf("no available pods for inference pool: %v", inferencePoolName)
+			return nil, fmt.Errorf("no available pods for inference pool: %v", inferencePoolName)
 		}
 
 		// Get target port from InferencePool
@@ -539,7 +524,7 @@ func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest) error 
 			accesslog.SetError(c, "port_discovery", fmt.Sprintf("inference pool %v has no target ports", inferencePoolName))
 			c.AbortWithStatusJSON(http.StatusBadRequest, fmt.Sprintf("inference pool %v has no target ports", inferencePoolName))
 			c.Set("finishReason", "port_discovery")
-			return fmt.Errorf("inference pool %v has no target ports", inferencePoolName)
+			return nil, fmt.Errorf("inference pool %v has no target ports", inferencePoolName)
 		}
 		// Use the first target port
 		port = int32(inferencePool.Spec.TargetPorts[0].Number)
@@ -549,22 +534,32 @@ func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest) error 
 		accesslog.SetError(c, "route_not_found", "route not found")
 		c.AbortWithStatusJSON(http.StatusNotFound, "route not found")
 		c.Set("finishReason", "route_not_found")
-		return fmt.Errorf("route not found")
+		return nil, fmt.Errorf("route not found")
 	}
 
-	// Common scheduling logic for both ModelServer and InferencePool
-	var prompt *common.ChatMessage
-	if cached, exists := c.Get(PromptKey); exists {
-		var ok bool
-		if prompt, ok = cached.(*common.ChatMessage); !ok {
-			accesslog.SetError(c, "prompt_parsing", "internal error: invalid prompt type")
-			c.AbortWithStatusJSON(http.StatusInternalServerError, "internal error")
-			return fmt.Errorf("invalid prompt type")
-		}
-	} else {
+	return &resolvedBackend{
+		pods:            pods,
+		port:            port,
+		modelServerName: modelServerName,
+		modelRoute:      modelRoute,
+		modelServer:     modelServer,
+		isLora:          isLora,
+	}, nil
+}
+
+func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest, backend *resolvedBackend) error {
+	modelName := modelRequest["model"].(string)
+	prompt, ok := c.Get(PromptKey)
+	if !ok {
 		accesslog.SetError(c, "prompt_parsing", "prompt not found")
 		c.AbortWithStatusJSON(http.StatusNotFound, "prompt not found")
 		return fmt.Errorf("prompt not found")
+	}
+	parsedPrompt, ok := prompt.(*common.ChatMessage)
+	if !ok {
+		accesslog.SetError(c, "prompt_parsing", "internal error: invalid prompt type")
+		c.AbortWithStatusJSON(http.StatusInternalServerError, "internal error")
+		return fmt.Errorf("invalid prompt type")
 	}
 
 	// Get metrics recorder from gin context
@@ -575,10 +570,43 @@ func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest) error 
 		}
 	}
 
+	if backend.provider != nil {
+		modelRouteName := ""
+		if backend.modelRoute != nil {
+			modelRouteName = fmt.Sprintf("%s/%s", backend.modelRoute.Namespace, backend.modelRoute.Name)
+			c.Set("modelRouteName", modelRouteName)
+		}
+		accesslog.SetRequestRouting(c, modelRouteName, "", "")
+		if err := r.proxyExternalProvider(c, c.Request, backend.provider, modelRequest, modelName); err != nil {
+			klog.Errorf("external provider request failed reqID: %s: %v", c.Request.Header.Get("x-request-id"), err)
+			var proxyErr *externalProxyError
+			if errors.As(err, &proxyErr) {
+				accesslog.SetError(c, proxyErr.reason, proxyErr.message)
+				c.Set("finishReason", proxyErr.reason)
+				if !c.Writer.Written() {
+					c.AbortWithStatusJSON(proxyErr.statusCode, proxyErr.message)
+				}
+				return nil
+			}
+
+			accesslog.SetError(c, "external_provider_proxy", "external provider request processing failed")
+			c.Set("finishReason", "external_provider_proxy")
+			if !c.Writer.Written() {
+				c.AbortWithStatusJSON(http.StatusInternalServerError, "request processing failed")
+			}
+		}
+		return nil
+	}
+
+	// Common scheduling logic for both ModelServer and InferencePool
+	if backend.modelServer != nil && backend.modelServer.Spec.Model != nil && !backend.isLora {
+		modelRequest["model"] = *backend.modelServer.Spec.Model
+	}
+
 	// Get PDGroup if available (only for ModelServer)
 	var pdGroup *v1alpha1.PDGroup
-	if modelServer != nil && modelServer.Spec.WorkloadSelector != nil {
-		pdGroup = modelServer.Spec.WorkloadSelector.PDGroup
+	if backend.modelServer != nil && backend.modelServer.Spec.WorkloadSelector != nil {
+		pdGroup = backend.modelServer.Spec.WorkloadSelector.PDGroup
 	}
 
 	sessionHeader := r.store.GetSessionIDHeader()
@@ -589,14 +617,14 @@ func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest) error 
 
 	ctx := &framework.Context{
 		Model:           modelName,
-		Prompt:          prompt,
+		Prompt:          parsedPrompt,
 		SessionID:       sessionID,
-		ModelServerName: modelServerName,
+		ModelServerName: backend.modelServerName,
 		PDGroup:         pdGroup,
 		MetricsRecorder: metricsRecorder,
 	}
 
-	err = r.scheduler.Schedule(ctx, pods)
+	err := r.scheduler.Schedule(ctx, backend.pods)
 	if err != nil {
 		accesslog.SetError(c, "scheduling", fmt.Sprintf("can't schedule to target pod: %v", err))
 		c.AbortWithStatusJSON(http.StatusBadRequest, fmt.Sprintf("can't schedule to target pod: %v", err))
@@ -604,10 +632,10 @@ func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest) error 
 	}
 
 	// Set complete request routing information in access log
-	modelServerFullName := fmt.Sprintf("%s/%s", modelServerName.Namespace, modelServerName.Name)
+	modelServerFullName := fmt.Sprintf("%s/%s", backend.modelServerName.Namespace, backend.modelServerName.Name)
 	modelRouteName := ""
-	if modelRoute != nil {
-		modelRouteName = fmt.Sprintf("%s/%s", modelRoute.Namespace, modelRoute.Name)
+	if backend.modelRoute != nil {
+		modelRouteName = fmt.Sprintf("%s/%s", backend.modelRoute.Namespace, backend.modelRoute.Name)
 		// Set the model route name in context for upstream connections
 		c.Set("modelRouteName", modelRouteName)
 	}
@@ -620,7 +648,7 @@ func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest) error 
 		accesslog.SetRequestRouting(c, modelRouteName, modelServerFullName, "")
 	}
 	req := c.Request
-	if err := r.proxyModelEndpoint(c, req, ctx, modelRequest, port); err != nil {
+	if err := r.proxyModelEndpoint(c, req, ctx, modelRequest, backend.port); err != nil {
 		klog.Errorf("request failed reqID: %s: %v", c.Request.Header.Get("x-request-id"), err)
 		accesslog.SetError(c, "proxy", "request processing failed")
 		if !c.Writer.Written() {
@@ -1366,7 +1394,7 @@ func (r *Router) proxyToPDDisaggregated(
 }
 
 // handleFairnessScheduling handles the fairness scheduling flow for requests.
-func (r *Router) handleFairnessScheduling(c *gin.Context, modelRequest ModelRequest, requestID string, modelName string) error {
+func (r *Router) handleFairnessScheduling(c *gin.Context, modelRequest ModelRequest, requestID string, modelName string, backend *resolvedBackend) error {
 	// Extract session ID from HTTP header for multi-turn conversation tracking.
 	sessionHeader := r.store.GetSessionIDHeader()
 	var sessionID string
@@ -1456,7 +1484,7 @@ func (r *Router) handleFairnessScheduling(c *gin.Context, modelRequest ModelRequ
 		}
 		klog.V(4).Infof("%s request dequeued: reqID=%s user=%s model=%s sessionBoost=%v waitTime=%v",
 			logPrefix, requestID, userId, modelName, queueReq.SessionBoost, time.Since(queueReq.RequestTime))
-		lbErr := r.doLoadbalance(c, modelRequest)
+		lbErr := r.doLoadbalance(c, modelRequest, backend)
 
 		// After a successful proxy, mark the session request as completed so follow-up
 		// requests from the same session get priority boost for prefix cache. Skip on

--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -271,7 +271,9 @@ type resolvedBackend struct {
 	pods                  []*datastore.PodInfo
 	port                  int32
 	modelServerName       types.NamespacedName
+	inferencePoolName     types.NamespacedName
 	inferencePoolFullName string
+	providerName          types.NamespacedName
 	modelRoute            *v1alpha1.ModelRoute
 	modelServer           *v1alpha1.ModelServer
 	provider              *v1alpha1.ExternalModelProvider
@@ -431,6 +433,7 @@ func (r *Router) resolveBackend(c *gin.Context, modelRequest ModelRequest) (*res
 	var pods []*datastore.PodInfo
 	var port int32
 	var modelServerName types.NamespacedName
+	var inferencePoolName types.NamespacedName
 	var modelTarget datastore.ModelTarget
 	var modelRoute *v1alpha1.ModelRoute
 	var modelServer *v1alpha1.ModelServer
@@ -466,7 +469,7 @@ func (r *Router) resolveBackend(c *gin.Context, modelRequest ModelRequest) (*res
 				c.AbortWithStatusJSON(http.StatusNotFound, fmt.Sprintf("can't find external model provider: %v", modelTarget.Name))
 				return nil, fmt.Errorf("can't find external model provider: %v", modelTarget.Name)
 			}
-			return &resolvedBackend{modelRoute: modelRoute, provider: provider}, nil
+			return &resolvedBackend{providerName: modelTarget.Name, modelRoute: modelRoute, provider: provider}, nil
 		}
 
 		modelServerName = modelTarget.Name
@@ -492,13 +495,14 @@ func (r *Router) resolveBackend(c *gin.Context, modelRequest ModelRequest) (*res
 		}
 
 		port = modelServer.Spec.WorkloadPort.Port
-	} else if matched, inferencePoolName, httpRouteErr := r.handleHTTPRoute(c, gatewayKey); httpRouteErr != nil {
+	} else if matched, matchedInferencePoolName, httpRouteErr := r.handleHTTPRoute(c, gatewayKey); httpRouteErr != nil {
 		klog.Errorf("failed to select InferencePool for matched HTTPRoute: %v", httpRouteErr)
 		accesslog.SetError(c, "inference_pool_selection", httpRouteErr.Error())
 		c.AbortWithStatusJSON(http.StatusServiceUnavailable, httpRouteErr.Error())
 		c.Set("finishReason", "inference_pool_selection")
 		return nil, httpRouteErr
 	} else if matched {
+		inferencePoolName = matchedInferencePoolName
 		// If ModelRoute is not matched, try to match HTTPRoute
 
 		// Get InferencePool from store
@@ -559,11 +563,59 @@ func (r *Router) resolveBackend(c *gin.Context, modelRequest ModelRequest) (*res
 		pods:                  pods,
 		port:                  port,
 		modelServerName:       modelServerName,
+		inferencePoolName:     inferencePoolName,
 		inferencePoolFullName: inferencePoolFullName,
 		modelRoute:            modelRoute,
 		modelServer:           modelServer,
 		isLora:                isLora,
 	}, nil
+}
+
+func (r *Router) refreshBackend(backend *resolvedBackend) error {
+	if backend.providerName.Name != "" {
+		provider := r.store.GetExternalModelProvider(backend.providerName)
+		if provider == nil {
+			return fmt.Errorf("can't find external model provider: %v", backend.providerName)
+		}
+		backend.provider = provider
+		return nil
+	}
+
+	if backend.modelServerName.Name != "" {
+		pods, modelServer, err := r.getPodsAndServer(backend.modelServerName)
+		if err != nil {
+			return err
+		}
+		if len(pods) == 0 {
+			return fmt.Errorf("no available pods for model server: %v", backend.modelServerName)
+		}
+		backend.pods = pods
+		backend.modelServer = modelServer
+		backend.port = modelServer.Spec.WorkloadPort.Port
+		return nil
+	}
+
+	if backend.inferencePoolName.Name != "" {
+		inferencePool := r.store.GetInferencePool(backend.inferencePoolFullName)
+		if inferencePool == nil {
+			return fmt.Errorf("can't find inference pool: %v", backend.inferencePoolName)
+		}
+		pods, err := r.store.GetPodsByInferencePool(backend.inferencePoolName)
+		if err != nil {
+			return fmt.Errorf("failed to get pods for inference pool %v: %w", backend.inferencePoolName, err)
+		}
+		if len(pods) == 0 {
+			return fmt.Errorf("no available pods for inference pool: %v", backend.inferencePoolName)
+		}
+		if len(inferencePool.Spec.TargetPorts) == 0 {
+			return fmt.Errorf("inference pool %v has no target ports", backend.inferencePoolName)
+		}
+		backend.pods = pods
+		backend.port = int32(inferencePool.Spec.TargetPorts[0].Number)
+		return nil
+	}
+
+	return fmt.Errorf("backend is not resolved")
 }
 
 func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest, backend *resolvedBackend) error {
@@ -1602,6 +1654,10 @@ func (r *Router) handleFairnessScheduling(c *gin.Context, modelRequest ModelRequ
 		}
 		klog.V(4).Infof("%s request dequeued: reqID=%s user=%s model=%s sessionBoost=%v waitTime=%v",
 			logPrefix, requestID, userId, modelName, queueReq.SessionBoost, time.Since(queueReq.RequestTime))
+		if err := r.refreshBackend(backend); err != nil {
+			c.AbortWithStatusJSON(http.StatusServiceUnavailable, err.Error())
+			return err
+		}
 		lbErr := r.doLoadbalance(c, modelRequest, backend)
 
 		// After a successful proxy, mark the session request as completed so follow-up

--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -267,6 +267,17 @@ func (r *Router) calculateRequestPriority(userID, modelName string) float64 {
 
 type ModelRequest map[string]interface{}
 
+type resolvedBackend struct {
+	pods                  []*datastore.PodInfo
+	port                  int32
+	modelServerName       types.NamespacedName
+	inferencePoolFullName string
+	modelRoute            *v1alpha1.ModelRoute
+	modelServer           *v1alpha1.ModelServer
+	provider              *v1alpha1.ExternalModelProvider
+	isLora                bool
+}
+
 func (r *Router) HandlerFunc() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		r.metrics.IncActiveRequests()
@@ -342,6 +353,30 @@ func (r *Router) HandlerFunc() gin.HandlerFunc {
 		// Record input tokens immediately
 		metricsRecorder.RecordInputTokens(inputTokens)
 
+		requestID := uuid.New().String()
+		if c.Request.Header.Get("x-request-id") == "" {
+			c.Request.Header.Set("x-request-id", requestID)
+		}
+
+		// Store metrics recorder in context for use in other functions
+		c.Set("metricsRecorder", metricsRecorder)
+
+		// Reject models with no registered ModelRoute before queueing. Queue
+		// cleanup is tied to the ModelRoute lifecycle, and fairness priority is
+		// computed from ModelRoute-level rate-limit configuration. The direct
+		// path still allows models routed through InferencePool/HTTPRoute.
+		if (EnableFairnessScheduling || EnableSessionBoost) && !hasModel {
+			accesslog.SetError(c, "route_not_found", "route not found")
+			c.AbortWithStatusJSON(http.StatusNotFound, "route not found")
+			c.Set("finishReason", "route_not_found")
+			return
+		}
+
+		backend, err := r.resolveBackend(c, modelRequest)
+		if err != nil {
+			return
+		}
+
 		// Apply rate limiting using the unified rate limiter
 		if err := r.loadRateLimiter.RateLimit(modelName, promptStr); err != nil {
 			var errorMsg string
@@ -370,45 +405,18 @@ func (r *Router) HandlerFunc() gin.HandlerFunc {
 			return
 		}
 
-		requestID := uuid.New().String()
-		if c.Request.Header.Get("x-request-id") == "" {
-			c.Request.Header.Set("x-request-id", requestID)
-		}
-
-		// Store metrics recorder in context for use in other functions
-		c.Set("metricsRecorder", metricsRecorder)
-
 		// step 3.1: direct load balancing when neither fairness scheduling nor
 		// session boost is enabled. doLoadbalance validates the route itself
 		// (a model may be routable via InferencePool/HTTPRoute even without a
 		// registered ModelRoute), so HasModel is not checked here.
 		if !EnableFairnessScheduling && !EnableSessionBoost {
-			_ = r.doLoadbalance(c, modelRequest)
+			_ = r.doLoadbalance(c, modelRequest, backend)
 			return
 		}
 
 		// step 3.2: queue scheduling. The queue orders requests by the active
 		// strategy: per-user fairness or session boost (mutually exclusive).
-		//
-		// Reject models with no registered ModelRoute here, before
-		// handleFairnessScheduling, so store.Enqueue can never be reached for
-		// an unregistered model name — which would otherwise leak a
-		// model-specific queue and goroutine forever, since queue cleanup is
-		// tied to the ModelRoute lifecycle. Fairness/session-boost priority is
-		// computed from ModelRoute-level rate-limit configuration, so (unlike
-		// the direct load-balancing path above) an InferencePool-only route
-		// cannot be scheduled through this path anyway. Using the same
-		// response and route_not_found observability labeling as the
-		// equivalent unregistered-model case in doLoadbalance keeps both
-		// paths consistent for callers and metrics/logging.
-		if !hasModel {
-			accesslog.SetError(c, "route_not_found", "route not found")
-			c.AbortWithStatusJSON(http.StatusNotFound, "route not found")
-			c.Set("finishReason", "route_not_found")
-			return
-		}
-
-		if err := r.handleFairnessScheduling(c, modelRequest, requestID, modelName); err != nil {
+		if err := r.handleFairnessScheduling(c, modelRequest, requestID, modelName, backend); err != nil {
 			accesslog.SetError(c, "scheduling", err.Error())
 			c.Set("finishReason", "scheduling")
 			return
@@ -416,7 +424,7 @@ func (r *Router) HandlerFunc() gin.HandlerFunc {
 	}
 }
 
-func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest) error {
+func (r *Router) resolveBackend(c *gin.Context, modelRequest ModelRequest) (*resolvedBackend, error) {
 	modelName := modelRequest["model"].(string)
 
 	// Check if this is an InferencePool request from HTTPRoute
@@ -456,38 +464,9 @@ func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest) error 
 				accesslog.SetErrorOrigin(c, "router")
 				c.Set("finishReason", "provider_discovery")
 				c.AbortWithStatusJSON(http.StatusNotFound, fmt.Sprintf("can't find external model provider: %v", modelTarget.Name))
-				return nil
+				return nil, fmt.Errorf("can't find external model provider: %v", modelTarget.Name)
 			}
-
-			modelRouteName := ""
-			if modelRoute != nil {
-				modelRouteName = fmt.Sprintf("%s/%s", modelRoute.Namespace, modelRoute.Name)
-				c.Set("modelRouteName", modelRouteName)
-			}
-			accesslog.SetRequestRouting(c, modelRouteName, "", "")
-			if err := r.proxyExternalProvider(c, c.Request, provider, modelRequest, modelName); err != nil {
-				klog.Errorf("external provider request failed reqID: %s: %v", c.Request.Header.Get("x-request-id"), err)
-				var proxyErr *externalProxyError
-				if errors.As(err, &proxyErr) {
-					accesslog.SetError(c, proxyErr.reason, proxyErr.message)
-					if proxyErr.origin != "" {
-						accesslog.SetErrorOrigin(c, proxyErr.origin)
-					}
-					c.Set("finishReason", proxyErr.reason)
-					if !c.Writer.Written() {
-						c.AbortWithStatusJSON(proxyErr.statusCode, proxyErr.message)
-					}
-					return nil
-				}
-
-				accesslog.SetError(c, "external_provider_proxy", "external provider request processing failed")
-				accesslog.SetErrorOrigin(c, "router")
-				c.Set("finishReason", "external_provider_proxy")
-				if !c.Writer.Written() {
-					c.AbortWithStatusJSON(http.StatusInternalServerError, "request processing failed")
-				}
-			}
-			return nil
+			return &resolvedBackend{modelRoute: modelRoute, provider: provider}, nil
 		}
 
 		modelServerName = modelTarget.Name
@@ -503,18 +482,13 @@ func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest) error 
 			accesslog.SetError(c, "pod_discovery", fmt.Sprintf("can't find model server: %v", modelServerName))
 			c.AbortWithStatusJSON(http.StatusNotFound, fmt.Sprintf("can't find model server: %v", modelServerName))
 			c.Set("finishReason", "pod_discovery")
-			return fmt.Errorf("can't find model server: %v", modelServerName)
+			return nil, fmt.Errorf("can't find model server: %v", modelServerName)
 		}
 		if len(pods) == 0 {
 			accesslog.SetError(c, "pod_discovery", fmt.Sprintf("no available pods for model server: %v", modelServerName))
 			c.AbortWithStatusJSON(http.StatusServiceUnavailable, fmt.Sprintf("no available pods for model server: %v", modelServerName))
 			c.Set("finishReason", "pod_discovery")
-			return fmt.Errorf("no available pods for model server: %v", modelServerName)
-		}
-
-		model := modelServer.Spec.Model
-		if model != nil && !isLora {
-			modelRequest["model"] = *model
+			return nil, fmt.Errorf("no available pods for model server: %v", modelServerName)
 		}
 
 		port = modelServer.Spec.WorkloadPort.Port
@@ -523,7 +497,7 @@ func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest) error 
 		accesslog.SetError(c, "inference_pool_selection", httpRouteErr.Error())
 		c.AbortWithStatusJSON(http.StatusServiceUnavailable, httpRouteErr.Error())
 		c.Set("finishReason", "inference_pool_selection")
-		return httpRouteErr
+		return nil, httpRouteErr
 	} else if matched {
 		// If ModelRoute is not matched, try to match HTTPRoute
 
@@ -536,7 +510,7 @@ func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest) error 
 			accesslog.SetError(c, "inference_pool_discovery", fmt.Sprintf("can't find inference pool: %v", inferencePoolName))
 			c.AbortWithStatusJSON(http.StatusNotFound, fmt.Sprintf("can't find inference pool: %v", inferencePoolName))
 			c.Set("finishReason", "inference_pool_discovery")
-			return fmt.Errorf("can't find inference pool: %v", inferencePoolName)
+			return nil, fmt.Errorf("can't find inference pool: %v", inferencePoolName)
 		}
 
 		// Get pods from InferencePool
@@ -547,19 +521,19 @@ func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest) error 
 				accesslog.SetError(c, "inference_pool_discovery", fmt.Sprintf("can't find inference pool: %v", inferencePoolName))
 				c.AbortWithStatusJSON(http.StatusNotFound, fmt.Sprintf("can't find inference pool: %v", inferencePoolName))
 				c.Set("finishReason", "inference_pool_discovery")
-				return fmt.Errorf("can't find inference pool %v: %w", inferencePoolName, err)
+				return nil, fmt.Errorf("can't find inference pool %v: %w", inferencePoolName, err)
 			}
 			accesslog.SetError(c, "pod_discovery", fmt.Sprintf("failed to get pods for inference pool: %v", inferencePoolName))
 			c.AbortWithStatusJSON(http.StatusInternalServerError, fmt.Sprintf("failed to get pods for inference pool: %v", inferencePoolName))
 			c.Set("finishReason", "pod_discovery")
-			return fmt.Errorf("failed to get pods for inference pool %v: %w", inferencePoolName, err)
+			return nil, fmt.Errorf("failed to get pods for inference pool %v: %w", inferencePoolName, err)
 		}
 		if len(pods) == 0 {
 			klog.Errorf("no available pods for inference pool: %v", inferencePoolName)
 			accesslog.SetError(c, "pod_discovery", fmt.Sprintf("no available pods for inference pool: %v", inferencePoolName))
 			c.AbortWithStatusJSON(http.StatusServiceUnavailable, fmt.Sprintf("no available pods for inference pool: %v", inferencePoolName))
 			c.Set("finishReason", "pod_discovery")
-			return fmt.Errorf("no available pods for inference pool: %v", inferencePoolName)
+			return nil, fmt.Errorf("no available pods for inference pool: %v", inferencePoolName)
 		}
 
 		// Get target port from InferencePool
@@ -568,7 +542,7 @@ func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest) error 
 			accesslog.SetError(c, "port_discovery", fmt.Sprintf("inference pool %v has no target ports", inferencePoolName))
 			c.AbortWithStatusJSON(http.StatusBadRequest, fmt.Sprintf("inference pool %v has no target ports", inferencePoolName))
 			c.Set("finishReason", "port_discovery")
-			return fmt.Errorf("inference pool %v has no target ports", inferencePoolName)
+			return nil, fmt.Errorf("inference pool %v has no target ports", inferencePoolName)
 		}
 		// Use the first target port
 		port = int32(inferencePool.Spec.TargetPorts[0].Number)
@@ -578,7 +552,63 @@ func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest) error 
 		accesslog.SetError(c, "route_not_found", "route not found")
 		c.AbortWithStatusJSON(http.StatusNotFound, "route not found")
 		c.Set("finishReason", "route_not_found")
-		return fmt.Errorf("route not found")
+		return nil, fmt.Errorf("route not found")
+	}
+
+	return &resolvedBackend{
+		pods:                  pods,
+		port:                  port,
+		modelServerName:       modelServerName,
+		inferencePoolFullName: inferencePoolFullName,
+		modelRoute:            modelRoute,
+		modelServer:           modelServer,
+		isLora:                isLora,
+	}, nil
+}
+
+func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest, backend *resolvedBackend) error {
+	modelName := modelRequest["model"].(string)
+	if backend.provider != nil {
+		modelRouteName := ""
+		if backend.modelRoute != nil {
+			modelRouteName = fmt.Sprintf("%s/%s", backend.modelRoute.Namespace, backend.modelRoute.Name)
+			c.Set("modelRouteName", modelRouteName)
+		}
+		accesslog.SetRequestRouting(c, modelRouteName, "", "")
+		if err := r.proxyExternalProvider(c, c.Request, backend.provider, modelRequest, modelName); err != nil {
+			klog.Errorf("external provider request failed reqID: %s: %v", c.Request.Header.Get("x-request-id"), err)
+			var proxyErr *externalProxyError
+			if errors.As(err, &proxyErr) {
+				accesslog.SetError(c, proxyErr.reason, proxyErr.message)
+				if proxyErr.origin != "" {
+					accesslog.SetErrorOrigin(c, proxyErr.origin)
+				}
+				c.Set("finishReason", proxyErr.reason)
+				if !c.Writer.Written() {
+					c.AbortWithStatusJSON(proxyErr.statusCode, proxyErr.message)
+				}
+				return nil
+			}
+
+			accesslog.SetError(c, "external_provider_proxy", "external provider request processing failed")
+			accesslog.SetErrorOrigin(c, "router")
+			c.Set("finishReason", "external_provider_proxy")
+			if !c.Writer.Written() {
+				c.AbortWithStatusJSON(http.StatusInternalServerError, "request processing failed")
+			}
+		}
+		return nil
+	}
+
+	pods := backend.pods
+	port := backend.port
+	modelServerName := backend.modelServerName
+	inferencePoolFullName := backend.inferencePoolFullName
+	modelRoute := backend.modelRoute
+	modelServer := backend.modelServer
+	isLora := backend.isLora
+	if modelServer != nil && modelServer.Spec.Model != nil && !isLora {
+		modelRequest["model"] = *modelServer.Spec.Model
 	}
 
 	// Common scheduling logic for both ModelServer and InferencePool
@@ -631,7 +661,7 @@ func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest) error 
 		MetricsRecorder: metricsRecorder,
 	}
 
-	err = r.scheduler.Schedule(ctx, pods)
+	err := r.scheduler.Schedule(ctx, pods)
 	if err != nil {
 		accesslog.SetError(c, "scheduling", fmt.Sprintf("can't schedule to target pod: %v", err))
 		c.AbortWithStatusJSON(http.StatusBadRequest, fmt.Sprintf("can't schedule to target pod: %v", err))
@@ -1482,7 +1512,7 @@ func (r *Router) proxyToPDDisaggregated(
 // The caller (HandlerFunc) validates that modelName has a registered
 // ModelRoute before invoking this function, so Enqueue can never be reached
 // for an unregistered model name.
-func (r *Router) handleFairnessScheduling(c *gin.Context, modelRequest ModelRequest, requestID string, modelName string) error {
+func (r *Router) handleFairnessScheduling(c *gin.Context, modelRequest ModelRequest, requestID string, modelName string, backend *resolvedBackend) error {
 	// Extract session ID from HTTP header for multi-turn conversation tracking.
 	sessionHeader := r.store.GetSessionIDHeader()
 	var sessionID string
@@ -1572,7 +1602,7 @@ func (r *Router) handleFairnessScheduling(c *gin.Context, modelRequest ModelRequ
 		}
 		klog.V(4).Infof("%s request dequeued: reqID=%s user=%s model=%s sessionBoost=%v waitTime=%v",
 			logPrefix, requestID, userId, modelName, queueReq.SessionBoost, time.Since(queueReq.RequestTime))
-		lbErr := r.doLoadbalance(c, modelRequest)
+		lbErr := r.doLoadbalance(c, modelRequest, backend)
 
 		// After a successful proxy, mark the session request as completed so follow-up
 		// requests from the same session get priority boost for prefix cache. Skip on

--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -571,11 +571,20 @@ func (r *Router) resolveBackend(c *gin.Context, modelRequest ModelRequest) (*res
 	}, nil
 }
 
-func (r *Router) refreshBackend(backend *resolvedBackend) error {
+func abortBackendRefresh(c *gin.Context, statusCode int, reason, message string) error {
+	accesslog.SetError(c, reason, message)
+	c.Set("finishReason", reason)
+	c.AbortWithStatusJSON(statusCode, message)
+	return errors.New(message)
+}
+
+func (r *Router) refreshBackend(c *gin.Context, backend *resolvedBackend) error {
 	if backend.providerName.Name != "" {
 		provider := r.store.GetExternalModelProvider(backend.providerName)
 		if provider == nil {
-			return fmt.Errorf("can't find external model provider: %v", backend.providerName)
+			message := fmt.Sprintf("can't find external model provider: %v", backend.providerName)
+			accesslog.SetErrorOrigin(c, "router")
+			return abortBackendRefresh(c, http.StatusNotFound, "provider_discovery", message)
 		}
 		backend.provider = provider
 		return nil
@@ -584,10 +593,13 @@ func (r *Router) refreshBackend(backend *resolvedBackend) error {
 	if backend.modelServerName.Name != "" {
 		pods, modelServer, err := r.getPodsAndServer(backend.modelServerName)
 		if err != nil {
-			return err
+			klog.Errorf("failed to get pods and model server: %v, %v", backend.modelServerName, err)
+			message := fmt.Sprintf("can't find model server: %v", backend.modelServerName)
+			return abortBackendRefresh(c, http.StatusNotFound, "pod_discovery", message)
 		}
 		if len(pods) == 0 {
-			return fmt.Errorf("no available pods for model server: %v", backend.modelServerName)
+			message := fmt.Sprintf("no available pods for model server: %v", backend.modelServerName)
+			return abortBackendRefresh(c, http.StatusServiceUnavailable, "pod_discovery", message)
 		}
 		backend.pods = pods
 		backend.modelServer = modelServer
@@ -598,24 +610,33 @@ func (r *Router) refreshBackend(backend *resolvedBackend) error {
 	if backend.inferencePoolName.Name != "" {
 		inferencePool := r.store.GetInferencePool(backend.inferencePoolFullName)
 		if inferencePool == nil {
-			return fmt.Errorf("can't find inference pool: %v", backend.inferencePoolName)
+			message := fmt.Sprintf("can't find inference pool: %v", backend.inferencePoolName)
+			return abortBackendRefresh(c, http.StatusNotFound, "inference_pool_discovery", message)
 		}
 		pods, err := r.store.GetPodsByInferencePool(backend.inferencePoolName)
 		if err != nil {
-			return fmt.Errorf("failed to get pods for inference pool %v: %w", backend.inferencePoolName, err)
+			klog.Errorf("failed to get pods for inference pool: %v, %v", backend.inferencePoolName, err)
+			if r.store.GetInferencePool(backend.inferencePoolFullName) == nil {
+				message := fmt.Sprintf("can't find inference pool: %v", backend.inferencePoolName)
+				return abortBackendRefresh(c, http.StatusNotFound, "inference_pool_discovery", message)
+			}
+			message := fmt.Sprintf("failed to get pods for inference pool: %v", backend.inferencePoolName)
+			return abortBackendRefresh(c, http.StatusInternalServerError, "pod_discovery", message)
 		}
 		if len(pods) == 0 {
-			return fmt.Errorf("no available pods for inference pool: %v", backend.inferencePoolName)
+			message := fmt.Sprintf("no available pods for inference pool: %v", backend.inferencePoolName)
+			return abortBackendRefresh(c, http.StatusServiceUnavailable, "pod_discovery", message)
 		}
 		if len(inferencePool.Spec.TargetPorts) == 0 {
-			return fmt.Errorf("inference pool %v has no target ports", backend.inferencePoolName)
+			message := fmt.Sprintf("inference pool %v has no target ports", backend.inferencePoolName)
+			return abortBackendRefresh(c, http.StatusBadRequest, "port_discovery", message)
 		}
 		backend.pods = pods
 		backend.port = int32(inferencePool.Spec.TargetPorts[0].Number)
 		return nil
 	}
 
-	return fmt.Errorf("backend is not resolved")
+	return abortBackendRefresh(c, http.StatusInternalServerError, "scheduling", "backend is not resolved")
 }
 
 func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest, backend *resolvedBackend) error {
@@ -1654,9 +1675,8 @@ func (r *Router) handleFairnessScheduling(c *gin.Context, modelRequest ModelRequ
 		}
 		klog.V(4).Infof("%s request dequeued: reqID=%s user=%s model=%s sessionBoost=%v waitTime=%v",
 			logPrefix, requestID, userId, modelName, queueReq.SessionBoost, time.Since(queueReq.RequestTime))
-		if err := r.refreshBackend(backend); err != nil {
-			c.AbortWithStatusJSON(http.StatusServiceUnavailable, err.Error())
-			return err
+		if err := r.refreshBackend(c, backend); err != nil {
+			return nil
 		}
 		lbErr := r.doLoadbalance(c, modelRequest, backend)
 

--- a/pkg/kthena-router/router/router_test.go
+++ b/pkg/kthena-router/router/router_test.go
@@ -2034,6 +2034,104 @@ func TestRouter_HandlerFunc_ScheduleFailure(t *testing.T) {
 	assert.Contains(t, w.Body.String(), "can't schedule to target pod")
 }
 
+func TestRouter_HandlerFunc_DoesNotRateLimitFailedPodDiscovery(t *testing.T) {
+	tests := []struct {
+		name                     string
+		enableFairnessScheduling bool
+	}{
+		{name: "direct"},
+		{name: "fairness scheduling", enableFairnessScheduling: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			previousFairnessScheduling := EnableFairnessScheduling
+			previousSessionBoost := EnableSessionBoost
+			EnableFairnessScheduling = tt.enableFairnessScheduling
+			EnableSessionBoost = false
+			defer func() {
+				EnableFairnessScheduling = previousFairnessScheduling
+				EnableSessionBoost = previousSessionBoost
+			}()
+
+			router, store, backend := setupTestRouter(t, nil)
+			defer backend.Close()
+
+			modelRoute := &aiv1alpha1.ModelRoute{
+				ObjectMeta: v1.ObjectMeta{Name: "mr-rate-limit", Namespace: "default"},
+				Spec: aiv1alpha1.ModelRouteSpec{
+					ModelName: "rate-limited-model",
+					Rules: []*aiv1alpha1.Rule{{
+						TargetModels: []*aiv1alpha1.TargetModel{{ModelServerName: "missing-backend"}},
+					}},
+				},
+			}
+			modelServer := &aiv1alpha1.ModelServer{
+				ObjectMeta: v1.ObjectMeta{Name: "missing-backend", Namespace: "default"},
+				Spec: aiv1alpha1.ModelServerSpec{
+					WorkloadPort:    aiv1alpha1.WorkloadPort{Port: 8080},
+					InferenceEngine: "vLLM",
+				},
+			}
+
+			if tt.enableFairnessScheduling {
+				router.store = &failingEnqueueStore{Store: store}
+			}
+
+			assert.NoError(t, store.AddOrUpdateModelRoute(modelRoute))
+			assert.NoError(t, store.AddOrUpdateModelServer(modelServer, sets.New[types.NamespacedName]()))
+			inputLimit := uint32(10)
+			assert.NoError(t, router.loadRateLimiter.AddOrUpdateLimiter("rate-limited-model", &aiv1alpha1.RateLimit{
+				InputTokensPerUnit: &inputLimit,
+				Unit:               aiv1alpha1.Second,
+			}))
+
+			requestBody := `{"model":"rate-limited-model","prompt":"1234567890123456789012345678901234567890"}`
+			for i := 0; i < 2; i++ {
+				w := httptest.NewRecorder()
+				c, _ := gin.CreateTestContext(w)
+				c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewBufferString(requestBody))
+				c.Request.Header.Set("Content-Type", "application/json")
+
+				router.HandlerFunc()(c)
+
+				assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+			}
+		})
+	}
+}
+
+func TestRouter_HandlerFunc_RateLimitsBeforeFairnessQueue(t *testing.T) {
+	previousFairnessScheduling := EnableFairnessScheduling
+	previousSessionBoost := EnableSessionBoost
+	EnableFairnessScheduling = true
+	EnableSessionBoost = false
+	defer func() {
+		EnableFairnessScheduling = previousFairnessScheduling
+		EnableSessionBoost = previousSessionBoost
+	}()
+
+	router, store, backend := setupFairnessTestRouter(t, nil)
+	defer backend.Close()
+	router.store = &failingEnqueueStore{Store: store}
+
+	inputLimit := uint32(1)
+	assert.NoError(t, router.loadRateLimiter.AddOrUpdateLimiter("fair-model", &aiv1alpha1.RateLimit{
+		InputTokensPerUnit: &inputLimit,
+		Unit:               aiv1alpha1.Second,
+	}))
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	requestBody := `{"model":"fair-model","prompt":"this request exceeds the configured limit"}`
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewBufferString(requestBody))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	router.HandlerFunc()(c)
+
+	assert.Equal(t, http.StatusTooManyRequests, w.Code)
+}
+
 func TestParseModelRequestValidatesModelName(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -2642,6 +2740,8 @@ func TestHandleFairnessScheduling(t *testing.T) {
 			prompt, perr := utils.ParsePrompt(modelRequest)
 			assert.NoError(t, perr)
 			c.Set(PromptKey, prompt)
+			resolvedBackend, err := router.resolveBackend(c, modelRequest)
+			assert.NoError(t, err)
 			if tt.setUserID {
 				c.Set(common.UserIdKey, "user-test")
 			}
@@ -2651,7 +2751,7 @@ func TestHandleFairnessScheduling(t *testing.T) {
 			// client cancellation mid-flight when needed.
 			done := make(chan error, 1)
 			go func() {
-				done <- router.handleFairnessScheduling(c, modelRequest, "req-test", "fair-model")
+				done <- router.handleFairnessScheduling(c, modelRequest, "req-test", "fair-model", resolvedBackend)
 			}()
 
 			if clientCancel != nil {
@@ -2695,4 +2795,49 @@ type failingEnqueueStore struct {
 
 func (s *failingEnqueueStore) Enqueue(req *datastore.Request) error {
 	return fmt.Errorf("injected enqueue failure")
+}
+
+type immediateFairnessStore struct {
+	datastore.Store
+	matchCalls atomic.Int32
+}
+
+func (s *immediateFairnessStore) MatchModelTarget(model string, req *http.Request, gatewayKey string) (datastore.ModelTarget, bool, *aiv1alpha1.ModelRoute, error) {
+	s.matchCalls.Add(1)
+	return s.Store.MatchModelTarget(model, req, gatewayKey)
+}
+
+func (s *immediateFairnessStore) Enqueue(req *datastore.Request) error {
+	close(req.NotifyChan)
+	return nil
+}
+
+func TestRouter_HandlerFunc_FairnessResolvesModelTargetOnce(t *testing.T) {
+	previousFairnessScheduling := EnableFairnessScheduling
+	previousSessionBoost := EnableSessionBoost
+	EnableFairnessScheduling = true
+	EnableSessionBoost = false
+	defer func() {
+		EnableFairnessScheduling = previousFairnessScheduling
+		EnableSessionBoost = previousSessionBoost
+	}()
+
+	backendHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"id":"fair-ok"}`)
+	})
+	router, store, backend := setupFairnessTestRouter(t, backendHandler)
+	defer backend.Close()
+	fairnessStore := &immediateFairnessStore{Store: store}
+	router.store = fairnessStore
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewBufferString(`{"model":"fair-model","prompt":"hello fairness"}`))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	router.HandlerFunc()(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, int32(1), fairnessStore.matchCalls.Load())
 }

--- a/pkg/kthena-router/router/router_test.go
+++ b/pkg/kthena-router/router/router_test.go
@@ -3016,6 +3016,45 @@ func TestRouter_HandlerFunc_FairnessRefreshesBackendAfterDequeue(t *testing.T) {
 	assert.Equal(t, int32(1), fairnessStore.matchCalls.Load())
 }
 
+func TestRouter_HandlerFunc_FairnessRefreshFailureUsesDiscoveryError(t *testing.T) {
+	previousFairnessScheduling := EnableFairnessScheduling
+	previousSessionBoost := EnableSessionBoost
+	EnableFairnessScheduling = true
+	EnableSessionBoost = false
+	defer func() {
+		EnableFairnessScheduling = previousFairnessScheduling
+		EnableSessionBoost = previousSessionBoost
+	}()
+
+	router, store, backend := setupFairnessTestRouter(t, nil)
+	defer backend.Close()
+
+	fairnessStore := &immediateFairnessStore{Store: store}
+	fairnessStore.beforeNotify = func() {
+		assert.NoError(t, store.DeleteModelServer(types.NamespacedName{Name: "ms-fair", Namespace: "default"}))
+	}
+	router.store = fairnessStore
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewBufferString(`{"model":"fair-model","prompt":"hello fairness"}`))
+	c.Request.Header.Set("Content-Type", "application/json")
+	accessCtx := accesslog.NewAccessLogContext("refresh-failure", http.MethodPost, c.Request.URL.Path, c.Request.Proto, "fair-model")
+	c.Set(accesslog.AccessLogContextKey, accessCtx)
+
+	router.HandlerFunc()(c)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.Contains(t, w.Body.String(), "can't find model server")
+	reason, exists := c.Get("finishReason")
+	assert.True(t, exists)
+	assert.Equal(t, "pod_discovery", reason)
+	if assert.NotNil(t, accessCtx.Error) {
+		assert.Equal(t, "pod_discovery", accessCtx.Error.Type)
+	}
+	assert.Equal(t, int32(1), fairnessStore.matchCalls.Load())
+}
+
 func TestUpstreamTimeoutFor(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/pkg/kthena-router/router/router_test.go
+++ b/pkg/kthena-router/router/router_test.go
@@ -2939,7 +2939,8 @@ func (s *failingEnqueueStore) Enqueue(req *datastore.Request) error {
 
 type immediateFairnessStore struct {
 	datastore.Store
-	matchCalls atomic.Int32
+	matchCalls   atomic.Int32
+	beforeNotify func()
 }
 
 func (s *immediateFairnessStore) MatchModelTarget(model string, req *http.Request, gatewayKey string) (datastore.ModelTarget, bool, *aiv1alpha1.ModelRoute, error) {
@@ -2948,11 +2949,14 @@ func (s *immediateFairnessStore) MatchModelTarget(model string, req *http.Reques
 }
 
 func (s *immediateFairnessStore) Enqueue(req *datastore.Request) error {
+	if s.beforeNotify != nil {
+		s.beforeNotify()
+	}
 	close(req.NotifyChan)
 	return nil
 }
 
-func TestRouter_HandlerFunc_FairnessResolvesModelTargetOnce(t *testing.T) {
+func TestRouter_HandlerFunc_FairnessRefreshesBackendAfterDequeue(t *testing.T) {
 	previousFairnessScheduling := EnableFairnessScheduling
 	previousSessionBoost := EnableSessionBoost
 	EnableFairnessScheduling = true
@@ -2962,13 +2966,42 @@ func TestRouter_HandlerFunc_FairnessResolvesModelTargetOnce(t *testing.T) {
 		EnableSessionBoost = previousSessionBoost
 	}()
 
-	backendHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	staleHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprint(w, `{"id":"fair-ok"}`)
+		fmt.Fprint(w, `{"id":"stale"}`)
 	})
-	router, store, backend := setupFairnessTestRouter(t, backendHandler)
-	defer backend.Close()
+	router, store, staleBackend := setupFairnessTestRouter(t, staleHandler)
+	defer staleBackend.Close()
+
+	freshHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"id":"fresh"}`)
+	})
+	freshBackend := httptest.NewServer(freshHandler)
+	defer freshBackend.Close()
+	freshBackendURL, _ := url.Parse(freshBackend.URL)
+	freshBackendPort, _ := strconv.Atoi(freshBackendURL.Port())
+
+	freshPodName := types.NamespacedName{Name: "pod-fresh", Namespace: "default"}
+	freshModelServer := &aiv1alpha1.ModelServer{
+		ObjectMeta: v1.ObjectMeta{Name: "ms-fair", Namespace: "default"},
+		Spec: aiv1alpha1.ModelServerSpec{
+			Model:           func(s string) *string { return &s }("fair-model-base"),
+			WorkloadPort:    aiv1alpha1.WorkloadPort{Port: int32(freshBackendPort)},
+			InferenceEngine: "vLLM",
+		},
+	}
+	freshPod := &corev1.Pod{
+		ObjectMeta: v1.ObjectMeta{Name: freshPodName.Name, Namespace: freshPodName.Namespace},
+		Status:     corev1.PodStatus{PodIP: freshBackendURL.Hostname(), Phase: corev1.PodRunning},
+	}
+
 	fairnessStore := &immediateFairnessStore{Store: store}
+	fairnessStore.beforeNotify = func() {
+		assert.NoError(t, store.DeletePod(types.NamespacedName{Name: "pod-fair", Namespace: "default"}))
+		assert.NoError(t, store.AddOrUpdateModelServer(freshModelServer, sets.New(freshPodName)))
+		assert.NoError(t, store.AddOrUpdatePod(freshPod, []*aiv1alpha1.ModelServer{freshModelServer}))
+	}
 	router.store = fairnessStore
 
 	w := httptest.NewRecorder()
@@ -2979,6 +3012,7 @@ func TestRouter_HandlerFunc_FairnessResolvesModelTargetOnce(t *testing.T) {
 	router.HandlerFunc()(c)
 
 	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"id":"fresh"`)
 	assert.Equal(t, int32(1), fairnessStore.matchCalls.Load())
 }
 

--- a/pkg/kthena-router/router/router_test.go
+++ b/pkg/kthena-router/router/router_test.go
@@ -2169,6 +2169,104 @@ func TestRouter_HandlerFunc_ScheduleFailure(t *testing.T) {
 	assert.Contains(t, w.Body.String(), "can't schedule to target pod")
 }
 
+func TestRouter_HandlerFunc_DoesNotRateLimitFailedPodDiscovery(t *testing.T) {
+	tests := []struct {
+		name                     string
+		enableFairnessScheduling bool
+	}{
+		{name: "direct"},
+		{name: "fairness scheduling", enableFairnessScheduling: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			previousFairnessScheduling := EnableFairnessScheduling
+			previousSessionBoost := EnableSessionBoost
+			EnableFairnessScheduling = tt.enableFairnessScheduling
+			EnableSessionBoost = false
+			defer func() {
+				EnableFairnessScheduling = previousFairnessScheduling
+				EnableSessionBoost = previousSessionBoost
+			}()
+
+			router, store, backend := setupTestRouter(t, nil)
+			defer backend.Close()
+
+			modelRoute := &aiv1alpha1.ModelRoute{
+				ObjectMeta: v1.ObjectMeta{Name: "mr-rate-limit", Namespace: "default"},
+				Spec: aiv1alpha1.ModelRouteSpec{
+					ModelName: "rate-limited-model",
+					Rules: []*aiv1alpha1.Rule{{
+						TargetModels: []*aiv1alpha1.TargetModel{{ModelServerName: "missing-backend"}},
+					}},
+				},
+			}
+			modelServer := &aiv1alpha1.ModelServer{
+				ObjectMeta: v1.ObjectMeta{Name: "missing-backend", Namespace: "default"},
+				Spec: aiv1alpha1.ModelServerSpec{
+					WorkloadPort:    aiv1alpha1.WorkloadPort{Port: 8080},
+					InferenceEngine: "vLLM",
+				},
+			}
+
+			if tt.enableFairnessScheduling {
+				router.store = &failingEnqueueStore{Store: store}
+			}
+
+			assert.NoError(t, store.AddOrUpdateModelRoute(modelRoute))
+			assert.NoError(t, store.AddOrUpdateModelServer(modelServer, sets.New[types.NamespacedName]()))
+			inputLimit := uint32(10)
+			assert.NoError(t, router.loadRateLimiter.AddOrUpdateLimiter("rate-limited-model", &aiv1alpha1.RateLimit{
+				InputTokensPerUnit: &inputLimit,
+				Unit:               aiv1alpha1.Second,
+			}))
+
+			requestBody := `{"model":"rate-limited-model","prompt":"1234567890123456789012345678901234567890"}`
+			for i := 0; i < 2; i++ {
+				w := httptest.NewRecorder()
+				c, _ := gin.CreateTestContext(w)
+				c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewBufferString(requestBody))
+				c.Request.Header.Set("Content-Type", "application/json")
+
+				router.HandlerFunc()(c)
+
+				assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+			}
+		})
+	}
+}
+
+func TestRouter_HandlerFunc_RateLimitsBeforeFairnessQueue(t *testing.T) {
+	previousFairnessScheduling := EnableFairnessScheduling
+	previousSessionBoost := EnableSessionBoost
+	EnableFairnessScheduling = true
+	EnableSessionBoost = false
+	defer func() {
+		EnableFairnessScheduling = previousFairnessScheduling
+		EnableSessionBoost = previousSessionBoost
+	}()
+
+	router, store, backend := setupFairnessTestRouter(t, nil)
+	defer backend.Close()
+	router.store = &failingEnqueueStore{Store: store}
+
+	inputLimit := uint32(1)
+	assert.NoError(t, router.loadRateLimiter.AddOrUpdateLimiter("fair-model", &aiv1alpha1.RateLimit{
+		InputTokensPerUnit: &inputLimit,
+		Unit:               aiv1alpha1.Second,
+	}))
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	requestBody := `{"model":"fair-model","prompt":"this request exceeds the configured limit"}`
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewBufferString(requestBody))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	router.HandlerFunc()(c)
+
+	assert.Equal(t, http.StatusTooManyRequests, w.Code)
+}
+
 func TestParseModelRequestValidatesModelName(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -2782,6 +2880,8 @@ func TestHandleFairnessScheduling(t *testing.T) {
 			prompt, perr := utils.ParsePrompt(modelRequest)
 			assert.NoError(t, perr)
 			c.Set(PromptKey, prompt)
+			resolvedBackend, err := router.resolveBackend(c, modelRequest)
+			assert.NoError(t, err)
 			if tt.setUserID {
 				c.Set(common.UserIdKey, "user-test")
 			}
@@ -2791,7 +2891,7 @@ func TestHandleFairnessScheduling(t *testing.T) {
 			// client cancellation mid-flight when needed.
 			done := make(chan error, 1)
 			go func() {
-				done <- router.handleFairnessScheduling(c, modelRequest, "req-test", "fair-model")
+				done <- router.handleFairnessScheduling(c, modelRequest, "req-test", "fair-model", resolvedBackend)
 			}()
 
 			if clientCancel != nil {
@@ -2835,6 +2935,51 @@ type failingEnqueueStore struct {
 
 func (s *failingEnqueueStore) Enqueue(req *datastore.Request) error {
 	return fmt.Errorf("injected enqueue failure")
+}
+
+type immediateFairnessStore struct {
+	datastore.Store
+	matchCalls atomic.Int32
+}
+
+func (s *immediateFairnessStore) MatchModelTarget(model string, req *http.Request, gatewayKey string) (datastore.ModelTarget, bool, *aiv1alpha1.ModelRoute, error) {
+	s.matchCalls.Add(1)
+	return s.Store.MatchModelTarget(model, req, gatewayKey)
+}
+
+func (s *immediateFairnessStore) Enqueue(req *datastore.Request) error {
+	close(req.NotifyChan)
+	return nil
+}
+
+func TestRouter_HandlerFunc_FairnessResolvesModelTargetOnce(t *testing.T) {
+	previousFairnessScheduling := EnableFairnessScheduling
+	previousSessionBoost := EnableSessionBoost
+	EnableFairnessScheduling = true
+	EnableSessionBoost = false
+	defer func() {
+		EnableFairnessScheduling = previousFairnessScheduling
+		EnableSessionBoost = previousSessionBoost
+	}()
+
+	backendHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"id":"fair-ok"}`)
+	})
+	router, store, backend := setupFairnessTestRouter(t, backendHandler)
+	defer backend.Close()
+	fairnessStore := &immediateFairnessStore{Store: store}
+	router.store = fairnessStore
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewBufferString(`{"model":"fair-model","prompt":"hello fairness"}`))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	router.HandlerFunc()(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, int32(1), fairnessStore.matchCalls.Load())
 }
 
 func TestUpstreamTimeoutFor(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Moves backend discovery ahead of input token rate limiting. Requests that fail backend discovery no longer consume quota.

For queued requests, rate limiting still happens before queue admission. The selected target is preserved across the queue wait, then its current pods and configuration are reloaded after admission. This avoids repeating weighted target selection while preventing stale backend routing.

**Which issue(s) this PR fixes**:

Fixes #991

**Bug evidence (required for bug-related PRs)**:

Configure a `ModelRoute` with an input token rate limit and route it to a `ModelServer` whose workload selector matches no pods.

Send the same completion request twice. Before this change:

1. The first request fails during pod discovery, but router logs show input tokens added to the rate-limit ledger.
2. The second request returns `429 input token rate limit exceeded`, although no inference request reached a backend.

The issue includes the workload manifests, requests, and router logs reproducing this behavior. The rate limiter currently runs before backend discovery, so the failed request mutates quota state.

This change resolves the route and confirms an available backend before calling `RateLimit`. Repeated requests with no available backend therefore continue to return the backend discovery error without draining quota.

**Special notes for your reviewer**:

The change also covers fairness scheduling. Backend validation and rate limiting occur before queue admission, and the resolved backend is passed through the queue instead of selecting a target again.

Rollback for failures after successful backend validation is not included. That requires separate quota reservation or refund semantics and is outside the scope of #991.

**Does this PR introduce a user-facing change?**:

```release-note
Fix router input token quota being consumed when backend pod discovery fails.
```
