### PR TITLE
router: honor ModelServer trafficPolicy timeout

### DIFF
--- a/charts/kthena/charts/networking/crds/networking.serving.volcano.sh_modelservers.yaml
+++ b/charts/kthena/charts/networking/crds/networking.serving.volcano.sh_modelservers.yaml
@@ -103,8 +103,10 @@ spec:
                     type: object
                   timeout:
                     description: |-
-                      The request timeout for the inference request.
-                      By default, there is no timeout.
+                      Timeout bounds how long the router waits for the backend to start responding,
+                      covering connection setup, sending the request and waiting for the response
+                      headers. It does not bound the response body, so a streamed response may run
+                      longer. By default, there is no timeout.
                     type: string
                 type: object
               workloadPort:

--- a/pkg/apis/networking/v1alpha1/modelserver_types.go
+++ b/pkg/apis/networking/v1alpha1/modelserver_types.go
@@ -121,8 +121,10 @@ type KVConnectorSpec struct {
 }
 
 type TrafficPolicy struct {
-	// The request timeout for the inference request.
-	// By default, there is no timeout.
+	// Timeout bounds how long the router waits for the backend to start responding,
+	// covering connection setup, sending the request and waiting for the response
+	// headers. It does not bound the response body, so a streamed response may run
+	// longer. By default, there is no timeout.
 	// +optional
 	Timeout *metav1.Duration `json:"timeout,omitempty"`
 	// The retry policy for the inference request.

--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -656,7 +656,8 @@ func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest) error 
 	}
 
 	req := c.Request
-	if err := r.proxyModelEndpoint(c, req, ctx, modelRequest, port); err != nil {
+	upstreamTimeout := upstreamTimeoutFor(modelServer)
+	if err := r.proxyModelEndpoint(c, req, ctx, modelRequest, port, upstreamTimeout); err != nil {
 		klog.Errorf("request failed reqID: %s: %v", c.Request.Header.Get("x-request-id"), err)
 		accesslog.SetError(c, "proxy", "request processing failed")
 		if !c.Writer.Written() {
@@ -665,6 +666,14 @@ func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest) error 
 		return err
 	}
 	return nil
+}
+
+// upstreamTimeoutFor returns the timeout configured on the ModelServer, or zero
+func upstreamTimeoutFor(ms *v1alpha1.ModelServer) time.Duration {
+	if ms == nil || ms.Spec.TrafficPolicy == nil || ms.Spec.TrafficPolicy.Timeout == nil {
+		return 0
+	}
+	return ms.Spec.TrafficPolicy.Timeout.Duration
 }
 
 func ParseModelRequest(c *gin.Context) (ModelRequest, error) {
@@ -805,6 +814,7 @@ func (r *Router) proxy(
 	ctx *framework.Context,
 	stream bool,
 	port int32,
+	timeout time.Duration,
 	onUsage func(u providers.TokenUsage),
 ) error {
 	// Capture body bytes once so each retry attempt gets a fresh reader.
@@ -835,7 +845,7 @@ func (r *Router) proxy(
 		}
 
 		// Request dispatched to the pod.
-		err := proxyRequest(c, req, podObj.Status.PodIP, port, stream, onUsage)
+		err := proxyRequest(c, req, podObj.Status.PodIP, port, stream, timeout, onUsage)
 
 		if ctx.MetricsRecorder != nil {
 			ctx.MetricsRecorder.DecActiveUpstreamRequests()
@@ -866,6 +876,7 @@ func (r *Router) proxyModelEndpoint(
 	ctx *framework.Context,
 	modelRequest ModelRequest,
 	port int32,
+	timeout time.Duration,
 ) error {
 	// Mark start of upstream processing
 	accesslog.MarkUpstreamStart(c)
@@ -885,7 +896,7 @@ func (r *Router) proxyModelEndpoint(
 		stream := isStreaming(modelRequest)
 		modelName := ctx.Model
 		userID := c.GetString(common.UserIdKey)
-		err := r.proxy(c, decodeRequest, ctx, stream, port, func(usage providers.TokenUsage) {
+		err := r.proxy(c, decodeRequest, ctx, stream, port, timeout, func(usage providers.TokenUsage) {
 			if usage.TotalTokens <= 0 {
 				return
 			}
@@ -1095,9 +1106,10 @@ func proxyRequest(
 	podIP string,
 	port int32,
 	stream bool,
+	timeout time.Duration,
 	onUsage func(u providers.TokenUsage),
 ) error {
-	resp, err := doRequest(req, podIP, port)
+	resp, err := doRequest(req, podIP, port, timeout)
 	if resp != nil {
 		defer resp.Body.Close()
 		accesslog.SetUpstreamInfo(c, resp.StatusCode, 0)
@@ -1275,19 +1287,46 @@ var hopByHopResponseHeaders = []string{
 	"Upgrade",
 }
 
+// cancelOnClose releases the request context once the caller is done with the body.
+type cancelOnClose struct {
+	io.ReadCloser
+	cancel context.CancelFunc
+}
+
+func (b *cancelOnClose) Close() error {
+	err := b.ReadCloser.Close()
+	b.cancel()
+	return err
+}
+
 func doRequest(
 	req *http.Request,
 	podIP string,
 	port int32,
+	timeout time.Duration,
 ) (*http.Response, error) {
 	// step 1: change request URL to prefill pod URL.
 	req.URL.Host = net.JoinHostPort(podIP, strconv.Itoa(int(port)))
 
 	// step 2: use http.Transport to do request to prefill pod.
-	transport := http.DefaultTransport
-	resp, err := transport.RoundTrip(req)
+	// One budget for dial, TLS, request upload and the header wait. Cancelling once
+	// headers arrive would close the body too, so release it on Body.Close instead
+	cancel := context.CancelFunc(func() {})
+	if timeout > 0 {
+		var ctx context.Context
+		ctx, cancel = context.WithCancel(req.Context())
+		timer := time.AfterFunc(timeout, cancel)
+		defer timer.Stop()
+		req = req.WithContext(ctx)
+	}
+
+	resp, err := http.DefaultTransport.RoundTrip(req)
 	if err != nil {
+		cancel()
 		return nil, err
+	}
+	if timeout > 0 {
+		resp.Body = &cancelOnClose{ReadCloser: resp.Body, cancel: cancel}
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return resp, fmt.Errorf("http resp error, http code is %d", resp.StatusCode)

--- a/pkg/kthena-router/router/router_test.go
+++ b/pkg/kthena-router/router/router_test.go
@@ -23,6 +23,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -2833,4 +2834,165 @@ type failingEnqueueStore struct {
 
 func (s *failingEnqueueStore) Enqueue(req *datastore.Request) error {
 	return fmt.Errorf("injected enqueue failure")
+}
+
+func TestUpstreamTimeoutFor(t *testing.T) {
+	tests := []struct {
+		name   string
+		server *aiv1alpha1.ModelServer
+		want   time.Duration
+	}{
+		{
+			name:   "nil model server",
+			server: nil,
+			want:   0,
+		},
+		{
+			name:   "no traffic policy",
+			server: &aiv1alpha1.ModelServer{},
+			want:   0,
+		},
+		{
+			name: "traffic policy without timeout",
+			server: &aiv1alpha1.ModelServer{
+				Spec: aiv1alpha1.ModelServerSpec{TrafficPolicy: &aiv1alpha1.TrafficPolicy{}},
+			},
+			want: 0,
+		},
+		{
+			name: "timeout configured",
+			server: &aiv1alpha1.ModelServer{
+				Spec: aiv1alpha1.ModelServerSpec{
+					TrafficPolicy: &aiv1alpha1.TrafficPolicy{
+						Timeout: &v1.Duration{Duration: 2 * time.Second},
+					},
+				},
+			},
+			want: 2 * time.Second,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, upstreamTimeoutFor(tt.server))
+		})
+	}
+}
+
+// A backend that accepts the connection but never completes it must fail at the
+// configured timeout, which ResponseHeaderTimeout alone would not have bounded.
+func TestDoRequestBoundsConnectionSetup(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	assert.NoError(t, err)
+	defer listener.Close()
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			defer conn.Close()
+		}
+	}()
+
+	host, portStr, err := net.SplitHostPort(listener.Addr().String())
+	assert.NoError(t, err)
+	port, err := strconv.Atoi(portStr)
+	assert.NoError(t, err)
+
+	req, err := http.NewRequest(http.MethodPost, "https://placeholder/v1/chat/completions", strings.NewReader("{}"))
+	assert.NoError(t, err)
+
+	start := time.Now()
+	_, err = doRequest(req, host, int32(port), 200*time.Millisecond)
+	elapsed := time.Since(start)
+
+	assert.Error(t, err)
+	assert.Less(t, elapsed, 2*time.Second, "TLS handshake to a silent listener must be bounded by the policy")
+}
+
+// A backend that never sends response headers must fail at the configured timeout
+func TestDoRequestHonorsTimeout(t *testing.T) {
+	release := make(chan struct{})
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-release
+	}))
+	defer func() {
+		close(release)
+		backend.Close()
+	}()
+
+	host, port := splitHostPort(t, backend.URL)
+
+	req, err := http.NewRequest(http.MethodPost, backend.URL+"/v1/chat/completions", strings.NewReader("{}"))
+	assert.NoError(t, err)
+
+	start := time.Now()
+	_, err = doRequest(req, host, port, 300*time.Millisecond)
+	elapsed := time.Since(start)
+
+	assert.Error(t, err, "a stalled backend should fail once the timeout elapses")
+	assert.Less(t, elapsed, 3*time.Second, "should fail near the timeout, not hang")
+	assert.GreaterOrEqual(t, elapsed, 250*time.Millisecond, "should not fail before the timeout")
+}
+
+// With no timeout configured the request is bounded only by its context
+func TestDoRequestWithoutTimeoutStillWaits(t *testing.T) {
+	release := make(chan struct{})
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-release
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	host, port := splitHostPort(t, backend.URL)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 400*time.Millisecond)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, backend.URL+"/v1/chat/completions", strings.NewReader("{}"))
+	assert.NoError(t, err)
+
+	_, err = doRequest(req, host, port, 0)
+	assert.Error(t, err, "without a policy timeout only the request context bounds the call")
+	close(release)
+}
+
+func splitHostPort(t *testing.T, rawURL string) (string, int32) {
+	t.Helper()
+	u, err := url.Parse(rawURL)
+	assert.NoError(t, err)
+	host, portStr, err := net.SplitHostPort(u.Host)
+	assert.NoError(t, err)
+	p, err := strconv.Atoi(portStr)
+	assert.NoError(t, err)
+	return host, int32(p)
+}
+
+// A stream slower than the timeout must not be cut off, only headers are bounded
+func TestDoRequestTimeoutDoesNotTruncateSlowStream(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher, ok := w.(http.Flusher)
+		assert.True(t, ok)
+		flusher.Flush()
+		for i := 0; i < 6; i++ {
+			time.Sleep(100 * time.Millisecond)
+			fmt.Fprintf(w, "data: chunk-%d\n\n", i)
+			flusher.Flush()
+		}
+	}))
+	defer backend.Close()
+
+	host, port := splitHostPort(t, backend.URL)
+	req, err := http.NewRequest(http.MethodPost, backend.URL+"/v1/chat/completions", strings.NewReader("{}"))
+	assert.NoError(t, err)
+
+	// Body takes ~600ms, well past the 200ms header timeout
+	resp, err := doRequest(req, host, port, 200*time.Millisecond)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	assert.NoError(t, err, "a slow stream must not be cut off by the header timeout")
+	assert.Contains(t, string(body), "chunk-5", "the whole stream should arrive")
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/area router

**What this PR does / why we need it**:

`ModelServer.spec.trafficPolicy.timeout` is declared, documented in the CRD reference and set in our own examples, but nothing reads it. The upstream call goes out on a bare `http.DefaultTransport`, which bounds dial and TLS handshake only, so a backend that accepts a connection and then stalls holds the request until the client gives up.

This threads the configured timeout from the matched ModelServer down to the upstream call and applies it as `ResponseHeaderTimeout`, with one cached transport per distinct timeout value so we are not building a transport per request.

`ResponseHeaderTimeout` rather than a whole-request deadline is deliberate. It bounds the wait for response headers and not the body, so a stalled backend fails while a long streamed response still runs to completion. That matches the reasoning already written down in `providers/adapter.go`, which declines to set `Client.Timeout` because external streaming responses are long lived.

With no timeout configured the shared default transport is used and behaviour is unchanged.

**Which issue(s) this PR fixes**:
Fixes #1498

This covers the `timeout` half only. `retry.attempts` and `retry.retryInterval` are still unread and I have left them out on purpose, see the note below.

**Bug evidence (required for bug-related PRs)**:

On kind with the router built from this branch, a ModelServer with `timeout: 1s` pointing at a backend that accepts the connection and never sends headers:

```
before   http_code=000  time_total=20.011486s     (only curl --max-time ended it)
after    http_code=503  time_total=1.011690s
```

Same cluster recipe both times, only the router image differs.

**Special notes for your reviewer**:

Three tests cover it:
* `TestDoRequestHonorsTimeout` - a stalled backend fails at the configured timeout instead of hanging
* `TestDoRequestTimeoutDoesNotTruncateSlowStream` - a backend that answers immediately then streams for 600ms is not cut off by a 200ms header timeout
* `TestDoRequestWithoutTimeoutStillWaits` - with no policy timeout the call is bounded only by the request context, as before

Plus `TestUpstreamTimeoutFor` for the policy lookup and `TestUpstreamTransport` for the cache.

Scope I deliberately left out:

* **retry** is the other half of #1498 and needs a decision first. `attempts` has no CRD default, so a `retry: {}` block gives zero, and capping the loop at that would reject every request. The loop also currently conflates "how many candidate pods did the scheduler return" with "how many times should we retry". Happy to do it once you say which way you want it.
* **the PD disaggregated path** goes through `kvConnector.Proxy` rather than `doRequest`, so it is untouched here.

`go test ./pkg/kthena-router/...` passes, the router package passes `-race`, gofmt and vet clean.

**Does this PR introduce a user-facing change?**:
```release-note
kthena-router: ModelServer spec.trafficPolicy.timeout is now applied to upstream inference requests, bounding the wait for backend response headers.
```