### PR TITLE
fix(rbac): allow controller to delete old ModelServings

### DIFF
--- a/charts/kthena/charts/workload/templates/kthena-controller-manager/rbac/cluster-role.yaml
+++ b/charts/kthena/charts/workload/templates/kthena-controller-manager/rbac/cluster-role.yaml
@@ -50,6 +50,7 @@ rules:
       - modelservings
     verbs:
       - create
+      - delete
       - get
       - list
       - patch


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Allows the controller to delete the old ModelServing when `spec.backend.name` changes.

**Which issue(s) this PR fixes**:

Fixes #1622

**Bug evidence (required for bug-related PRs)**:

With the default Helm RBAC, the controller cannot delete ModelServings:

```bash
kubectl auth can-i delete modelservings.workload.serving.volcano.sh \
  --as=system:serviceaccount:<kthena-namespace>:kthena-controller-manager
# no
```

A backend rename triggers this delete path, causing reconciliation to fail with Forbidden:
https://github.com/volcano-sh/kthena/blob/b8d1ac7083934691af6802a24063e2485fb1109d/pkg/model-booster-controller/controller/model_serving_handler.go#L70-L78

**Special notes for your reviewer**:
RBAC-only change.

**Does this PR introduce a user-facing change?**:

```release-note
Fix ModelBooster backend rename cleanup with the default Helm RBAC.
```
