### PR TITLE
model-serving: apply the PluginScope target kubebuilder markers

### DIFF
--- a/charts/kthena/charts/workload/crds/workload.serving.volcano.sh_modelservings.yaml
+++ b/charts/kthena/charts/workload/crds/workload.serving.volcano.sh_modelservings.yaml
@@ -83,10 +83,13 @@ spec:
                             type: string
                           type: array
                         target:
-                          description: |-
-                            Target limits the plugin to specific pod target (Entry/Worker/All).
-                            kubebuilder:default=All
-                            kubebuilder:validation:Enum={All,Entry,Worker}
+                          default: All
+                          description: Target limits the plugin to specific pod target
+                            (Entry/Worker/All).
+                          enum:
+                          - All
+                          - Entry
+                          - Worker
                           type: string
                       type: object
                     type:

--- a/docs/kthena/docs/reference/crd/workload.serving.volcano.sh.md
+++ b/docs/kthena/docs/reference/crd/workload.serving.volcano.sh.md
@@ -677,7 +677,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `roles` _string array_ | Roles limits the plugin to the specified role names. |  |  |
-| `target` _[PluginTarget](#plugintarget)_ | Target limits the plugin to specific pod target (Entry/Worker/All).<br />kubebuilder:default=All<br />kubebuilder:validation:Enum=\{All,Entry,Worker\} |  |  |
+| `target` _[PluginTarget](#plugintarget)_ | Target limits the plugin to specific pod target (Entry/Worker/All). | All | Enum: [All Entry Worker] <br /> |
 
 
 #### PluginSpec

--- a/pkg/apis/workload/v1alpha1/model_serving_types.go
+++ b/pkg/apis/workload/v1alpha1/model_serving_types.go
@@ -92,8 +92,8 @@ type PluginScope struct {
 	// +optional
 	Roles []string `json:"roles,omitempty"`
 	// Target limits the plugin to specific pod target (Entry/Worker/All).
-	// kubebuilder:default=All
-	// kubebuilder:validation:Enum={All,Entry,Worker}
+	// +kubebuilder:default=All
+	// +kubebuilder:validation:Enum={All,Entry,Worker}
 	Target PluginTarget `json:"target,omitempty"`
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The `default` and `Enum` markers on `PluginScope.Target` are written without the leading plus, so controller-gen reads them as prose rather than as markers. `PluginSpec.Type` immediately below carries the same pair correctly, which is what makes the difference visible.

Two consequences, both in generated output that ships.

The CRD carries the marker text in the field description and applies neither constraint:

```yaml
target:
  description: |-
    Target limits the plugin to specific pod target (Entry/Worker/All).
    kubebuilder:default=All
    kubebuilder:validation:Enum={All,Entry,Worker}
  type: string
```

and the reference docs render the same text in the Description column with Default and Validation empty:

```
| `target` _[PluginTarget](#plugintarget)_ | Target limits the plugin to specific pod target (Entry/Worker/All).<br />kubebuilder:default=All<br />kubebuilder:validation:Enum=\{All,Entry,Worker\} |  |  |
```

Because the enum never reaches the API server, `spec.plugins[].scope.target` accepts any string. `shouldRun` compares the value against the `All`, `Entry` and `Worker` constants, so a value that does not match, a lowercase `worker` for instance, falls through both branches and the plugin silently does not run on any pod.

After the change:

```yaml
target:
  default: All
  description: Target limits the plugin to specific pod target (Entry/Worker/All).
  enum:
  - All
  - Entry
  - Worker
  type: string
```

```
| `target` _[PluginTarget](#plugintarget)_ | Target limits the plugin to specific pod target (Entry/Worker/All). | All | Enum: [All Entry Worker] <br /> |
```

These are the only two malformed kubebuilder markers in the repository, so the change is two characters plus the regenerated CRD and reference docs.

**Which issue(s) this PR fixes**:

Fixes #1630 

**Special notes for your reviewer**:

Generated with the versions the Makefile pins, `CONTROLLER_TOOLS_VERSION v0.17.2` and `CRD_REF_DOCS_VERSION v0.2.0`, through the normal targets including `hack/update-crd.sh`. Re-running generation on this commit produces no further diff.

**Does this PR introduce a user-facing change?**

```release-note
spec.plugins[].scope.target on ModelServing now defaults to All and is validated against All, Entry and Worker. Previously any string was accepted and an unrecognised value silently disabled the plugin.
```