### PR TITLE
fix(downloader): fail when S3 credentials are missing

### DIFF
--- a/python/kthena/downloader/s3.py
+++ b/python/kthena/downloader/s3.py
@@ -74,8 +74,7 @@ class S3Downloader(ModelDownloader):
         logger.info(f"Syncing: {self.model_uri} to {output_dir}")
 
         if not self.access_key or not self.secret_key:
-            logger.error("Missing credentials")
-            return
+            raise ValueError("Missing credentials")
 
         os.makedirs(output_dir, exist_ok=True)
         bucket_name, bucket_path = parse_bucket_from_model_url(self.model_uri, "s3")

--- a/python/kthena/tests/test_downloader_s3.py
+++ b/python/kthena/tests/test_downloader_s3.py
@@ -122,6 +122,20 @@ class TestDownloadModel(unittest.TestCase):
         )
         mock_popen.assert_called_once()
 
+    def test_s3_download_missing_credentials(self):
+        for access_key, secret_key in [(None, "fake_sk"), ("fake_ak", None)]:
+            downloader = S3Downloader(
+                model_uri=self.source,
+                access_key=access_key,
+                secret_key=secret_key,
+                endpoint=None,
+            )
+
+            with self.assertRaises(ValueError) as context:
+                downloader.download(self.output_dir)
+
+            self.assertIn("Missing credentials", str(context.exception))
+
     def test_get_s3_downloader(self):
         downloader = get_downloader(self.source, self.credentials)
         self.assertIsInstance(


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fail the S3 downloader when either access key or secret key is missing. It currently logs an error and exits successfully without downloading anything, so Kubernetes may start the model container with an empty model directory.

**Which issue(s) this PR fixes**:

Fixes #1595

**Bug evidence (required for bug-related PRs)**:

Run the downloader without `ACCESS_KEY` or `SECRET_KEY`:

```bash
docker run --rm kthena-downloader:latest \
  --source s3://example-bucket/model \
  --output-dir /tmp/model
```
It logs Missing credentials but returns exit code 0.
The silent return is here:
https://github.com/volcano-sh/kthena/blob/0de61cc5dc7e2638a88ad408fba71ce37b396097/python/kthena/downloader/s3.py#L74-L79

The downloader is used as a ModelBooster init container. Since no exception reaches the existing CLI error handler, Kubernetes treats the download as successful even though the model directory is empty.
This change raises ValueError instead, which is already handled by the CLI and results in a non-zero exit code.

**Special notes for your reviewer:**
Kept this small and added coverage for both missing access key and missing secret key.

**Does this PR introduce a user-facing change?"**
```release-note
S3 model downloads now fail when required credentials are missing.
```