### PR TITLE
docs: add gpu-free-quick-start.md

### DIFF
--- a/docs/kthena/docs/getting-started/gpu-free-quick-start.md
+++ b/docs/kthena/docs/getting-started/gpu-free-quick-start.md
@@ -4,73 +4,18 @@ sidebar_position: 3
 
 # GPU-Free Quick Start
 
-Evaluate Kthena end to end on a Kubernetes cluster **without GPUs or NPUs**.
-
-This guide deploys a mock inference backend that mimics the vLLM API, exposes it
-through Kthena's `ModelServer` and `ModelRoute` resources, and sends a test inference
-request through the Kthena router. Everything runs on CPU-only nodes, so it works on a
-laptop or in CI.
-
-The steps below are platform-neutral. They were tested on a [Kind](https://kind.sigs.k8s.io/)
-cluster, but the same workflow applies to Minikube, Docker Desktop Kubernetes, CI
-clusters, and any other CPU-only Kubernetes environment.
+Try out Kthena on a Kubernetes cluster **without GPUs or NPUs**! This guide deploys a
+mock inference backend that mimics the vLLM API, exposes it through a `ModelServer` and
+a `ModelRoute`, and sends a test inference request through the Kthena router.
 
 ## Prerequisites
 
-- A running Kubernetes cluster (version 1.20 or later) with no GPU required.
-  For a local cluster with Kind:
+- A CPU-only Kubernetes cluster, such as a local [Kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) cluster
+- Kthena installed on your Kubernetes cluster (see [Installation](./installation.md))
+- Access to a Kubernetes cluster with `kubectl` configured
+- Pod in Kubernetes can access the internet
 
-  ```bash
-  kind create cluster --name kthena-demo
-  ```
-
-- `kubectl` configured to access the cluster
-- `helm` (version 3.0 or later)
-- Kthena installed on the cluster — see [Installation](./installation.md). The quickest
-  path:
-
-  ```bash
-  helm install kthena oci://ghcr.io/volcano-sh/charts/kthena --version v1.0.0 --namespace kthena-system --create-namespace
-  ```
-
-- [Volcano](https://volcano.sh/en/docs/installation/) installed if you plan to explore
-  `ModelServing` workloads afterwards. It is **not required** for this guide: the mock
-  backend is a plain Kubernetes `Deployment` scheduled by the default scheduler.
-
-## Step 1: Verify Kthena Components and CRDs
-
-Check that the control plane components are running:
-
-```bash
-kubectl get pods -n kthena-system
-```
-
-Expected output (names will vary):
-
-```text
-NAME                                        READY   STATUS    RESTARTS   AGE
-kthena-controller-manager-xxxxxxxxx-xxxxx   1/1     Running   0          1m
-kthena-router-xxxxxxxxx-xxxxx               1/1     Running   0          1m
-```
-
-Check that the Kthena CRDs are installed:
-
-```bash
-kubectl get crd | grep volcano.sh
-```
-
-Expected output includes the networking and workload CRDs (list from Kthena v1.0.0;
-newer versions may install additional CRDs):
-
-```text
-autoscalingpolicies.workload.serving.volcano.sh
-modelboosters.workload.serving.volcano.sh
-modelroutes.networking.serving.volcano.sh
-modelservers.networking.serving.volcano.sh
-modelservings.workload.serving.volcano.sh
-```
-
-## Step 2: Deploy the Mock Inference Backend
+## Step 1: Deploy the Mock Inference Backend
 
 The repository ships a mock backend that emulates a vLLM server: it exposes the same
 OpenAI-compatible HTTP API and metrics endpoint, but returns simulated responses
@@ -96,7 +41,7 @@ deepseek-r1-1-5b-xxxxxxxxx-xxxxx    1/1     Running   0          1m
 deepseek-r1-1-5b-xxxxxxxxx-xxxxx    1/1     Running   0          1m
 ```
 
-## Step 3: Create the ModelServer and ModelRoute
+## Step 2: Create the ModelServer and ModelRoute
 
 A `ModelServer` tells the router which Pods serve a model (via a workload selector and
 port). A `ModelRoute` declares a routable model name and maps it to one or more
@@ -123,7 +68,7 @@ NAME                                                              AGE
 modelroute.networking.serving.volcano.sh/deepseek-simple          1m
 ```
 
-## Step 4: Port-Forward the Kthena Router
+## Step 3: Port-Forward the Kthena Router
 
 The router Service is of type `LoadBalancer`. On clusters without a load-balancer
 implementation (such as a default Kind cluster) its external IP stays `<pending>`, so
@@ -133,12 +78,18 @@ use a port-forward for local access:
 kubectl port-forward -n kthena-system svc/kthena-router 8080:80
 ```
 
+If port 8080 is already taken on your machine (for example, Podman occupies it by
+default), forward a different local port instead, such as
+`kubectl port-forward -n kthena-system svc/kthena-router 18080:80`, and use that port
+in the next step.
+
 Keep this command running and continue in a second terminal.
 
-## Step 5: Send a Test Inference Request
+## Step 4: Send a Test Inference Request
 
 The `ModelRoute` above registers the model name `deepseek-simple`. Send an
-OpenAI-style completion request through the router:
+OpenAI-style completion request through the router (the current mock image requires
+`max_tokens` and `"stream": true`):
 
 ```bash
 curl -N http://localhost:8080/v1/completions \
@@ -151,10 +102,6 @@ curl -N http://localhost:8080/v1/completions \
         "stream": true
     }'
 ```
-
-Two request fields matter with the current mock image: `max_tokens` is required (the
-mocker needs an explicit output length), and `stream: true` avoids a router/mock
-interaction documented in the troubleshooting section below.
 
 Expected response is a stream of SSE chunks with simulated tokens, ending in `[DONE]`:
 
@@ -173,91 +120,3 @@ Note that the response reports the backend model name
 name `deepseek-simple`: the router matched the `model` field against the `ModelRoute`,
 rewrote it to the `ModelServer`'s base model, picked a ready backend Pod from the
 `ModelServer`'s selector, and forwarded the request.
-
-## Step 6: Troubleshooting and Resource Inspection
-
-**Non-streaming request fails with `"request to all pods failed"` (HTTP 404).** The
-router log (`kubectl logs -n kthena-system deploy/kthena-router`) shows
-`http resp error, http code is 400` for every backend attempt. For non-streaming
-requests the router adds an `include_usage` field to the forwarded request body, and
-strict OpenAI-compatible backends — including current builds of the mock image — reject
-unknown parameters (`Validation: Unsupported parameter(s): include_usage`). Use
-`"stream": true` as shown above. Requests without `max_tokens` fail similarly, with the
-mock returning `max_output_tokens must be specified for mocker`.
-
-**Request returns an error or no route is matched.** Confirm the `model` field in the
-request matches `spec.modelName` of the `ModelRoute`, then inspect the resources:
-
-```bash
-kubectl describe modelroute deepseek-simple
-kubectl describe modelserver deepseek-r1-1-5b
-```
-
-**Router does not pick up backend Pods.** The `ModelServer`'s `workloadSelector` must
-match the Pod labels, and the Pods must be `Ready`:
-
-```bash
-kubectl get pods -l app=deepseek-r1-1-5b -o wide
-```
-
-**Check the router logs.** Routing decisions and configuration errors are visible in
-the router log:
-
-```bash
-kubectl logs -n kthena-system deploy/kthena-router
-```
-
-**Mock Pods stay in `ContainerCreating`.** The mock backend image is hosted on
-`ghcr.io`, and on a slow connection the pull can take a long time — check with
-`kubectl describe pod <pod-name>` (a single `Pulling image ...` event with no error
-means the pull is still in progress). To bypass a slow or blocked in-cluster pull,
-pull the image locally and load it into the cluster (Kind example):
-
-```bash
-docker pull ghcr.io/faust-benchou/dynamo-mocker-vllm:latest
-kind load docker-image ghcr.io/faust-benchou/dynamo-mocker-vllm:latest --name kthena-demo
-```
-
-## Step 7: Cleanup
-
-Remove the demo resources:
-
-```bash
-kubectl delete -f https://raw.githubusercontent.com/volcano-sh/kthena/refs/heads/main/examples/kthena-router/ModelRouteSimple.yaml
-kubectl delete -f https://raw.githubusercontent.com/volcano-sh/kthena/refs/heads/main/examples/kthena-router/ModelServer-ds1.5b.yaml
-kubectl delete -f https://raw.githubusercontent.com/volcano-sh/kthena/refs/heads/main/examples/kthena-router/LLM-Mock-ds1.5b.yaml
-```
-
-Expected output (older kubectl versions omit the `from default namespace` suffix):
-
-```text
-modelroute.networking.serving.volcano.sh "deepseek-simple" deleted from default namespace
-modelserver.networking.serving.volcano.sh "deepseek-r1-1-5b" deleted from default namespace
-deployment.apps "deepseek-r1-1-5b" deleted from default namespace
-```
-
-To remove Kthena and the local cluster entirely:
-
-```bash
-helm uninstall kthena -n kthena-system
-kind delete cluster --name kthena-demo
-```
-
-## Limitations of Mock Inference
-
-The mock backend is for evaluating Kthena's control plane and routing behavior, not
-model quality or performance:
-
-- Responses are canned strings, not real model output; token counts and timings in the
-  response are simulated.
-- Latency, throughput, and KV-cache utilization do not reflect a real inference engine,
-  so load-aware and KV-cache-aware scheduling behave on synthetic metrics only.
-- Engine-specific features such as LoRA adapter loading are only emulated at the API
-  level.
-
-## Next Steps
-
-- Deploy a real model with GPUs following the [Quick Start](./quick-start.md)
-- Explore routing strategies in [Router Routing](../user-guide/router-routing.md)
-- Expose the router through the Gateway API — see
-  [Gateway API Support](../user-guide/gateway-api-support.md)

--- a/docs/kthena/docs/getting-started/gpu-free-quick-start.md
+++ b/docs/kthena/docs/getting-started/gpu-free-quick-start.md
@@ -1,0 +1,263 @@
+---
+sidebar_position: 3
+---
+
+# GPU-Free Quick Start
+
+Evaluate Kthena end to end on a Kubernetes cluster **without GPUs or NPUs**.
+
+This guide deploys a mock inference backend that mimics the vLLM API, exposes it
+through Kthena's `ModelServer` and `ModelRoute` resources, and sends a test inference
+request through the Kthena router. Everything runs on CPU-only nodes, so it works on a
+laptop or in CI.
+
+The steps below are platform-neutral. They were tested on a [Kind](https://kind.sigs.k8s.io/)
+cluster, but the same workflow applies to Minikube, Docker Desktop Kubernetes, CI
+clusters, and any other CPU-only Kubernetes environment.
+
+## Prerequisites
+
+- A running Kubernetes cluster (version 1.20 or later) with no GPU required.
+  For a local cluster with Kind:
+
+  ```bash
+  kind create cluster --name kthena-demo
+  ```
+
+- `kubectl` configured to access the cluster
+- `helm` (version 3.0 or later)
+- Kthena installed on the cluster — see [Installation](./installation.md). The quickest
+  path:
+
+  ```bash
+  helm install kthena oci://ghcr.io/volcano-sh/charts/kthena --version v1.0.0 --namespace kthena-system --create-namespace
+  ```
+
+- [Volcano](https://volcano.sh/en/docs/installation/) installed if you plan to explore
+  `ModelServing` workloads afterwards. It is **not required** for this guide: the mock
+  backend is a plain Kubernetes `Deployment` scheduled by the default scheduler.
+
+## Step 1: Verify Kthena Components and CRDs
+
+Check that the control plane components are running:
+
+```bash
+kubectl get pods -n kthena-system
+```
+
+Expected output (names will vary):
+
+```text
+NAME                                        READY   STATUS    RESTARTS   AGE
+kthena-controller-manager-xxxxxxxxx-xxxxx   1/1     Running   0          1m
+kthena-router-xxxxxxxxx-xxxxx               1/1     Running   0          1m
+```
+
+Check that the Kthena CRDs are installed:
+
+```bash
+kubectl get crd | grep volcano.sh
+```
+
+Expected output includes the networking and workload CRDs (list from Kthena v1.0.0;
+newer versions may install additional CRDs):
+
+```text
+autoscalingpolicies.workload.serving.volcano.sh
+modelboosters.workload.serving.volcano.sh
+modelroutes.networking.serving.volcano.sh
+modelservers.networking.serving.volcano.sh
+modelservings.workload.serving.volcano.sh
+```
+
+## Step 2: Deploy the Mock Inference Backend
+
+The repository ships a mock backend that emulates a vLLM server: it exposes the same
+OpenAI-compatible HTTP API and metrics endpoint, but returns simulated responses
+instead of running a real model — no GPU, no model weights.
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/volcano-sh/kthena/refs/heads/main/examples/kthena-router/LLM-Mock-ds1.5b.yaml
+```
+
+Wait for the mock Pods to become ready:
+
+```bash
+kubectl wait --for=condition=Ready pod -l app=deepseek-r1-1-5b --timeout=180s
+kubectl get pods -l app=deepseek-r1-1-5b
+```
+
+Expected output:
+
+```text
+NAME                                READY   STATUS    RESTARTS   AGE
+deepseek-r1-1-5b-xxxxxxxxx-xxxxx    1/1     Running   0          1m
+deepseek-r1-1-5b-xxxxxxxxx-xxxxx    1/1     Running   0          1m
+deepseek-r1-1-5b-xxxxxxxxx-xxxxx    1/1     Running   0          1m
+```
+
+## Step 3: Create the ModelServer and ModelRoute
+
+A `ModelServer` tells the router which Pods serve a model (via a workload selector and
+port). A `ModelRoute` declares a routable model name and maps it to one or more
+`ModelServer` targets.
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/volcano-sh/kthena/refs/heads/main/examples/kthena-router/ModelServer-ds1.5b.yaml
+kubectl apply -f https://raw.githubusercontent.com/volcano-sh/kthena/refs/heads/main/examples/kthena-router/ModelRouteSimple.yaml
+```
+
+Verify both resources exist:
+
+```bash
+kubectl get modelservers,modelroutes
+```
+
+Expected output:
+
+```text
+NAME                                                              AGE
+modelserver.networking.serving.volcano.sh/deepseek-r1-1-5b        1m
+
+NAME                                                              AGE
+modelroute.networking.serving.volcano.sh/deepseek-simple          1m
+```
+
+## Step 4: Port-Forward the Kthena Router
+
+The router Service is of type `LoadBalancer`. On clusters without a load-balancer
+implementation (such as a default Kind cluster) its external IP stays `<pending>`, so
+use a port-forward for local access:
+
+```bash
+kubectl port-forward -n kthena-system svc/kthena-router 8080:80
+```
+
+Keep this command running and continue in a second terminal.
+
+## Step 5: Send a Test Inference Request
+
+The `ModelRoute` above registers the model name `deepseek-simple`. Send an
+OpenAI-style completion request through the router:
+
+```bash
+curl -N http://localhost:8080/v1/completions \
+    -H "Content-Type: application/json" \
+    -d '{
+        "model": "deepseek-simple",
+        "prompt": "San Francisco is a",
+        "max_tokens": 5,
+        "temperature": 0,
+        "stream": true
+    }'
+```
+
+Two request fields matter with the current mock image: `max_tokens` is required (the
+mocker needs an explicit output length), and `stream: true` avoids a router/mock
+interaction documented in the troubleshooting section below.
+
+Expected response is a stream of SSE chunks with simulated tokens, ending in `[DONE]`:
+
+```text
+data: {"id":"cmpl-4282ab27-171f-4ccf-82a3-adbebc84151a","choices":[{"text":"En","index":0}],"created":1786508011,"model":"deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B","system_fingerprint":null,"object":"text_completion","usage":null}
+
+...
+
+data: {"id":"cmpl-4282ab27-171f-4ccf-82a3-adbebc84151a","choices":[{"text":"","index":0,"finish_reason":"length"}],"created":1786508011,"model":"deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B","system_fingerprint":null,"object":"text_completion","usage":null,"nvext":{"timing":{"request_received_ms":1786508011068,"total_time_ms":54.605582999999996}}}
+
+data: [DONE]
+```
+
+Note that the response reports the backend model name
+(`deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B`) even though the request used the routed
+name `deepseek-simple`: the router matched the `model` field against the `ModelRoute`,
+rewrote it to the `ModelServer`'s base model, picked a ready backend Pod from the
+`ModelServer`'s selector, and forwarded the request.
+
+## Step 6: Troubleshooting and Resource Inspection
+
+**Non-streaming request fails with `"request to all pods failed"` (HTTP 404).** The
+router log (`kubectl logs -n kthena-system deploy/kthena-router`) shows
+`http resp error, http code is 400` for every backend attempt. For non-streaming
+requests the router adds an `include_usage` field to the forwarded request body, and
+strict OpenAI-compatible backends — including current builds of the mock image — reject
+unknown parameters (`Validation: Unsupported parameter(s): include_usage`). Use
+`"stream": true` as shown above. Requests without `max_tokens` fail similarly, with the
+mock returning `max_output_tokens must be specified for mocker`.
+
+**Request returns an error or no route is matched.** Confirm the `model` field in the
+request matches `spec.modelName` of the `ModelRoute`, then inspect the resources:
+
+```bash
+kubectl describe modelroute deepseek-simple
+kubectl describe modelserver deepseek-r1-1-5b
+```
+
+**Router does not pick up backend Pods.** The `ModelServer`'s `workloadSelector` must
+match the Pod labels, and the Pods must be `Ready`:
+
+```bash
+kubectl get pods -l app=deepseek-r1-1-5b -o wide
+```
+
+**Check the router logs.** Routing decisions and configuration errors are visible in
+the router log:
+
+```bash
+kubectl logs -n kthena-system deploy/kthena-router
+```
+
+**Mock Pods stay in `ContainerCreating`.** The mock backend image is hosted on
+`ghcr.io`, and on a slow connection the pull can take a long time — check with
+`kubectl describe pod <pod-name>` (a single `Pulling image ...` event with no error
+means the pull is still in progress). To bypass a slow or blocked in-cluster pull,
+pull the image locally and load it into the cluster (Kind example):
+
+```bash
+docker pull ghcr.io/faust-benchou/dynamo-mocker-vllm:latest
+kind load docker-image ghcr.io/faust-benchou/dynamo-mocker-vllm:latest --name kthena-demo
+```
+
+## Step 7: Cleanup
+
+Remove the demo resources:
+
+```bash
+kubectl delete -f https://raw.githubusercontent.com/volcano-sh/kthena/refs/heads/main/examples/kthena-router/ModelRouteSimple.yaml
+kubectl delete -f https://raw.githubusercontent.com/volcano-sh/kthena/refs/heads/main/examples/kthena-router/ModelServer-ds1.5b.yaml
+kubectl delete -f https://raw.githubusercontent.com/volcano-sh/kthena/refs/heads/main/examples/kthena-router/LLM-Mock-ds1.5b.yaml
+```
+
+Expected output (older kubectl versions omit the `from default namespace` suffix):
+
+```text
+modelroute.networking.serving.volcano.sh "deepseek-simple" deleted from default namespace
+modelserver.networking.serving.volcano.sh "deepseek-r1-1-5b" deleted from default namespace
+deployment.apps "deepseek-r1-1-5b" deleted from default namespace
+```
+
+To remove Kthena and the local cluster entirely:
+
+```bash
+helm uninstall kthena -n kthena-system
+kind delete cluster --name kthena-demo
+```
+
+## Limitations of Mock Inference
+
+The mock backend is for evaluating Kthena's control plane and routing behavior, not
+model quality or performance:
+
+- Responses are canned strings, not real model output; token counts and timings in the
+  response are simulated.
+- Latency, throughput, and KV-cache utilization do not reflect a real inference engine,
+  so load-aware and KV-cache-aware scheduling behave on synthetic metrics only.
+- Engine-specific features such as LoRA adapter loading are only emulated at the API
+  level.
+
+## Next Steps
+
+- Deploy a real model with GPUs following the [Quick Start](./quick-start.md)
+- Explore routing strategies in [Router Routing](../user-guide/router-routing.md)
+- Expose the router through the Gateway API — see
+  [Gateway API Support](../user-guide/gateway-api-support.md)

--- a/docs/kthena/docs/getting-started/gpu-free-quick-start.md
+++ b/docs/kthena/docs/getting-started/gpu-free-quick-start.md
@@ -4,9 +4,7 @@ sidebar_position: 3
 
 # GPU-Free Quick Start
 
-Try out Kthena on a Kubernetes cluster **without GPUs or NPUs**! This guide deploys a
-mock inference backend that mimics the vLLM API, exposes it through a `ModelServer` and
-a `ModelRoute`, and sends a test inference request through the Kthena router.
+Try out Kthena on a Kubernetes cluster **without GPUs or NPUs**! This guide deploys a mock inference backend that mimics the vLLM API, exposes it through a `ModelServer` and a `ModelRoute`, and sends a test inference request through the Kthena router.
 
 ## Prerequisites
 
@@ -14,12 +12,11 @@ a `ModelRoute`, and sends a test inference request through the Kthena router.
 - Kthena installed on your Kubernetes cluster (see [Installation](./installation.md))
 - Access to a Kubernetes cluster with `kubectl` configured
 - Pod in Kubernetes can access the internet
+- [volcano](https://volcano.sh/en/docs/installation/) is installed.
 
 ## Step 1: Deploy the Mock Inference Backend
 
-The repository ships a mock backend that emulates a vLLM server: it exposes the same
-OpenAI-compatible HTTP API and metrics endpoint, but returns simulated responses
-instead of running a real model — no GPU, no model weights.
+The repository ships a mock backend that emulates a vLLM server: it exposes the same OpenAI-compatible HTTP API and metrics endpoint, but returns simulated responses instead of running a real model — no GPU, no model weights.
 
 ```bash
 kubectl apply -f https://raw.githubusercontent.com/volcano-sh/kthena/refs/heads/main/examples/kthena-router/LLM-Mock-ds1.5b.yaml
@@ -43,9 +40,7 @@ deepseek-r1-1-5b-xxxxxxxxx-xxxxx    1/1     Running   0          1m
 
 ## Step 2: Create the ModelServer and ModelRoute
 
-A `ModelServer` tells the router which Pods serve a model (via a workload selector and
-port). A `ModelRoute` declares a routable model name and maps it to one or more
-`ModelServer` targets.
+A `ModelServer` tells the router which Pods serve a model (via a workload selector and port). A `ModelRoute` declares a routable model name and maps it to one or more `ModelServer` targets.
 
 ```bash
 kubectl apply -f https://raw.githubusercontent.com/volcano-sh/kthena/refs/heads/main/examples/kthena-router/ModelServer-ds1.5b.yaml
@@ -70,26 +65,19 @@ modelroute.networking.serving.volcano.sh/deepseek-simple          1m
 
 ## Step 3: Port-Forward the Kthena Router
 
-The router Service is of type `LoadBalancer`. On clusters without a load-balancer
-implementation (such as a default Kind cluster) its external IP stays `<pending>`, so
-use a port-forward for local access:
+The router Service is of type `LoadBalancer`. On clusters without a load-balancer implementation (such as a default Kind cluster) its external IP stays `<pending>`, so use a port-forward for local access:
 
 ```bash
 kubectl port-forward -n kthena-system svc/kthena-router 8080:80
 ```
 
-If port 8080 is already taken on your machine (for example, Podman occupies it by
-default), forward a different local port instead, such as
-`kubectl port-forward -n kthena-system svc/kthena-router 18080:80`, and use that port
-in the next step.
+If port 8080 is already taken on your machine (for example, Podman occupies it by default), forward a different local port instead, such as `kubectl port-forward -n kthena-system svc/kthena-router 18080:80`, and use that port in the next step.
 
 Keep this command running and continue in a second terminal.
 
 ## Step 4: Send a Test Inference Request
 
-The `ModelRoute` above registers the model name `deepseek-simple`. Send an
-OpenAI-style completion request through the router (the current mock image requires
-`max_tokens` and `"stream": true`):
+The `ModelRoute` above registers the model name `deepseek-simple`. Send an OpenAI-style completion request through the router (the current mock image requires `max_tokens` and `"stream": true`):
 
 ```bash
 curl -N http://localhost:8080/v1/completions \
@@ -115,8 +103,4 @@ data: {"id":"cmpl-4282ab27-171f-4ccf-82a3-adbebc84151a","choices":[{"text":"","i
 data: [DONE]
 ```
 
-Note that the response reports the backend model name
-(`deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B`) even though the request used the routed
-name `deepseek-simple`: the router matched the `model` field against the `ModelRoute`,
-rewrote it to the `ModelServer`'s base model, picked a ready backend Pod from the
-`ModelServer`'s selector, and forwarded the request.
+Note that the response reports the backend model name (`deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B`) even though the request used the routed name `deepseek-simple`: the router matched the `model` field against the `ModelRoute`, rewrote it to the `ModelServer`'s base model, picked a ready backend Pod from the `ModelServer`'s selector, and forwarded the request.

--- a/docs/kthena/docs/getting-started/quick-start.md
+++ b/docs/kthena/docs/getting-started/quick-start.md
@@ -9,6 +9,10 @@ import CodeBlock from '@theme/CodeBlock';
 Get up and running with Kthena in minutes! This guide will walk you through deploying your first AI model.
 We'll install a model from Hugging Face and perform inference using a simple curl command.
 
+:::tip
+No GPUs available? Follow the [GPU-Free Quick Start](./gpu-free-quick-start.md) to evaluate Kthena end to end with a mock inference backend on a CPU-only cluster.
+:::
+
 Kthena provides two ways to quickly deploy LLMs. We recommend starting with `ModelServing` for flexible, self-hosted deployments.
 
 ## Prerequisites

--- a/docs/kthena/sidebars.ts
+++ b/docs/kthena/sidebars.ts
@@ -19,7 +19,7 @@ const sidebars: SidebarsConfig = {
     {
       type: 'category',
       label: 'Getting Started',
-      items: ['getting-started/installation', 'getting-started/quick-start'],
+      items: ['getting-started/installation', 'getting-started/quick-start', 'getting-started/gpu-free-quick-start'],
     },
     {
       type: 'category',


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

This PR adds a new "GPU-Free Quick Start" guide that walks users through deploying Kthena end-to-end on a CPU-only cluster, using a mock vLLM backend exposed via `ModelServer` and `ModelRoute`. The new page is registered in `sidebars.ts` under Getting Started. The existing quick-start guide gets a cross-link pointing users without GPU/NPU hardware to the new guide.

**Which issue(s) this PR fixes**:
Fixes #1563

**Bug evidence (required for bug-related PRs)**:

N/A

**Special notes for your reviewer**:

This PR was written in part with the assistance of generative AI, and every step in the guide was executed and verified end-to-end on the author's local Kind cluster.

Tested environment: Kind v0.30.0 / Kubernetes v1.34.0 / macOS (Apple Silicon), CPU-only.

Sample output from Step 5 (streaming completion request through the Kthena router):

```text
data: {"id":"cmpl-4282ab27-171f-4ccf-82a3-adbebc84151a","choices":[{"text":"En","index":0}],"created":1786508011,"model":"deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B","system_fingerprint":null,"object":"text_completion","usage":null}

...

data: {"id":"cmpl-4282ab27-171f-4ccf-82a3-adbebc84151a","choices":[{"text":"","index":0,"finish_reason":"length"}],"created":1786508011,"model":"deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B","system_fingerprint":null,"object":"text_completion","usage":null,"nvext":{"timing":{"request_received_ms":1786508011068,"total_time_ms":54.605582999999996}}}

data: [DONE]
```

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```