### PR TITLE
docs: document the kvcache-aware tokenizer port arguments

### DIFF
--- a/docs/kthena/docs/user-guide/kvcache-aware.md
+++ b/docs/kthena/docs/user-guide/kvcache-aware.md
@@ -295,10 +295,12 @@ data:
 
 **Plugin arguments:**
 
-| Parameter          | Default | Description                                                                      |
-| ------------------ | ------- | -------------------------------------------------------------------------------- |
-| `blockSizeToHash`  | 16      | Number of tokens per block. Must match the vLLM block size for optimal matching. |
-| `maxBlocksToMatch` | 128     | Maximum number of blocks to process per request. Limits Redis queries.           |
+| Parameter             | Default | Description                                                                      |
+| --------------------- | ------- | -------------------------------------------------------------------------------- |
+| `blockSizeToHash`     | 16      | Number of tokens per block. Must match the vLLM block size for optimal matching. |
+| `maxBlocksToMatch`    | 128     | Maximum number of blocks to process per request. Limits Redis queries.           |
+| `vllmTokenizerPort`   | 8000    | Port used to fetch the tokenizer from vLLM pods.                                 |
+| `sglangTokenizerPort` | 30000   | Port used to fetch the tokenizer from SGLang pods.                               |
 
 **Helm values:**
 


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

The plugin arguments table in the kvcache-aware user guide lists `blockSizeToHash` and
`maxBlocksToMatch`. `KVCacheAwareArgs` has four fields, and all four are unmarshalled from
the same `pluginConfig.args` block the guide already shows:

https://github.com/volcano-sh/kthena/blob/825397bca03decfc18da757af386906d34f4fb7f/pkg/kthena-router/scheduler/plugins/kvcache_aware.go#L80-L87

`vllmTokenizerPort` falls back to 8000 and `sglangTokenizerPort` to 30000, and they become
the tokenizer endpoint port map for `EngineVLLM` and `EngineSGLang`:

https://github.com/volcano-sh/kthena/blob/825397bca03decfc18da757af386906d34f4fb7f/pkg/kthena-router/scheduler/plugins/kvcache_aware.go#L145-L161

Neither appears anywhere under `docs/`, `charts/` or `examples/`, so serving on a non-default
port is undocumented even though the plugin accepts the setting.

The first column is widened so the longer names stay aligned with the rest of the tables in
this file.

**Which issue(s) this PR fixes**:

None, this is a small documentation correction.

**Special notes for your reviewer**:

#1293 also adds a row to this table, so the two changes are additive.

**Does this PR introduce a user-facing change?**:
```release-note
NONE