### PR TITLE
router: size the prefix-cache hash result up front

### DIFF
--- a/pkg/kthena-router/scheduler/plugins/prefix_cache.go
+++ b/pkg/kthena-router/scheduler/plugins/prefix_cache.go
@@ -225,10 +225,17 @@ func (p *PrefixCache) PostSchedule(ctx *framework.Context, index int) {
 }
 
 func (p *PrefixCache) hashPrompt(model string, prompt string) []uint64 {
-	res := []uint64{}
 	if len(prompt) == 0 {
-		return res
+		return []uint64{}
 	}
+
+	// Size from the blocks this prompt will produce. Capping at maxBlocksToMatch
+	// instead would give a single-block prompt the full maximum backing array.
+	blocks := (len(prompt) + p.blockSizeToHash - 1) / p.blockSizeToHash
+	if blocks > p.maxBlocksToMatch {
+		blocks = p.maxBlocksToMatch
+	}
+	res := make([]uint64, 0, blocks)
 
 	// Initialize first block hash
 	// Use model name as the first hash to avoid hash collision

--- a/pkg/kthena-router/scheduler/plugins/prefix_cache_test.go
+++ b/pkg/kthena-router/scheduler/plugins/prefix_cache_test.go
@@ -433,25 +433,62 @@ func TestHashPromptEquivalence(t *testing.T) {
 	}
 }
 
-// BenchmarkHashPrompt isolates the per-request hashing allocation, the data-plane
-// hot path. b.ReportAllocs surfaces the per-op allocations eliminated by the
-// strconv.AppendUint buffer reuse.
-func BenchmarkHashPrompt(b *testing.B) {
-	var promptBuf strings.Builder
-	promptBuf.Grow(8192)
-	for i := 0; i < 8192; i++ {
-		promptBuf.WriteByte(byte('a' + (i % 26)))
-	}
-	prompt := promptBuf.String()
-
+// TestHashPromptResultCapacity pins the result slice to the blocks the prompt
+// produces. Sizing it at maxBlocksToMatch instead gives every prompt the full
+// backing array, which costs short prompts far more than the growth it avoids.
+func TestHashPromptResultCapacity(t *testing.T) {
 	p := &PrefixCache{
 		blockSizeToHash:  64,
 		maxBlocksToMatch: 128,
 	}
 
-	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		_ = p.hashPrompt("bench-model", prompt)
+	// Block counts are deliberately not powers of two. Growing the slice by append
+	// lands on a power-of-two capacity, so these are the lengths where a grown
+	// result and a sized one differ.
+	cases := []struct {
+		promptLen  int
+		wantHashes int
+	}{
+		{192, 3},
+		{320, 5},
+		{1600, 25},
+		{32768, 128}, // capped at maxBlocksToMatch
+	}
+	for _, tc := range cases {
+		got := p.hashPrompt("test-model", strings.Repeat("a", tc.promptLen))
+		if len(got) != tc.wantHashes {
+			t.Fatalf("prompt %dB: got %d hashes, want %d", tc.promptLen, len(got), tc.wantHashes)
+		}
+		if cap(got) != tc.wantHashes {
+			t.Fatalf("prompt %dB: result cap %d, want %d", tc.promptLen, cap(got), tc.wantHashes)
+		}
+	}
+}
+
+// BenchmarkHashPrompt isolates the per-request hashing allocation, the data-plane
+// hot path. b.ReportAllocs surfaces the per-op allocations eliminated by the
+// strconv.AppendUint buffer reuse and by sizing the result slice up front. Sizes
+// span a single block to beyond maxBlocksToMatch.
+func BenchmarkHashPrompt(b *testing.B) {
+	p := &PrefixCache{
+		blockSizeToHash:  64,
+		maxBlocksToMatch: 128,
+	}
+
+	for _, promptLen := range []int{64, 512, 2048, 8192, 32768} {
+		var promptBuf strings.Builder
+		promptBuf.Grow(promptLen)
+		for i := 0; i < promptLen; i++ {
+			promptBuf.WriteByte(byte('a' + (i % 26)))
+		}
+		prompt := promptBuf.String()
+
+		b.Run(fmt.Sprintf("prompt=%dB", promptLen), func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_ = p.hashPrompt("bench-model", prompt)
+			}
+		})
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement

**What this PR does / why we need it**:

`hashPrompt` started from an empty slice and appended one hash per block, so the result grew and copied its way up on every request. The block count is known before the loop from the prompt length, `blockSizeToHash` and `maxBlocksToMatch`, so the slice can be allocated once.

The sizing is taken from the blocks the prompt will actually produce, not from `maxBlocksToMatch`. A flat cap removes the same growth but hands every prompt the full backing array, which costs a single-block prompt 1144 bytes against 128 today and runs measurably slower. The existing benchmark used an 8192 byte prompt, exactly 128 blocks at the default block size, which is the one input where the two choices look identical, so the benchmark now spans a single block to beyond `maxBlocksToMatch`.

go1.26.5 linux/amd64, `-benchtime=1s -count=6`, medians:

```
prompt    before                        after
   64B     194 ns   128 B   3 allocs     190 ns   128 B   3 allocs
  512B     756 ns   240 B   6 allocs     675 ns   184 B   3 allocs
 2048B    2612 ns   624 B   8 allocs    2338 ns   376 B   3 allocs
 8192B    9756 ns  2160 B  10 allocs    8904 ns  1144 B   3 allocs
32768B    9884 ns  2160 B  10 allocs    8924 ns  1144 B   3 allocs
```

Allocations flatten to 3 at every size and bytes never regress. A 64 byte prompt is unchanged, the 2.4% is inside run to run spread.

Output is unchanged. `TestHashPromptEquivalence` still checks the frozen 128 block hash chain, and `TestHashPromptResultCapacity` pins the capacity to the block count. Its lengths are deliberately not powers of two, since `append` growth lands on a power-of-two capacity and would otherwise match the sized result by accident; it fails on main with `prompt 192B: result cap 4, want 3`.

**Which issue(s) this PR fixes**:

Fixes #1627

**Special notes for your reviewer**:

Dividing by `blockSizeToHash` is safe, `NewPrefixCache` clamps it to the default when `<= 0`.

**Does this PR introduce a user-facing change?**

```release-note
NONE
```