### PR TITLE
fix(router): support optional sectionName and port in HTTPRoute gateway listener matching

### DIFF
--- a/pkg/kthena-router/router/httproute_match.go
+++ b/pkg/kthena-router/router/httproute_match.go
@@ -133,12 +133,18 @@ func httpRouteMatchesGatewayListener(route *gatewayv1.HTTPRoute, gatewayKey, lis
 			continue
 		}
 		if listenerName == "" && listenerPort == 0 {
-			return parentRef.SectionName == nil && parentRef.Port == nil
+			if parentRef.SectionName == nil && parentRef.Port == nil {
+				return true
+			}
+			continue
 		}
-		if parentRef.SectionName != nil && string(*parentRef.SectionName) == listenerName &&
-			parentRef.Port != nil && int(*parentRef.Port) == listenerPort {
-			return true
+		if parentRef.SectionName != nil && string(*parentRef.SectionName) != listenerName {
+			continue
 		}
+		if parentRef.Port != nil && int(*parentRef.Port) != listenerPort {
+			continue
+		}
+		return true
 	}
 	return false
 }

--- a/pkg/kthena-router/router/httproute_match_test.go
+++ b/pkg/kthena-router/router/httproute_match_test.go
@@ -167,16 +167,126 @@ func TestRouter_FindHTTPRouteMatch(t *testing.T) {
 			listenerPort: 8080,
 		},
 		{
-			name: "skips unprocessed route with listener context",
+			name: "matches route without sectionName and port against active listener",
 			routes: []*gatewayv1.HTTPRoute{
 				route("route", nil, []gatewayv1.HTTPRouteRule{
 					pathRule("/chat", "pool"),
 				}),
 			},
+			host:           "api.example.com",
+			path:           "/chat",
+			listenerName:   "public",
+			listenerPort:   8080,
+			expectedRoute:  "route",
+			expectedPool:   "pool",
+			expectedPrefix: "/chat",
+		},
+		{
+			name: "matches route with sectionName only against matching listener",
+			routes: []*gatewayv1.HTTPRoute{
+				func() *gatewayv1.HTTPRoute {
+					r := route("route", nil, []gatewayv1.HTTPRouteRule{
+						pathRule("/chat", "pool"),
+					})
+					section := gatewayv1.SectionName("public")
+					r.Spec.ParentRefs[0].SectionName = &section
+					return r
+				}(),
+			},
+			host:           "api.example.com",
+			path:           "/chat",
+			listenerName:   "public",
+			listenerPort:   8080,
+			expectedRoute:  "route",
+			expectedPool:   "pool",
+			expectedPrefix: "/chat",
+		},
+		{
+			name: "skips route with sectionName only against different listener",
+			routes: []*gatewayv1.HTTPRoute{
+				func() *gatewayv1.HTTPRoute {
+					r := route("route", nil, []gatewayv1.HTTPRouteRule{
+						pathRule("/chat", "pool"),
+					})
+					section := gatewayv1.SectionName("private")
+					r.Spec.ParentRefs[0].SectionName = &section
+					return r
+				}(),
+			},
 			host:         "api.example.com",
 			path:         "/chat",
 			listenerName: "public",
 			listenerPort: 8080,
+		},
+		{
+			name: "matches route with port only against matching port",
+			routes: []*gatewayv1.HTTPRoute{
+				func() *gatewayv1.HTTPRoute {
+					r := route("route", nil, []gatewayv1.HTTPRouteRule{
+						pathRule("/chat", "pool"),
+					})
+					port := gatewayv1.PortNumber(8080)
+					r.Spec.ParentRefs[0].Port = &port
+					return r
+				}(),
+			},
+			host:           "api.example.com",
+			path:           "/chat",
+			listenerName:   "public",
+			listenerPort:   8080,
+			expectedRoute:  "route",
+			expectedPool:   "pool",
+			expectedPrefix: "/chat",
+		},
+		{
+			name: "skips route with port only against different port",
+			routes: []*gatewayv1.HTTPRoute{
+				func() *gatewayv1.HTTPRoute {
+					r := route("route", nil, []gatewayv1.HTTPRouteRule{
+						pathRule("/chat", "pool"),
+					})
+					port := gatewayv1.PortNumber(9090)
+					r.Spec.ParentRefs[0].Port = &port
+					return r
+				}(),
+			},
+			host:         "api.example.com",
+			path:         "/chat",
+			listenerName: "public",
+			listenerPort: 8080,
+		},
+		{
+			name: "matches route with multiple parentRefs when second parentRef matches",
+			routes: []*gatewayv1.HTTPRoute{
+				func() *gatewayv1.HTTPRoute {
+					r := route("route", nil, []gatewayv1.HTTPRouteRule{
+						pathRule("/chat", "pool"),
+					})
+					otherGw := gatewayv1.ObjectName("other-gw")
+					sectionPrivate := gatewayv1.SectionName("private")
+					sectionPublic := gatewayv1.SectionName("public")
+					r.Spec.ParentRefs = []gatewayv1.ParentReference{
+						{
+							Name:        otherGw,
+							Kind:        &kind,
+							SectionName: &sectionPrivate,
+						},
+						{
+							Name:        "gw",
+							Kind:        &kind,
+							SectionName: &sectionPublic,
+						},
+					}
+					return r
+				}(),
+			},
+			host:           "api.example.com",
+			path:           "/chat",
+			listenerName:   "public",
+			listenerPort:   8080,
+			expectedRoute:  "route",
+			expectedPool:   "pool",
+			expectedPrefix: "/chat",
 		},
 		{
 			name: "skips listener-scoped route without listener context",
@@ -187,6 +297,36 @@ func TestRouter_FindHTTPRouteMatch(t *testing.T) {
 			},
 			host: "api.example.com",
 			path: "/chat",
+		},
+		{
+			name: "matches multiple parentRefs without listener context when one has no section/port",
+			routes: []*gatewayv1.HTTPRoute{
+				func() *gatewayv1.HTTPRoute {
+					r := route("route", nil, []gatewayv1.HTTPRouteRule{
+						pathRule("/chat", "pool"),
+					})
+					sectionPrivate := gatewayv1.SectionName("private")
+					portPrivate := gatewayv1.PortNumber(8081)
+					r.Spec.ParentRefs = []gatewayv1.ParentReference{
+						{
+							Name:        "gw",
+							Kind:        &kind,
+							SectionName: &sectionPrivate,
+							Port:        &portPrivate,
+						},
+						{
+							Name: "gw",
+							Kind: &kind,
+						},
+					}
+					return r
+				}(),
+			},
+			host:           "api.example.com",
+			path:           "/chat",
+			expectedRoute:  "route",
+			expectedPool:   "pool",
+			expectedPrefix: "/chat",
 		},
 		{
 			name: "prefers longest prefix in a single route",


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

In `pkg/kthena-router/router/httproute_match.go`, `httpRouteMatchesGatewayListener` previously required `parentRef.SectionName != nil && parentRef.Port != nil` simultaneously for incoming requests handled by active listeners.

This caused standard Kubernetes Gateway API `HTTPRoute` resources (which omit `sectionName` or `port` to attach to all listeners on a Gateway) as well as routes specifying only `sectionName` or only `port` to be dropped from request matching. Additionally, when `listenerName == ""` and `listenerPort == 0`, a direct return terminated the parentRef evaluation loop prematurely without evaluating subsequent parentRefs.

This change:
1. Evaluates `sectionName` and `port` as optional filter constraints in accordance with the Kubernetes Gateway API `ParentReference` specification.
2. Allows standard `HTTPRoute` resources without `sectionName`/`port` to match active listeners.
3. Allows routes specifying only `sectionName` or only `port` to match when their specified constraint matches.
4. Allows evaluating all `parentRefs` in `route.Spec.ParentRefs` sequentially without premature loop termination.
5. Adds unit test cases in `httproute_match_test.go` covering all parentRef permutations.

**Which issue(s) this PR fixes**:
Fixes #1624

**Bug evidence (required for bug-related PRs)**:

When the router runs in Gateway API mode (`cmd/kthena-router/app/router.go`), incoming requests matched to a listener set `GatewayListenerNameKey` and `GatewayListenerPortKey` on the request context:
https://github.com/volcano-sh/kthena/blob/b8d1ac7083934691af6802a24063e2485fb1109d/cmd/kthena-router/app/router.go#L268-L270

During routing, `findHTTPRouteMatch` calls `httpRouteMatchesGatewayListener`:
https://github.com/volcano-sh/kthena/blob/b8d1ac7083934691af6802a24063e2485fb1109d/pkg/kthena-router/router/httproute_match.go#L123-L144

Before this fix, for a standard `HTTPRoute` with `parentRefs: [{name: "gw"}]` (where `SectionName` and `Port` are nil) receiving traffic on listener `http:8080`:
- `parentRef.SectionName != nil` was false.
- `parentRef.Port != nil` was false.
- `httpRouteMatchesGatewayListener` returned `false`, causing `findHTTPRouteMatch` to drop the route and return HTTP 404/503.

**Special notes for your reviewer**:

All unit tests run and pass:
```bash
go test -v -run TestRouter_FindHTTPRouteMatch ./pkg/kthena-router/router/...
go test ./pkg/kthena-router/...
```

**Does this PR introduce a user-facing change?**:

```release-note
Fix Gateway API HTTPRoute matching to support omitted and single-field (sectionName or port) parentRefs.
```
