### PR TITLE
fix(router): reject unregistered models before fairness/session-boost queuing

### DIFF
--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -1453,6 +1453,14 @@ func (r *Router) proxyToPDDisaggregated(
 
 // handleFairnessScheduling handles the fairness scheduling flow for requests.
 func (r *Router) handleFairnessScheduling(c *gin.Context, modelRequest ModelRequest, requestID string, modelName string) error {
+	// Reject unregistered models before Enqueue can spawn a model-specific queue
+	// and goroutine for them; queue cleanup is tied to the ModelRoute lifecycle,
+	// so a name with no ModelRoute would otherwise leak both indefinitely.
+	if !r.store.HasModel(modelName) {
+		c.AbortWithStatusJSON(http.StatusNotFound, "route not found")
+		return fmt.Errorf("route not found")
+	}
+
 	// Extract session ID from HTTP header for multi-turn conversation tracking.
 	sessionHeader := r.store.GetSessionIDHeader()
 	var sessionID string

--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -297,8 +297,9 @@ func (r *Router) HandlerFunc() gin.HandlerFunc {
 
 		// Create metrics recorder for this request
 		path := c.Request.URL.Path
+		hasModel := r.store.HasModel(modelName)
 		metricsModel := metrics.UnknownModel
-		if r.store.HasModel(modelName) {
+		if hasModel {
 			metricsModel = modelName
 		}
 		metricsRecorder := metrics.NewRequestMetricsRecorder(r.metrics, metricsModel, path)
@@ -378,7 +379,9 @@ func (r *Router) HandlerFunc() gin.HandlerFunc {
 		c.Set("metricsRecorder", metricsRecorder)
 
 		// step 3.1: direct load balancing when neither fairness scheduling nor
-		// session boost is enabled.
+		// session boost is enabled. doLoadbalance validates the route itself
+		// (a model may be routable via InferencePool/HTTPRoute even without a
+		// registered ModelRoute), so HasModel is not checked here.
 		if !EnableFairnessScheduling && !EnableSessionBoost {
 			_ = r.doLoadbalance(c, modelRequest)
 			return
@@ -386,6 +389,25 @@ func (r *Router) HandlerFunc() gin.HandlerFunc {
 
 		// step 3.2: queue scheduling. The queue orders requests by the active
 		// strategy: per-user fairness or session boost (mutually exclusive).
+		//
+		// Reject models with no registered ModelRoute here, before
+		// handleFairnessScheduling, so store.Enqueue can never be reached for
+		// an unregistered model name — which would otherwise leak a
+		// model-specific queue and goroutine forever, since queue cleanup is
+		// tied to the ModelRoute lifecycle. Fairness/session-boost priority is
+		// computed from ModelRoute-level rate-limit configuration, so (unlike
+		// the direct load-balancing path above) an InferencePool-only route
+		// cannot be scheduled through this path anyway. Using the same
+		// response and route_not_found observability labeling as the
+		// equivalent unregistered-model case in doLoadbalance keeps both
+		// paths consistent for callers and metrics/logging.
+		if !hasModel {
+			accesslog.SetError(c, "route_not_found", "route not found")
+			c.AbortWithStatusJSON(http.StatusNotFound, "route not found")
+			c.Set("finishReason", "route_not_found")
+			return
+		}
+
 		if err := r.handleFairnessScheduling(c, modelRequest, requestID, modelName); err != nil {
 			accesslog.SetError(c, "scheduling", err.Error())
 			c.Set("finishReason", "scheduling")
@@ -1452,15 +1474,10 @@ func (r *Router) proxyToPDDisaggregated(
 }
 
 // handleFairnessScheduling handles the fairness scheduling flow for requests.
+// The caller (HandlerFunc) validates that modelName has a registered
+// ModelRoute before invoking this function, so Enqueue can never be reached
+// for an unregistered model name.
 func (r *Router) handleFairnessScheduling(c *gin.Context, modelRequest ModelRequest, requestID string, modelName string) error {
-	// Reject unregistered models before Enqueue can spawn a model-specific queue
-	// and goroutine for them; queue cleanup is tied to the ModelRoute lifecycle,
-	// so a name with no ModelRoute would otherwise leak both indefinitely.
-	if !r.store.HasModel(modelName) {
-		c.AbortWithStatusJSON(http.StatusNotFound, "route not found")
-		return fmt.Errorf("route not found")
-	}
-
 	// Extract session ID from HTTP header for multi-turn conversation tracking.
 	sessionHeader := r.store.GetSessionIDHeader()
 	var sessionID string

--- a/pkg/kthena-router/router/router_test.go
+++ b/pkg/kthena-router/router/router_test.go
@@ -2892,65 +2892,6 @@ func (s *enqueueSpyStore) Enqueue(req *datastore.Request) error {
 	return s.Store.Enqueue(req)
 }
 
-// TestHandleFairnessScheduling_UnknownModel covers the shared validation path
-// used by both ENABLE_FAIRNESS_SCHEDULING and ENABLE_SESSION_BOOST: a request
-// for a model with no registered ModelRoute must be rejected before it can
-// reach store.Enqueue, since Enqueue unconditionally creates a per-model queue
-// and goroutine keyed by the (client-supplied) model name, and that queue is
-// never cleaned up because cleanup is tied to the ModelRoute lifecycle.
-func TestHandleFairnessScheduling_UnknownModel(t *testing.T) {
-	tests := []struct {
-		name               string
-		enableSessionBoost bool
-	}{
-		{name: "fairness mode"},
-		{name: "session boost mode", enableSessionBoost: true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			router, store, backend := setupFairnessTestRouter(t, nil)
-			defer backend.Close()
-
-			prevEnableSessionBoost := EnableSessionBoost
-			EnableSessionBoost = tt.enableSessionBoost
-			defer func() { EnableSessionBoost = prevEnableSessionBoost }()
-
-			spy := &enqueueSpyStore{Store: store}
-			router.store = spy
-			router.queueTimeout = 5 * time.Second
-
-			ctx, cancel := context.WithCancel(context.Background())
-			router.store.Run(ctx)
-			defer cancel()
-
-			w := httptest.NewRecorder()
-			c, _ := gin.CreateTestContext(w)
-			reqBody := `{"model":"never-registered-model","prompt":"hello"}`
-			c.Request, _ = http.NewRequest("POST", "/v1/chat/completions", bytes.NewBufferString(reqBody))
-			c.Request.Header.Set("Content-Type", "application/json")
-
-			modelRequest, err := ParseModelRequest(c)
-			assert.NoError(t, err)
-			prompt, perr := utils.ParsePrompt(modelRequest)
-			assert.NoError(t, perr)
-			c.Set(PromptKey, prompt)
-			c.Set("metricsRecorder", metrics.NewRequestMetricsRecorder(router.metrics, "never-registered-model", "/v1/chat/completions"))
-
-			err = router.handleFairnessScheduling(c, modelRequest, "req-unknown", "never-registered-model")
-
-			assert.Error(t, err)
-			assert.Equal(t, http.StatusNotFound, w.Code)
-			assert.Contains(t, w.Body.String(), "route not found")
-			assert.False(t, spy.enqueued.Load(), "unknown model must be rejected before reaching Enqueue")
-
-			for _, stat := range store.GetRequestWaitingQueueStats() {
-				assert.NotEqual(t, "never-registered-model", stat.Model, "no queue should be created for an unregistered model")
-			}
-		})
-	}
-}
-
 // A backend that accepts the connection but never completes it must fail at the
 // configured timeout, which ResponseHeaderTimeout alone would not have bounded.
 func TestDoRequestBoundsConnectionSetup(t *testing.T) {
@@ -3070,12 +3011,19 @@ func TestDoRequestTimeoutDoesNotTruncateSlowStream(t *testing.T) {
 	assert.Contains(t, string(body), "chunk-5", "the whole stream should arrive")
 }
 
-// TestRouter_HandlerFunc_UnknownModel_QueueSchedulingRejectsBeforeQueueing is an
-// integration-style check that the same protection holds through the full
-// HandlerFunc entry point (HTTP request -> handleFairnessScheduling -> Enqueue)
-// for both scheduling strategies, matching the existing (non-queued) unknown
-// model behavior asserted by TestRouter_HandlerFunc_UnknownModelMetricsUseBoundedLabel.
-func TestRouter_HandlerFunc_UnknownModel_QueueSchedulingRejectsBeforeQueueing(t *testing.T) {
+// TestRouter_HandlerFunc_UnknownModel_RejectsBeforeQueueing is an
+// integration-style check that a request for a model with no registered
+// ModelRoute is rejected by the shared validation in HandlerFunc, before the
+// router chooses between the queued (fairness/session-boost) and direct
+// load-balancing paths. It covers all three configurations (fairness
+// scheduling, session boost, and neither) and asserts observability
+// end-to-end: unknown-model requests must be labeled "route_not_found", not
+// "scheduling", regardless of which path they would have taken. For the
+// queued paths it also proves store.Enqueue is never reached, since Enqueue
+// unconditionally creates a per-model queue and goroutine keyed by the
+// (client-supplied) model name, and that queue is never cleaned up because
+// cleanup is tied to the ModelRoute lifecycle.
+func TestRouter_HandlerFunc_UnknownModel_RejectsBeforeQueueing(t *testing.T) {
 	tests := []struct {
 		name                     string
 		enableFairnessScheduling bool
@@ -3083,6 +3031,7 @@ func TestRouter_HandlerFunc_UnknownModel_QueueSchedulingRejectsBeforeQueueing(t 
 	}{
 		{name: "fairness scheduling enabled", enableFairnessScheduling: true},
 		{name: "session boost enabled", enableSessionBoost: true},
+		{name: "neither scheduling mode enabled"},
 	}
 
 	for _, tt := range tests {
@@ -3112,7 +3061,15 @@ func TestRouter_HandlerFunc_UnknownModel_QueueSchedulingRejectsBeforeQueueing(t 
 
 			assert.Equal(t, http.StatusNotFound, w.Code)
 			assert.Contains(t, w.Body.String(), "route not found")
+
+			reason, ok := c.Get("finishReason")
+			assert.True(t, ok)
+			assert.Equal(t, "route_not_found", reason, "unknown model must be labeled route_not_found, not scheduling")
+
 			assert.False(t, spy.enqueued.Load(), "unknown model must be rejected before reaching Enqueue")
+			for _, stat := range store.GetRequestWaitingQueueStats() {
+				assert.NotEqual(t, "never-registered-model", stat.Model, "no queue should be created for an unregistered model")
+			}
 		})
 	}
 }

--- a/pkg/kthena-router/router/router_test.go
+++ b/pkg/kthena-router/router/router_test.go
@@ -2878,6 +2878,79 @@ func TestUpstreamTimeoutFor(t *testing.T) {
 	}
 }
 
+// enqueueSpyStore wraps a real Store and records whether Enqueue was invoked.
+// Enqueue is the sole place that creates a model-specific waiting queue and its
+// dequeue goroutine (on first use for a given model name), so asserting it was
+// never called is proof that no queue/goroutine was created for that request.
+type enqueueSpyStore struct {
+	datastore.Store
+	enqueued atomic.Bool
+}
+
+func (s *enqueueSpyStore) Enqueue(req *datastore.Request) error {
+	s.enqueued.Store(true)
+	return s.Store.Enqueue(req)
+}
+
+// TestHandleFairnessScheduling_UnknownModel covers the shared validation path
+// used by both ENABLE_FAIRNESS_SCHEDULING and ENABLE_SESSION_BOOST: a request
+// for a model with no registered ModelRoute must be rejected before it can
+// reach store.Enqueue, since Enqueue unconditionally creates a per-model queue
+// and goroutine keyed by the (client-supplied) model name, and that queue is
+// never cleaned up because cleanup is tied to the ModelRoute lifecycle.
+func TestHandleFairnessScheduling_UnknownModel(t *testing.T) {
+	tests := []struct {
+		name               string
+		enableSessionBoost bool
+	}{
+		{name: "fairness mode"},
+		{name: "session boost mode", enableSessionBoost: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			router, store, backend := setupFairnessTestRouter(t, nil)
+			defer backend.Close()
+
+			prevEnableSessionBoost := EnableSessionBoost
+			EnableSessionBoost = tt.enableSessionBoost
+			defer func() { EnableSessionBoost = prevEnableSessionBoost }()
+
+			spy := &enqueueSpyStore{Store: store}
+			router.store = spy
+			router.queueTimeout = 5 * time.Second
+
+			ctx, cancel := context.WithCancel(context.Background())
+			router.store.Run(ctx)
+			defer cancel()
+
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			reqBody := `{"model":"never-registered-model","prompt":"hello"}`
+			c.Request, _ = http.NewRequest("POST", "/v1/chat/completions", bytes.NewBufferString(reqBody))
+			c.Request.Header.Set("Content-Type", "application/json")
+
+			modelRequest, err := ParseModelRequest(c)
+			assert.NoError(t, err)
+			prompt, perr := utils.ParsePrompt(modelRequest)
+			assert.NoError(t, perr)
+			c.Set(PromptKey, prompt)
+			c.Set("metricsRecorder", metrics.NewRequestMetricsRecorder(router.metrics, "never-registered-model", "/v1/chat/completions"))
+
+			err = router.handleFairnessScheduling(c, modelRequest, "req-unknown", "never-registered-model")
+
+			assert.Error(t, err)
+			assert.Equal(t, http.StatusNotFound, w.Code)
+			assert.Contains(t, w.Body.String(), "route not found")
+			assert.False(t, spy.enqueued.Load(), "unknown model must be rejected before reaching Enqueue")
+
+			for _, stat := range store.GetRequestWaitingQueueStats() {
+				assert.NotEqual(t, "never-registered-model", stat.Model, "no queue should be created for an unregistered model")
+			}
+		})
+	}
+}
+
 // A backend that accepts the connection but never completes it must fail at the
 // configured timeout, which ResponseHeaderTimeout alone would not have bounded.
 func TestDoRequestBoundsConnectionSetup(t *testing.T) {
@@ -2995,4 +3068,51 @@ func TestDoRequestTimeoutDoesNotTruncateSlowStream(t *testing.T) {
 	body, err := io.ReadAll(resp.Body)
 	assert.NoError(t, err, "a slow stream must not be cut off by the header timeout")
 	assert.Contains(t, string(body), "chunk-5", "the whole stream should arrive")
+}
+
+// TestRouter_HandlerFunc_UnknownModel_QueueSchedulingRejectsBeforeQueueing is an
+// integration-style check that the same protection holds through the full
+// HandlerFunc entry point (HTTP request -> handleFairnessScheduling -> Enqueue)
+// for both scheduling strategies, matching the existing (non-queued) unknown
+// model behavior asserted by TestRouter_HandlerFunc_UnknownModelMetricsUseBoundedLabel.
+func TestRouter_HandlerFunc_UnknownModel_QueueSchedulingRejectsBeforeQueueing(t *testing.T) {
+	tests := []struct {
+		name                     string
+		enableFairnessScheduling bool
+		enableSessionBoost       bool
+	}{
+		{name: "fairness scheduling enabled", enableFairnessScheduling: true},
+		{name: "session boost enabled", enableSessionBoost: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			router, store, backend := setupTestRouter(t, nil)
+			defer backend.Close()
+
+			prevEnableFairnessScheduling := EnableFairnessScheduling
+			prevEnableSessionBoost := EnableSessionBoost
+			EnableFairnessScheduling = tt.enableFairnessScheduling
+			EnableSessionBoost = tt.enableSessionBoost
+			defer func() {
+				EnableFairnessScheduling = prevEnableFairnessScheduling
+				EnableSessionBoost = prevEnableSessionBoost
+			}()
+
+			spy := &enqueueSpyStore{Store: store}
+			router.store = spy
+
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			reqBody := `{"model":"never-registered-model","prompt":"hello"}`
+			c.Request, _ = http.NewRequest("POST", "/v1/chat/completions", bytes.NewBufferString(reqBody))
+			c.Request.Header.Set("Content-Type", "application/json")
+
+			router.HandlerFunc()(c)
+
+			assert.Equal(t, http.StatusNotFound, w.Code)
+			assert.Contains(t, w.Body.String(), "route not found")
+			assert.False(t, spy.enqueued.Load(), "unknown model must be rejected before reaching Enqueue")
+		})
+	}
 }


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it

When fairness scheduling or session boost is enabled, requests for unknown model names could reach the scheduling queue and create a new model-specific queue and goroutine.

`handleFairnessScheduling` is the shared entry point for both `ENABLE_FAIRNESS_SCHEDULING` and `ENABLE_SESSION_BOOST`. Previously, it passed the client-supplied model name directly to `store.Enqueue` without checking whether the model was registered.

`store.Enqueue` creates a model-specific waiting queue and goroutine when a new model name is encountered. Since cleanup is tied to the `ModelRoute` lifecycle, queues created for model names that never had a corresponding `ModelRoute` were not cleaned up.

This PR fixes the issue by checking `store.HasModel(modelName)` before calling `store.Enqueue`. Unknown models now receive the existing `404 "route not found"` response and are rejected before any model-specific queue or goroutine is created.

Regression tests cover both the direct fairness scheduling path and the router handler path, verifying that unknown models are rejected before queueing occurs.

## Which issue(s) this PR fixes

Fixes #1613

## Bug evidence (required for bug-related PRs)

The issue occurs when fairness scheduling or session boost is enabled and a client sends requests using model names that are not registered as `ModelRoute` resources.

For example, a client could repeatedly send requests using different, non-existent model names:

```text
model=unknown-model-1
model=unknown-model-2
model=unknown-model-3
```
The request reaches handleFairnessScheduling, which is shared by both fairness scheduling and session boost. Before this fix, the client-provided model name was passed directly to store.Enqueue.

store.Enqueue uses the model name as a key and creates a model-specific waiting queue and goroutine when the key does not already exist. Therefore, every previously unseen unknown model name could create another queue and goroutine.

The cleanup path is tied to the ModelRoute lifecycle. Since these unknown model names never correspond to a registered ModelRoute, their queues do not enter the normal cleanup path and remain allocated.

As a result, a client can continuously increase router memory usage and goroutine count simply by sending requests with distinct, unregistered model names.

The fix validates the requested model with the existing store.HasModel(modelName) check before calling store.Enqueue. Unknown models are rejected with the existing 404 "route not found" response, so no model-specific queue or goroutine is created.

Regression tests reproduce this production path through:

- the direct handleFairnessScheduling path, verifying that an unknown model is rejected before Enqueue;
- the router handler path, verifying that an unknown model receives the expected 404 response and does not enter queue scheduling.

The regression tests were also verified to fail when the fix is removed and pass when the fix is restored.

Special notes for your reviewer:

- handleFairnessScheduling is the shared entry point for both fairness scheduling and session boost, so one validation covers both features.
- The check uses the existing race-safe store.HasModel() implementation; no new model registry or synchronization mechanism was introduced.
- Unknown models are rejected before store.Enqueue is reached.
- Registered-model behavior is unchanged.
- No queue cleanup or ModelRoute lifecycle behavior was changed.
- The change is limited to the router validation path and regression tests.
- Regression tests were verified to fail with the fix removed and pass with the fix restored.
gofmt, go vet, go build ./..., and the router test suite pass.
- Router/datastore race tests also pass.
- No API or CRD changes are introduced.

Does this PR introduce a user-facing change?:

Yes. Requests for unregistered model names now return the existing 404 "route not found" response before entering fairness/session-boost scheduling, instead of creating a model-specific scheduling queue.

Requests for unregistered model names are rejected with the existing 404 response before fairness/session-boost scheduling, preventing creation of orphaned model-specific queues and goroutines.

