### PR TITLE
model-serving-controller: guard OwnerReferences index in role reconcilation

### DIFF
--- a/pkg/model-serving-controller/controller/model_serving_controller.go
+++ b/pkg/model-serving-controller/controller/model_serving_controller.go
@@ -1104,8 +1104,13 @@ func (c *ModelServingController) manageRoleReplicasPerGroup(ctx context.Context,
 		for _, pod := range pods {
 			if !utils.IsOwnedByModelServingWithUID(pod, ms.UID) {
 				// If the pod is not owned by the ModelServing, we do not need to handle it.
-				klog.Warningf("manageRoleReplicasPerGroup: pod %s/%s may be left from previous same-named ModelServing %s/%s (expected UID=%s, got UID=%s), re-enqueuing",
-					pod.Namespace, pod.Name, ms.Namespace, ms.Name, ms.UID, pod.OwnerReferences[0].UID)
+				if len(pod.OwnerReferences) > 0 {
+					klog.Warningf("manageRoleReplicasPerGroup: pod %s/%s may be left from previous same-named ModelServing %s/%s (expected UID=%s, got UID=%s), re-enqueuing",
+						pod.Namespace, pod.Name, ms.Namespace, ms.Name, ms.UID, pod.OwnerReferences[0].UID)
+				} else {
+					klog.Warningf("manageRoleReplicasPerGroup: pod %s/%s has no owner references, expected ModelServing %s/%s (UID=%s), re-enqueuing",
+						pod.Namespace, pod.Name, ms.Namespace, ms.Name, ms.UID)
+				}
 				c.enqueueModelServingAfter(ms, 1*time.Second)
 				break
 			}

--- a/pkg/model-serving-controller/controller/model_serving_controller.go
+++ b/pkg/model-serving-controller/controller/model_serving_controller.go
@@ -1103,11 +1103,15 @@ func (c *ModelServingController) manageRoleReplicasPerGroup(ctx context.Context,
 		}
 		for _, pod := range pods {
 			if len(pod.OwnerReferences) == 0 {
-				// If the pod has no owner references, it cannot be owned by the ModelServing.
+				// An ownerless pod can never belong to this (or any) ModelServing, but unlike a
+				// pod with a mismatched owner UID, a missing owner reference is not evidence that
+				// its sibling pods for this role are affected the same way (entry/worker pods for
+				// the same role instance are always created with identical owner references), so
+				// keep inspecting the remaining pods instead of stopping early.
 				klog.Warningf("manageRoleReplicasPerGroup: pod %s/%s has no owner references, expected ModelServing %s/%s (UID=%s), re-enqueuing",
 					pod.Namespace, pod.Name, ms.Namespace, ms.Name, ms.UID)
 				c.enqueueModelServingAfter(ms, 1*time.Second)
-				break
+				continue
 			}
 			if !utils.IsOwnedByModelServingWithUID(pod, ms.UID) {
 				// If the pod is not owned by the ModelServing, we do not need to handle it.

--- a/pkg/model-serving-controller/controller/model_serving_controller.go
+++ b/pkg/model-serving-controller/controller/model_serving_controller.go
@@ -1102,15 +1102,17 @@ func (c *ModelServingController) manageRoleReplicasPerGroup(ctx context.Context,
 			continue
 		}
 		for _, pod := range pods {
+			if len(pod.OwnerReferences) == 0 {
+				// If the pod has no owner references, it cannot be owned by the ModelServing.
+				klog.Warningf("manageRoleReplicasPerGroup: pod %s/%s has no owner references, expected ModelServing %s/%s (UID=%s), re-enqueuing",
+					pod.Namespace, pod.Name, ms.Namespace, ms.Name, ms.UID)
+				c.enqueueModelServingAfter(ms, 1*time.Second)
+				break
+			}
 			if !utils.IsOwnedByModelServingWithUID(pod, ms.UID) {
 				// If the pod is not owned by the ModelServing, we do not need to handle it.
-				if len(pod.OwnerReferences) > 0 {
-					klog.Warningf("manageRoleReplicasPerGroup: pod %s/%s may be left from previous same-named ModelServing %s/%s (expected UID=%s, got UID=%s), re-enqueuing",
-						pod.Namespace, pod.Name, ms.Namespace, ms.Name, ms.UID, pod.OwnerReferences[0].UID)
-				} else {
-					klog.Warningf("manageRoleReplicasPerGroup: pod %s/%s has no owner references, expected ModelServing %s/%s (UID=%s), re-enqueuing",
-						pod.Namespace, pod.Name, ms.Namespace, ms.Name, ms.UID)
-				}
+				klog.Warningf("manageRoleReplicasPerGroup: pod %s/%s may be left from previous same-named ModelServing %s/%s (expected UID=%s, got UID=%s), re-enqueuing",
+					pod.Namespace, pod.Name, ms.Namespace, ms.Name, ms.UID, pod.OwnerReferences[0].UID)
 				c.enqueueModelServingAfter(ms, 1*time.Second)
 				break
 			}

--- a/pkg/model-serving-controller/controller/model_serving_controller_test.go
+++ b/pkg/model-serving-controller/controller/model_serving_controller_test.go
@@ -2671,16 +2671,17 @@ func TestManageRoleReplicasWithPartitionProtectedServingGroupAlignsToControllerR
 
 func TestManageRoleReplicas(t *testing.T) {
 	tests := []struct {
-		name             string
-		roleReplicas     int32
-		workerReplicas   int32
-		initialRoleIDs   []int
-		addEntryPod      bool
-		mismatchOwnerUID bool
-		noOwnerRef       bool
-		expectedRoleSize int
-		expectedPodCount int
-		expectRequeue    bool
+		name              string
+		roleReplicas      int32
+		workerReplicas    int32
+		initialRoleIDs    []int
+		addEntryPod       bool
+		mismatchOwnerUID  bool
+		noOwnerRef        bool
+		addOwnedWorkerPod bool
+		expectedRoleSize  int
+		expectedPodCount  int
+		expectRequeue     bool
 	}{
 		{
 			name:             "recreate missing pods when role count matches",
@@ -2733,6 +2734,18 @@ func TestManageRoleReplicas(t *testing.T) {
 			expectedRoleSize: 1,
 			expectedPodCount: 1,
 			expectRequeue:    true,
+		},
+		{
+			name:              "ownerless pod does not block processing of a validly owned sibling pod",
+			roleReplicas:      1,
+			workerReplicas:    1,
+			initialRoleIDs:    []int{0},
+			addEntryPod:       true,
+			noOwnerRef:        true,
+			addOwnedWorkerPod: true,
+			expectedRoleSize:  1,
+			expectedPodCount:  2,
+			expectRequeue:     true,
 		},
 	}
 
@@ -2804,6 +2817,15 @@ func TestManageRoleReplicas(t *testing.T) {
 				_, err = kubeClient.CoreV1().Pods(ms.Namespace).Create(context.Background(), entryPod, metav1.CreateOptions{})
 				assert.NoError(t, err)
 				assert.NoError(t, controller.podsInformer.GetIndexer().Add(entryPod))
+
+				if tt.addOwnedWorkerPod {
+					// Sibling pod for the same role instance, validly owned by ms, placed
+					// after the ownerless entry pod to prove it is still processed.
+					workerPod := utils.GenerateWorkerPod(ms.Spec.Template.Roles[0], ms, entryPod, groupName, utils.GenerateRoleID(roleName, 0), 1, revision, "test-roleTemplateHash")
+					_, err = kubeClient.CoreV1().Pods(ms.Namespace).Create(context.Background(), workerPod, metav1.CreateOptions{})
+					assert.NoError(t, err)
+					assert.NoError(t, controller.podsInformer.GetIndexer().Add(workerPod))
+				}
 			}
 
 			controller.manageRoleReplicasPerGroup(context.Background(), ms, groupName, ms.Spec.Template.Roles[0], 0, revision)

--- a/pkg/model-serving-controller/controller/model_serving_controller_test.go
+++ b/pkg/model-serving-controller/controller/model_serving_controller_test.go
@@ -2677,6 +2677,7 @@ func TestManageRoleReplicas(t *testing.T) {
 		initialRoleIDs   []int
 		addEntryPod      bool
 		mismatchOwnerUID bool
+		noOwnerRef       bool
 		expectedRoleSize int
 		expectedPodCount int
 		expectRequeue    bool
@@ -2718,6 +2719,17 @@ func TestManageRoleReplicas(t *testing.T) {
 			initialRoleIDs:   []int{0},
 			addEntryPod:      true,
 			mismatchOwnerUID: true,
+			expectedRoleSize: 1,
+			expectedPodCount: 1,
+			expectRequeue:    true,
+		},
+		{
+			name:             "reenqueue without panicking when pod has no owner references",
+			roleReplicas:     1,
+			workerReplicas:   0,
+			initialRoleIDs:   []int{0},
+			addEntryPod:      true,
+			noOwnerRef:       true,
 			expectedRoleSize: 1,
 			expectedPodCount: 1,
 			expectRequeue:    true,
@@ -2785,6 +2797,9 @@ func TestManageRoleReplicas(t *testing.T) {
 				entryPod := utils.GenerateEntryPod(ms.Spec.Template.Roles[0], ms, groupName, utils.GenerateRoleID(roleName, 0), revision, "test-roleTemplateHash")
 				if tt.mismatchOwnerUID && len(entryPod.OwnerReferences) > 0 {
 					entryPod.OwnerReferences[0].UID = types.UID("mismatched-uid")
+				}
+				if tt.noOwnerRef {
+					entryPod.OwnerReferences = nil
 				}
 				_, err = kubeClient.CoreV1().Pods(ms.Namespace).Create(context.Background(), entryPod, metav1.CreateOptions{})
 				assert.NoError(t, err)


### PR DESCRIPTION


## What type of PR is this?

/kind bug

## What this PR does / why we need it

This fixes a panic in `manageRoleReplicasPerGroup` when the controller encounters a Pod with the expected role labels but no `OwnerReferences`.

The controller already treats such a Pod as not owned by the current `ModelServing`, but the warning path assumed `OwnerReferences[0]` always existed. This caused an `index out of range` panic and could terminate the `kthena-controller-manager` process.

The fix handles ownerless Pods separately and continues checking the remaining Pods. It does not re-enqueue the ownerless case because nothing in this reconciliation path can delete or adopt the Pod, which would otherwise cause an endless requeue loop.

The existing behavior for Pods with a mismatched owner UID is unchanged.

A regression test covers the ownerless Pod case and verifies that reconciliation does not panic.

## Which issue(s) this PR fixes

Fixes #1611

## Bug evidence (required for bug-related PRs)

The affected path runs in the ModelServing controller worker goroutine, so the panic can terminate the controller process and stop reconciliation for other ModelServing resources.

The fix guards the owner-reference access and allows reconciliation to continue normally.

A regression test covers a label-matching Pod with `OwnerReferences = nil` and verifies that `manageRoleReplicasPerGroup` does not panic and still re-enqueues the `ModelServing`.

## Validation

* `go test ./pkg/model-serving-controller/controller/... -run TestManageRoleReplicas -v`
* `go test ./pkg/model-serving-controller/...`
* `go build ./...`
* `go vet ./pkg/model-serving-controller/...`
* `gofmt -l` on changed files

All passed.

## Special notes for your reviewer

The change is intentionally small and limited to the unsafe `OwnerReferences[0]` access, ownerless-Pod handling, and regression tests.

* Existing behavior for Pods with a mismatched owner is preserved.
* Ownerless Pods are handled safely and do not trigger an endless requeue loop.
* Remaining Pods continue to be inspected after an ownerless Pod.
* No deletion, scaling, recovery, or reconciliation logic was modified.
* No API or CRD changes are introduced.


## Does this PR introduce a user-facing change?

NONE
