### PR TITLE
fix(model-booster): clamp vLLM worker pods to avoid negative workerReplicas

### DIFF
--- a/pkg/model-booster-controller/convert/model_serving.go
+++ b/pkg/model-booster-controller/convert/model_serving.go
@@ -223,13 +223,6 @@ func buildVllmModelServing(model *workload.ModelBooster) (*workload.ModelServing
 	if workersMap[workload.ModelWorkerTypeServer] == nil {
 		return nil, fmt.Errorf("server worker not found in backend: %s", backend.Name)
 	}
-	// Pods is the total pod count for the server role (1 leader + N-1 Ray workers), so a
-	// role can never meaningfully have zero pods. Because Pods is a plain int32, an omitted
-	// value is indistinguishable from an explicit 0, so both are treated as the documented
-	// single-pod baseline to avoid computing a negative WORKER_REPLICAS below.
-	if serverWorker := workersMap[workload.ModelWorkerTypeServer]; serverWorker.Pods < 1 {
-		serverWorker.Pods = 1
-	}
 	enginePort, err := utils.GetEnginePort(backend)
 	if err != nil {
 		return nil, err
@@ -341,11 +334,14 @@ func buildVllmModelServing(model *workload.ModelBooster) (*workload.ModelServing
 		"ENGINE_SERVER_RESOURCES":            workersMap[workload.ModelWorkerTypeServer].Resources,
 		"ENGINE_SERVER_IMAGE":                workersMap[workload.ModelWorkerTypeServer].Image,
 		"ENGINE_SERVER_COMMAND":              commands,
-		"WORKER_REPLICAS":                    workersMap[workload.ModelWorkerTypeServer].Pods - 1,
-		"SCHEDULER_NAME":                     backend.SchedulerName,
-		"RUNTIME_CLASS_NAME":                 backend.RuntimeClassName,
-		"SERVER_AFFINITY":                    workersMap[workload.ModelWorkerTypeServer].Affinity,
-		"SERVER_TOLERATIONS":                 workersMap[workload.ModelWorkerTypeServer].Tolerations,
+		// Pods has no schema default (Minimum is 0), so an omitted or explicit-zero value
+		// decodes to 0. Clamp to 1 here so WORKER_REPLICAS is never negative; buildCommands'
+		// only Pods-dependent branch is guarded by "> 1", so it behaves the same either way.
+		"WORKER_REPLICAS":    max(workersMap[workload.ModelWorkerTypeServer].Pods, 1) - 1,
+		"SCHEDULER_NAME":     backend.SchedulerName,
+		"RUNTIME_CLASS_NAME": backend.RuntimeClassName,
+		"SERVER_AFFINITY":    workersMap[workload.ModelWorkerTypeServer].Affinity,
+		"SERVER_TOLERATIONS": workersMap[workload.ModelWorkerTypeServer].Tolerations,
 	}
 	return loadModelServingTemplate(VllmTemplatePath, &data)
 }

--- a/pkg/model-booster-controller/convert/model_serving.go
+++ b/pkg/model-booster-controller/convert/model_serving.go
@@ -223,7 +223,6 @@ func buildVllmModelServing(model *workload.ModelBooster) (*workload.ModelServing
 	if workersMap[workload.ModelWorkerTypeServer] == nil {
 		return nil, fmt.Errorf("server worker not found in backend: %s", backend.Name)
 	}
-	serverPods := effectiveServerPods(workersMap)
 	enginePort, err := utils.GetEnginePort(backend)
 	if err != nil {
 		return nil, err
@@ -283,6 +282,13 @@ func buildVllmModelServing(model *workload.ModelBooster) (*workload.ModelServing
 	}
 
 	engineEnv := buildEngineEnvVars(backend)
+	// Pods has no schema default (Minimum is 0), so an omitted or explicit-zero value
+	// decodes to 0. A role can never meaningfully have zero pods, so treat that as the
+	// single-pod baseline (no extra Ray workers) instead of computing a negative replicas.
+	workerReplicas := workersMap[workload.ModelWorkerTypeServer].Pods - 1
+	if workersMap[workload.ModelWorkerTypeServer].Pods <= 1 {
+		workerReplicas = 0
+	}
 	data := map[string]interface{}{
 		"MODEL_SERVING_TEMPLATE_METADATA": &metav1.ObjectMeta{
 			Name:      utils.GetBackendResourceName(model.Name, backend.Name),
@@ -335,7 +341,7 @@ func buildVllmModelServing(model *workload.ModelBooster) (*workload.ModelServing
 		"ENGINE_SERVER_RESOURCES":            workersMap[workload.ModelWorkerTypeServer].Resources,
 		"ENGINE_SERVER_IMAGE":                workersMap[workload.ModelWorkerTypeServer].Image,
 		"ENGINE_SERVER_COMMAND":              commands,
-		"WORKER_REPLICAS":                    serverPods - 1,
+		"WORKER_REPLICAS":                    workerReplicas,
 		"SCHEDULER_NAME":                     backend.SchedulerName,
 		"RUNTIME_CLASS_NAME":                 backend.RuntimeClassName,
 		"SERVER_AFFINITY":                    workersMap[workload.ModelWorkerTypeServer].Affinity,
@@ -353,30 +359,15 @@ func mapWorkers(workers []workload.ModelWorker) map[workload.ModelWorkerType]*wo
 	return workersMap
 }
 
-// effectiveServerPods returns the effective pod count for the server role (1 leader + N-1
-// Ray workers), or 0 if the backend has no server worker. Pods has no schema default
-// (Minimum is 0), so an omitted value and an explicit `pods: 0` both decode to 0, but a
-// role can never meaningfully have zero pods. This is the single source of truth every
-// Pods-derived calculation in the vLLM conversion path must use, so the clamp can't be
-// forgotten at a new use-site the way it was when the negative-WORKER_REPLICAS bug (#1612)
-// was introduced.
-func effectiveServerPods(workersMap map[workload.ModelWorkerType]*workload.ModelWorker) int32 {
-	serverWorker := workersMap[workload.ModelWorkerTypeServer]
-	if serverWorker == nil {
-		return 0
-	}
-	return max(serverWorker.Pods, 1)
-}
-
 // buildCommands constructs the command list for the backend.
 func buildCommands(backend *workload.ModelBackend, workerConfig *apiextensionsv1.JSON, modelDownloadPath string,
 	workersMap map[workload.ModelWorkerType]*workload.ModelWorker) ([]string, error) {
 	commands := []string{"python3", "-m", "vllm.entrypoints.openai.api_server", "--model", modelDownloadPath}
 	args, err := utils.ConvertVLLMArgsFromJson(workerConfig)
 	commands = append(commands, args...)
-	if serverPods := effectiveServerPods(workersMap); serverPods > 1 {
+	if workersMap[workload.ModelWorkerTypeServer] != nil && workersMap[workload.ModelWorkerTypeServer].Pods > 1 {
 		commands = append(commands, "--distributed_executor_backend", "ray")
-		commands = []string{"bash", "-c", fmt.Sprintf("chmod u+x %s && %s leader --ray_cluster_size=%d --num-gpus=%d && %s", VllmMultiNodeServingScriptPath, VllmMultiNodeServingScriptPath, serverPods, utils.GetDeviceNum(workersMap[workload.ModelWorkerTypeServer]), strings.Join(commands, " "))}
+		commands = []string{"bash", "-c", fmt.Sprintf("chmod u+x %s && %s leader --ray_cluster_size=%d --num-gpus=%d && %s", VllmMultiNodeServingScriptPath, VllmMultiNodeServingScriptPath, workersMap[workload.ModelWorkerTypeServer].Pods, utils.GetDeviceNum(workersMap[workload.ModelWorkerTypeServer]), strings.Join(commands, " "))}
 	}
 
 	// vllm image does not have mooncake-transfer-engine or nixl installed by default

--- a/pkg/model-booster-controller/convert/model_serving.go
+++ b/pkg/model-booster-controller/convert/model_serving.go
@@ -223,6 +223,13 @@ func buildVllmModelServing(model *workload.ModelBooster) (*workload.ModelServing
 	if workersMap[workload.ModelWorkerTypeServer] == nil {
 		return nil, fmt.Errorf("server worker not found in backend: %s", backend.Name)
 	}
+	// Pods is the total pod count for the server role (1 leader + N-1 Ray workers), so a
+	// role can never meaningfully have zero pods. Because Pods is a plain int32, an omitted
+	// value is indistinguishable from an explicit 0, so both are treated as the documented
+	// single-pod baseline to avoid computing a negative WORKER_REPLICAS below.
+	if serverWorker := workersMap[workload.ModelWorkerTypeServer]; serverWorker.Pods < 1 {
+		serverWorker.Pods = 1
+	}
 	enginePort, err := utils.GetEnginePort(backend)
 	if err != nil {
 		return nil, err

--- a/pkg/model-booster-controller/convert/model_serving.go
+++ b/pkg/model-booster-controller/convert/model_serving.go
@@ -223,6 +223,7 @@ func buildVllmModelServing(model *workload.ModelBooster) (*workload.ModelServing
 	if workersMap[workload.ModelWorkerTypeServer] == nil {
 		return nil, fmt.Errorf("server worker not found in backend: %s", backend.Name)
 	}
+	serverPods := effectiveServerPods(workersMap)
 	enginePort, err := utils.GetEnginePort(backend)
 	if err != nil {
 		return nil, err
@@ -334,14 +335,11 @@ func buildVllmModelServing(model *workload.ModelBooster) (*workload.ModelServing
 		"ENGINE_SERVER_RESOURCES":            workersMap[workload.ModelWorkerTypeServer].Resources,
 		"ENGINE_SERVER_IMAGE":                workersMap[workload.ModelWorkerTypeServer].Image,
 		"ENGINE_SERVER_COMMAND":              commands,
-		// Pods has no schema default (Minimum is 0), so an omitted or explicit-zero value
-		// decodes to 0. Clamp to 1 here so WORKER_REPLICAS is never negative; buildCommands'
-		// only Pods-dependent branch is guarded by "> 1", so it behaves the same either way.
-		"WORKER_REPLICAS":    max(workersMap[workload.ModelWorkerTypeServer].Pods, 1) - 1,
-		"SCHEDULER_NAME":     backend.SchedulerName,
-		"RUNTIME_CLASS_NAME": backend.RuntimeClassName,
-		"SERVER_AFFINITY":    workersMap[workload.ModelWorkerTypeServer].Affinity,
-		"SERVER_TOLERATIONS": workersMap[workload.ModelWorkerTypeServer].Tolerations,
+		"WORKER_REPLICAS":                    serverPods - 1,
+		"SCHEDULER_NAME":                     backend.SchedulerName,
+		"RUNTIME_CLASS_NAME":                 backend.RuntimeClassName,
+		"SERVER_AFFINITY":                    workersMap[workload.ModelWorkerTypeServer].Affinity,
+		"SERVER_TOLERATIONS":                 workersMap[workload.ModelWorkerTypeServer].Tolerations,
 	}
 	return loadModelServingTemplate(VllmTemplatePath, &data)
 }
@@ -355,15 +353,30 @@ func mapWorkers(workers []workload.ModelWorker) map[workload.ModelWorkerType]*wo
 	return workersMap
 }
 
+// effectiveServerPods returns the effective pod count for the server role (1 leader + N-1
+// Ray workers), or 0 if the backend has no server worker. Pods has no schema default
+// (Minimum is 0), so an omitted value and an explicit `pods: 0` both decode to 0, but a
+// role can never meaningfully have zero pods. This is the single source of truth every
+// Pods-derived calculation in the vLLM conversion path must use, so the clamp can't be
+// forgotten at a new use-site the way it was when the negative-WORKER_REPLICAS bug (#1612)
+// was introduced.
+func effectiveServerPods(workersMap map[workload.ModelWorkerType]*workload.ModelWorker) int32 {
+	serverWorker := workersMap[workload.ModelWorkerTypeServer]
+	if serverWorker == nil {
+		return 0
+	}
+	return max(serverWorker.Pods, 1)
+}
+
 // buildCommands constructs the command list for the backend.
 func buildCommands(backend *workload.ModelBackend, workerConfig *apiextensionsv1.JSON, modelDownloadPath string,
 	workersMap map[workload.ModelWorkerType]*workload.ModelWorker) ([]string, error) {
 	commands := []string{"python3", "-m", "vllm.entrypoints.openai.api_server", "--model", modelDownloadPath}
 	args, err := utils.ConvertVLLMArgsFromJson(workerConfig)
 	commands = append(commands, args...)
-	if workersMap[workload.ModelWorkerTypeServer] != nil && workersMap[workload.ModelWorkerTypeServer].Pods > 1 {
+	if serverPods := effectiveServerPods(workersMap); serverPods > 1 {
 		commands = append(commands, "--distributed_executor_backend", "ray")
-		commands = []string{"bash", "-c", fmt.Sprintf("chmod u+x %s && %s leader --ray_cluster_size=%d --num-gpus=%d && %s", VllmMultiNodeServingScriptPath, VllmMultiNodeServingScriptPath, workersMap[workload.ModelWorkerTypeServer].Pods, utils.GetDeviceNum(workersMap[workload.ModelWorkerTypeServer]), strings.Join(commands, " "))}
+		commands = []string{"bash", "-c", fmt.Sprintf("chmod u+x %s && %s leader --ray_cluster_size=%d --num-gpus=%d && %s", VllmMultiNodeServingScriptPath, VllmMultiNodeServingScriptPath, serverPods, utils.GetDeviceNum(workersMap[workload.ModelWorkerTypeServer]), strings.Join(commands, " "))}
 	}
 
 	// vllm image does not have mooncake-transfer-engine or nixl installed by default

--- a/pkg/model-booster-controller/convert/model_serving_test.go
+++ b/pkg/model-booster-controller/convert/model_serving_test.go
@@ -373,19 +373,36 @@ func TestCreateModelServingResources(t *testing.T) {
 	}
 }
 
-// TestBuildModelServingWorkerPodsToWorkerReplicas covers the regression from #1612: an
-// omitted (or explicit zero) workers[].pods must not produce a negative workerReplicas.
-// Pods is a plain int32, so an omitted field and an explicit `pods: 0` are indistinguishable
-// on the wire; both are exercised here to demonstrate they intentionally resolve to the same
-// single-pod baseline (workerReplicas: 0) rather than diverging.
+// TestBuildModelServingWorkerPodsOmitted covers the regression from #1612 using a fixture
+// whose worker block has no `pods` key at all, so YAML unmarshalling naturally zeroes the
+// field (rather than a test setting Workers[0].Pods = 0 directly on an already-loaded
+// object). This is the actual shape of the reported bug: a ModelBooster manifest that never
+// mentions pods must still produce a valid (non-negative) workerReplicas.
+func TestBuildModelServingWorkerPodsOmitted(t *testing.T) {
+	model := loadYaml[workload.ModelBooster](t, "testdata/input/model-with-pods-omitted.yaml")
+	require.Equal(t, int32(0), model.Spec.Backend.Workers[0].Pods,
+		"fixture must omit pods so unmarshalling produces the zero value naturally")
+
+	got, err := BuildModelServing(model)
+	require.NoError(t, err)
+	require.Len(t, got.Spec.Template.Roles, 1)
+
+	workerReplicas := got.Spec.Template.Roles[0].WorkerReplicas
+	assert.GreaterOrEqual(t, workerReplicas, int32(0), "workerReplicas must never be negative")
+	assert.Equal(t, int32(0), workerReplicas)
+}
+
+// TestBuildModelServingWorkerPodsToWorkerReplicas covers the workerReplicas calculation for
+// explicit pods values: an explicit zero (distinct from the omitted-field fixture above,
+// which exercises the same zero value reached through YAML unmarshalling instead of direct
+// assignment), the single-pod baseline, and a multi-node value.
 func TestBuildModelServingWorkerPodsToWorkerReplicas(t *testing.T) {
 	tests := []struct {
 		name               string
 		pods               int32
 		wantWorkerReplicas int32
 	}{
-		{name: "pods omitted defaults to a single pod", pods: 0, wantWorkerReplicas: 0},
-		{name: "pods: 0 behaves the same as omitted", pods: 0, wantWorkerReplicas: 0},
+		{name: "pods: 0 explicit", pods: 0, wantWorkerReplicas: 0},
 		{name: "pods: 1 is a single pod with no extra workers", pods: 1, wantWorkerReplicas: 0},
 		{name: "pods > 1 adds Ray workers", pods: 3, wantWorkerReplicas: 2},
 	}

--- a/pkg/model-booster-controller/convert/model_serving_test.go
+++ b/pkg/model-booster-controller/convert/model_serving_test.go
@@ -18,6 +18,7 @@ package convert
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -395,16 +396,20 @@ func TestBuildModelServingWorkerPodsOmitted(t *testing.T) {
 // TestBuildModelServingWorkerPodsToWorkerReplicas covers the workerReplicas calculation for
 // explicit pods values: an explicit zero (distinct from the omitted-field fixture above,
 // which exercises the same zero value reached through YAML unmarshalling instead of direct
-// assignment), the single-pod baseline, and a multi-node value.
+// assignment), the single-pod baseline, and a multi-node value. It also asserts that
+// buildCommands' Ray-leader command generation - which reads the same effectiveServerPods
+// value as WORKER_REPLICAS - keeps its existing "> 1" behavior for every case, so the
+// centralized clamp doesn't change command generation.
 func TestBuildModelServingWorkerPodsToWorkerReplicas(t *testing.T) {
 	tests := []struct {
 		name               string
 		pods               int32
 		wantWorkerReplicas int32
+		wantRayLeaderCmd   bool
 	}{
-		{name: "pods: 0 explicit", pods: 0, wantWorkerReplicas: 0},
-		{name: "pods: 1 is a single pod with no extra workers", pods: 1, wantWorkerReplicas: 0},
-		{name: "pods > 1 adds Ray workers", pods: 3, wantWorkerReplicas: 2},
+		{name: "pods: 0 explicit", pods: 0, wantWorkerReplicas: 0, wantRayLeaderCmd: false},
+		{name: "pods: 1 is a single pod with no extra workers", pods: 1, wantWorkerReplicas: 0, wantRayLeaderCmd: false},
+		{name: "pods > 1 adds Ray workers", pods: 3, wantWorkerReplicas: 2, wantRayLeaderCmd: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -418,6 +423,24 @@ func TestBuildModelServingWorkerPodsToWorkerReplicas(t *testing.T) {
 			workerReplicas := got.Spec.Template.Roles[0].WorkerReplicas
 			assert.GreaterOrEqual(t, workerReplicas, int32(0), "workerReplicas must never be negative")
 			assert.Equal(t, tt.wantWorkerReplicas, workerReplicas)
+
+			var engine *corev1.Container
+			for i := range got.Spec.Template.Roles[0].EntryTemplate.Spec.Containers {
+				container := &got.Spec.Template.Roles[0].EntryTemplate.Spec.Containers[i]
+				if container.Name == "engine" {
+					engine = container
+					break
+				}
+			}
+			require.NotNil(t, engine)
+			command := strings.Join(engine.Command, " ")
+			if tt.wantRayLeaderCmd {
+				assert.Contains(t, command, fmt.Sprintf("leader --ray_cluster_size=%d", tt.wantWorkerReplicas+1))
+				assert.Contains(t, command, "--distributed_executor_backend ray")
+			} else {
+				assert.NotContains(t, command, "leader --ray_cluster_size")
+				assert.NotContains(t, command, "--distributed_executor_backend")
+			}
 		})
 	}
 }

--- a/pkg/model-booster-controller/convert/model_serving_test.go
+++ b/pkg/model-booster-controller/convert/model_serving_test.go
@@ -373,6 +373,38 @@ func TestCreateModelServingResources(t *testing.T) {
 	}
 }
 
+// TestBuildModelServingWorkerPodsToWorkerReplicas covers the regression from #1612: an
+// omitted (or explicit zero) workers[].pods must not produce a negative workerReplicas.
+// Pods is a plain int32, so an omitted field and an explicit `pods: 0` are indistinguishable
+// on the wire; both are exercised here to demonstrate they intentionally resolve to the same
+// single-pod baseline (workerReplicas: 0) rather than diverging.
+func TestBuildModelServingWorkerPodsToWorkerReplicas(t *testing.T) {
+	tests := []struct {
+		name               string
+		pods               int32
+		wantWorkerReplicas int32
+	}{
+		{name: "pods omitted defaults to a single pod", pods: 0, wantWorkerReplicas: 0},
+		{name: "pods: 0 behaves the same as omitted", pods: 0, wantWorkerReplicas: 0},
+		{name: "pods: 1 is a single pod with no extra workers", pods: 1, wantWorkerReplicas: 0},
+		{name: "pods > 1 adds Ray workers", pods: 3, wantWorkerReplicas: 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := loadYaml[workload.ModelBooster](t, "testdata/input/model.yaml")
+			model.Spec.Backend.Workers[0].Pods = tt.pods
+
+			got, err := BuildModelServing(model)
+			require.NoError(t, err)
+			require.Len(t, got.Spec.Template.Roles, 1)
+
+			workerReplicas := got.Spec.Template.Roles[0].WorkerReplicas
+			assert.GreaterOrEqual(t, workerReplicas, int32(0), "workerReplicas must never be negative")
+			assert.Equal(t, tt.wantWorkerReplicas, workerReplicas)
+		})
+	}
+}
+
 func TestBuildModelServingVLLMPreStopHandlesUnavailableMetrics(t *testing.T) {
 	model := loadYaml[workload.ModelBooster](t, "testdata/input/model.yaml")
 	serving, err := BuildModelServing(model)

--- a/pkg/model-booster-controller/convert/model_serving_test.go
+++ b/pkg/model-booster-controller/convert/model_serving_test.go
@@ -397,9 +397,8 @@ func TestBuildModelServingWorkerPodsOmitted(t *testing.T) {
 // explicit pods values: an explicit zero (distinct from the omitted-field fixture above,
 // which exercises the same zero value reached through YAML unmarshalling instead of direct
 // assignment), the single-pod baseline, and a multi-node value. It also asserts that
-// buildCommands' Ray-leader command generation - which reads the same effectiveServerPods
-// value as WORKER_REPLICAS - keeps its existing "> 1" behavior for every case, so the
-// centralized clamp doesn't change command generation.
+// buildCommands' Ray-leader command generation, which is derived from the same Pods field
+// as WORKER_REPLICAS, keeps its existing "> 1" behavior for every case.
 func TestBuildModelServingWorkerPodsToWorkerReplicas(t *testing.T) {
 	tests := []struct {
 		name               string

--- a/pkg/model-booster-controller/convert/testdata/input/model-with-pods-omitted.yaml
+++ b/pkg/model-booster-controller/convert/testdata/input/model-with-pods-omitted.yaml
@@ -1,0 +1,36 @@
+apiVersion: workload.serving.volcano.sh/v1alpha1
+kind: ModelBooster
+metadata:
+  name: test-model
+  namespace: default
+  uid: randomUID
+spec:
+  backend:
+    name: backend1
+    type: vLLM
+    modelURI: s3://aios_models/deepseek-ai/DeepSeek-V3-W8A8/vllm-ascend
+    cacheURI: hostpath:///tmp/test
+    replicas: 0
+    env:
+      - name: ENDPOINT
+        value: https://obs.test.com
+      - name: RUNTIME_PORT
+        value: "8900"
+    envFrom:
+      - secretRef:
+          name: test-secret
+    workers:
+      - image: vllm-server:latest
+        config:
+          block-size: 128
+          gpu-memory-utilization: 0.9
+          max-model-len: 32768
+          tensor-parallel-size: 2
+          trust-remote-code: ""
+          served-model-name: "deepseek-v3"
+        resources:
+          limits:
+            cpu: 100m
+            huawei.com/ascend-1980: "1"
+            memory: 1Gi
+        type: server


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fixes an issue where a vLLM ModelBooster with `workers[].pods` omitted could generate an invalid `workerReplicas: -1` in the generated ModelServing.

`workers[].pods` is a plain `int32`, so an omitted value and an explicit `pods: 0` both decode to the zero value. `buildVllmModelServing` previously used this value directly as `pods - 1`, resulting in `workerReplicas: -1`.

Since `pods` represents the total number of pods for the server role, with one pod serving as the leader, values below 1 are treated as the single-pod baseline before calculating worker replicas. This ensures the generated `workerReplicas` can never be negative.

The fix also adds regression coverage for:
- `pods` omitted
- `pods: 0`
- `pods: 1`
- `pods: 3`

**Which issue(s) this PR fixes**:

Fixes #1612

**Bug evidence (required for bug-related PRs)**:

A vLLM ModelBooster with the following configuration can trigger the issue:

```yaml
apiVersion: workload.serving.volcano.sh/v1alpha1
kind: ModelBooster
spec:
  backend:
    type: vLLM
    workers:
      - type: Server
        image: vllm/vllm-openai:latest
```
Because workers[].pods is omitted, it is decoded as 0. The vLLM conversion logic previously calculated:
workerReplicas = pods - 1
               = 0 - 1
               = -1

The generated ModelServing therefore contains workerReplicas: -1, which is rejected by the ModelServing validation webhook because worker replicas cannot be negative.

The ModelBooster then enters Failed status and repeatedly retries the same invalid generated configuration.

The fix treats a zero/omitted pods value as the single-pod baseline before calculating worker replicas, so the generated ModelServing remains valid and the negative replica count cannot occur.

Regression tests reproduce the conversion boundary for omitted/zero and positive pod counts and verify that workerReplicas is never negative.

Special notes for your reviewer:

- The change is limited to the vLLM ModelBooster-to-ModelServing conversion and its regression tests.
- workers[].pods remains an int32; no API or CRD changes are introduced.
- Values below 1 are clamped to the single-pod baseline before calculating worker replicas.
- Existing behavior for valid positive pod counts is preserved.
- No ModelServing reconciliation, scaling, or validation logic was changed.

Does this PR introduce a user-facing change?:

NONE