### PR TITLE
docs: sync quick-start booster asset with the applied example

### DIFF
--- a/docs/kthena/docs/assets/examples/model-booster/Qwen2.5-0.5B-Instruct.yaml
+++ b/docs/kthena/docs/assets/examples/model-booster/Qwen2.5-0.5B-Instruct.yaml
@@ -7,11 +7,11 @@ spec:
     name: "backend1"
     type: "vLLM"
     modelURI: "hf://Qwen/Qwen2.5-0.5B-Instruct"
-    cacheURI: "hostpath:///tmp/cache"
+    cacheURI: "hostpath://tmp/cache"
     replicas: 1
     env:
-      - name: "HF_ENDPOINT" # Optional: Use a Hugging Face mirror if you have network issues
-        value: "https://hf-mirror.com"
+      - name: "HF_ENDPOINT" # Optional: set to https://hf-mirror.com if you have network issues
+        value: "https://huggingface.co"
     workers:
       - type: "server"
         image: "vllm/vllm-openai-cpu:latest" # This model will run on CPU, for more details visit https://docs.vllm.ai/en/stable/getting_started/installation/cpu.html#pre-built-images

--- a/examples/model-booster/Qwen2.5-0.5B-Instruct.yaml
+++ b/examples/model-booster/Qwen2.5-0.5B-Instruct.yaml
@@ -10,7 +10,7 @@ spec:
     cacheURI: "hostpath://tmp/cache"
     replicas: 1
     env:
-      - name: "HF_ENDPOINT" # Use Hugging Face directly
+      - name: "HF_ENDPOINT" # Optional: set to https://hf-mirror.com if you have network issues
         value: "https://huggingface.co"
     workers:
       - type: "server"


### PR DESCRIPTION
/kind documentation

**What this PR does / why we need it**:

The Quick Start renders the docs copy of the ModelBooster example (`docs/kthena/docs/assets/examples/model-booster/Qwen2.5-0.5B-Instruct.yaml` via the `?raw` import) but its apply command installs the repo copy (`examples/model-booster/Qwen2.5-0.5B-Instruct.yaml` via the raw GitHub URL). The two have drifted, so users read one manifest and deploy another:

- The docs copy sets `HF_ENDPOINT` to `https://hf-mirror.com`; the applied copy uses `https://huggingface.co`. Both now use the upstream default, and the mirror stays available as the comment's suggestion for users behind restrictive networks.
- The docs copy writes `cacheURI: "hostpath:///tmp/cache"`; the applied copy uses `hostpath://tmp/cache`. Both parse to the same `/tmp/cache` mount (`GetCachePath` joins host and path), so this is cosmetic; both files now use the two-slash form the sibling examples in this directory already use.

The two files are byte-identical after this change.

**Which issue(s) this PR fixes**:
None, a two-file sync of the same example.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
