### PR TITLE
docs: match the real event handler log line in kvcache troubleshooting

### DIFF
--- a/docs/kthena/docs/user-guide/kvcache-aware.md
+++ b/docs/kthena/docs/user-guide/kvcache-aware.md
@@ -334,8 +334,8 @@ kubectl logs <vllm-pod> -c runtime -n <namespace> | grep -iE "redis|zmq|kv"
 
 Expected messages:
 - `Redis client initialized successfully`
-- `vLLM ZMQ subscriber initialized successfully`
-- `Event handlers registered successfully`
+- `vLLM ZMQ subscriber initialized successfully` (or `SGLang ZMQ subscriber initialized successfully`)
+- `vLLM KV-cache event handler registered` (or `SGLang KV-cache event handler registered`)
 
 ### 3. Inspect Redis Keys
 

--- a/docs/kthena/versioned_docs/version-v1.0.0/user-guide/kvcache-aware.md
+++ b/docs/kthena/versioned_docs/version-v1.0.0/user-guide/kvcache-aware.md
@@ -334,8 +334,8 @@ kubectl logs <vllm-pod> -c runtime -n <namespace> | grep -iE "redis|zmq|kv"
 
 Expected messages:
 - `Redis client initialized successfully`
-- `vLLM ZMQ subscriber initialized successfully`
-- `Event handlers registered successfully`
+- `vLLM ZMQ subscriber initialized successfully` (or `SGLang ZMQ subscriber initialized successfully`)
+- `vLLM KV-cache event handler registered` (or `SGLang KV-cache event handler registered`)
 
 ### 3. Inspect Redis Keys
 


### PR DESCRIPTION
/kind documentation

**What this PR does / why we need it**:

The kvcache-aware troubleshooting section tells users to expect `Event handlers registered successfully` in the runtime sidecar logs, but the sidecar never logs that line. It logs `vLLM KV-cache event handler registered` (`python/kthena/runtime/app.py:125`) or the SGLang variant (`:134`). A user grepping for the documented string finds nothing and concludes the sidecar is broken.

The ZMQ subscriber bullet gets the same treatment for symmetry: its vLLM string is real (`app.py:161`), and the SGLang counterpart (`:176`) is now shown the same way. The Redis bullet matches the code (`app.py:103`) and stays as it is.

The v1.0.0 versioned copy has the same lines, and the runtime at the v1.0.0 tag logs the same real strings, so the fix applies there too.

**Which issue(s) this PR fixes**:
None, a doc mismatch against the code.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
