### PR TITLE
cli: fall back to kubeconfig context namespace instead of hardcoded default

### DIFF
--- a/cli/kthena/cmd/describe.go
+++ b/cli/kthena/cmd/describe.go
@@ -146,15 +146,12 @@ func runDescribeTemplate(cmd *cobra.Command, args []string) error {
 func runDescribeModelBooster(cmd *cobra.Command, args []string) error {
 	modelName := args[0]
 
-	client, err := getKthenaClient()
+	client, contextNamespace, err := getKthenaClient()
 	if err != nil {
 		return err
 	}
 
-	namespace := getNamespace
-	if namespace == "" {
-		namespace = "default"
-	}
+	namespace := resolveGetNamespace(contextNamespace)
 	ctx := context.Background()
 
 	model, err := client.WorkloadV1alpha1().ModelBoosters(namespace).Get(ctx, modelName, metav1.GetOptions{})
@@ -184,15 +181,12 @@ func runDescribeModelBooster(cmd *cobra.Command, args []string) error {
 func runDescribeModelServing(cmd *cobra.Command, args []string) error {
 	modelServingName := args[0]
 
-	client, err := getKthenaClient()
+	client, contextNamespace, err := getKthenaClient()
 	if err != nil {
 		return err
 	}
 
-	namespace := getNamespace
-	if namespace == "" {
-		namespace = "default"
-	}
+	namespace := resolveGetNamespace(contextNamespace)
 	ctx := context.Background()
 
 	modelServing, err := client.WorkloadV1alpha1().ModelServings(namespace).Get(ctx, modelServingName, metav1.GetOptions{})
@@ -222,15 +216,12 @@ func runDescribeModelServing(cmd *cobra.Command, args []string) error {
 func runDescribeAutoscalingPolicy(cmd *cobra.Command, args []string) error {
 	policyName := args[0]
 
-	client, err := getKthenaClient()
+	client, contextNamespace, err := getKthenaClient()
 	if err != nil {
 		return err
 	}
 
-	namespace := getNamespace
-	if namespace == "" {
-		namespace = "default"
-	}
+	namespace := resolveGetNamespace(contextNamespace)
 	ctx := context.Background()
 
 	policy, err := client.WorkloadV1alpha1().AutoscalingPolicies(namespace).Get(ctx, policyName, metav1.GetOptions{})
@@ -259,15 +250,12 @@ func runDescribeAutoscalingPolicy(cmd *cobra.Command, args []string) error {
 func runDescribeModelRoute(cmd *cobra.Command, args []string) error {
 	routeName := args[0]
 
-	client, err := getKthenaClient()
+	client, contextNamespace, err := getKthenaClient()
 	if err != nil {
 		return err
 	}
 
-	namespace := getNamespace
-	if namespace == "" {
-		namespace = "default"
-	}
+	namespace := resolveGetNamespace(contextNamespace)
 	ctx := context.Background()
 
 	route, err := client.NetworkingV1alpha1().ModelRoutes(namespace).Get(ctx, routeName, metav1.GetOptions{})
@@ -296,15 +284,12 @@ func runDescribeModelRoute(cmd *cobra.Command, args []string) error {
 func runDescribeModelServer(cmd *cobra.Command, args []string) error {
 	serverName := args[0]
 
-	client, err := getKthenaClient()
+	client, contextNamespace, err := getKthenaClient()
 	if err != nil {
 		return err
 	}
 
-	namespace := getNamespace
-	if namespace == "" {
-		namespace = "default"
-	}
+	namespace := resolveGetNamespace(contextNamespace)
 	ctx := context.Background()
 
 	server, err := client.NetworkingV1alpha1().ModelServers(namespace).Get(ctx, serverName, metav1.GetOptions{})

--- a/cli/kthena/cmd/get.go
+++ b/cli/kthena/cmd/get.go
@@ -210,28 +210,44 @@ func runGetTemplate(cmd *cobra.Command, args []string) error {
 	return w.Flush()
 }
 
-func getKthenaClient() (*versioned.Clientset, error) {
-	config, err := clientcmd.BuildConfigFromFlags("", clientcmd.RecommendedHomeFile)
+// getKthenaClient builds a kthena clientset and also returns the namespace
+// from the current kubeconfig context so callers can fall back to it when
+// the user hasn't passed -n/--namespace explicitly.
+func getKthenaClient() (client *versioned.Clientset, contextNamespace string, err error) {
+	loadingRules := &clientcmd.ClientConfigLoadingRules{ExplicitPath: clientcmd.RecommendedHomeFile}
+	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, &clientcmd.ConfigOverrides{})
+
+	restConfig, err := kubeConfig.ClientConfig()
 	if err != nil {
-		return nil, fmt.Errorf("failed to load kubeconfig: %v", err)
+		return nil, "", fmt.Errorf("failed to load kubeconfig: %v", err)
 	}
 
-	client, err := versioned.NewForConfig(config)
+	client, err = versioned.NewForConfig(restConfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create kthena client: %v", err)
+		return nil, "", fmt.Errorf("failed to create kthena client: %v", err)
 	}
 
-	return client, nil
+	// Namespace() falls back to "default" itself if the context has none set
+	// so contextNamespace is always non empty on success
+	contextNamespace, _, err = kubeConfig.Namespace()
+	if err != nil {
+		contextNamespace = "default"
+	}
+
+	return client, contextNamespace, nil
 }
 
-func resolveGetNamespace() string {
+// resolveGetNamespace picks the effective namespace with kubectl's usual
+// precedence: --all-namespaces wins outright, then an explicit -n/--namespace
+// flag, then the current kubeconfig context's namespace.
+func resolveGetNamespace(contextNamespace string) string {
 	if getAllNamespaces {
 		return ""
 	}
 	if getNamespace != "" {
 		return getNamespace
 	}
-	return "default"
+	return contextNamespace
 }
 
 // getModelServingStatus derives a human-readable status from ModelServing conditions.
@@ -275,12 +291,12 @@ func getModelBoosterStatus(conditions []metav1.Condition) string {
 }
 
 func runGetModelBoosters(cmd *cobra.Command, args []string) error {
-	client, err := getKthenaClient()
+	client, contextNamespace, err := getKthenaClient()
 	if err != nil {
 		return err
 	}
 
-	namespace := resolveGetNamespace()
+	namespace := resolveGetNamespace(contextNamespace)
 	ctx := context.Background()
 
 	models, err := client.WorkloadV1alpha1().ModelBoosters(namespace).List(ctx, metav1.ListOptions{})
@@ -340,12 +356,12 @@ func runGetModelBoosters(cmd *cobra.Command, args []string) error {
 }
 
 func runGetModelServings(cmd *cobra.Command, args []string) error {
-	client, err := getKthenaClient()
+	client, contextNamespace, err := getKthenaClient()
 	if err != nil {
 		return err
 	}
 
-	namespace := resolveGetNamespace()
+	namespace := resolveGetNamespace(contextNamespace)
 	ctx := context.Background()
 
 	modelServingList, err := client.WorkloadV1alpha1().ModelServings(namespace).List(ctx, metav1.ListOptions{})
@@ -385,12 +401,12 @@ func runGetModelServings(cmd *cobra.Command, args []string) error {
 }
 
 func runGetAutoscalingPolicies(cmd *cobra.Command, args []string) error {
-	client, err := getKthenaClient()
+	client, contextNamespace, err := getKthenaClient()
 	if err != nil {
 		return err
 	}
 
-	namespace := resolveGetNamespace()
+	namespace := resolveGetNamespace(contextNamespace)
 	ctx := context.Background()
 
 	policies, err := client.WorkloadV1alpha1().AutoscalingPolicies(namespace).List(ctx, metav1.ListOptions{})
@@ -445,12 +461,12 @@ var getModelServersCmd = &cobra.Command{
 }
 
 func runGetModelRoutes(cmd *cobra.Command, args []string) error {
-	client, err := getKthenaClient()
+	client, contextNamespace, err := getKthenaClient()
 	if err != nil {
 		return err
 	}
 
-	namespace := resolveGetNamespace()
+	namespace := resolveGetNamespace(contextNamespace)
 	ctx := context.Background()
 
 	routes, err := client.NetworkingV1alpha1().ModelRoutes(namespace).List(ctx, metav1.ListOptions{})
@@ -496,12 +512,12 @@ func runGetModelRoutes(cmd *cobra.Command, args []string) error {
 }
 
 func runGetModelServers(cmd *cobra.Command, args []string) error {
-	client, err := getKthenaClient()
+	client, contextNamespace, err := getKthenaClient()
 	if err != nil {
 		return err
 	}
 
-	namespace := resolveGetNamespace()
+	namespace := resolveGetNamespace(contextNamespace)
 	ctx := context.Background()
 
 	servers, err := client.NetworkingV1alpha1().ModelServers(namespace).List(ctx, metav1.ListOptions{})


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
`-n/--namespace` docs itself as defaulting to the current kubeconfig  contexts namespace  but the fallback was hardcoded to `"default"` in both `get` and `describe` so  the context was never actually read `getKthenaClient()` built the client via `clientcmd.BuildConfigFromFlags`, which discards the `ClientConfig` handle needed to call `.Namespace()`.
Switched to `clientcmd.NewNonInteractiveDeferredLoadingClientConfig` to  keep that handle, and unified the fallback logic (`resolveGetNamespace`) across both commands instead of duplicating it 5x in `describe.go`.

**Which issue(s) this PR fixes**:
Fixes #1601

**Bug evidence (required for bug-related PRs)**:
Reproduced on a `kind-kthena-e2e` cluster with the kubeconfig context namespace set to `kube-system` throughout (confirmed by the same
context producing the correct `kube-system` result after checking out the fix — no context change between the two runs below):

$ kthena get model-servings
No ModelServings found in namespace default.


After (this PR's code, same context, no changes in between):

$ kthena get model-servings
No ModelServings found in namespace kube-system.


Buggy code: https://github.com/volcano-sh/kthena/blob/ee39d80d8bdded8d39c2b149fdf2710e6ea3ddd9/cli/kthena/cmd/get.go#L213-L235

**Special notes for your reviewer**:
`getKthenaClient()` signature changed from `(*versioned.Clientset, error)`
to `(*versioned.Clientset, string, error)`; updated all 10 call sites
(5 in `get.go`, 5 in `describe.go`). `go build ./cli/...` and
`go vet ./cli/...` pass clean.

**Does this PR introduce a user-facing change?**:
```release-note
`kthena get`/`kthena describe` now fall back to the current kubeconfig
context's namespace instead of always defaulting to `default`.
```
