### PR TITLE
router: normalize external provider credentials

### DIFF
--- a/pkg/apis/networking/v1alpha1/externalmodelprovider_types.go
+++ b/pkg/apis/networking/v1alpha1/externalmodelprovider_types.go
@@ -55,6 +55,7 @@ const (
 	ExternalModelProviderReasonCredentialResolved    = "CredentialResolved"
 	ExternalModelProviderReasonCredentialNotFound    = "CredentialNotFound"
 	ExternalModelProviderReasonCredentialKeyNotFound = "CredentialKeyNotFound"
+	ExternalModelProviderReasonCredentialInvalid     = "CredentialInvalid"
 )
 
 // ExternalModelProviderSpec defines the desired state of ExternalModelProvider.

--- a/pkg/kthena-router/controller/externalmodelprovider_controller.go
+++ b/pkg/kthena-router/controller/externalmodelprovider_controller.go
@@ -367,6 +367,10 @@ func (c *ExternalModelProviderController) reconcileProviderStatus(provider *netw
 			credentialCondition.Status = metav1.ConditionFalse
 			credentialCondition.Reason = networkingv1alpha1.ExternalModelProviderReasonCredentialKeyNotFound
 			credentialCondition.Message = "Credential Secret key is not found"
+		} else if _, err := providers.NormalizeCredential(value); err != nil {
+			credentialCondition.Status = metav1.ConditionFalse
+			credentialCondition.Reason = networkingv1alpha1.ExternalModelProviderReasonCredentialInvalid
+			credentialCondition.Message = err.Error()
 		}
 	}
 

--- a/pkg/kthena-router/controller/externalmodelprovider_controller_test.go
+++ b/pkg/kthena-router/controller/externalmodelprovider_controller_test.go
@@ -319,6 +319,44 @@ func TestExternalModelProviderController_StatusForCredentials(t *testing.T) {
 	assertProviderCondition(t, kthenaClient, "default", "openai-provider", aiv1alpha1.ExternalModelProviderConditionReady, metav1.ConditionTrue, aiv1alpha1.ExternalModelProviderReasonReady)
 	assertProviderCondition(t, kthenaClient, "default", "openai-provider", aiv1alpha1.ExternalModelProviderConditionCredentialsResolved, metav1.ConditionTrue, aiv1alpha1.ExternalModelProviderReasonCredentialResolved)
 
+	secretWithWhitespaceOnlyKey := secret.DeepCopy()
+	secretWithWhitespaceOnlyKey.Data = map[string][]byte{
+		"api-key": []byte(" \t\r\n"),
+	}
+	_, err = kubeClient.CoreV1().Secrets("default").Update(context.Background(), secretWithWhitespaceOnlyKey, metav1.UpdateOptions{})
+	assert.NoError(t, err)
+	found = waitForObjectInCache(t, 2*time.Second, func() bool {
+		got, err := controller.secretLister.Secrets("default").Get("provider-secret")
+		return err == nil && string(got.Data["api-key"]) == " \t\r\n"
+	})
+	assert.True(t, found, "Secret update should be reflected in cache")
+
+	err = controller.syncSecretHandler("default/provider-secret")
+	assert.NoError(t, err)
+	err = controller.syncHandler("default/openai-provider")
+	assert.NoError(t, err)
+	assertProviderCondition(t, kthenaClient, "default", "openai-provider", aiv1alpha1.ExternalModelProviderConditionReady, metav1.ConditionFalse, aiv1alpha1.ExternalModelProviderReasonCredentialInvalid)
+	assertProviderCondition(t, kthenaClient, "default", "openai-provider", aiv1alpha1.ExternalModelProviderConditionCredentialsResolved, metav1.ConditionFalse, aiv1alpha1.ExternalModelProviderReasonCredentialInvalid)
+
+	secretWithTrailingNewline := secret.DeepCopy()
+	secretWithTrailingNewline.Data = map[string][]byte{
+		"api-key": []byte("test-key\n"),
+	}
+	_, err = kubeClient.CoreV1().Secrets("default").Update(context.Background(), secretWithTrailingNewline, metav1.UpdateOptions{})
+	assert.NoError(t, err)
+	found = waitForObjectInCache(t, 2*time.Second, func() bool {
+		got, err := controller.secretLister.Secrets("default").Get("provider-secret")
+		return err == nil && string(got.Data["api-key"]) == "test-key\n"
+	})
+	assert.True(t, found, "Secret update should be reflected in cache")
+
+	err = controller.syncSecretHandler("default/provider-secret")
+	assert.NoError(t, err)
+	err = controller.syncHandler("default/openai-provider")
+	assert.NoError(t, err)
+	assertProviderCondition(t, kthenaClient, "default", "openai-provider", aiv1alpha1.ExternalModelProviderConditionReady, metav1.ConditionTrue, aiv1alpha1.ExternalModelProviderReasonReady)
+	assertProviderCondition(t, kthenaClient, "default", "openai-provider", aiv1alpha1.ExternalModelProviderConditionCredentialsResolved, metav1.ConditionTrue, aiv1alpha1.ExternalModelProviderReasonCredentialResolved)
+
 	secretWithoutKey := secret.DeepCopy()
 	secretWithoutKey.Data = map[string][]byte{
 		"other-key": []byte("test-key"),

--- a/pkg/kthena-router/providers/adapter.go
+++ b/pkg/kthena-router/providers/adapter.go
@@ -256,7 +256,22 @@ func providerToken(provider *networkingv1alpha1.ExternalModelProvider, secret *c
 	if !ok || len(value) == 0 {
 		return "", newConfigurationError("secret key %s is not found", key)
 	}
-	return string(value), nil
+	return NormalizeCredential(value)
+}
+
+// NormalizeCredential removes surrounding whitespace commonly introduced by
+// Secret creation workflows and validates that the result is safe to place in
+// an HTTP header. Callers should use this for both status validation and
+// request construction so they agree on whether a credential is usable.
+func NormalizeCredential(value []byte) (string, error) {
+	token := strings.TrimSpace(string(value))
+	if token == "" {
+		return "", newConfigurationError("provider credential is empty after trimming whitespace")
+	}
+	if !httpguts.ValidHeaderFieldValue(token) {
+		return "", newConfigurationError("provider credential contains invalid HTTP header characters")
+	}
+	return token, nil
 }
 
 func applyProviderAuth(headers http.Header, provider *networkingv1alpha1.ExternalModelProvider, secret *corev1.Secret, defaultScheme networkingv1alpha1.ProviderAuthScheme) error {

--- a/pkg/kthena-router/providers/adapter_test.go
+++ b/pkg/kthena-router/providers/adapter_test.go
@@ -514,6 +514,72 @@ func TestProviderAuthSchemeOverride(t *testing.T) {
 	}
 }
 
+func TestApplyProviderAuthNormalizesCredential(t *testing.T) {
+	tests := []struct {
+		name       string
+		value      string
+		scheme     networkingv1alpha1.ProviderAuthScheme
+		wantHeader string
+		wantValue  string
+		wantErr    bool
+	}{
+		{
+			name:       "bearer token with trailing newline",
+			value:      "provider-key\n",
+			scheme:     networkingv1alpha1.ProviderAuthSchemeBearer,
+			wantHeader: "Authorization",
+			wantValue:  "Bearer provider-key",
+		},
+		{
+			name:       "api key with surrounding whitespace",
+			value:      " \tprovider-key\r\n",
+			scheme:     networkingv1alpha1.ProviderAuthSchemeAPIKey,
+			wantHeader: "x-api-key",
+			wantValue:  "provider-key",
+		},
+		{
+			name:    "whitespace only credential",
+			value:   " \t\r\n",
+			scheme:  networkingv1alpha1.ProviderAuthSchemeBearer,
+			wantErr: true,
+		},
+		{
+			name:    "embedded newline",
+			value:   "provider\nkey",
+			scheme:  networkingv1alpha1.ProviderAuthSchemeAPIKey,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := &networkingv1alpha1.ExternalModelProvider{
+				Spec: networkingv1alpha1.ExternalModelProviderSpec{
+					Auth: &networkingv1alpha1.ProviderAuth{
+						Scheme: tt.scheme,
+						SecretRef: corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "provider-secret"},
+							Key:                  "api-key",
+						},
+					},
+				},
+			}
+			secret := &corev1.Secret{Data: map[string][]byte{"api-key": []byte(tt.value)}}
+			headers := http.Header{}
+
+			err := applyProviderAuth(headers, provider, secret, networkingv1alpha1.ProviderAuthSchemeBearer)
+			if tt.wantErr {
+				assert.Error(t, err)
+				var configurationError *ConfigurationError
+				assert.ErrorAs(t, err, &configurationError)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantValue, headers.Get(tt.wantHeader))
+		})
+	}
+}
+
 func TestOpenAIAdapterResponseParser(t *testing.T) {
 	adapter, err := NewAdapter(networkingv1alpha1.OpenAI)
 	assert.NoError(t, err)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Normalize surrounding whitespace in Secret-backed ExternalModelProvider credentials before injecting them into `Authorization` or `x-api-key` headers.

The normalization and HTTP-header validation are shared by request construction and controller status reconciliation. Whitespace-only credentials and credentials containing invalid header characters now set `CredentialsResolved=False` and `Ready=False` with the new `CredentialInvalid` reason, instead of reporting the provider as ready and failing every request later.

Regression coverage includes Bearer credentials with trailing newlines, API keys with surrounding whitespace, whitespace-only credentials, embedded newlines, and the corresponding provider status transitions.

**Which issue(s) this PR fixes**:
Fixes #1636

**Bug evidence (required for bug-related PRs)**:

A credential created from shell output can contain a trailing newline. For example, the Secret value `cHJvdmlkZXIta2V5Cg==` decodes to `provider-key\n`. Before this change, the controller only checked that the value was non-empty and marked the provider Ready:

https://github.com/volcano-sh/kthena/blob/b8d1ac7083934691af6802a24063e2485fb1109d/pkg/kthena-router/controller/externalmodelprovider_controller.go#L350-L371

The request path then copied the value verbatim into the authentication header:

https://github.com/volcano-sh/kthena/blob/b8d1ac7083934691af6802a24063e2485fb1109d/pkg/kthena-router/providers/adapter.go#L247-L278

Using that path with a real HTTP client and upstream listener, request construction succeeded but `http.Client.Do` rejected the request before it reached the upstream:

```
net/http: invalid header field value for "Authorization"
```

The change trims surrounding whitespace before header injection and validates the normalized value during both reconciliation and request construction.

**Special notes for your reviewer**:

AI assistance was used to investigate the failure, draft the implementation, and add tests. The author reviewed the changes and validation results.

Validation:

- `go test ./pkg/kthena-router/...`
- `go test ./pkg/apis/networking/v1alpha1 ./pkg/kthena-router/providers ./pkg/kthena-router/controller`
- `go test ./pkg/kthena-router/providers ./pkg/kthena-router/controller -run 'TestApplyProviderAuthNormalizesCredential|TestExternalModelProviderController_StatusForCredentials' -count=20`
- `go vet ./pkg/apis/networking/v1alpha1 ./pkg/kthena-router/providers ./pkg/kthena-router/controller`
- `git diff --check`

**Does this PR introduce a user-facing change?**:

```release-note
Normalize surrounding whitespace in ExternalModelProvider Secret credentials and report unusable credentials as CredentialInvalid.
```
