### PR TITLE
docs: propose ModelServing revision history and rollback

### DIFF
--- a/docs/proposal/modelserving-revision-history-and-rollback.md
+++ b/docs/proposal/modelserving-revision-history-and-rollback.md
@@ -1,0 +1,205 @@
+---
+title: ModelServing Revision History and Rollback
+authors:
+- "@acsoto"
+reviewers:
+- TBD
+approvers:
+- TBD
+
+creation-date: 2026-08-13
+
+---
+
+## ModelServing Revision History and Rollback
+
+### Summary
+
+This proposal makes ModelServing revisions stable, retained, and usable for
+rollback. It aligns revision lifecycle and rollback behavior with Kubernetes
+StatefulSet: revision data is immutable, equivalent historical revisions are
+reused, and rollback updates the desired spec before following the existing
+rolling update flow.
+
+Related issue: [#1584](https://github.com/volcano-sh/kthena/issues/1584).
+
+### Motivation
+
+ModelServing already creates `ControllerRevision` objects, but the revision
+hash and stored data are built from different inputs. Operational changes such
+as Role scaling can therefore keep the same hash while changing the stored
+data. In addition, revision numbers do not form a history and completed
+revisions are removed.
+
+These behaviors prevent reliable recovery of an earlier desired workload.
+
+#### Goals
+
+- Build the workload hash and `ControllerRevision.Data` from the same data.
+- Keep revision data immutable and revision numbers monotonic.
+- Retain recent history without deleting revisions used by live workloads.
+- Restore a historical ModelServing workload through the existing rollout
+  strategies.
+- Preserve current capacity and rollout policies during rollback.
+
+#### Non-Goals
+
+- A separate rollback state machine.
+- Rollback of an individual Role.
+- Guaranteed CLI rollback to legacy revisions.
+
+### Proposal
+
+ModelServing will record the desired workload revision before scale and rollout
+reconciliation. This also records template changes when `replicas` is zero.
+
+The CLI will expose revision history and rollback:
+
+```bash
+kthena rollout history modelserving <name>
+kthena rollout undo modelserving <name> --to-revision=<revision>
+```
+
+Omitting `--to-revision`, or setting it to zero, selects the previous revision.
+The CLI applies the selected revision to `ModelServing.spec`. The controller
+then handles the change as a normal `ServingGroupRollingUpdate` or
+`RoleRollingUpdate`.
+
+The CLI retries conflicts by reading the latest ModelServing and reapplying the
+revision, so concurrent changes to operational fields are not overwritten.
+
+### Design Details
+
+#### Revision Data
+
+`ControllerRevision.Data` will contain a deterministic strategic merge patch
+with only workload-defining fields. API defaults and nil/empty values are
+normalized before serialization; Role and plugin order is preserved because it
+is semantically significant.
+
+| Revisioned fields | Operational fields |
+| --- | --- |
+| `schedulerName` | ModelServing and Role `replicas` |
+| Pod-mutating `plugins` | `rolloutStrategy` |
+| Role identity | `maxUnavailable` and `partition` |
+| Role entry and worker templates | `recoveryPolicy` |
+| `workerReplicas` | `restartGracePeriodSeconds` |
+| | `gangPolicy` and `networkTopology` |
+
+Role and plugin lists use replace semantics so applying a revision can remove
+entries added after that revision. The serialized patch is used unchanged as
+`ControllerRevision.Data.Raw` and as the primary hash input.
+
+`ControllerRevision.Data` is never modified after creation. The revision hash
+continues to identify workload content and is used in the ControllerRevision
+name, ModelServing status, and workload labels.
+
+#### Applying a Revision
+
+Applying a revision restores revisioned fields and preserves operational
+fields from the current ModelServing.
+
+- ModelServing replicas remain unchanged.
+- A Role present in both specs keeps its current replicas.
+- A Role restored from history uses the API default replicas value of `1`.
+- A current Role absent from the target revision is removed.
+
+The resulting spec must still satisfy current API validation. In particular,
+an operational `gangPolicy` can prevent removal of a Role referenced by
+`minRoleReplicas`; the CLI rejects such a rollback without changing the
+ModelServing.
+
+Partition-protected workloads also use this rule: their template comes from
+the historical revision, while their Role replicas come from the current spec.
+This replaces the current behavior that restores Role replicas from revision
+data.
+
+#### Revision Lifecycle
+
+For each desired workload, the controller builds a candidate revision with:
+
+```text
+nextRevision = max(history.Revision) + 1
+```
+
+It then follows the StatefulSet revision lifecycle:
+
+1. If the candidate equals the latest revision, reuse the latest revision.
+2. If it equals an older revision, reuse that ControllerRevision and advance
+   its `Revision` to `nextRevision`.
+3. Otherwise, create a new ControllerRevision.
+
+Only the numeric `Revision` is updated when an older revision is reused; its
+name and Data remain unchanged. For example:
+
+```text
+A(revision=1) -> B(revision=2) -> C(revision=3)
+rollback to A
+A's ControllerRevision is reused with revision=4
+```
+
+Hash collisions are handled with a collision count stored in
+`ModelServingStatus`:
+
+```go
+CollisionCount *int32 `json:"collisionCount,omitempty"`
+```
+
+A name collision with different Data increments the collision count and salts
+the hash calculation. Existing Data is never overwritten.
+
+#### History Retention
+
+`ModelServingSpec` will add:
+
+```go
+// +kubebuilder:default=10
+// +kubebuilder:validation:Minimum=0
+RevisionHistoryLimit *int32 `json:"revisionHistoryLimit,omitempty"`
+```
+
+The default is `10`. Zero retains no non-live history, and negative values are
+rejected.
+
+The limit applies to non-live history. Revisions referenced by
+`CurrentRevision`, `UpdateRevision`, or existing child workloads are live and
+do not count toward the limit. Non-live revisions are deleted from oldest to
+newest until at most `revisionHistoryLimit` remain.
+
+Live revision discovery must use persisted workload state, including Pod
+revision labels, rather than relying only on the controller's in-memory store.
+
+#### Compatibility
+
+New revisions will carry the annotation
+`modelserving.volcano.sh/revision-data-version: "v1"` so they can be
+distinguished from the legacy wrapped Role list.
+
+- Legacy revisions remain readable for active rollout and recovery.
+- After upgrade, the controller records the current desired workload in the
+  new format without changing the revision hash used by existing workloads.
+  The legacy hash remains active until the next revisioned spec change, which
+  prevents a controller upgrade from triggering a rollout.
+- CLI history and rollback only guarantee revisions in the new format.
+- Legacy revision Data is not rewritten or renumbered and is removed through
+  normal history retention once it is no longer live.
+
+#### Test Plan
+
+The implementation will add unit and end-to-end coverage for revision
+lifecycle, rollback, retention, and compatibility behavior.
+
+### Alternatives
+
+#### Append-only rollback history
+
+Creating another ControllerRevision whenever old content becomes desired would
+preserve every transition as a separate object. This was rejected because it
+duplicates revision data and diverges from the StatefulSet lifecycle. Reusing
+an equivalent revision also preserves the existing `<name>-<hash>` identity.
+
+#### Controller-managed rollback state
+
+Adding a rollback request to the API would require separate rollback state and
+completion handling. Updating the desired spec through the CLI keeps rollback
+declarative and reuses the existing rollout implementation.

--- a/docs/proposal/modelserving-revision-history-and-rollback.md
+++ b/docs/proposal/modelserving-revision-history-and-rollback.md
@@ -73,22 +73,37 @@ revision, so concurrent changes to operational fields are not overwritten.
 #### Revision Data
 
 `ControllerRevision.Data` will contain a deterministic strategic merge patch
-with only workload-defining fields. API defaults and nil/empty values are
-normalized before serialization; Role and plugin order is preserved because it
-is semantically significant.
+with only explicitly selected workload-defining fields. `BuildRevisionData`
+constructs this projection from an allowlist; it must not copy the API object
+and remove known operational fields. API defaults and nil/empty values are
+normalized before serialization.
 
 | Revisioned fields | Operational fields |
 | --- | --- |
 | `schedulerName` | ModelServing and Role `replicas` |
-| Pod-mutating `plugins` | `rolloutStrategy` |
+| `plugins` | `rolloutStrategy` |
 | Role identity | `maxUnavailable` and `partition` |
 | Role entry and worker templates | `recoveryPolicy` |
 | `workerReplicas` | `restartGracePeriodSeconds` |
 | | `gangPolicy` and `networkTopology` |
 
-Role and plugin lists use replace semantics so applying a revision can remove
-entries added after that revision. The serialized patch is used unchanged as
+Roles are identified by name and stored in canonical name order, so reordering
+otherwise identical Roles does not create a revision. Plugin order is preserved
+because plugin hooks execute in spec order and may mutate the same Pod. All
+plugins are revisioned because the current plugin API does not declare whether
+an `OnPodCreate` hook mutates the Pod. Role-name lists within a plugin scope are
+also canonicalized because their order is not significant.
+
+Revision membership uses replace semantics so applying a revision can remove
+Roles and plugins added after that revision. `ApplyRevision` preserves the
+operational Role properties described below while restoring the plugin chain
+exactly. The serialized patch is used unchanged as
 `ControllerRevision.Data.Raw` and as the primary hash input.
+
+`networkTopology` remains operational: changing it updates the PodGroup and
+SubGroupPolicy but does not relocate existing Pods. The new policy applies to
+subsequent scheduling and recovery. In contrast, `schedulerName` is written to
+`PodSpec.schedulerName` and requires Pod replacement to converge.
 
 `ControllerRevision.Data` is never modified after creation. The revision hash
 continues to identify workload content and is used in the ControllerRevision
@@ -100,8 +115,10 @@ Applying a revision restores revisioned fields and preserves operational
 fields from the current ModelServing.
 
 - ModelServing replicas remain unchanged.
-- A Role present in both specs keeps its current replicas.
-- A Role restored from history uses the API default replicas value of `1`.
+- A Role present in both specs keeps its current replicas and list position.
+- A Role restored from history uses the API default replicas value of `1` and
+  is appended in canonical name order after Roles retained from the current
+  spec.
 - A current Role absent from the target revision is removed.
 
 The resulting spec must still satisfy current API validation. In particular,

--- a/docs/proposal/modelserving-revision-history-and-rollback.md
+++ b/docs/proposal/modelserving-revision-history-and-rollback.md
@@ -47,7 +47,6 @@ These behaviors prevent reliable recovery of an earlier desired workload.
 - A separate rollback state machine.
 - Rollback of an individual Role.
 - Guaranteed CLI rollback to legacy revisions.
-- Zero-disruption migration from the legacy revision data format.
 
 ### Proposal
 
@@ -94,14 +93,6 @@ entries added after that revision. The serialized patch is used unchanged as
 `ControllerRevision.Data` is never modified after creation. The revision hash
 continues to identify workload content and is used in the ControllerRevision
 name, ModelServing status, and workload labels.
-
-The v1 revision data format is a compatibility contract. A new optional field
-whose unset value preserves existing workload behavior must remain omitted from
-revision data, so adding the field alone does not change existing revisions. A
-new default that changes the rendered workload is revisioned normally. A future
-format or normalization change that changes serialized data may create a new
-revision and trigger a rollout, and must be documented as an explicit
-migration.
 
 #### Applying a Revision
 
@@ -175,13 +166,10 @@ The limit applies to non-live history. Revisions referenced by
 do not count toward the limit. Non-live revisions are deleted from oldest to
 newest until at most `revisionHistoryLimit` remain.
 
-Live revision discovery must use persisted workload state, including Pod
-revision labels, rather than relying only on the controller's in-memory store.
-GC must not run while workload deletion or recovery is in progress. If a
-partition-protected workload can temporarily have no Pod, the controller must
-persist its exact revision assignment before deletion and treat that assignment
-as live until the replacement is created. This prevents GC, including with a
-limit of zero, from removing a revision during the deletion window.
+Revision references required for partition-protected recovery must survive Pod
+deletion and controller restart, and remain live until the replacement is
+created. GC therefore cannot rely only on existing Pod labels or the
+controller's in-memory store.
 
 #### Compatibility
 

--- a/docs/proposal/modelserving-revision-history-and-rollback.md
+++ b/docs/proposal/modelserving-revision-history-and-rollback.md
@@ -47,6 +47,7 @@ These behaviors prevent reliable recovery of an earlier desired workload.
 - A separate rollback state machine.
 - Rollback of an individual Role.
 - Guaranteed CLI rollback to legacy revisions.
+- Zero-disruption migration from the legacy revision data format.
 
 ### Proposal
 
@@ -93,6 +94,14 @@ entries added after that revision. The serialized patch is used unchanged as
 `ControllerRevision.Data` is never modified after creation. The revision hash
 continues to identify workload content and is used in the ControllerRevision
 name, ModelServing status, and workload labels.
+
+The v1 revision data format is a compatibility contract. A new optional field
+whose unset value preserves existing workload behavior must remain omitted from
+revision data, so adding the field alone does not change existing revisions. A
+new default that changes the rendered workload is revisioned normally. A future
+format or normalization change that changes serialized data may create a new
+revision and trigger a rollout, and must be documented as an explicit
+migration.
 
 #### Applying a Revision
 
@@ -168,6 +177,11 @@ newest until at most `revisionHistoryLimit` remain.
 
 Live revision discovery must use persisted workload state, including Pod
 revision labels, rather than relying only on the controller's in-memory store.
+GC must not run while workload deletion or recovery is in progress. If a
+partition-protected workload can temporarily have no Pod, the controller must
+persist its exact revision assignment before deletion and treat that assignment
+as live until the replacement is created. This prevents GC, including with a
+limit of zero, from removing a revision during the deletion window.
 
 #### Compatibility
 
@@ -176,10 +190,13 @@ New revisions will carry the annotation
 distinguished from the legacy wrapped Role list.
 
 - Legacy revisions remain readable for active rollout and recovery.
-- After upgrade, the controller records the current desired workload in the
-  new format without changing the revision hash used by existing workloads.
-  The legacy hash remains active until the next revisioned spec change, which
-  prevents a controller upgrade from triggering a rollout.
+- The first reconciliation with the v1 format builds revision data and a hash
+  through the normal revision lifecycle. Because this identity differs from a
+  legacy revision, upgrading the controller initiates a one-time rollout of an
+  otherwise unchanged ModelServing.
+- The migration does not persist a compatibility baseline or maintain an alias
+  between legacy and v1 revisions. The one-time rollout follows the configured
+  rollout strategy, `maxUnavailable`, and `partition`.
 - CLI history and rollback only guarantee revisions in the new format.
 - Legacy revision Data is not rewritten or renumbered and is removed through
   normal history retention once it is no longer live.
@@ -203,3 +220,10 @@ an equivalent revision also preserves the existing `<name>-<hash>` identity.
 Adding a rollback request to the API would require separate rollback state and
 completion handling. Updating the desired spec through the CLI keeps rollback
 declarative and reuses the existing rollout implementation.
+
+#### Zero-rollout legacy migration
+
+Keeping the legacy revision active while recording equivalent v1 data would
+require a persistent compatibility baseline or alias and special reconciliation
+and GC rules. This was rejected in favor of a one-time rollout through the
+normal revision lifecycle.

--- a/docs/proposal/modelserving-revision-history-and-rollback.md
+++ b/docs/proposal/modelserving-revision-history-and-rollback.md
@@ -21,8 +21,6 @@ StatefulSet: revision data is immutable, equivalent historical revisions are
 reused, and rollback updates the desired spec before following the existing
 rolling update flow.
 
-Related issue: [#1584](https://github.com/volcano-sh/kthena/issues/1584).
-
 ### Motivation
 
 ModelServing already creates `ControllerRevision` objects, but the revision

--- a/docs/proposal/modelserving-revision-history-and-rollback.md
+++ b/docs/proposal/modelserving-revision-history-and-rollback.md
@@ -65,6 +65,10 @@ The CLI applies the selected revision to `ModelServing.spec`. The controller
 then handles the change as a normal `ServingGroupRollingUpdate` or
 `RoleRollingUpdate`.
 
+Both rollout strategies must treat a change to any revisioned field applicable
+to a workload as an update. The mechanism used to detect outdated workloads is
+an implementation detail of each strategy.
+
 The CLI retries conflicts by reading the latest ModelServing and reapplying the
 revision, so concurrent changes to operational fields are not overwritten.
 
@@ -126,10 +130,11 @@ an operational `gangPolicy` can prevent removal of a Role referenced by
 `minRoleReplicas`; the CLI rejects such a rollback without changing the
 ModelServing.
 
-Partition-protected workloads also use this rule: their template comes from
-the historical revision, while their Role replicas come from the current spec.
-This replaces the current behavior that restores Role replicas from revision
-data.
+When a workload is created or recovered for revision R, all revisioned fields,
+including `schedulerName`, `plugins`, and Role templates, come from R, while
+operational fields come from the current ModelServing. This also applies to
+partition-protected recovery. Role replicas therefore come from the current
+spec, replacing the current behavior that restores them from revision data.
 
 #### Revision Lifecycle
 

--- a/docs/proposal/modelserving-revision-history-and-rollback.md
+++ b/docs/proposal/modelserving-revision-history-and-rollback.md
@@ -16,10 +16,22 @@ creation-date: 2026-08-13
 ### Summary
 
 This proposal makes ModelServing revisions stable, retained, and usable for
-rollback. It aligns revision lifecycle and rollback behavior with Kubernetes
-StatefulSet: revision data is immutable, equivalent historical revisions are
-reused, and rollback updates the desired spec before following the existing
-rolling update flow.
+rollback. It aligns the revision lifecycle with Kubernetes StatefulSet and the
+general RBG model: historical workload definition is versioned, while the
+current controller and runtime context is used to construct the desired
+workload.
+
+The central contract is:
+
+> A `ControllerRevision` stores the versioned workload declaration that should
+> be restored by rollback. It does not snapshot every input that can affect the
+> final rendered Pod.
+
+Revision identity is the versioned user workload declaration. A desired
+workload is produced by combining that declaration with the current rendering
+context. Rollback restores the declaration only. It does not promise bit-for-
+bit or field-for-field reproduction of the Pod that existed when the revision
+was created.
 
 ### Motivation
 
@@ -29,27 +41,78 @@ as Role scaling can therefore keep the same hash while changing the stored
 data. In addition, revision numbers do not form a history and completed
 revisions are removed.
 
-These behaviors prevent reliable recovery of an earlier desired workload.
+These behaviors prevent reliable recovery of an earlier desired workload. The
+design also needs a clear boundary so that every new controller or plugin input
+does not silently become historical revision data.
 
 #### Goals
 
-- Build the workload hash and `ControllerRevision.Data` from the same data.
-- Keep revision data immutable and revision numbers monotonic.
+- Define revision identity as a small, explicit workload declaration.
+- Build deterministic revision data and its identity from the same allowlisted
+  projection.
+- Keep revision data immutable, reuse equivalent revisions, and make revision
+  numbers monotonic.
 - Retain recent history without deleting revisions used by live workloads.
-- Restore a historical ModelServing workload through the existing rollout
+- Restore a historical workload definition through the existing rollout
   strategies.
-- Preserve current capacity and rollout policies during rollback.
+- Preserve current capacity, scheduling, ownership, and rollout policies during
+  rollback.
+- Define plugin rendering dependencies without snapshotting arbitrary live
+  ModelServing state or plugin implementation details.
 
 #### Non-Goals
 
+- Bit-for-bit reproduction of a historical Pod.
+- A revision of every input that can affect final Pod rendering.
+- Snapshotting `OwnerReferences`, plugin executable code, or implementation
+  versions in `ControllerRevision.Data`.
 - A separate rollback state machine.
 - Rollback of an individual Role.
 - Guaranteed CLI rollback to legacy revisions.
+- Runtime implementation changes in this documentation PR; those are reviewed
+  separately in #1767.
 
 ### Proposal
 
-ModelServing will record the desired workload revision before scale and rollout
-reconciliation. This also records template changes when `replicas` is zero.
+ModelServing will record the versioned workload declaration before scale and
+rollout reconciliation. This also records template changes when `replicas` is
+zero.
+
+The semantic model is:
+
+```text
+revision
+    = versioned user workload declaration
+
+desired workload
+    = historical/current revisioned workload definition
+    + current rendering context
+```
+
+The resulting flow is:
+
+```text
+ControllerRevision
+    |
+    | historical workload declaration
+    v
+Roles / templates / workerReplicas / plugins
+    |
+    + current scheduler / current owner context / current controller behavior
+    v
+desired workload
+    |
+    v
+compare with existing workload
+    |
+    v
+replace or update when effective rendering differs
+```
+
+The current rendering context may include the current scheduler configuration,
+the current owning LWS identity when a plugin needs it, Pod and Role identity,
+and the behavior of the current controller and plugin implementations. These
+inputs are deliberately not historical revision data.
 
 The CLI will expose revision history and rollback:
 
@@ -59,84 +122,305 @@ kthena rollout undo modelserving <name> --to-revision=<revision>
 ```
 
 Omitting `--to-revision`, or setting it to zero, selects the previous revision.
-The CLI applies the selected revision to `ModelServing.spec`. The controller
-then handles the change as a normal `ServingGroupRollingUpdate` or
-`RoleRollingUpdate`.
+The CLI reads the selected `ControllerRevision` and applies its revisioned
+fields to `ModelServing.spec`. The controller then handles the resulting change
+as a normal `ServingGroupRollingUpdate` or `RoleRollingUpdate`.
 
-Both rollout strategies must treat a change to any revisioned field applicable
-to a workload as an update. The mechanism used to detect outdated workloads is
-an implementation detail of each strategy.
+Both rollout strategies must replace a workload when a change to its effective
+rendered workload requires replacement. The comparison is not required to use
+exactly the same inputs as `ControllerRevision.Data`, because current rendering
+inputs intentionally live outside the revision. The concrete comparison or
+hashing mechanism remains an implementation detail of each strategy.
 
 The CLI retries conflicts by reading the latest ModelServing and reapplying the
-revision, so concurrent changes to operational fields are not overwritten.
+revisioned fields, so concurrent changes to operational fields are not
+overwritten.
 
 ### Design Details
 
 #### Revision Data
 
 `ControllerRevision.Data` will contain a deterministic strategic merge patch
-with only explicitly selected workload-defining fields. `BuildRevisionData`
+with only explicitly selected workload-definition fields. `BuildRevisionData`
 constructs this projection from an allowlist; it must not copy the API object
 and remove known operational fields. API defaults and nil/empty values are
 normalized before serialization.
 
-| Revisioned fields | Operational fields |
-| --- | --- |
-| `schedulerName` | ModelServing and Role `replicas` |
-| `plugins` | `rolloutStrategy` |
-| Role identity | `maxUnavailable` and `partition` |
-| Role entry and worker templates | `recoveryPolicy` |
-| `workerReplicas` | `restartGracePeriodSeconds` |
-| | `gangPolicy` and `networkTopology` |
+The revisioned workload inputs are:
 
-Roles are identified by name and stored in canonical name order, so reordering
-otherwise identical Roles does not create a revision. Plugin order is preserved
-because plugin hooks execute in spec order and may mutate the same Pod. All
-plugins are revisioned because the current plugin API does not declare whether
-an `OnPodCreate` hook mutates the Pod. Role-name lists within a plugin scope are
-also canonicalized because their order is not significant.
+```text
+- Role identity and membership
+- Role entry template
+- Role worker template
+- workerReplicas
+- plugins
+```
+
+`plugins` remains revisioned for now. The entire `PluginSpec` participates in
+the revision identity:
+
+```text
+- name
+- type
+- config
+- scope
+- plugin list order
+```
+
+This is required because plugin configuration is explicitly supplied by the
+user as part of the workload declaration, `OnPodCreate` plugins may mutate the
+Pod, and plugin order is semantically significant: a later plugin can observe
+or overwrite an earlier mutation. The current plugin API does not declare
+which plugins or configuration fields affect Pod rendering, so this proposal
+does not introduce plugin-specific revision metadata.
+
+Canonicalization is still required:
+
+- Opaque JSON `config` is canonicalized before hashing and serialization.
+- `scope.roles` is canonicalized because role-list order has no semantic
+  meaning.
+- Plugin list order is preserved because execution order is significant.
+- Roles are stored in canonical name order, so reordering otherwise identical
+  Roles does not create a revision.
+
+For `RoleRollingUpdate`, only plugins applicable to the specific Role
+participate in that Role's workload identity. A plugin scoped only to `prefill`
+must not make `decode` outdated. A plugin with no role restriction applies to
+each applicable Role, and the relative order of the applicable plugins remains
+the order in the ModelServing plugin list.
 
 Revision membership uses replace semantics so applying a revision can remove
 Roles and plugins added after that revision. `ApplyRevision` preserves the
 operational Role properties described below while restoring the plugin chain
-exactly. The serialized patch is used unchanged as
-`ControllerRevision.Data.Raw` and as the primary hash input.
+represented by the revision. The serialized patch is used unchanged as
+`ControllerRevision.Data.Raw` and as the primary revision identity input.
 
-`networkTopology` remains operational: changing it updates the PodGroup and
-SubGroupPolicy but does not relocate existing Pods. The new policy applies to
-subsequent scheduling and recovery. In contrast, `schedulerName` is written to
-`PodSpec.schedulerName` and requires Pod replacement to converge.
+`ControllerRevision.Data` is immutable after creation. The revision identity is
+used in the ControllerRevision name, ModelServing status, and workload labels.
+Changes to current rendering inputs do not create a new ControllerRevision;
+they are handled by effective-rendering comparison and reconciliation.
 
-`ControllerRevision.Data` is never modified after creation. The revision hash
-continues to identify workload content and is used in the ControllerRevision
-name, ModelServing status, and workload labels.
+#### Current Rendering Context and Plugin Contract
+
+`schedulerName` is a current rendering input, not a revisioned field. The
+controller uses the current scheduler configuration when constructing Pods.
+Changing `schedulerName` must still make workloads whose final Pod
+`schedulerName` changes outdated and cause replacement.
+
+For example:
+
+```text
+revision A:
+  image = v1
+
+revision B:
+  image = v2
+
+current schedulerName:
+  new-scheduler
+
+rollback B -> A
+```
+
+The resulting workload is:
+
+```text
+image = v1
+schedulerName = new-scheduler
+```
+
+It must not restore the scheduler that happened to be configured when revision
+A was created.
+
+The current plugin API exposes the whole ModelServing object through
+`HookRequest.ModelServing`. That shape is an implementation compatibility
+detail, not a promise that arbitrary live ModelServing fields are part of the
+historical rendering contract. The intended semantic rule is:
+
+> `OnPodCreate` workload mutation should depend only on the plugin
+> declaration/configuration, Pod and Role identity, and explicitly supported
+> current rendering context.
+
+Plugins must not rely on arbitrary live fields such as:
+
+```text
+- ModelServing status
+- rolloutStrategy
+- replicas
+- unrelated Roles
+- controller revision bookkeeping labels
+- PodGroup operational annotations
+- arbitrary external mutable state
+```
+
+If a plugin requires runtime context, that context must be explicitly defined
+and supplied as current rendering context. A synthetic partial ModelServing
+object may be used temporarily for compatibility, but this proposal defines
+the semantic dependency contract rather than standardizing that workaround as
+the long-term API model.
+
+OwnerReferences are live object-relationship metadata, not part of the
+historical workload declaration. They must not be stored in revision data or
+included in the revision identity. In particular, do not add a historical
+owner-reference field or store historical APIVersion, Kind, Name, UID,
+`controller`, or `blockOwnerDeletion` values for plugin rendering. The
+`ControllerRevision` object's own live metadata may still use the ownership
+needed for its lifecycle; that metadata is not revision data and must not be
+passed to a plugin as historical context.
+
+This matters for the built-in `lws-standard-labels` plugin. It derives labels
+from the current owning LeaderWorkerSet. If revision A was originally owned by
+LWS `foo`, but the current ModelServing is later owned by LWS `bar`, recovery
+of revision A must use the current LWS identity:
+
+```text
+LWS name = bar
+```
+
+It must not add historical labels referring to `foo`. If the implementation
+needs to expose this identity to the plugin, it should pass only the minimum
+current rendering context required, such as the current LeaderWorkerSet name.
+
+ControllerRevision stores plugin declaration and configuration, not plugin
+executable code. Built-in plugin implementations should preserve rendering
+compatibility for previously supported configuration semantics. If a plugin
+intentionally introduces incompatible rendering behavior, it should use an
+explicit configuration or behavior version. This proposal does not snapshot
+plugin implementation versions or add a new versioning subsystem.
+
+#### Revisioned, Rendering, and Operational Inputs
+
+The proposal distinguishes three categories:
+
+| Category | Examples | Stored in ControllerRevision | Restored by rollback | Can trigger workload replacement |
+| --- | --- | --- | --- | --- |
+| Revisioned workload inputs | Role identity and membership, Role entry and worker templates, `workerReplicas`, applicable `PluginSpec` chain | Yes | Yes | Yes |
+| Current rendering inputs | `schedulerName`, current owning LWS identity, explicitly supported current rendering context | No | No | Yes, when the final Pod/workload changes |
+| Operational/control inputs | ModelServing/Role `replicas`, `rolloutStrategy`, `partition`, `maxUnavailable`, `maxSurge`, `recoveryPolicy`, `restartGracePeriodSeconds`, `gangPolicy`, `networkTopology` | No | No | Only when their semantics directly require it; normally they control reconciliation rather than workload identity |
+
+The controller should reason about the effective workload as:
+
+```text
+EffectiveRendering =
+    RevisionedWorkloadInputs
+  + CurrentRenderingInputs
+```
+
+A workload is outdated when its effective rendered workload differs from the
+currently desired effective rendered workload. This rule intentionally differs
+from requiring outdated-workload detection to use exactly the same fields as
+revision data: `schedulerName` and current LWS identity can be outside the
+revision while still requiring replacement when they change the rendered
+workload. The exact comparison or hashing implementation is implementation
+specific.
+
+Operational fields control capacity, rollout progression, recovery, or
+scheduling policy. They are preserved when rollback changes the workload
+version and normally affect reconciliation rather than revision identity.
 
 #### Applying a Revision
 
-Applying a revision restores revisioned fields and preserves operational
-fields from the current ModelServing.
+Applying revision R restores only the revisioned workload definition and
+preserves current non-revisioned values.
 
-- ModelServing replicas remain unchanged.
-- A Role present in both specs keeps its current replicas and list position.
-- A Role restored from history uses the API default replicas value of `1` and
-  is appended in canonical name order after Roles retained from the current
-  spec.
-- A current Role absent from the target revision is removed.
+Preserve:
+
+```text
+- ModelServing replicas
+- Role replicas
+- schedulerName
+- rolloutStrategy
+- maxUnavailable
+- maxSurge
+- partition
+- recoveryPolicy
+- restartGracePeriodSeconds
+- gangPolicy
+- networkTopology
+- live OwnerReferences
+```
+
+Restore:
+
+```text
+- Role membership and identity
+- Role entry and worker Pod templates
+- workerReplicas
+- plugins
+```
+
+For a Role present in both the current spec and revision R, its current
+operational replica count and list position are preserved. A Role restored from
+history that is absent from the current spec may use the existing documented
+default replica behavior (currently `1`) and is appended in canonical name
+order after retained Roles. A current Role absent from R is removed.
 
 The resulting spec must still satisfy current API validation. In particular,
-an operational `gangPolicy` can prevent removal of a Role referenced by
-`minRoleReplicas`; the CLI rejects such a rollback without changing the
+the current operational `gangPolicy` can prevent removal of a Role referenced
+by `minRoleReplicas`; the CLI rejects such a rollback without changing the
 ModelServing.
 
-When a workload is created or recovered for revision R, all revisioned fields,
-including `schedulerName`, `plugins`, and Role templates, come from R, while
-operational fields come from the current ModelServing. This also applies to
-partition-protected recovery. Role replicas therefore come from the current
-spec, replacing the current behavior that restores them from revision data.
+Rollback restores only the workload definition; all non-revisioned fields stay
+current. The controller then renders the restored definition using the current
+context.
+
+#### Effective Rendering and Outdated Workloads
+
+The controller must apply the effective-rendering rule in both
+`ServingGroupRollingUpdate` and `RoleRollingUpdate`:
+
+1. Select the revisioned workload definition for the workload being created or
+   recovered.
+2. Combine it with current rendering inputs.
+3. Construct the desired effective workload using the current controller and
+   plugin implementations.
+4. Compare the desired effective workload with the existing workload.
+5. Replace or update the workload when the rollout strategy requires it.
+
+For `RoleRollingUpdate`, the per-Role comparison must use that Role's
+revisioned definition and only its applicable plugin chain. A change to a
+plugin scoped only to `prefill` must not make a `decode` workload outdated.
+Operational fields remain available to the rollout and reconciliation logic,
+but do not become revision identity merely because they influence capacity or
+progression.
+
+The contract is about the effective workload selected by the current
+implementation. A plugin hook is not required to reproduce the output of an
+older controller or plugin implementation, and an old Pod is not guaranteed to
+be reproduced after controller, plugin, scheduler integration, owner context,
+or other runtime behavior changes.
+
+#### Rollback and Recovery
+
+Historical recovery restores the workload definition represented by revision R
+and then renders it under the current context:
+
+```text
+recover revision R
+    ↓
+load revisioned Role/plugin definition from R
+    ↓
+combine with current scheduler/runtime/owner context
+    ↓
+construct desired Pod or workload
+```
+
+A recovered historical Role can therefore use the current scheduler and can
+receive labels derived from the current LWS owner. That is expected behavior.
+Historical scheduler or owner metadata is not required for recovery and must
+not be treated as part of the recovery contract.
+
+Revision references required for partition-protected workloads must survive
+Pod deletion and controller restart. The controller must be able to determine
+which historical workload revision a protected workload should use even when
+the Pod and in-memory store are gone. After that revision is selected, the
+replacement workload is rendered with the current rendering context; this
+requirement does not depend on historical scheduler or owner metadata.
 
 #### Revision Lifecycle
 
-For each desired workload, the controller builds a candidate revision with:
+For each desired workload, the controller builds a candidate revision from the
+revisioned workload inputs only:
 
 ```text
 nextRevision = max(history.Revision) + 1
@@ -150,13 +434,16 @@ It then follows the StatefulSet revision lifecycle:
 3. Otherwise, create a new ControllerRevision.
 
 Only the numeric `Revision` is updated when an older revision is reused; its
-name and Data remain unchanged. For example:
+name and immutable Data remain unchanged. For example:
 
 ```text
 A(revision=1) -> B(revision=2) -> C(revision=3)
 rollback to A
 A's ControllerRevision is reused with revision=4
 ```
+
+Changes only to current rendering inputs do not create a revision. They can
+still make effective workloads outdated and require replacement.
 
 Hash collisions are handled with a collision count stored in
 `ModelServingStatus`:
@@ -186,10 +473,9 @@ The limit applies to non-live history. Revisions referenced by
 do not count toward the limit. Non-live revisions are deleted from oldest to
 newest until at most `revisionHistoryLimit` remain.
 
-Revision references required for partition-protected recovery must survive Pod
-deletion and controller restart, and remain live until the replacement is
-created. GC therefore cannot rely only on existing Pod labels or the
-controller's in-memory store.
+The revision references required for partition-protected recovery remain live
+until the replacement is created. Garbage collection therefore cannot rely
+only on existing Pod labels or the controller's in-memory store.
 
 #### Compatibility
 
@@ -208,13 +494,42 @@ distinguished from the legacy wrapped Role list.
 - CLI history and rollback only guarantee revisions in the new format.
 - Legacy revision Data is not rewritten or renumbered and is removed through
   normal history retention once it is no longer live.
+- Built-in plugins should preserve the rendering semantics of previously
+  supported configurations; intentionally incompatible behavior requires an
+  explicit plugin configuration or behavior version.
 
 #### Test Plan
 
-The implementation will add unit and end-to-end coverage for revision
-lifecycle, rollback, retention, and compatibility behavior.
+The implementation will add unit and end-to-end coverage for:
+
+- deterministic allowlist projection, canonical JSON configuration, role-scope
+  normalization, and preserved plugin order;
+- equivalent revision reuse, immutable Data, monotonic numbers, collision
+  handling, retention, live-revision protection, and legacy compatibility;
+- rollback restoring Role/plugin definitions while preserving all current
+  operational fields, including `schedulerName`, `maxSurge`, and live owner
+  relationships;
+- scheduler changes causing replacement without creating historical scheduler
+  data;
+- RoleRollingUpdate filtering plugin identity by Role applicability;
+- protected recovery after Pod deletion and controller restart using the
+  selected historical revision with current scheduler and owner context;
+- LWS label rendering using the current owning LWS rather than a historical
+  owner; and
+- plugin implementation compatibility expectations for previously supported
+  configuration semantics.
 
 ### Alternatives
+
+#### Snapshot every rendering input
+
+Including scheduler settings, OwnerReferences, controller bookkeeping, and all
+live ModelServing fields in every revision could make a historical Pod appear
+more reproducible. It would also couple revision history to operational state,
+arbitrary plugin reads, and implementation details that cannot be reliably
+restored. It expands the revision every time a controller integration reads a
+new field and still cannot snapshot executable plugin behavior. This proposal
+keeps the revision at the workload declaration boundary instead.
 
 #### Append-only rollback history
 
@@ -235,3 +550,9 @@ Keeping the legacy revision active while recording equivalent v1 data would
 require a persistent compatibility baseline or alias and special reconciliation
 and GC rules. This was rejected in favor of a one-time rollout through the
 normal revision lifecycle.
+
+### Scope
+
+This PR changes only this design proposal. Runtime changes are intentionally
+out of scope and should be reviewed separately against the simplified
+revision/current-rendering contract.

--- a/docs/proposal/modelserving-revision-history-and-rollback.md
+++ b/docs/proposal/modelserving-revision-history-and-rollback.md
@@ -20,10 +20,10 @@ rollback. A `ControllerRevision` stores the versioned workload declaration that
 should be restored by rollback. It does not attempt to snapshot every input
 that can affect the final rendered Pod.
 
-Rollback restores the versioned workload declaration, and the controller then
-uses the current operational values and live object context while constructing
-the workload. The proposal does not promise bit-for-bit or field-for-field
-reproduction of the Pod that existed when a revision was created.
+Rollback restores the versioned workload declaration while preserving current
+operational fields and live object metadata such as OwnerReferences. The
+proposal does not promise bit-for-bit or field-for-field reproduction of the
+Pod that existed when a revision was created.
 
 ### Motivation
 
@@ -57,8 +57,6 @@ make a small, explicit revision boundary necessary.
 - A separate rollback state machine.
 - Rollback of an individual Role.
 - Guaranteed CLI rollback to legacy revisions.
-- Runtime implementation changes in this documentation PR; those are reviewed
-  separately in #1767.
 
 ### Proposal
 
@@ -98,8 +96,8 @@ overwritten.
 
 #### Revision Data
 
-`ControllerRevision.Data` contains a deterministic strategic merge patch with
-only explicitly selected workload-definition fields. `BuildRevisionData`
+`ControllerRevision.Data` contains a deterministic serialized projection of the
+revisioned fields. `BuildRevisionData`
 constructs this projection from an allowlist; it must not copy the API object
 and remove known operational fields. API defaults and nil/empty values are
 normalized before serialization.
@@ -297,9 +295,6 @@ distinguished from the legacy wrapped Role list.
 - CLI history and rollback only guarantee revisions in the new format.
 - Legacy revision Data is not rewritten or renumbered and is removed through
   normal history retention once it is no longer live.
-- Built-in plugins should preserve previously supported configuration
-  semantics; incompatible behavior should use an explicit configuration or
-  behavior version.
 
 #### Test Plan
 

--- a/docs/proposal/modelserving-revision-history-and-rollback.md
+++ b/docs/proposal/modelserving-revision-history-and-rollback.md
@@ -16,22 +16,14 @@ creation-date: 2026-08-13
 ### Summary
 
 This proposal makes ModelServing revisions stable, retained, and usable for
-rollback. It aligns the revision lifecycle with Kubernetes StatefulSet and the
-general RBG model: historical workload definition is versioned, while the
-current controller and runtime context is used to construct the desired
-workload.
+rollback. A `ControllerRevision` stores the versioned workload declaration that
+should be restored by rollback. It does not attempt to snapshot every input
+that can affect the final rendered Pod.
 
-The central contract is:
-
-> A `ControllerRevision` stores the versioned workload declaration that should
-> be restored by rollback. It does not snapshot every input that can affect the
-> final rendered Pod.
-
-Revision identity is the versioned user workload declaration. A desired
-workload is produced by combining that declaration with the current rendering
-context. Rollback restores the declaration only. It does not promise bit-for-
-bit or field-for-field reproduction of the Pod that existed when the revision
-was created.
+Rollback restores the versioned workload declaration, and the controller then
+uses the current operational values and live object context while constructing
+the workload. The proposal does not promise bit-for-bit or field-for-field
+reproduction of the Pod that existed when a revision was created.
 
 ### Motivation
 
@@ -41,31 +33,27 @@ as Role scaling can therefore keep the same hash while changing the stored
 data. In addition, revision numbers do not form a history and completed
 revisions are removed.
 
-These behaviors prevent reliable recovery of an earlier desired workload. The
-design also needs a clear boundary so that every new controller or plugin input
-does not silently become historical revision data.
+These behaviors prevent reliable recovery of an earlier desired workload and
+make a small, explicit revision boundary necessary.
 
 #### Goals
 
-- Define revision identity as a small, explicit workload declaration.
-- Build deterministic revision data and its identity from the same allowlisted
+- Define revision identity as the versioned user workload declaration.
+- Build deterministic revision data and its hash from the same allowlisted
   projection.
 - Keep revision data immutable, reuse equivalent revisions, and make revision
   numbers monotonic.
 - Retain recent history without deleting revisions used by live workloads.
-- Restore a historical workload definition through the existing rollout
+- Restore a historical workload declaration through the existing rollout
   strategies.
-- Preserve current capacity, scheduling, ownership, and rollout policies during
-  rollback.
-- Define plugin rendering dependencies without snapshotting arbitrary live
-  ModelServing state or plugin implementation details.
+- Preserve current operational values during rollback.
 
 #### Non-Goals
 
 - Bit-for-bit reproduction of a historical Pod.
-- A revision of every input that can affect final Pod rendering.
-- Snapshotting `OwnerReferences`, plugin executable code, or implementation
-  versions in `ControllerRevision.Data`.
+- Snapshotting every input that can affect final Pod rendering.
+- Snapshotting `OwnerReferences` in `ControllerRevision.Data` or revision
+  identity.
 - A separate rollback state machine.
 - Rollback of an individual Role.
 - Guaranteed CLI rollback to legacy revisions.
@@ -74,47 +62,10 @@ does not silently become historical revision data.
 
 ### Proposal
 
-ModelServing will record the versioned workload declaration before scale and
-rollout reconciliation. This also records template changes when `replicas` is
-zero.
+ModelServing records a workload revision before scale and rollout
+reconciliation. This also records template changes when `replicas` is zero.
 
-The semantic model is:
-
-```text
-revision
-    = versioned user workload declaration
-
-desired workload
-    = historical/current revisioned workload definition
-    + current rendering context
-```
-
-The resulting flow is:
-
-```text
-ControllerRevision
-    |
-    | historical workload declaration
-    v
-Roles / templates / workerReplicas / plugins
-    |
-    + current scheduler / current owner context / current controller behavior
-    v
-desired workload
-    |
-    v
-compare with existing workload
-    |
-    v
-replace or update when effective rendering differs
-```
-
-The current rendering context may include the current scheduler configuration,
-the current owning LWS identity when a plugin needs it, Pod and Role identity,
-and the behavior of the current controller and plugin implementations. These
-inputs are deliberately not historical revision data.
-
-The CLI will expose revision history and rollback:
+The CLI exposes revision history and rollback:
 
 ```bash
 kthena rollout history modelserving <name>
@@ -126,11 +77,18 @@ The CLI reads the selected `ControllerRevision` and applies its revisioned
 fields to `ModelServing.spec`. The controller then handles the resulting change
 as a normal `ServingGroupRollingUpdate` or `RoleRollingUpdate`.
 
-Both rollout strategies must replace a workload when a change to its effective
-rendered workload requires replacement. The comparison is not required to use
-exactly the same inputs as `ControllerRevision.Data`, because current rendering
-inputs intentionally live outside the revision. The concrete comparison or
-hashing mechanism remains an implementation detail of each strategy.
+Kthena's rollout is revision-gated: `manageRollingUpdate` first identifies
+outdated ServingGroups using `ServingGroup.Revision != desiredRevision`, and
+Role-level outdated comparison happens after a group enters that path. This
+proposal therefore does not add another rendering hash, generation, or
+independent semantic-comparison mechanism.
+
+Both rollout strategies must treat a change to any revisioned field applicable
+to a workload as an update. Under `RoleRollingUpdate`, the comparison must
+include ModelServing-level revisioned fields applicable to the Role, that
+Role's revisioned definition, and the applicable plugin chain, using the same
+canonical normalization as revision data. The concrete comparison or hashing
+mechanism remains an implementation detail.
 
 The CLI retries conflicts by reading the latest ModelServing and reapplying the
 revisioned fields, so concurrent changes to operational fields are not
@@ -140,24 +98,24 @@ overwritten.
 
 #### Revision Data
 
-`ControllerRevision.Data` will contain a deterministic strategic merge patch
-with only explicitly selected workload-definition fields. `BuildRevisionData`
+`ControllerRevision.Data` contains a deterministic strategic merge patch with
+only explicitly selected workload-definition fields. `BuildRevisionData`
 constructs this projection from an allowlist; it must not copy the API object
 and remove known operational fields. API defaults and nil/empty values are
 normalized before serialization.
 
-The revisioned workload inputs are:
+Revisioned fields are:
 
 ```text
-- Role identity and membership
-- Role entry template
-- Role worker template
-- workerReplicas
+- schedulerName
 - plugins
+- Role identity and membership
+- Role entryTemplate
+- Role workerTemplate
+- workerReplicas
 ```
 
-`plugins` remains revisioned for now. The entire `PluginSpec` participates in
-the revision identity:
+The full `PluginSpec` participates in revision identity:
 
 ```text
 - name
@@ -167,266 +125,118 @@ the revision identity:
 - plugin list order
 ```
 
-This is required because plugin configuration is explicitly supplied by the
-user as part of the workload declaration, `OnPodCreate` plugins may mutate the
-Pod, and plugin order is semantically significant: a later plugin can observe
-or overwrite an earlier mutation. The current plugin API does not declare
-which plugins or configuration fields affect Pod rendering, so this proposal
-does not introduce plugin-specific revision metadata.
+Plugin configuration is a user-supplied workload declaration, and
+`OnPodCreate` may mutate Pods. The current plugin API does not declare which
+plugins or configuration fields affect Pod rendering, so this proposal does
+not introduce plugin-specific revision metadata.
 
-Canonicalization is still required:
+Canonicalization is required for opaque JSON `config` and unordered
+`scope.roles`. Plugin list order is preserved because hook execution order is
+semantically significant. Roles are stored in canonical name order, so
+reordering otherwise identical Roles does not create a revision.
 
-- Opaque JSON `config` is canonicalized before hashing and serialization.
-- `scope.roles` is canonicalized because role-list order has no semantic
-  meaning.
-- Plugin list order is preserved because execution order is significant.
-- Roles are stored in canonical name order, so reordering otherwise identical
-  Roles does not create a revision.
+Under `RoleRollingUpdate`, only plugins applicable to the specific Role
+participate in that Role's outdated-workload comparison. A plugin scoped only to
+`prefill` must not make `decode` outdated. The applicable plugins retain their
+relative order from the ModelServing plugin list.
 
-For `RoleRollingUpdate`, only plugins applicable to the specific Role
-participate in that Role's workload identity. A plugin scoped only to `prefill`
-must not make `decode` outdated. A plugin with no role restriction applies to
-each applicable Role, and the relative order of the applicable plugins remains
-the order in the ModelServing plugin list.
+The serialized patch is used unchanged as `ControllerRevision.Data.Raw` and as
+the primary hash input. `ControllerRevision.Data` is immutable after creation.
+Changes to any revisioned field, including `schedulerName`, therefore produce
+a new desired revision identity or reuse an equivalent historical revision and
+enter the normal revision-driven rollout path.
 
-Revision membership uses replace semantics so applying a revision can remove
-Roles and plugins added after that revision. `ApplyRevision` preserves the
-operational Role properties described below while restoring the plugin chain
-represented by the revision. The serialized patch is used unchanged as
-`ControllerRevision.Data.Raw` and as the primary revision identity input.
+#### Operational Fields
 
-`ControllerRevision.Data` is immutable after creation. The revision identity is
-used in the ControllerRevision name, ModelServing status, and workload labels.
-Changes to current rendering inputs do not create a new ControllerRevision;
-they are handled by effective-rendering comparison and reconciliation.
-
-#### Current Rendering Context and Plugin Contract
-
-`schedulerName` is a current rendering input, not a revisioned field. The
-controller uses the current scheduler configuration when constructing Pods.
-Changing `schedulerName` must still make workloads whose final Pod
-`schedulerName` changes outdated and cause replacement.
-
-For example:
+The following fields are operational and are not stored in
+`ControllerRevision.Data`:
 
 ```text
-revision A:
-  image = v1
-
-revision B:
-  image = v2
-
-current schedulerName:
-  new-scheduler
-
-rollback B -> A
-```
-
-The resulting workload is:
-
-```text
-image = v1
-schedulerName = new-scheduler
-```
-
-It must not restore the scheduler that happened to be configured when revision
-A was created.
-
-The current plugin API exposes the whole ModelServing object through
-`HookRequest.ModelServing`. That shape is an implementation compatibility
-detail, not a promise that arbitrary live ModelServing fields are part of the
-historical rendering contract. The intended semantic rule is:
-
-> `OnPodCreate` workload mutation should depend only on the plugin
-> declaration/configuration, Pod and Role identity, and explicitly supported
-> current rendering context.
-
-Plugins must not rely on arbitrary live fields such as:
-
-```text
-- ModelServing status
+- ModelServing replicas
+- Role replicas
 - rolloutStrategy
-- replicas
-- unrelated Roles
-- controller revision bookkeeping labels
-- PodGroup operational annotations
-- arbitrary external mutable state
+- partition
+- maxUnavailable
+- maxSurge
+- recoveryPolicy
+- restartGracePeriodSeconds
+- gangPolicy
+- networkTopology
 ```
 
-If a plugin requires runtime context, that context must be explicitly defined
-and supplied as current rendering context. A synthetic partial ModelServing
-object may be used temporarily for compatibility, but this proposal defines
-the semantic dependency contract rather than standardizing that workaround as
-the long-term API model.
+They control capacity, rollout progression, recovery, or scheduling policy;
+rollback preserves them and they normally affect reconciliation rather than
+revision identity.
 
-OwnerReferences are live object-relationship metadata, not part of the
-historical workload declaration. They must not be stored in revision data or
-included in the revision identity. In particular, do not add a historical
-owner-reference field or store historical APIVersion, Kind, Name, UID,
-`controller`, or `blockOwnerDeletion` values for plugin rendering. The
-`ControllerRevision` object's own live metadata may still use the ownership
-needed for its lifecycle; that metadata is not revision data and must not be
-passed to a plugin as historical context.
-
-This matters for the built-in `lws-standard-labels` plugin. It derives labels
-from the current owning LeaderWorkerSet. If revision A was originally owned by
-LWS `foo`, but the current ModelServing is later owned by LWS `bar`, recovery
-of revision A must use the current LWS identity:
-
-```text
-LWS name = bar
-```
-
-It must not add historical labels referring to `foo`. If the implementation
-needs to expose this identity to the plugin, it should pass only the minimum
-current rendering context required, such as the current LeaderWorkerSet name.
-
-ControllerRevision stores plugin declaration and configuration, not plugin
-executable code. Built-in plugin implementations should preserve rendering
-compatibility for previously supported configuration semantics. If a plugin
-intentionally introduces incompatible rendering behavior, it should use an
-explicit configuration or behavior version. This proposal does not snapshot
-plugin implementation versions or add a new versioning subsystem.
-
-#### Revisioned, Rendering, and Operational Inputs
-
-The proposal distinguishes three categories:
-
-| Category | Examples | Stored in ControllerRevision | Restored by rollback | Can trigger workload replacement |
-| --- | --- | --- | --- | --- |
-| Revisioned workload inputs | Role identity and membership, Role entry and worker templates, `workerReplicas`, applicable `PluginSpec` chain | Yes | Yes | Yes |
-| Current rendering inputs | `schedulerName`, current owning LWS identity, explicitly supported current rendering context | No | No | Yes, when the final Pod/workload changes |
-| Operational/control inputs | ModelServing/Role `replicas`, `rolloutStrategy`, `partition`, `maxUnavailable`, `maxSurge`, `recoveryPolicy`, `restartGracePeriodSeconds`, `gangPolicy`, `networkTopology` | No | No | Only when their semantics directly require it; normally they control reconciliation rather than workload identity |
-
-The controller should reason about the effective workload as:
-
-```text
-EffectiveRendering =
-    RevisionedWorkloadInputs
-  + CurrentRenderingInputs
-```
-
-A workload is outdated when its effective rendered workload differs from the
-currently desired effective rendered workload. This rule intentionally differs
-from requiring outdated-workload detection to use exactly the same fields as
-revision data: `schedulerName` and current LWS identity can be outside the
-revision while still requiring replacement when they change the rendered
-workload. The exact comparison or hashing implementation is implementation
-specific.
-
-Operational fields control capacity, rollout progression, recovery, or
-scheduling policy. They are preserved when rollback changes the workload
-version and normally affect reconciliation rather than revision identity.
+`networkTopology` remains operational: changing it updates the PodGroup and
+SubGroupPolicy but does not relocate existing Pods. The new policy applies to
+subsequent scheduling and recovery. In contrast, `schedulerName` is revisioned
+and requires the affected Pods to be replaced when it changes.
 
 #### Applying a Revision
 
-Applying revision R restores only the revisioned workload definition and
-preserves current non-revisioned values.
+Applying revision R restores all revisioned fields and preserves current
+operational fields.
 
 Preserve:
 
 ```text
 - ModelServing replicas
 - Role replicas
-- schedulerName
 - rolloutStrategy
+- partition
 - maxUnavailable
 - maxSurge
-- partition
 - recoveryPolicy
 - restartGracePeriodSeconds
 - gangPolicy
 - networkTopology
-- live OwnerReferences
+- live object metadata and OwnerReferences
 ```
 
 Restore:
 
 ```text
-- Role membership and identity
-- Role entry and worker Pod templates
-- workerReplicas
+- schedulerName
 - plugins
+- Role membership and identity
+- Role entryTemplate and workerTemplate
+- workerReplicas
 ```
 
 For a Role present in both the current spec and revision R, its current
-operational replica count and list position are preserved. A Role restored from
-history that is absent from the current spec may use the existing documented
-default replica behavior (currently `1`) and is appended in canonical name
-order after retained Roles. A current Role absent from R is removed.
+operational replica count and list position are preserved. A restored Role that
+is absent from the current spec may use the documented default replica behavior
+(currently `1`) and is appended in canonical name order; a current Role absent
+from R is removed.
 
 The resulting spec must still satisfy current API validation. In particular,
-the current operational `gangPolicy` can prevent removal of a Role referenced
-by `minRoleReplicas`; the CLI rejects such a rollback without changing the
+the current `gangPolicy` can prevent removal of a Role referenced by
+`minRoleReplicas`; the CLI rejects such a rollback without changing the
 ModelServing.
 
-Rollback restores only the workload definition; all non-revisioned fields stay
-current. The controller then renders the restored definition using the current
-context.
+OwnerReferences are live object-relationship metadata, not part of the
+historical workload declaration. They must not be stored in revision data or
+included in revision identity, and historical ownership metadata is not
+restored. If the `lws-standard-labels` plugin needs ownership information when
+creating a Pod, it may use the current ModelServing ownership context.
 
-#### Effective Rendering and Outdated Workloads
-
-The controller must apply the effective-rendering rule in both
-`ServingGroupRollingUpdate` and `RoleRollingUpdate`:
-
-1. Select the revisioned workload definition for the workload being created or
-   recovered.
-2. Combine it with current rendering inputs.
-3. Construct the desired effective workload using the current controller and
-   plugin implementations.
-4. Compare the desired effective workload with the existing workload.
-5. Replace or update the workload when the rollout strategy requires it.
-
-For `RoleRollingUpdate`, the per-Role comparison must use that Role's
-revisioned definition and only its applicable plugin chain. A change to a
-plugin scoped only to `prefill` must not make a `decode` workload outdated.
-Operational fields remain available to the rollout and reconciliation logic,
-but do not become revision identity merely because they influence capacity or
-progression.
-
-The contract is about the effective workload selected by the current
-implementation. A plugin hook is not required to reproduce the output of an
-older controller or plugin implementation, and an old Pod is not guaranteed to
-be reproduced after controller, plugin, scheduler integration, owner context,
-or other runtime behavior changes.
-
-#### Rollback and Recovery
-
-Historical recovery restores the workload definition represented by revision R
-and then renders it under the current context:
-
-```text
-recover revision R
-    ↓
-load revisioned Role/plugin definition from R
-    ↓
-combine with current scheduler/runtime/owner context
-    ↓
-construct desired Pod or workload
-```
-
-A recovered historical Role can therefore use the current scheduler and can
-receive labels derived from the current LWS owner. That is expected behavior.
-Historical scheduler or owner metadata is not required for recovery and must
-not be treated as part of the recovery contract.
-
-Revision references required for partition-protected workloads must survive
-Pod deletion and controller restart. The controller must be able to determine
-which historical workload revision a protected workload should use even when
-the Pod and in-memory store are gone. After that revision is selected, the
-replacement workload is rendered with the current rendering context; this
-requirement does not depend on historical scheduler or owner metadata.
+Partition-protected recovery uses the selected historical revision for the
+workload definition, then follows the same rollout and Pod construction path.
+Revision references required for this recovery must survive Pod deletion and
+controller restart; garbage collection cannot rely only on existing Pod labels
+or the controller's in-memory store.
 
 #### Revision Lifecycle
 
 For each desired workload, the controller builds a candidate revision from the
-revisioned workload inputs only:
+revisioned fields only:
 
 ```text
 nextRevision = max(history.Revision) + 1
 ```
 
-It then follows the StatefulSet revision lifecycle:
+It then follows this lifecycle:
 
 1. If the candidate equals the latest revision, reuse the latest revision.
 2. If it equals an older revision, reuse that ControllerRevision and advance
@@ -441,9 +251,6 @@ A(revision=1) -> B(revision=2) -> C(revision=3)
 rollback to A
 A's ControllerRevision is reused with revision=4
 ```
-
-Changes only to current rendering inputs do not create a revision. They can
-still make effective workloads outdated and require replacement.
 
 Hash collisions are handled with a collision count stored in
 `ModelServingStatus`:
@@ -473,13 +280,9 @@ The limit applies to non-live history. Revisions referenced by
 do not count toward the limit. Non-live revisions are deleted from oldest to
 newest until at most `revisionHistoryLimit` remain.
 
-The revision references required for partition-protected recovery remain live
-until the replacement is created. Garbage collection therefore cannot rely
-only on existing Pod labels or the controller's in-memory store.
-
 #### Compatibility
 
-New revisions will carry the annotation
+New revisions carry the annotation
 `modelserving.volcano.sh/revision-data-version: "v1"` so they can be
 distinguished from the legacy wrapped Role list.
 
@@ -494,65 +297,14 @@ distinguished from the legacy wrapped Role list.
 - CLI history and rollback only guarantee revisions in the new format.
 - Legacy revision Data is not rewritten or renumbered and is removed through
   normal history retention once it is no longer live.
-- Built-in plugins should preserve the rendering semantics of previously
-  supported configurations; intentionally incompatible behavior requires an
-  explicit plugin configuration or behavior version.
+- Built-in plugins should preserve previously supported configuration
+  semantics; incompatible behavior should use an explicit configuration or
+  behavior version.
 
 #### Test Plan
 
-The implementation will add unit and end-to-end coverage for:
-
-- deterministic allowlist projection, canonical JSON configuration, role-scope
-  normalization, and preserved plugin order;
-- equivalent revision reuse, immutable Data, monotonic numbers, collision
-  handling, retention, live-revision protection, and legacy compatibility;
-- rollback restoring Role/plugin definitions while preserving all current
-  operational fields, including `schedulerName`, `maxSurge`, and live owner
-  relationships;
-- scheduler changes causing replacement without creating historical scheduler
-  data;
-- RoleRollingUpdate filtering plugin identity by Role applicability;
-- protected recovery after Pod deletion and controller restart using the
-  selected historical revision with current scheduler and owner context;
-- LWS label rendering using the current owning LWS rather than a historical
-  owner; and
-- plugin implementation compatibility expectations for previously supported
-  configuration semantics.
-
-### Alternatives
-
-#### Snapshot every rendering input
-
-Including scheduler settings, OwnerReferences, controller bookkeeping, and all
-live ModelServing fields in every revision could make a historical Pod appear
-more reproducible. It would also couple revision history to operational state,
-arbitrary plugin reads, and implementation details that cannot be reliably
-restored. It expands the revision every time a controller integration reads a
-new field and still cannot snapshot executable plugin behavior. This proposal
-keeps the revision at the workload declaration boundary instead.
-
-#### Append-only rollback history
-
-Creating another ControllerRevision whenever old content becomes desired would
-preserve every transition as a separate object. This was rejected because it
-duplicates revision data and diverges from the StatefulSet lifecycle. Reusing
-an equivalent revision also preserves the existing `<name>-<hash>` identity.
-
-#### Controller-managed rollback state
-
-Adding a rollback request to the API would require separate rollback state and
-completion handling. Updating the desired spec through the CLI keeps rollback
-declarative and reuses the existing rollout implementation.
-
-#### Zero-rollout legacy migration
-
-Keeping the legacy revision active while recording equivalent v1 data would
-require a persistent compatibility baseline or alias and special reconciliation
-and GC rules. This was rejected in favor of a one-time rollout through the
-normal revision lifecycle.
-
-### Scope
-
-This PR changes only this design proposal. Runtime changes are intentionally
-out of scope and should be reviewed separately against the simplified
-revision/current-rendering contract.
+The implementation will add unit and end-to-end coverage for revision
+projection and canonicalization, plugin ordering and Role applicability,
+revision lifecycle and collision handling, retention and legacy compatibility,
+rollback preservation of operational fields, scheduler-driven rollout, and
+partition-protected recovery after Pod deletion or controller restart.


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement
/kind documentation

**What this PR does / why we need it**:

Proposes a StatefulSet-aligned design for stable ModelServing revision history and CLI-driven rollback. It defines revision data, lifecycle, rollback semantics, history retention, and legacy compatibility.

**Which issue(s) this PR fixes**:
Refs #1584

**Bug evidence (required for bug-related PRs)**:
N/A

**Special notes for your reviewer**:

This is a design proposal only and does not change runtime behavior.

This PR was written in part with the assistance of generative AI.

Validated with `git show --check HEAD`.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
