### PR TITLE
fix(autoscaler): limit pod metric response size

### DIFF
--- a/pkg/autoscaler/autoscaler/metric_collector.go
+++ b/pkg/autoscaler/autoscaler/metric_collector.go
@@ -48,6 +48,8 @@ import (
 	inferControllerUtils "github.com/volcano-sh/kthena/pkg/model-serving-controller/utils"
 )
 
+const maxPodMetricResponseSize = 10 << 20
+
 type MetricCollector struct {
 	PastHistograms *datastructure.SnapshotSlidingWindow[map[string]HistogramInfo]
 	Target         *v1alpha1.Target
@@ -377,9 +379,12 @@ func (collector *MetricCollector) scrapePod(ctx context.Context, pod *corev1.Pod
 	if !util.IsRequestSuccess(resp.StatusCode) || resp.Body == nil {
 		return "", fmt.Errorf("invalid metric response for pod %s", pod.Name)
 	}
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxPodMetricResponseSize+1))
 	if err != nil {
 		return "", err
+	}
+	if len(body) > maxPodMetricResponseSize {
+		return "", fmt.Errorf("metric response for pod %s exceeds %d bytes", pod.Name, maxPodMetricResponseSize)
 	}
 	return string(body), nil
 }

--- a/pkg/autoscaler/autoscaler/metric_collector_test.go
+++ b/pkg/autoscaler/autoscaler/metric_collector_test.go
@@ -375,6 +375,28 @@ func TestBuildPodMetricURL(t *testing.T) {
 	}
 }
 
+func TestScrapePodRejectsLargeResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, strings.Repeat("x", maxPodMetricResponseSize+1))
+	}))
+	t.Cleanup(server.Close)
+
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	port, err := strconv.Atoi(serverURL.Port())
+	require.NoError(t, err)
+
+	collector := &MetricCollector{}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pod"},
+		Status:     corev1.PodStatus{PodIP: "127.0.0.1"},
+	}
+	_, err = collector.scrapePod(context.Background(), pod, &workload.PodMetricSource{Port: int32(port)})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds")
+}
+
 func TestUpdateMetricsKeepsReadyPodMetricsWhenAnotherPodIsUnready(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = io.WriteString(w, "# TYPE queue_depth gauge\nqueue_depth 40\n# TYPE queue_depth_alt gauge\nqueue_depth_alt 40\n")


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Limits pod metric responses to 10 MiB. The autoscaler currently reads the full response into memory, so a broken metrics endpoint can cause large allocations in the controller-manager.

**Which issue(s) this PR fixes**:

Fixes #1609

**Bug evidence (required for bug-related PRs)**:

Run a metrics endpoint that returns a large response:

```bash
python3 -c 'from http.server import BaseHTTPRequestHandler,HTTPServer
class H(BaseHTTPRequestHandler):
    def do_GET(self):
        body=b"x"*500_000_000
        self.send_response(200)
        self.end_headers()
        self.wfile.write(body)
HTTPServer(("0.0.0.0",8100),H).serve_forever()'
```

Configure the endpoint as a PodMetricSource and trigger autoscaler reconciliation. The controller-manager buffers the full response in scrapePod():

https://github.com/volcano-sh/kthena/blob/b4646f3a543eba03f4a02d63c3af944909c4fab9/pkg/autoscaler/autoscaler/metric_collector.go#L364-L384

The request timeout only limits duration, not the number of bytes read. This change reads at most 10 MiB plus one byte and returns an error when the response exceeds the limit.

**Special notes for your reviewer:**
Kept the limit local to pod metric scraping. Added a regression test using an HTTP test server.

**Does this PR introduce a user-facing change?:**

```release-note
Autoscaler pod metric responses are now limited to 10 MiB.
```