### PR TITLE
docs: fix the router ConfigMap example key and nesting

### DIFF
--- a/docs/kthena/docs/user-guide/config-router.md
+++ b/docs/kthena/docs/user-guide/config-router.md
@@ -69,39 +69,40 @@ metadata:
   name: kthena-router-config
   namespace: default
 data:
-  schedulerConfiguration: |-
-    pluginConfig:
-    - name: least-request
-      args: 
-        maxWaitingRequests: 10
-    - name: least-latency
-      args:
-        TTFTTPOTWeightFactor: 0.5
-    - name: prefix-cache
-      args:
-        blockSizeToHash: 64
-        maxBlocksToMatch: 128
-        maxHashCacheSize: 50000
-    - name: kvcache-aware
-      args:
-        blockSizeToHash: 16
-        maxBlocksToMatch: 128
-    plugins:
-      Filter:
-        enabled:
-          - least-request
-        disabled:
-          - lora-affinity
-      Score:
-        enabled:
-          - name: least-request
-            weight: 1
-          - name: kvcache-aware
-            weight: 1
-          - name: least-latency
-            weight: 1
-          - name: prefix-cache
-            weight: 1
+  routerConfiguration: |-
+    scheduler:
+      pluginConfig:
+      - name: least-request
+        args: 
+          maxWaitingRequests: 10
+      - name: least-latency
+        args:
+          TTFTTPOTWeightFactor: 0.5
+      - name: prefix-cache
+        args:
+          blockSizeToHash: 64
+          maxBlocksToMatch: 128
+          maxHashCacheSize: 50000
+      - name: kvcache-aware
+        args:
+          blockSizeToHash: 16
+          maxBlocksToMatch: 128
+      plugins:
+        Filter:
+          enabled:
+            - least-request
+          disabled:
+            - lora-affinity
+        Score:
+          enabled:
+            - name: least-request
+              weight: 1
+            - name: kvcache-aware
+              weight: 1
+            - name: least-latency
+              weight: 1
+            - name: prefix-cache
+              weight: 1
 ```
 
 If you want to use Authentication feature of router. Here is an example:

--- a/docs/kthena/docs/user-guide/config-router.md
+++ b/docs/kthena/docs/user-guide/config-router.md
@@ -67,7 +67,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: kthena-router-config
-  namespace: default
+  namespace: <namespace>
 data:
   routerConfiguration: |-
     scheduler:

--- a/docs/kthena/versioned_docs/version-v0.1.0/user-guide/config-router.md
+++ b/docs/kthena/versioned_docs/version-v0.1.0/user-guide/config-router.md
@@ -65,35 +65,36 @@ metadata:
   name: kthena-router-config
   namespace: default
 data:
-  schedulerConfiguration: |-
-    pluginConfig:
-    - name: least-request
-      args: 
-        maxWaitingRequests: 10
-    - name: least-latency
-      args:
-        TTFTTPOTWeightFactor: 0.5
-    - name: prefix-cache
-      args:
-        blockSizeToHash: 64
-        maxBlocksToMatch: 128
-        maxHashCacheSize: 50000
-    plugins:
-      Filter:
-        enabled:
-          - least-request
-        disabled:
-          - lora-affinity
-      Score:
-        enabled:
-          - name: least-request
-            weight: 1
-          - name: kv-cache
-            weight: 1
-          - name: least-latency
-            weight: 1
-          - name: prefix-cache
-            weight: 1
+  routerConfiguration: |-
+    scheduler:
+      pluginConfig:
+      - name: least-request
+        args: 
+          maxWaitingRequests: 10
+      - name: least-latency
+        args:
+          TTFTTPOTWeightFactor: 0.5
+      - name: prefix-cache
+        args:
+          blockSizeToHash: 64
+          maxBlocksToMatch: 128
+          maxHashCacheSize: 50000
+      plugins:
+        Filter:
+          enabled:
+            - least-request
+          disabled:
+            - lora-affinity
+        Score:
+          enabled:
+            - name: least-request
+              weight: 1
+            - name: kv-cache
+              weight: 1
+            - name: least-latency
+              weight: 1
+            - name: prefix-cache
+              weight: 1
 ```
 
 If you want to use Authentication feature of router. Here is an example:

--- a/docs/kthena/versioned_docs/version-v0.1.0/user-guide/config-router.md
+++ b/docs/kthena/versioned_docs/version-v0.1.0/user-guide/config-router.md
@@ -58,12 +58,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: kthena-router-config
-  namespace: default
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: kthena-router-config
-  namespace: default
+  namespace: <namespace>
 data:
   routerConfiguration: |-
     scheduler:

--- a/docs/kthena/versioned_docs/version-v0.2.0/user-guide/config-router.md
+++ b/docs/kthena/versioned_docs/version-v0.2.0/user-guide/config-router.md
@@ -65,35 +65,36 @@ metadata:
   name: kthena-router-config
   namespace: default
 data:
-  schedulerConfiguration: |-
-    pluginConfig:
-    - name: least-request
-      args: 
-        maxWaitingRequests: 10
-    - name: least-latency
-      args:
-        TTFTTPOTWeightFactor: 0.5
-    - name: prefix-cache
-      args:
-        blockSizeToHash: 64
-        maxBlocksToMatch: 128
-        maxHashCacheSize: 50000
-    plugins:
-      Filter:
-        enabled:
-          - least-request
-        disabled:
-          - lora-affinity
-      Score:
-        enabled:
-          - name: least-request
-            weight: 1
-          - name: kv-cache
-            weight: 1
-          - name: least-latency
-            weight: 1
-          - name: prefix-cache
-            weight: 1
+  routerConfiguration: |-
+    scheduler:
+      pluginConfig:
+      - name: least-request
+        args: 
+          maxWaitingRequests: 10
+      - name: least-latency
+        args:
+          TTFTTPOTWeightFactor: 0.5
+      - name: prefix-cache
+        args:
+          blockSizeToHash: 64
+          maxBlocksToMatch: 128
+          maxHashCacheSize: 50000
+      plugins:
+        Filter:
+          enabled:
+            - least-request
+          disabled:
+            - lora-affinity
+        Score:
+          enabled:
+            - name: least-request
+              weight: 1
+            - name: kv-cache
+              weight: 1
+            - name: least-latency
+              weight: 1
+            - name: prefix-cache
+              weight: 1
 ```
 
 If you want to use Authentication feature of router. Here is an example:

--- a/docs/kthena/versioned_docs/version-v0.2.0/user-guide/config-router.md
+++ b/docs/kthena/versioned_docs/version-v0.2.0/user-guide/config-router.md
@@ -58,12 +58,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: kthena-router-config
-  namespace: default
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: kthena-router-config
-  namespace: default
+  namespace: <namespace>
 data:
   routerConfiguration: |-
     scheduler:

--- a/docs/kthena/versioned_docs/version-v0.3.0/user-guide/config-router.md
+++ b/docs/kthena/versioned_docs/version-v0.3.0/user-guide/config-router.md
@@ -65,35 +65,36 @@ metadata:
   name: kthena-router-config
   namespace: default
 data:
-  schedulerConfiguration: |-
-    pluginConfig:
-    - name: least-request
-      args: 
-        maxWaitingRequests: 10
-    - name: least-latency
-      args:
-        TTFTTPOTWeightFactor: 0.5
-    - name: prefix-cache
-      args:
-        blockSizeToHash: 64
-        maxBlocksToMatch: 128
-        maxHashCacheSize: 50000
-    plugins:
-      Filter:
-        enabled:
-          - least-request
-        disabled:
-          - lora-affinity
-      Score:
-        enabled:
-          - name: least-request
-            weight: 1
-          - name: kv-cache
-            weight: 1
-          - name: least-latency
-            weight: 1
-          - name: prefix-cache
-            weight: 1
+  routerConfiguration: |-
+    scheduler:
+      pluginConfig:
+      - name: least-request
+        args: 
+          maxWaitingRequests: 10
+      - name: least-latency
+        args:
+          TTFTTPOTWeightFactor: 0.5
+      - name: prefix-cache
+        args:
+          blockSizeToHash: 64
+          maxBlocksToMatch: 128
+          maxHashCacheSize: 50000
+      plugins:
+        Filter:
+          enabled:
+            - least-request
+          disabled:
+            - lora-affinity
+        Score:
+          enabled:
+            - name: least-request
+              weight: 1
+            - name: kv-cache
+              weight: 1
+            - name: least-latency
+              weight: 1
+            - name: prefix-cache
+              weight: 1
 ```
 
 If you want to use Authentication feature of router. Here is an example:

--- a/docs/kthena/versioned_docs/version-v0.3.0/user-guide/config-router.md
+++ b/docs/kthena/versioned_docs/version-v0.3.0/user-guide/config-router.md
@@ -58,12 +58,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: kthena-router-config
-  namespace: default
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: kthena-router-config
-  namespace: default
+  namespace: <namespace>
 data:
   routerConfiguration: |-
     scheduler:

--- a/docs/kthena/versioned_docs/version-v0.4.0/user-guide/config-router.md
+++ b/docs/kthena/versioned_docs/version-v0.4.0/user-guide/config-router.md
@@ -65,35 +65,36 @@ metadata:
   name: kthena-router-config
   namespace: default
 data:
-  schedulerConfiguration: |-
-    pluginConfig:
-    - name: least-request
-      args: 
-        maxWaitingRequests: 10
-    - name: least-latency
-      args:
-        TTFTTPOTWeightFactor: 0.5
-    - name: prefix-cache
-      args:
-        blockSizeToHash: 64
-        maxBlocksToMatch: 128
-        maxHashCacheSize: 50000
-    plugins:
-      Filter:
-        enabled:
-          - least-request
-        disabled:
-          - lora-affinity
-      Score:
-        enabled:
-          - name: least-request
-            weight: 1
-          - name: kv-cache
-            weight: 1
-          - name: least-latency
-            weight: 1
-          - name: prefix-cache
-            weight: 1
+  routerConfiguration: |-
+    scheduler:
+      pluginConfig:
+      - name: least-request
+        args: 
+          maxWaitingRequests: 10
+      - name: least-latency
+        args:
+          TTFTTPOTWeightFactor: 0.5
+      - name: prefix-cache
+        args:
+          blockSizeToHash: 64
+          maxBlocksToMatch: 128
+          maxHashCacheSize: 50000
+      plugins:
+        Filter:
+          enabled:
+            - least-request
+          disabled:
+            - lora-affinity
+        Score:
+          enabled:
+            - name: least-request
+              weight: 1
+            - name: kv-cache
+              weight: 1
+            - name: least-latency
+              weight: 1
+            - name: prefix-cache
+              weight: 1
 ```
 
 If you want to use Authentication feature of router. Here is an example:

--- a/docs/kthena/versioned_docs/version-v0.4.0/user-guide/config-router.md
+++ b/docs/kthena/versioned_docs/version-v0.4.0/user-guide/config-router.md
@@ -58,12 +58,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: kthena-router-config
-  namespace: default
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: kthena-router-config
-  namespace: default
+  namespace: <namespace>
 data:
   routerConfiguration: |-
     scheduler:

--- a/docs/kthena/versioned_docs/version-v1.0.0/user-guide/config-router.md
+++ b/docs/kthena/versioned_docs/version-v1.0.0/user-guide/config-router.md
@@ -59,7 +59,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: kthena-router-config
-  namespace: default
+  namespace: <namespace>
 data:
   routerConfiguration: |-
     scheduler:

--- a/docs/kthena/versioned_docs/version-v1.0.0/user-guide/config-router.md
+++ b/docs/kthena/versioned_docs/version-v1.0.0/user-guide/config-router.md
@@ -61,39 +61,40 @@ metadata:
   name: kthena-router-config
   namespace: default
 data:
-  schedulerConfiguration: |-
-    pluginConfig:
-    - name: least-request
-      args: 
-        maxWaitingRequests: 10
-    - name: least-latency
-      args:
-        TTFTTPOTWeightFactor: 0.5
-    - name: prefix-cache
-      args:
-        blockSizeToHash: 64
-        maxBlocksToMatch: 128
-        maxHashCacheSize: 50000
-    - name: kvcache-aware
-      args:
-        blockSizeToHash: 16
-        maxBlocksToMatch: 128
-    plugins:
-      Filter:
-        enabled:
-          - least-request
-        disabled:
-          - lora-affinity
-      Score:
-        enabled:
-          - name: least-request
-            weight: 1
-          - name: kvcache-aware
-            weight: 1
-          - name: least-latency
-            weight: 1
-          - name: prefix-cache
-            weight: 1
+  routerConfiguration: |-
+    scheduler:
+      pluginConfig:
+      - name: least-request
+        args: 
+          maxWaitingRequests: 10
+      - name: least-latency
+        args:
+          TTFTTPOTWeightFactor: 0.5
+      - name: prefix-cache
+        args:
+          blockSizeToHash: 64
+          maxBlocksToMatch: 128
+          maxHashCacheSize: 50000
+      - name: kvcache-aware
+        args:
+          blockSizeToHash: 16
+          maxBlocksToMatch: 128
+      plugins:
+        Filter:
+          enabled:
+            - least-request
+          disabled:
+            - lora-affinity
+        Score:
+          enabled:
+            - name: least-request
+              weight: 1
+            - name: kvcache-aware
+              weight: 1
+            - name: least-latency
+              weight: 1
+            - name: prefix-cache
+              weight: 1
 ```
 
 If you want to use Authentication feature of router. Here is an example:


### PR DESCRIPTION
/kind documentation

**What this PR does / why we need it**:

The first ConfigMap example in the router configuration guide could not work as written. Three separate defects, all in the same block:

1. The data key was `schedulerConfiguration`, which no code path reads. The deployment subPath-mounts `routerConfiguration` to the fixed path the router loads, so the example's config was never seen.
2. The fields sat at top level, but the parser unmarshals into `RouterConfiguration`, which expects them under `scheduler:`. They were dropped as unknown fields.
3. It set `namespace: default`, while the chart creates the router's ConfigMap in the release namespace (documented install: `kthena-system`), so applying it produced an unrelated ConfigMap the router never mounts.

Mechanism and file references in #1599.

Running the example through the router's own `ParseRouterConfig` plus `LoadSchedulerConfig` shows what the first two cost:

- before: `pluginConfigs=0 scoreWeights=map[] filters=[]`, an entirely empty scheduler config
- after: `pluginConfigs=4 scoreWeights=map[kvcache-aware:1 least-latency:1 least-request:1 prefix-cache:1] filters=[least-request]`

The example now uses the `routerConfiguration` key with the `scheduler:` nesting, and `namespace: <namespace>`, matching both the authentication example further down this page and the other router-ConfigMap examples in the repo (`kvcache-aware.md`, `examples/redis/README.md`).

**Scope:** all five published doc versions carry this example (`versions.json` lists v1.0.0 through v0.1.0), and every release tag from v0.1.0 to v1.0.0 subPath-mounts `routerConfiguration` and loads `/etc/config/routerConfiguration.yaml`, so it was never correct for any of them. Each versioned copy is fixed in place, keeping its own plugin set and names (the v0.x copies keep `kv-cache`); only the data key, the nesting, and the namespace change. The four v0.x copies additionally had the ConfigMap header pasted twice inside the same snippet, which is removed. Each result was verified by parsing it back through the router's config loader.

**Which issue(s) this PR fixes**:
Fixes #1599

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
