### PR TITLE
fix: require workloadPort in ModelServer

### DIFF
--- a/charts/kthena/charts/networking/crds/networking.serving.volcano.sh_modelservers.yaml
+++ b/charts/kthena/charts/networking/crds/networking.serving.volcano.sh_modelservers.yaml
@@ -171,6 +171,7 @@ spec:
                 type: object
             required:
             - inferenceEngine
+            - workloadPort
             - workloadSelector
             type: object
           status:

--- a/docs/kthena/docs/reference/crd/networking.serving.volcano.sh.md
+++ b/docs/kthena/docs/reference/crd/networking.serving.volcano.sh.md
@@ -335,7 +335,7 @@ _Appears in:_
 | `model` _string_ | The real model that the modelServers are running.<br />If the `model` in LLM inference request is different from this field, it should be overwritten by this field.<br />Otherwise, the `model` in LLM inference request will not be mutated. |  | MaxLength: 256 <br /> |
 | `inferenceEngine` _[InferenceEngine](#inferenceengine)_ | The inference engine used to serve the model. |  | Enum: [vLLM SGLang] <br />Required: \{\} <br /> |
 | `workloadSelector` _[WorkloadSelector](#workloadselector)_ | WorkloadSelector is used to match the model serving instances.<br />Currently, they must be pods within the same namespace as modelServer object. |  | Required: \{\} <br /> |
-| `workloadPort` _[WorkloadPort](#workloadport)_ | WorkloadPort defines the port and protocol configuration for the model server. |  |  |
+| `workloadPort` _[WorkloadPort](#workloadport)_ | WorkloadPort defines the port and protocol configuration for the model server. |  | Required: \{\} <br /> |
 | `trafficPolicy` _[TrafficPolicy](#trafficpolicy)_ | Traffic Policy for accessing the model server instance. |  |  |
 | `kvConnector` _[KVConnectorSpec](#kvconnectorspec)_ | KVConnector specifies the KV connector configuration for PD disaggregated routing |  |  |
 

--- a/pkg/apis/networking/v1alpha1/modelserver_types.go
+++ b/pkg/apis/networking/v1alpha1/modelserver_types.go
@@ -38,7 +38,8 @@ type ModelServerSpec struct {
 	WorkloadSelector *WorkloadSelector `json:"workloadSelector"`
 
 	// WorkloadPort defines the port and protocol configuration for the model server.
-	WorkloadPort WorkloadPort `json:"workloadPort,omitempty"`
+	// +kubebuilder:validation:Required
+	WorkloadPort WorkloadPort `json:"workloadPort"`
 
 	// Traffic Policy for accessing the model server instance.
 	// +optional


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Requires `spec.workloadPort` on ModelServer resources. Without it, the router uses the zero-value port.

**Which issue(s) this PR fixes**:

N/A

**Bug evidence (required for bug-related PRs)**:

The following ModelServer is currently accepted:

```yaml
apiVersion: networking.serving.volcano.sh/v1alpha1
kind: ModelServer
metadata:
  name: missing-port
spec:
  inferenceEngine: vLLM
  workloadSelector:
    matchLabels:
      app: demo
```

workloadPort is optional in the API and omitted from the CRD required list:
https://github.com/volcano-sh/kthena/blob/b8d1ac7083934691af6802a24063e2485fb1109d/pkg/apis/networking/v1alpha1/modelserver_types.go#L40-L41
The router later reads the missing value as port 0:
https://github.com/volcano-sh/kthena/blob/b8d1ac7083934691af6802a24063e2485fb1109d/pkg/kthena-router/router/router.go#L487-L493
This change rejects the resource during admission instead

**Special notes for your reviewer**:

Existing examples and ModelBooster-generated ModelServers already provide workloadPort.

**Does this PR introduce a user-facing change?**:

```release-note
Reject ModelServer resources that omit spec.workloadPort.
```
