### PR TITLE
router: validate KV-cache tokenizer ports

### DIFF
--- a/pkg/kthena-router/scheduler/plugins/kvcache_aware.go
+++ b/pkg/kthena-router/scheduler/plugins/kvcache_aware.go
@@ -177,14 +177,13 @@ func NewKVCacheAware(pluginArg runtime.RawExtension) *KVCacheAware {
 }
 
 func normalizeTokenizerPort(engine string, configuredPort, defaultPort int) int {
-	if configuredPort == 0 {
-		return defaultPort
+	if configuredPort >= 1 && configuredPort <= maxTokenizerPort {
+		return configuredPort
 	}
-	if configuredPort < 1 || configuredPort > maxTokenizerPort {
+	if configuredPort != 0 {
 		klog.Warningf("KVCacheAware: invalid %s tokenizer port %d, using default %d", engine, configuredPort, defaultPort)
-		return defaultPort
 	}
-	return configuredPort
+	return defaultPort
 }
 
 func (t *KVCacheAware) Name() string {

--- a/pkg/kthena-router/scheduler/plugins/kvcache_aware.go
+++ b/pkg/kthena-router/scheduler/plugins/kvcache_aware.go
@@ -69,6 +69,7 @@ const (
 
 	// defaultSGLangTokenizerPort is the upstream-default port for sglang
 	defaultSGLangTokenizerPort = 30000
+	maxTokenizerPort           = 65535
 
 	// kvCacheFieldFreshDuration matches the runtime mapping key expiry
 	kvCacheFieldFreshDuration = 24 * time.Hour
@@ -142,14 +143,8 @@ func NewKVCacheAware(pluginArg runtime.RawExtension) *KVCacheAware {
 		maxBlocksToMatch = defaultMaxBlocksToMatch
 	}
 
-	vllmPort := args.VLLMTokenizerPort
-	if vllmPort <= 0 {
-		vllmPort = defaultVLLMTokenizerPort
-	}
-	sglangPort := args.SGLangTokenizerPort
-	if sglangPort <= 0 {
-		sglangPort = defaultSGLangTokenizerPort
-	}
+	vllmPort := normalizeTokenizerPort(tokenization.EngineVLLM, args.VLLMTokenizerPort, defaultVLLMTokenizerPort)
+	sglangPort := normalizeTokenizerPort(tokenization.EngineSGLang, args.SGLangTokenizerPort, defaultSGLangTokenizerPort)
 
 	klog.Infof("KVCacheAware: config blockSizeToHash=%d, maxBlocksToMatch=%d, vllmTokenizerPort=%d, sglangTokenizerPort=%d",
 		blockSizeToHash, maxBlocksToMatch, vllmPort, sglangPort)
@@ -179,6 +174,17 @@ func NewKVCacheAware(pluginArg runtime.RawExtension) *KVCacheAware {
 	}
 	plugin.startGC()
 	return plugin
+}
+
+func normalizeTokenizerPort(engine string, configuredPort, defaultPort int) int {
+	if configuredPort == 0 {
+		return defaultPort
+	}
+	if configuredPort < 1 || configuredPort > maxTokenizerPort {
+		klog.Warningf("KVCacheAware: invalid %s tokenizer port %d, using default %d", engine, configuredPort, defaultPort)
+		return defaultPort
+	}
+	return configuredPort
 }
 
 func (t *KVCacheAware) Name() string {

--- a/pkg/kthena-router/scheduler/plugins/kvcache_aware_test.go
+++ b/pkg/kthena-router/scheduler/plugins/kvcache_aware_test.go
@@ -625,6 +625,29 @@ func TestNewKVCacheAware_Core(t *testing.T) {
 	}
 }
 
+func TestNormalizeTokenizerPort(t *testing.T) {
+	tests := []struct {
+		name           string
+		configuredPort int
+		defaultPort    int
+		want           int
+	}{
+		{name: "unset uses default", configuredPort: 0, defaultPort: 8000, want: 8000},
+		{name: "negative uses default", configuredPort: -1, defaultPort: 8000, want: 8000},
+		{name: "minimum is accepted", configuredPort: 1, defaultPort: 8000, want: 1},
+		{name: "maximum is accepted", configuredPort: 65535, defaultPort: 8000, want: 65535},
+		{name: "above maximum uses default", configuredPort: 65536, defaultPort: 8000, want: 8000},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizeTokenizerPort(tokenization.EngineVLLM, tt.configuredPort, tt.defaultPort); got != tt.want {
+				t.Fatalf("normalizeTokenizerPort() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestKVCacheAware_Score_Core(t *testing.T) {
 	pods := createTestPods("pod1", "pod2", "pod3")
 

--- a/pkg/kthena-router/scheduler/plugins/tokenization/tokenization_test.go
+++ b/pkg/kthena-router/scheduler/plugins/tokenization/tokenization_test.go
@@ -191,6 +191,17 @@ func TestBuildTokenizerEndpoint(t *testing.T) {
 	}
 }
 
+func TestTokenizerManagerRejectsOutOfRangePort(t *testing.T) {
+	manager := NewTokenizerManager(TokenizerManagerConfig{
+		EndpointPorts: map[string]int{EngineVLLM: maxEndpointPort + 1},
+	})
+	pod := testutil.PodInfoWithEngine("pod-vllm", "default", "10.0.0.10", EngineVLLM)
+
+	if tokenizer := manager.GetTokenizer("test-model", []*datastore.PodInfo{pod}); tokenizer != nil {
+		t.Fatalf("expected no tokenizer for an out-of-range endpoint port, got %T", tokenizer)
+	}
+}
+
 // Test error types
 func TestErrorTypes(t *testing.T) {
 	t.Run("ErrTokenizationFailed", func(t *testing.T) {

--- a/pkg/kthena-router/scheduler/plugins/tokenization/tokenizer_manager.go
+++ b/pkg/kthena-router/scheduler/plugins/tokenization/tokenizer_manager.go
@@ -32,6 +32,8 @@ import (
 	"k8s.io/klog/v2"
 )
 
+const maxEndpointPort = 65535
+
 // Remote tokenization is always attempted when an engine port exists.
 type TokenizerManagerConfig struct {
 	EndpointPorts map[string]int
@@ -81,7 +83,7 @@ func (m *TokenizerManager) createTokenizerFromPods(model string, pods []*datasto
 			continue
 		}
 		port, ok := m.config.EndpointPorts[engine]
-		if !ok || port <= 0 {
+		if !ok || port < 1 || port > maxEndpointPort {
 			klog.Warningf("TokenizerManager: no valid endpoint port for engine %q, skipping pod %s", engine, pod.Name)
 			continue
 		}


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

Validates the KV-cache-aware scheduler's `vllmTokenizerPort` and `sglangTokenizerPort` overrides against the TCP port range.

- An unset value (`0`) continues to use the engine default.
- Explicit values below 1 or above 65535 fall back to the engine default with a warning.
- `TokenizerManager` defensively skips any out-of-range endpoint port supplied by another caller.
- Boundary tests cover 0, negative values, 1, 65535, and 65536.

Previously, only the lower bound was checked. An override such as `70000` reached the request path, so the router started normally but remote tokenization failed when KV-cache-aware scoring tried to contact the backend.

**Which issue(s) this PR fixes**:
Fixes #1632

**Bug evidence (required for bug-related PRs)**:

The production configuration path accepted this override:

```yaml
plugins:
  score:
    enabled:
      - name: kvcache-aware
        args:
          vllmTokenizerPort: 70000
```

Before this change, `NewKVCacheAware` only replaced values `<= 0`, and `TokenizerManager` repeated the same lower-bound-only check. The resulting tokenizer endpoint reached Go's HTTP transport. A minimal request through that transport reproduces the request-time failure:

```text
Get "http://127.0.0.1:70000/tokenize": dial tcp: address 70000: invalid port
```

The fix prevents that invalid endpoint from being constructed: the plugin falls back to port 8000 for vLLM (or 30000 for SGLang), while the manager rejects invalid direct configuration defensively.

**Special notes for your reviewer**:

Validation performed:

- `go test ./pkg/kthena-router/scheduler/plugins/tokenization ./pkg/kthena-router/scheduler/plugins -count=1`
- `go test ./pkg/kthena-router/scheduler/plugins -run TestNormalizeTokenizerPort -count=100`
- `go test ./pkg/kthena-router/scheduler/plugins/tokenization -run TestTokenizerManagerRejectsOutOfRangePort -count=100`
- `go vet ./pkg/kthena-router/scheduler/plugins/...`
- `git diff --check`

This contribution was implemented with AI assistance and manually reviewed and tested before submission.

**Does this PR introduce a user-facing change?**:
```release-note
Invalid KV-cache tokenizer port overrides now fall back to the engine default instead of failing tokenization at request time.
```