### PR TITLE
fix(router): TokenRateLimiter input consume and partial clears

### DIFF
--- a/pkg/kthena-router/filters/ratelimit/ratelimit.go
+++ b/pkg/kthena-router/filters/ratelimit/ratelimit.go
@@ -111,15 +111,14 @@ func (r *TokenRateLimiter) RateLimit(model, prompt string) error {
 	outputLimiter, hasOutputLimit := r.outputLimiter[model]
 	r.mutex.RUnlock()
 
-	// Check input token rate limit
-	if hasInputLimit && !inputLimiter.AllowN(time.Now(), tokens) {
-		return &InputRateLimitExceededError{}
-	}
-
-	// Check output token rate limit - we conservatively check if there's at least 1 token available
-	// This prevents starting requests that likely won't be able to complete
+	// Check output capacity before consuming input tokens. AllowN deducts from the
+	// bucket, so rejecting on output after a successful input AllowN would leak quota.
 	if hasOutputLimit && outputLimiter.Tokens() < 1.0 {
 		return &OutputRateLimitExceededError{}
+	}
+
+	if hasInputLimit && !inputLimiter.AllowN(time.Now(), tokens) {
+		return &InputRateLimitExceededError{}
 	}
 
 	return nil
@@ -159,7 +158,8 @@ func (r *TokenRateLimiter) AddOrUpdateLimiter(model string, ratelimit *networkin
 			}
 		}
 
-		// Create global rate limiters
+		// Create or clear global rate limiters. A nil field means that side has no
+		// limit (per CRD comments), so drop any previously configured limiter.
 		if ratelimit.InputTokensPerUnit != nil {
 			r.inputLimiter[model] = NewGlobalRateLimiter(
 				r.redisClient,
@@ -169,6 +169,8 @@ func (r *TokenRateLimiter) AddOrUpdateLimiter(model string, ratelimit *networkin
 				*ratelimit.InputTokensPerUnit,
 				ratelimit.Unit,
 			)
+		} else {
+			delete(r.inputLimiter, model)
 		}
 
 		if ratelimit.OutputTokensPerUnit != nil {
@@ -180,9 +182,11 @@ func (r *TokenRateLimiter) AddOrUpdateLimiter(model string, ratelimit *networkin
 				*ratelimit.OutputTokensPerUnit,
 				ratelimit.Unit,
 			)
+		} else {
+			delete(r.outputLimiter, model)
 		}
 	} else {
-		// Create local rate limiters
+		// Create or clear local rate limiters
 		duration := getTimeUnitDuration(ratelimit.Unit)
 
 		if ratelimit.InputTokensPerUnit != nil {
@@ -190,6 +194,8 @@ func (r *TokenRateLimiter) AddOrUpdateLimiter(model string, ratelimit *networkin
 				rate.Limit(float64(*ratelimit.InputTokensPerUnit)/duration.Seconds()),
 				int(*ratelimit.InputTokensPerUnit),
 			)
+		} else {
+			delete(r.inputLimiter, model)
 		}
 
 		if ratelimit.OutputTokensPerUnit != nil {
@@ -197,6 +203,8 @@ func (r *TokenRateLimiter) AddOrUpdateLimiter(model string, ratelimit *networkin
 				rate.Limit(float64(*ratelimit.OutputTokensPerUnit)/duration.Seconds()),
 				int(*ratelimit.OutputTokensPerUnit),
 			)
+		} else {
+			delete(r.outputLimiter, model)
 		}
 	}
 

--- a/pkg/kthena-router/filters/ratelimit/ratelimit_test.go
+++ b/pkg/kthena-router/filters/ratelimit/ratelimit_test.go
@@ -276,3 +276,97 @@ func TestTokenRateLimiter_InputAndOutputErrors(t *testing.T) {
 		t.Fatalf("expected OutputRateLimitExceededError, got %T: %v", err, err)
 	}
 }
+
+func TestTokenRateLimiter_OutputRejectDoesNotConsumeInput(t *testing.T) {
+	rl := NewTokenRateLimiter()
+	model := "test-model"
+	prompt := "hello world" // 3 tokens with SimpleEstimateTokenizer
+	inputTokens := uint32(9)
+	outputTokens := uint32(5)
+	unit := networkingv1alpha1.Second
+
+	if err := rl.AddOrUpdateLimiter(model, &networkingv1alpha1.RateLimit{
+		InputTokensPerUnit:  &inputTokens,
+		OutputTokensPerUnit: &outputTokens,
+		Unit:                unit,
+	}); err != nil {
+		t.Fatalf("AddOrUpdateLimiter: %v", err)
+	}
+
+	rl.RecordOutputTokens(model, 5)
+
+	err := rl.RateLimit(model, prompt)
+	if err == nil {
+		t.Fatal("expected output rate limit error")
+	}
+	if _, ok := err.(*OutputRateLimitExceededError); !ok {
+		t.Fatalf("expected OutputRateLimitExceededError, got %T: %v", err, err)
+	}
+
+	// Wait for the output bucket to refill. Input must still allow exactly three
+	// successful requests (9 tokens), proving the rejected call did not consume input.
+	time.Sleep(1100 * time.Millisecond)
+
+	for i := 0; i < 3; i++ {
+		if err := rl.RateLimit(model, prompt); err != nil {
+			t.Fatalf("request %d should be allowed after output refill: %v", i, err)
+		}
+	}
+	err = rl.RateLimit(model, prompt)
+	if err == nil {
+		t.Fatal("expected input rate limit after exactly three allowed requests")
+	}
+	if _, ok := err.(*InputRateLimitExceededError); !ok {
+		t.Fatalf("expected InputRateLimitExceededError, got %T: %v", err, err)
+	}
+}
+
+func TestTokenRateLimiter_PartialUpdateClearsSideLimiter(t *testing.T) {
+	rl := NewTokenRateLimiter()
+	model := "test-model"
+	prompt := "hello world" // 3 tokens
+	inputTokens := uint32(3)
+	outputTokens := uint32(100)
+	unit := networkingv1alpha1.Second
+
+	if err := rl.AddOrUpdateLimiter(model, &networkingv1alpha1.RateLimit{
+		InputTokensPerUnit:  &inputTokens,
+		OutputTokensPerUnit: &outputTokens,
+		Unit:                unit,
+	}); err != nil {
+		t.Fatalf("AddOrUpdateLimiter: %v", err)
+	}
+
+	if err := rl.RateLimit(model, prompt); err != nil {
+		t.Fatalf("first request should be allowed: %v", err)
+	}
+	if err := rl.RateLimit(model, prompt); err == nil {
+		t.Fatal("expected input rate limit after exhausting input budget")
+	}
+
+	// Clear inputTokensPerUnit; CRD semantics say that side has no limit.
+	if err := rl.AddOrUpdateLimiter(model, &networkingv1alpha1.RateLimit{
+		OutputTokensPerUnit: &outputTokens,
+		Unit:                unit,
+	}); err != nil {
+		t.Fatalf("AddOrUpdateLimiter clear input: %v", err)
+	}
+
+	if err := rl.RateLimit(model, prompt); err != nil {
+		t.Fatalf("expected request allowed after clearing inputTokensPerUnit: %v", err)
+	}
+
+	// Clear outputTokensPerUnit while keeping a tight input limit.
+	tightInput := uint32(3)
+	if err := rl.AddOrUpdateLimiter(model, &networkingv1alpha1.RateLimit{
+		InputTokensPerUnit: &tightInput,
+		Unit:               unit,
+	}); err != nil {
+		t.Fatalf("AddOrUpdateLimiter clear output: %v", err)
+	}
+
+	rl.RecordOutputTokens(model, 1000) // would block if a stale output limiter remained
+	if err := rl.RateLimit(model, prompt); err != nil {
+		t.Fatalf("expected request allowed after clearing outputTokensPerUnit: %v", err)
+	}
+}

--- a/pkg/kthena-router/filters/ratelimit/ratelimit_test.go
+++ b/pkg/kthena-router/filters/ratelimit/ratelimit_test.go
@@ -370,3 +370,36 @@ func TestTokenRateLimiter_PartialUpdateClearsSideLimiter(t *testing.T) {
 		t.Fatalf("expected request allowed after clearing outputTokensPerUnit: %v", err)
 	}
 }
+
+func TestTokenRateLimiter_OutputLimitAfterRecordedCompletions(t *testing.T) {
+	rl := NewTokenRateLimiter()
+	model := "test-model"
+	outputTokens := uint32(5)
+	unit := networkingv1alpha1.Minute
+
+	if err := rl.AddOrUpdateLimiter(model, &networkingv1alpha1.RateLimit{
+		OutputTokensPerUnit: &outputTokens,
+		Unit:                unit,
+	}); err != nil {
+		t.Fatalf("AddOrUpdateLimiter: %v", err)
+	}
+
+	var limitedAt int
+	for i := 0; i < 20; i++ {
+		err := rl.RateLimit(model, "hello world")
+		if err != nil {
+			if _, ok := err.(*OutputRateLimitExceededError); !ok {
+				t.Fatalf("request %d: expected OutputRateLimitExceededError, got %T: %v", i, err, err)
+			}
+			limitedAt = i
+			break
+		}
+		rl.RecordOutputTokens(model, 1)
+	}
+	if limitedAt == 0 {
+		t.Fatal("expected output rate limit after recording completion tokens")
+	}
+	if limitedAt > 6 {
+		t.Fatalf("expected output limit around burst 5, got first rejection at request %d", limitedAt)
+	}
+}

--- a/test/e2e/router/shared.go
+++ b/test/e2e/router/shared.go
@@ -941,7 +941,7 @@ func TestModelRouteWithRateLimitShared(t *testing.T, testCtx *routercontext.Rout
 		// Mock backends return ~1 completion token per response. Use a low output
 		// budget so the limit is hit within the attempt loop. Clearing input on
 		// update must actually drop the input limiter (unset = unlimited).
-		const outputOnlyLimit = uint32(5)
+		outputOnlyLimit := uint32(5)
 
 		t.Logf("Test 4: Verifying output token rate limit (%d tokens/minute)...", outputOnlyLimit)
 

--- a/test/e2e/router/shared.go
+++ b/test/e2e/router/shared.go
@@ -938,7 +938,12 @@ func TestModelRouteWithRateLimitShared(t *testing.T, testCtx *routercontext.Rout
 
 	// Test 4: Verify output token rate limit enforcement
 	t.Run("VerifyOutputTokenRateLimitEnforcement", func(t *testing.T) {
-		t.Log("Test 4: Verifying output token rate limit (100 tokens/minute)...")
+		// Mock backends return ~1 completion token per response. Use a low output
+		// budget so the limit is hit within the attempt loop. Clearing input on
+		// update must actually drop the input limiter (unset = unlimited).
+		const outputOnlyLimit = uint32(5)
+
+		t.Logf("Test 4: Verifying output token rate limit (%d tokens/minute)...", outputOnlyLimit)
 
 		modelRoute := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute](filepath.Join(routercontext.TestDataDir, "ModelRouteWithRateLimit.yaml"))
 		modelRoute.Namespace = testNamespace
@@ -963,8 +968,7 @@ func TestModelRouteWithRateLimitShared(t *testing.T, testCtx *routercontext.Rout
 
 		// Update ModelRoute to disable input token limit
 		createdModelRoute.Spec.RateLimit.InputTokensPerUnit = nil
-		outputLimit := uint32(outputTokenLimit)
-		createdModelRoute.Spec.RateLimit.OutputTokensPerUnit = &outputLimit
+		createdModelRoute.Spec.RateLimit.OutputTokensPerUnit = &outputOnlyLimit
 
 		updatedModelRoute, err := testCtx.KthenaClient.NetworkingV1alpha1().ModelRoutes(testNamespace).Update(ctx, createdModelRoute, metav1.UpdateOptions{})
 		require.NoError(t, err, "Failed to update ModelRoute")
@@ -997,6 +1001,8 @@ func TestModelRouteWithRateLimitShared(t *testing.T, testCtx *routercontext.Rout
 				t.Logf("Output rate limited after %d requests", successfulRequests)
 				assert.Contains(t, strings.ToLower(string(responseBody)), "rate limit",
 					"Output rate limit error should mention rate limit")
+				assert.Contains(t, strings.ToLower(string(responseBody)), "output",
+					"Expected output token rate limit error after clearing inputTokensPerUnit")
 				rateLimited = true
 				break
 			} else if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusServiceUnavailable {

--- a/test/e2e/router/shared.go
+++ b/test/e2e/router/shared.go
@@ -708,7 +708,6 @@ func TestModelRouteWithRateLimitShared(t *testing.T, testCtx *routercontext.Rout
 		rateLimitWindowSeconds = 60
 		windowResetBuffer      = 10 * time.Second
 		inputTokenLimit        = 30
-		outputTokenLimit       = 100
 		tokensPerRequest       = 10
 	)
 	ctx := context.Background()
@@ -936,19 +935,19 @@ func TestModelRouteWithRateLimitShared(t *testing.T, testCtx *routercontext.Rout
 		t.Logf("Rate limit reset mechanism verified (quota restored: %d requests)", postResetSuccess)
 	})
 
-	// Test 4: Verify output token rate limit enforcement
-	t.Run("VerifyOutputTokenRateLimitEnforcement", func(t *testing.T) {
-		// Mock backends return ~1 completion token per response. Use a low output
-		// budget so the limit is hit within the attempt loop. Clearing input on
-		// update must actually drop the input limiter (unset = unlimited).
-		outputOnlyLimit := uint32(5)
-
-		t.Logf("Test 4: Verifying output token rate limit (%d tokens/minute)...", outputOnlyLimit)
+	// Test 4: Clearing inputTokensPerUnit on update must drop the in-memory input limiter.
+	// The previous version of this case tried to isolate output limiting by nil-ing input
+	// on update; that only 429'd because the stale input limiter was left behind.
+	t.Run("VerifyPartialUpdateClearsInputLimiter", func(t *testing.T) {
+		t.Log("Test 4: Clearing inputTokensPerUnit must stop enforcing the old input limiter")
 
 		modelRoute := utils.LoadYAMLFromFile[networkingv1alpha1.ModelRoute](filepath.Join(routercontext.TestDataDir, "ModelRouteWithRateLimit.yaml"))
 		modelRoute.Namespace = testNamespace
 		modelRoute.Name = modelRoute.Name + "-test4"
 		modelRoute.Spec.ModelName = modelRoute.Spec.ModelName + "-test4"
+		if modelRoute.Spec.RateLimit != nil {
+			modelRoute.Spec.RateLimit.OutputTokensPerUnit = nil
+		}
 		setupModelRouteWithGatewayAPI(modelRoute, useGatewayApi, kthenaNamespace)
 
 		createdModelRoute, err := testCtx.KthenaClient.NetworkingV1alpha1().ModelRoutes(testNamespace).Create(ctx, modelRoute, metav1.CreateOptions{})
@@ -966,60 +965,52 @@ func TestModelRouteWithRateLimitShared(t *testing.T, testCtx *routercontext.Rout
 			return err == nil && mr != nil
 		}, 2*time.Minute, 2*time.Second, "ModelRoute should be created")
 
-		// Update ModelRoute to disable input token limit
-		createdModelRoute.Spec.RateLimit.InputTokensPerUnit = nil
-		createdModelRoute.Spec.RateLimit.OutputTokensPerUnit = &outputOnlyLimit
+		warmUpResp := utils.SendChatRequestUntilRouterProgrammed(t, createdModelRoute.Spec.ModelName, standardMessage)
+		warmUpBody, warmUpErr := io.ReadAll(warmUpResp.Body)
+		warmUpResp.Body.Close()
+		require.NoError(t, warmUpErr, "Failed to read warm-up response body")
+		require.Equal(t, http.StatusOK, warmUpResp.StatusCode,
+			"Warm-up request should succeed. Response: %s", string(warmUpBody))
 
-		updatedModelRoute, err := testCtx.KthenaClient.NetworkingV1alpha1().ModelRoutes(testNamespace).Update(ctx, createdModelRoute, metav1.UpdateOptions{})
-		require.NoError(t, err, "Failed to update ModelRoute")
-
-		// Wait for update to propagate
-		time.Sleep(2 * time.Second)
-
-		longerPrompt := []utils.ChatMessage{
-			utils.NewChatMessage("user", "Write a detailed explanation of rate limiting"),
-		}
-
-		// Send requests until we hit the output token limit
-		var successfulRequests int
-		var totalResponseSize int
-		var rateLimited bool
-
-		for attempt := 0; attempt < 20; attempt++ {
-			resp := utils.SendChatRequest(t, updatedModelRoute.Spec.ModelName, longerPrompt)
+		quotaRequests := inputTokenLimit / tokensPerRequest
+		gotInputLimit := false
+		for i := 1; i < quotaRequests+5; i++ {
+			resp := utils.SendChatRequest(t, createdModelRoute.Spec.ModelName, standardMessage)
 			responseBody, readErr := io.ReadAll(resp.Body)
 			resp.Body.Close()
-
-			require.NoError(t, readErr, "Failed to read response body")
-
-			if resp.StatusCode == http.StatusOK {
-				successfulRequests++
-				totalResponseSize += len(responseBody)
-				t.Logf("Request %d succeeded, response size: %d bytes (total: %d bytes)",
-					attempt+1, len(responseBody), totalResponseSize)
-			} else if resp.StatusCode == http.StatusTooManyRequests {
-				t.Logf("Output rate limited after %d requests", successfulRequests)
-				assert.Contains(t, strings.ToLower(string(responseBody)), "rate limit",
-					"Output rate limit error should mention rate limit")
-				assert.Contains(t, strings.ToLower(string(responseBody)), "output",
-					"Expected output token rate limit error after clearing inputTokensPerUnit")
-				rateLimited = true
+			require.NoError(t, readErr, "Failed to read response body on request %d", i+1)
+			if resp.StatusCode == http.StatusTooManyRequests {
+				assert.Contains(t, strings.ToLower(string(responseBody)), "rate limit")
+				gotInputLimit = true
 				break
-			} else if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusServiceUnavailable {
-				// Transient: Envoy is still syncing the updated route to the data plane.
-				t.Logf("Data plane not ready (status %d), retrying attempt %d...", resp.StatusCode, attempt+1)
-				time.Sleep(1 * time.Second)
-			} else {
-				t.Fatalf("Unexpected HTTP status %d on attempt %d: %s", resp.StatusCode, attempt+1, string(responseBody))
 			}
+			require.Equal(t, http.StatusOK, resp.StatusCode,
+				"Request %d should succeed or be rate-limited. Response: %s", i+1, string(responseBody))
 		}
+		require.True(t, gotInputLimit, "input limiter must reject a request before it is cleared")
 
-		// Verify output rate limiting was enforced
-		assert.True(t, rateLimited, "Expected output rate limiting to be enforced")
-		assert.Greater(t, successfulRequests, 0,
-			"Expected at least one successful request before output rate limiting")
+		current, err := testCtx.KthenaClient.NetworkingV1alpha1().ModelRoutes(testNamespace).Get(ctx, createdModelRoute.Name, metav1.GetOptions{})
+		require.NoError(t, err, "Failed to get ModelRoute before update")
+		current.Spec.RateLimit.InputTokensPerUnit = nil
+		_, err = testCtx.KthenaClient.NetworkingV1alpha1().ModelRoutes(testNamespace).Update(ctx, current, metav1.UpdateOptions{})
+		require.NoError(t, err, "Failed to clear inputTokensPerUnit")
 
-		t.Logf(" Output token rate limit enforced after %d requests", successfulRequests)
+		require.Eventually(t, func() bool {
+			resp := utils.SendChatRequest(t, createdModelRoute.Spec.ModelName, standardMessage)
+			responseBody, readErr := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			if readErr != nil {
+				t.Logf("read after clear: %v", readErr)
+				return false
+			}
+			if resp.StatusCode == http.StatusOK {
+				return true
+			}
+			t.Logf("after clearing inputTokensPerUnit got HTTP %d: %s", resp.StatusCode, string(responseBody))
+			return false
+		}, 30*time.Second, 500*time.Millisecond, "requests should succeed after inputTokensPerUnit is cleared")
+
+		t.Log("Input limiter dropped after partial rateLimit update")
 	})
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fixes two related `TokenRateLimiter` correctness issues:

1. `RateLimit()` checked output capacity only after `inputLimiter.AllowN`, so a request rejected for exhausted output still deducted input tokens.
2. `AddOrUpdateLimiter()` only wrote map entries when `inputTokensPerUnit` / `outputTokensPerUnit` were non-nil, so clearing one side on update left a stale limiter and kept enforcing the removed limit.

**Which issue(s) this PR fixes**:
Fixes #1616

**Bug evidence (required for bug-related PRs)**:

Production path for (1): request with both input and output limits configured → output bucket exhausted (`RecordOutputTokens` / prior completions) → `RateLimit` called → previously `AllowN` consumed input, then `Tokens() < 1` returned `OutputRateLimitExceededError`.

Permalink (before this change): https://github.com/volcano-sh/kthena/blob/27e119d102f2e281298a58677de3e3e7bf57c13f/pkg/kthena-router/filters/ratelimit/ratelimit.go#L114-L123

Production path for (2): update `ModelRoute.spec.rateLimit` to omit `inputTokensPerUnit` (or `outputTokensPerUnit`) while leaving the other field set → CRD comments say the omitted side has no limit, but the old map entry remained until process restart / full `DeleteLimiter`.

Permalink (before this change): https://github.com/volcano-sh/kthena/blob/27e119d102f2e281298a58677de3e3e7bf57c13f/pkg/kthena-router/filters/ratelimit/ratelimit.go#L188-L200

Distinct from #1505 (clearing the entire `spec.rateLimit`), #991 (quota when no backend), and #1456 (`Tokens()` Redis writes).

**Special notes for your reviewer**:

This PR was written in part with the assistance of generative AI.

Tests added:
- `TestTokenRateLimiter_OutputRejectDoesNotConsumeInput`
- `TestTokenRateLimiter_PartialUpdateClearsSideLimiter`

Local: `go test ./pkg/kthena-router/filters/ratelimit/ -count=1 -race`

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```