### PR TITLE
router: fail conf test when an expected error is missing

### DIFF
--- a/pkg/kthena-router/scheduler/plugins/conf/conf_test.go
+++ b/pkg/kthena-router/scheduler/plugins/conf/conf_test.go
@@ -36,31 +36,40 @@ func TestLoadSchedulerConfig(t *testing.T) {
 			expectErrs: "",
 		},
 		{
-			name:       "empty plugins config",
+			name:       "missing config file",
 			configFile: "non-existent-file.yaml",
 			expectErrs: "failed to read config file",
 		},
 		{
 			name:       "invalid YAML syntax",
+			configFile: "../../../utils/testdata/configmap-malformed.yaml",
+			expectErrs: "failed to Unmarshal routerConfiguration",
+		},
+		{
+			name:       "plugin entry is not a mapping",
 			configFile: "../../../utils/testdata/configmap-invalid.yaml",
-			expectErrs: "failed to Unmarshal schedulerConfiguration",
+			expectErrs: "plugin configuration must be a mapping",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			routerConf, err := ParseRouterConfig(tc.configFile)
-			if err != nil {
-				if !strings.Contains(err.Error(), tc.expectErrs) {
-					t.Errorf("expected error %q, got %q", tc.expectErrs, err.Error())
-				}
-			} else {
+			if err == nil {
 				_, _, _, err = LoadSchedulerConfig(&routerConf.Scheduler)
+			}
+			if tc.expectErrs == "" {
 				if err != nil {
-					if !strings.Contains(err.Error(), tc.expectErrs) {
-						t.Errorf("expected error %q, got %q", tc.expectErrs, err.Error())
-					}
+					t.Errorf("expected no error, got %q", err.Error())
 				}
+				return
+			}
+			if err == nil {
+				t.Errorf("expected error %q, got none", tc.expectErrs)
+				return
+			}
+			if !strings.Contains(err.Error(), tc.expectErrs) {
+				t.Errorf("expected error %q, got %q", tc.expectErrs, err.Error())
 			}
 		})
 	}

--- a/pkg/kthena-router/utils/testdata/configmap-invalid.yaml
+++ b/pkg/kthena-router/utils/testdata/configmap-invalid.yaml
@@ -1,2 +1,3 @@
-pluginConfig:
-- invalid
+scheduler:
+  pluginConfig:
+  - invalid

--- a/pkg/kthena-router/utils/testdata/configmap-malformed.yaml
+++ b/pkg/kthena-router/utils/testdata/configmap-malformed.yaml
@@ -1,0 +1,1 @@
+scheduler: [


### PR DESCRIPTION
/kind test

**What this PR does / why we need it**:

`TestLoadSchedulerConfig` could not fail when an expected error never happened, and its `invalid YAML syntax` case had rotted into exactly that no-op: the fixture's `pluginConfig:` sat at top level, `RouterConfiguration` has no such field so parsing dropped it and succeeded, and the expected string `failed to Unmarshal schedulerConfiguration` exists nowhere in the code (the real message says `routerConfiguration`, `conf.go:107`). Mechanism and proof in #1600.

The harness now treats the cases symmetrically: empty `expectErrs` means no error is allowed, non-empty means an error must happen and contain the string. That closes both holes, the expected-error-never-happens one and the unexpected-error-in-the-success-case one (`strings.Contains(err, "")` was always true).

The table changes with it:

- `invalid YAML syntax` now points at a new fixture that is genuinely malformed (`scheduler: [`), asserting the real wrap `failed to Unmarshal routerConfiguration`.
- The old fixture's evident intent, a scalar plugin entry, is preserved as its own case: moved under `scheduler:` so it actually reaches `PluginConfig.UnmarshalYAML`, asserting `plugin configuration must be a mapping`. The fixture has no other consumers.
- The case named `empty plugins config` pointed at `non-existent-file.yaml`; it is renamed `missing config file`.

Flip-checked: with the new harness and the old fixture, the scalar-entry case fails with `expected error "plugin configuration must be a mapping", got none`, which is the no-op made visible.

**Which issue(s) this PR fixes**:
Fixes #1600

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
