### PR TITLE
runtime: retry Redis operations against the current client

### DIFF
--- a/python/kthena/runtime/redis_client.py
+++ b/python/kthena/runtime/redis_client.py
@@ -103,6 +103,8 @@ class RedisClient:
             await self.connect()
 
     async def _execute_with_retry(self, operation, *args, **kwargs) -> Any:
+        # operation must resolve self._client when called. A bound method would
+        # keep addressing the client that the reconnect below replaces.
         last_error = None
         for attempt in range(self.config.max_retries + 1):
             try:
@@ -123,7 +125,9 @@ class RedisClient:
 
     async def keys(self, pattern: str) -> List[str]:
         try:
-            result = await self._execute_with_retry(self._client.keys, pattern)
+            result = await self._execute_with_retry(
+                lambda *a, **kw: self._client.keys(*a, **kw), pattern
+            )
             return result or []
         except (RedisError, ConnectionError, TimeoutError):
             return []
@@ -141,7 +145,8 @@ class RedisClient:
         try:
             while True:
                 cursor, batch = await self._execute_with_retry(
-                    self._client.scan, cursor=cursor, match=pattern, count=count
+                    lambda **kw: self._client.scan(**kw),
+                    cursor=cursor, match=pattern, count=count,
                 )
                 keys.extend(batch)
                 if cursor == 0:

--- a/python/kthena/tests/test_redis_client.py
+++ b/python/kthena/tests/test_redis_client.py
@@ -1,0 +1,119 @@
+# Copyright The Volcano Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from redis.exceptions import ConnectionError
+
+from kthena.runtime.redis_client import RedisClient
+
+
+class _FakeRedis:
+    """One instance per connection, so tests can tell which one was called."""
+
+    def __init__(self, generation, fail=False):
+        self.generation = generation
+        self.fail = fail
+        self.scan_calls = 0
+        self.keys_calls = 0
+
+    async def scan(self, cursor=0, match=None, count=None):
+        self.scan_calls += 1
+        if self.fail:
+            raise ConnectionError(f"generation {self.generation} is down")
+        return 0, [f"key-{self.generation}"]
+
+    async def keys(self, pattern):
+        self.keys_calls += 1
+        if self.fail:
+            raise ConnectionError(f"generation {self.generation} is down")
+        return [f"key-{self.generation}"]
+
+
+def _client_failing_first_connection():
+    """A RedisClient whose connect() installs a new _FakeRedis each time.
+
+    The first connection always fails, later ones succeed, which is what a
+    dropped connection followed by a successful reconnect looks like.
+    """
+    client = RedisClient()
+    client.config.retry_delay = 0
+    clients = []
+
+    async def fake_connect():
+        if client._connected:
+            return
+        redis = _FakeRedis(len(clients), fail=len(clients) == 0)
+        clients.append(redis)
+        client._client = redis
+        client._connected = True
+
+    client.connect = fake_connect
+    return client, clients
+
+
+@pytest.mark.asyncio
+async def test_scan_keys_retries_against_the_reconnected_client():
+    client, clients = _client_failing_first_connection()
+    await client.connect()
+
+    result = await client.scan_keys("prefix*")
+
+    assert result == ["key-1"]
+    assert clients[0].scan_calls == 1
+    assert clients[1].scan_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_keys_retries_against_the_reconnected_client():
+    client, clients = _client_failing_first_connection()
+    await client.connect()
+
+    result = await client.keys("prefix*")
+
+    assert result == ["key-1"]
+    assert clients[0].keys_calls == 1
+    assert clients[1].keys_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_scan_keys_connects_on_demand():
+    client, clients = _client_failing_first_connection()
+
+    result = await client.scan_keys("prefix*")
+
+    assert result == ["key-1"]
+
+
+@pytest.mark.asyncio
+async def test_keys_connects_on_demand():
+    client, clients = _client_failing_first_connection()
+
+    result = await client.keys("prefix*")
+
+    assert result == ["key-1"]
+
+
+@pytest.mark.asyncio
+async def test_scan_keys_returns_empty_when_every_attempt_fails():
+    client = RedisClient()
+    client.config.retry_delay = 0
+
+    async def fake_connect():
+        client._client = _FakeRedis(0, fail=True)
+        client._connected = True
+
+    client.connect = fake_connect
+
+    assert await client.scan_keys("prefix*") == []
+    assert await client.keys("prefix*") == []


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`keys()` and `scan_keys()` passed `self._client.keys` and `self._client.scan` into `_execute_with_retry`. Python resolves those attributes at the call site, so the bound method addressed whichever client object existed before the retry loop ran. On a `ConnectionError` the loop clears `_connected` and reconnects, and `connect()` assigns a new `redis.Redis` to `self._client`, but the retry kept invoking the old bound method. Every attempt went back to the connection that had already failed, and both methods then returned an empty list rather than raising, which a caller cannot tell apart from no keys matching.

Resolving `self._client` inside a lambda makes each attempt address the current client. It also makes the `_ensure_connected` call inside the loop effective, since `self._client.scan` previously raised `AttributeError` when the client was `None`, either before the first `connect()` or after `_cleanup_connection()`.

Driving the real `RedisClient` with a fake whose client object is replaced on each `connect()`, counting calls per client generation:

```
before   scan {gen0: 4, gen1: 0, gen2: 0, gen3: 0}   returned []
after    scan {gen0: 1, gen1: 1}                     returned ['key-1']
```

Generation 0 is the dead client. Before, it absorbed all four attempts and the reconnected clients were never called.

Adds `python/kthena/tests/test_redis_client.py`, which had no tests. All five cases fail on main and pass here.

**Which issue(s) this PR fixes**:

Fixes #1618

**Special notes for your reviewer**:

Scoped to the callable change only. @aeron-gh suggested keeping the connection pool cleanup separate, and that is the right call for a second reason: doing it as `_cleanup_connection()` inside `_execute_with_retry` introduces a race. `connect()` is guarded by `_connection_lock` and `_cleanup_connection()` is not, so with two concurrent operations one coroutine's cleanup can disconnect the pool the other just established. I have a failing test for that, so the pool fix wants to live inside `connect()` under the lock, in its own PR.

**Does this PR introduce a user-facing change?**

```release-note
Fixed the runtime Redis client retrying against the failed connection instead of the reconnected one, which made keys() and scan_keys() return an empty list after a transient connection error.
```