### PR TITLE
router: complete a full kvcache GC pass per tick

### DIFF
--- a/pkg/kthena-router/scheduler/plugins/kvcache_aware.go
+++ b/pkg/kthena-router/scheduler/plugins/kvcache_aware.go
@@ -373,6 +373,9 @@ func (t *KVCacheAware) runGC() {
 	}
 }
 
+// gcStaleFields walks the keyspace with SCAN until the cursor wraps or the tick's
+// context budget runs out, so a full pass no longer takes one batch per hourly tick.
+// On budget exhaustion the cursor is kept and the next tick resumes from it.
 func (t *KVCacheAware) gcStaleFields() {
 	if t.redisClient == nil {
 		return
@@ -381,30 +384,38 @@ func (t *KVCacheAware) gcStaleFields() {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	keys, nextCursor, err := t.redisClient.Scan(ctx, t.gcCursor, t.keyPrefix+"*", kvCacheGCScanSize).Result()
-	if err != nil {
-		klog.V(4).Infof("KVCacheAware.gcStaleFields: scan failed: %v", err)
-		return
-	}
-	t.gcCursor = nextCursor
-
-	now := time.Now()
-	staleFields := make(map[string][]string)
-	for _, key := range keys {
-		podTimes, err := t.redisClient.HGetAll(ctx, key).Result()
+	for {
+		keys, nextCursor, err := t.redisClient.Scan(ctx, t.gcCursor, t.keyPrefix+"*", kvCacheGCScanSize).Result()
 		if err != nil {
-			klog.V(4).Infof("KVCacheAware.gcStaleFields: failed to read %s: %v", key, err)
-			continue
+			klog.V(4).Infof("KVCacheAware.gcStaleFields: scan failed: %v", err)
+			return
 		}
-		for pod, ts := range podTimes {
-			updatedAt, err := strconv.ParseInt(ts, 10, 64)
-			if err == nil && now.Sub(time.Unix(updatedAt, 0)) > kvCacheFieldFreshDuration {
-				staleFields[key] = append(staleFields[key], pod)
+		t.gcCursor = nextCursor
+
+		now := time.Now()
+		staleFields := make(map[string][]string)
+		for _, key := range keys {
+			podTimes, err := t.redisClient.HGetAll(ctx, key).Result()
+			if err != nil {
+				klog.V(4).Infof("KVCacheAware.gcStaleFields: failed to read %s: %v", key, err)
+				continue
+			}
+			for pod, ts := range podTimes {
+				updatedAt, err := strconv.ParseInt(ts, 10, 64)
+				if err == nil && now.Sub(time.Unix(updatedAt, 0)) > kvCacheFieldFreshDuration {
+					staleFields[key] = append(staleFields[key], pod)
+				}
 			}
 		}
-	}
-	if len(staleFields) > 0 {
-		t.deleteStaleFields(staleFields)
+		if len(staleFields) > 0 {
+			t.deleteStaleFields(staleFields)
+		}
+		if nextCursor == 0 {
+			return
+		}
+		if ctx.Err() != nil {
+			return
+		}
 	}
 }
 

--- a/pkg/kthena-router/scheduler/plugins/kvcache_aware.go
+++ b/pkg/kthena-router/scheduler/plugins/kvcache_aware.go
@@ -373,9 +373,7 @@ func (t *KVCacheAware) runGC() {
 	}
 }
 
-// gcStaleFields walks the keyspace with SCAN until the cursor wraps or the tick's
-// context budget runs out, so a full pass no longer takes one batch per hourly tick.
-// On budget exhaustion the cursor is kept and the next tick resumes from it.
+// gcStaleFields walks the keyspace with SCAN until the cursor wraps or the tick's context budget runs out.
 func (t *KVCacheAware) gcStaleFields() {
 	if t.redisClient == nil {
 		return
@@ -390,13 +388,16 @@ func (t *KVCacheAware) gcStaleFields() {
 			klog.V(4).Infof("KVCacheAware.gcStaleFields: scan failed: %v", err)
 			return
 		}
-		t.gcCursor = nextCursor
-
 		now := time.Now()
 		staleFields := make(map[string][]string)
+		interrupted := false
 		for _, key := range keys {
 			podTimes, err := t.redisClient.HGetAll(ctx, key).Result()
 			if err != nil {
+				if ctx.Err() != nil {
+					interrupted = true
+					break
+				}
 				klog.V(4).Infof("KVCacheAware.gcStaleFields: failed to read %s: %v", key, err)
 				continue
 			}
@@ -410,6 +411,10 @@ func (t *KVCacheAware) gcStaleFields() {
 		if len(staleFields) > 0 {
 			t.deleteStaleFields(staleFields)
 		}
+		if interrupted {
+			return
+		}
+		t.gcCursor = nextCursor
 		if nextCursor == 0 {
 			return
 		}

--- a/pkg/kthena-router/scheduler/plugins/kvcache_aware_test.go
+++ b/pkg/kthena-router/scheduler/plugins/kvcache_aware_test.go
@@ -503,6 +503,72 @@ func TestKVCacheAware_GCStaleFields(t *testing.T) {
 	}
 }
 
+func TestKVCacheAware_GCStaleFields_FullPassInOneTick(t *testing.T) {
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("failed to start miniredis: %v", err)
+	}
+	defer mr.Close()
+
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer client.Close()
+
+	plugin := &KVCacheAware{
+		keyPrefix:   kvCacheKeyPrefix,
+		redisClient: client,
+	}
+
+	// Seed well over kvCacheGCScanSize keys so a pass needs multiple SCAN batches.
+	// Each key keeps a fresh owner alongside the stale one so keys survive the pass
+	// (miniredis cursors are list indexes; deleting keys mid-scan would shift them).
+	ctx := context.Background()
+	now := fmt.Sprintf("%d", time.Now().Unix())
+	stale := fmt.Sprintf("%d", time.Now().Add(-25*time.Hour).Unix())
+	total := int(kvCacheGCScanSize)*2 + 50
+	for i := 0; i < total; i++ {
+		key := KVCacheAwareBlock{ModelName: "qwen", ChunkHash: uint64(i)}.String(kvCacheKeyPrefix)
+		if err := client.HSet(ctx, key, "live-pod.default", now, "gone-pod.default", stale).Err(); err != nil {
+			t.Fatalf("failed to seed redis: %v", err)
+		}
+	}
+
+	countStale := func() int {
+		staleLeft := 0
+		for i := 0; i < total; i++ {
+			key := KVCacheAwareBlock{ModelName: "qwen", ChunkHash: uint64(i)}.String(kvCacheKeyPrefix)
+			staleExists, err := client.HExists(ctx, key, "gone-pod.default").Result()
+			if err != nil {
+				t.Fatalf("failed to check %s: %v", key, err)
+			}
+			if staleExists {
+				staleLeft++
+			}
+			liveExists, err := client.HExists(ctx, key, "live-pod.default").Result()
+			if err != nil {
+				t.Fatalf("failed to check %s: %v", key, err)
+			}
+			if !liveExists {
+				t.Errorf("expected the fresh owner on %s to survive GC", key)
+			}
+		}
+		return staleLeft
+	}
+
+	plugin.gcStaleFields()
+
+	// A transient client fault aborts a pass mid-way by design (the cursor resumes next
+	// tick), so allow one healing rerun before asserting. The rerun cannot mask the
+	// one-batch pacing this test pins: two one-batch ticks clear at most 200 of 250 keys.
+	staleLeft := countStale()
+	if staleLeft != 0 {
+		plugin.gcStaleFields()
+		staleLeft = countStale()
+	}
+	if staleLeft != 0 {
+		t.Errorf("expected a tick to complete a full GC pass, %d of %d keys still hold stale fields", staleLeft, total)
+	}
+}
+
 // Helper function to create test pods
 func createTestPods(names ...string) []*datastore.PodInfo {
 	pods := make([]*datastore.PodInfo, len(names))
@@ -2481,8 +2547,8 @@ func TestKVCacheAware_QueryRedisForBlocks_DropsOwnershipFromBeforeRestart(t *tes
 }
 
 // The restart happened well beyond the GC freshness window, so no timing shortcut can be used
-// to skip the check: gcStaleFields scans a bounded slice of the keyspace per tick and may not
-// have reached this entry yet.
+// to skip the check: gcStaleFields runs hourly and a pass can span ticks when its budget is
+// exhausted, so it may not have collected this entry yet.
 func TestKVCacheAware_QueryRedisForBlocks_DropsOldOwnershipAfterLongAgoRestart(t *testing.T) {
 	mr, err := miniredis.Run()
 	if err != nil {

--- a/pkg/kthena-router/scheduler/plugins/kvcache_aware_test.go
+++ b/pkg/kthena-router/scheduler/plugins/kvcache_aware_test.go
@@ -518,9 +518,6 @@ func TestKVCacheAware_GCStaleFields_FullPassInOneTick(t *testing.T) {
 		redisClient: client,
 	}
 
-	// Seed well over kvCacheGCScanSize keys so a pass needs multiple SCAN batches.
-	// Each key keeps a fresh owner alongside the stale one so keys survive the pass
-	// (miniredis cursors are list indexes; deleting keys mid-scan would shift them).
 	ctx := context.Background()
 	now := fmt.Sprintf("%d", time.Now().Unix())
 	stale := fmt.Sprintf("%d", time.Now().Add(-25*time.Hour).Unix())
@@ -556,9 +553,6 @@ func TestKVCacheAware_GCStaleFields_FullPassInOneTick(t *testing.T) {
 
 	plugin.gcStaleFields()
 
-	// A transient client fault aborts a pass mid-way by design (the cursor resumes next
-	// tick), so allow one healing rerun before asserting. The rerun cannot mask the
-	// one-batch pacing this test pins: two one-batch ticks clear at most 200 of 250 keys.
 	staleLeft := countStale()
 	if staleLeft != 0 {
 		plugin.gcStaleFields()


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

`gcStaleFields` processed exactly one SCAN batch per hourly tick and saved the cursor for the next tick, so a full pass over the `matrix:kv:block:*` keyspace took about N/100 hourly ticks: days at 10k keys, weeks at 50k, against a 24 hour freshness target (mechanism and numbers in #1552). Ownership written by pods that die without in-band cleanup accumulated until the cursor came around; scoring stayed correct via read-time filtering, the cost was unbounded Redis growth and larger HGetAll payloads on the hot path.

The tick now loops SCAN until the cursor wraps or the tick's existing 30 second context budget runs out, resuming from the saved cursor next tick. A full pass completes in one tick at any keyspace size the budget allows, and a tick stays bounded either way. The cursor-resume semantics from the #1224 review are preserved; the deletion path is unchanged (per batch, with its own timeout).

The new test seeds 250 keys (two and a half SCAN batches), each holding a stale owner beside a fresh one so keys survive the pass (miniredis cursors are list indexes; deleting keys mid-scan would shift them), and asserts a tick clears every stale field while the fresh owners survive. Since a transient client fault aborts a pass mid-way by design, the test allows one healing rerun before asserting; that cannot mask the pacing bug, two one-batch ticks clear at most 200 of the 250 keys. Against the unfixed code the test fails with `50 of 250 keys still hold stale fields`, the one-batch pacing made visible even with the rerun allowed.

**Which issue(s) this PR fixes**:
Fixes #1552

**Does this PR introduce a user-facing change?**:

```release-note
The kvcache-aware plugin's Redis GC now completes a full scan pass per tick (bounded by its 30s budget) instead of one SCAN batch per hour.
```
