### PR TITLE
rbac: allow controller-manager to delete modelservers and modelroutes

### DIFF
--- a/charts/kthena/charts/workload/templates/kthena-controller-manager/rbac/cluster-role.yaml
+++ b/charts/kthena/charts/workload/templates/kthena-controller-manager/rbac/cluster-role.yaml
@@ -15,6 +15,7 @@ rules:
       - update
       - patch
       - get
+      - delete
   - apiGroups:
       - apiextensions.k8s.io
     resources:


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Adds the `delete` verb to the controller-manager ClusterRole rule for `networking.serving.volcano.sh`. That rule currently grants `watch, list, create, update, patch, get` on `modelservers` and `modelroutes`, so every delete the controller issues on them is denied. The ModelBooster controller deletes ModelServers when a backend is removed or renamed (`model_server_handler.go` L70) and deletes ModelRoutes for recreation when `spec.modelName` changes (`model_route_handler.go` L45, L84), and all of those calls are forbidden under the default Helm RBAC. Same class as #1623, which fixed this for modelservings.

**Which issue(s) this PR fixes**:

None. Per the review guidance on #1623, one-line fixes do not need a separate issue; the full trace is in #1645, closed in favor of tracking here.

**Bug evidence (required for bug-related PRs)**:

```bash
kubectl auth can-i delete modelservers.networking.serving.volcano.sh \
  --as=system:serviceaccount:<kthena-namespace>:kthena-controller-manager
# no
kubectl auth can-i delete modelroutes.networking.serving.volcano.sh \
  --as=system:serviceaccount:<kthena-namespace>:kthena-controller-manager
# no
```

The server delete failure makes booster reconciliation return an error and leaks the old ModelServer, which keeps matching pods. The route delete failure blocks the immutable-modelName recreation flow, so the route keeps routing on the old model name.

**Special notes for your reviewer**:

One line; the same rule already carries every other verb the controller uses on these resources.
