### PR TITLE
test(tokenization): synchronize concurrent request counter

### DIFF
--- a/pkg/kthena-router/scheduler/plugins/tokenization/tokenization_test.go
+++ b/pkg/kthena-router/scheduler/plugins/tokenization/tokenization_test.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -814,14 +815,14 @@ func TestJSONSerialization(t *testing.T) {
 // Test concurrent access
 func TestConcurrentAccess(t *testing.T) {
 	// Create a mock server for concurrent testing
-	requestCount := 0
+	var requestCount atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		requestCount++
+		count := requestCount.Add(1)
 		time.Sleep(10 * time.Millisecond) // Simulate processing time
 		response := map[string]interface{}{
 			"count":         1,
 			"max_model_len": 1024,
-			"tokens":        []int{requestCount},
+			"tokens":        []int32{count},
 		}
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(response)
@@ -859,8 +860,8 @@ func TestConcurrentAccess(t *testing.T) {
 	}
 
 	// Verify that all requests were processed
-	if requestCount != numRequests {
-		t.Errorf("Expected %d requests, got %d", numRequests, requestCount)
+	if got := requestCount.Load(); got != numRequests {
+		t.Errorf("Expected %d requests, got %d", numRequests, got)
 	}
 }
 


### PR DESCRIPTION
## What changed

- replace the unsynchronized mock-server request counter with `atomic.Int32`
- use `Add` for handler updates and `Load` for the final assertion
- keep each mock token response tied to the atomically assigned request count

## Why

`TestConcurrentAccess` deliberately serves requests concurrently, but its plain integer counter was read and written by multiple goroutines. That creates a data race and can lose increments, making the test flaky under concurrent execution and race detection.

## Validation

- `go test ./pkg/kthena-router/scheduler/plugins/tokenization -run TestConcurrentAccess -count=100`
- `go test ./pkg/kthena-router/scheduler/plugins/tokenization -count=1`
- `git diff --check`

`go test -race` could not run locally because the installed Windows C compiler does not support the required 64-bit cgo mode; Linux CI remains the final race-enabled environment.

Fixes #1604