### PR TITLE
router: drop the per-block intersection map in kvcache scoring

### DIFF
--- a/pkg/kthena-router/scheduler/plugins/kvcache_aware.go
+++ b/pkg/kthena-router/scheduler/plugins/kvcache_aware.go
@@ -476,56 +476,51 @@ func freshOwners(entries map[string]string, ownerStartedAt map[string]int64) []s
 
 // calculatePodScores returns per-pod scores and the longest block match length (used for the match_ratio metric).
 func (t *KVCacheAware) calculatePodScores(blockHashes []uint64, blockToPods map[uint64][]string) (map[string]int, int) {
-	podScores := make(map[string]int)
-
 	if len(blockHashes) == 0 {
 		klog.V(4).Infof("KVCacheAware.calculateScores: no block hashes to process")
-		return podScores, 0
+		return map[string]int{}, 0
 	}
 
 	firstBlockPods, exists := blockToPods[blockHashes[0]]
 	if !exists || len(firstBlockPods) == 0 {
 		klog.V(4).Infof("KVCacheAware.calculateScores: first block hash=%d has no cached pods — all scores 0", blockHashes[0])
-		return podScores, 0
+		return map[string]int{}, 0
 	}
+
+	// only pods holding the first block can ever score, so this is the final size.
+	podScores := make(map[string]int, len(firstBlockPods))
 
 	klog.V(4).Infof("KVCacheAware.calculateScores: first block matched pods=%v, starting prefix matching across %d blocks",
 		firstBlockPods, len(blockHashes))
 
-	activePods := make(map[string]bool, len(firstBlockPods))
 	for _, podName := range firstBlockPods {
-		activePods[podName] = true
 		podScores[podName] = 1
 	}
 
+	// A pod is still matching at block i exactly when its score is i, so podScores
+	// doubles as the active set and no per-block intersection map is needed.
 	lastMatchedBlock := 0
 	for i := 1; i < len(blockHashes); i++ {
-		if len(activePods) == 0 {
-			klog.V(4).Infof("KVCacheAware.calculateScores: no active pods left at block %d", i)
-			break
-		}
-
 		blockPods, exists := blockToPods[blockHashes[i]]
 		if !exists || len(blockPods) == 0 {
 			klog.V(4).Infof("KVCacheAware.calculateScores: block[%d] hash=%d has no cached pods, stopping", i, blockHashes[i])
 			break
 		}
 
-		nextActivePods := make(map[string]bool)
+		stillActive := 0
 		for _, podName := range blockPods {
-			if activePods[podName] {
-				nextActivePods[podName] = true
+			if podScores[podName] == i {
 				podScores[podName]++
+				stillActive++
 			}
 		}
 
-		if len(nextActivePods) == 0 {
+		if stillActive == 0 {
 			klog.V(4).Infof("KVCacheAware.calculateScores: no pod survived intersection at block %d", i)
 			break
 		}
 
 		lastMatchedBlock = i
-		activePods = nextActivePods
 	}
 
 	totalBlocks := len(blockHashes)

--- a/pkg/kthena-router/scheduler/plugins/kvcache_aware_test.go
+++ b/pkg/kthena-router/scheduler/plugins/kvcache_aware_test.go
@@ -2518,3 +2518,52 @@ func TestKVCacheAware_QueryRedisForBlocks_DropsOldOwnershipAfterLongAgoRestart(t
 		t.Errorf("stale ownership survived a long-ago restart: got %v, want none", result[hash])
 	}
 }
+
+// benchPodScoreInput builds a prefix-matching workload: matchFrac of the blocks are held by
+// every pod, and the rest by an unrelated pod so the intersection empties there.
+func benchPodScoreInput(blocks, pods int, matchFrac float64) ([]uint64, map[uint64][]string) {
+	hashes := make([]uint64, blocks)
+	blockToPods := make(map[uint64][]string, blocks)
+	names := make([]string, pods)
+	for p := 0; p < pods; p++ {
+		names[p] = fmt.Sprintf("vllm-decode-%d.default", p)
+	}
+	cut := int(float64(blocks) * matchFrac)
+	for b := 0; b < blocks; b++ {
+		hashes[b] = uint64(b + 1)
+		if b < cut {
+			owners := make([]string, pods)
+			copy(owners, names)
+			blockToPods[hashes[b]] = owners
+			continue
+		}
+		blockToPods[hashes[b]] = []string{"other.default"}
+	}
+	return hashes, blockToPods
+}
+
+func BenchmarkCalculatePodScores(b *testing.B) {
+	cases := []struct {
+		pods      int
+		matchFrac float64
+	}{
+		{2, 1.0},
+		{8, 1.0},
+		{32, 1.0},
+		{8, 0.3},
+		{32, 0.3},
+	}
+
+	for _, c := range cases {
+		name := fmt.Sprintf("blocks=%d/pods=%d/match=%.0f%%", defaultMaxBlocksToMatch, c.pods, c.matchFrac*100)
+		b.Run(name, func(b *testing.B) {
+			blockHashes, blockToPods := benchPodScoreInput(defaultMaxBlocksToMatch, c.pods, c.matchFrac)
+			plugin := &KVCacheAware{}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				plugin.calculatePodScores(blockHashes, blockToPods)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement

**What this PR does / why we need it**:

`calculatePodScores` kept the set of pods still matching the prompt's prefix in a map and rebuilt that map from scratch on every block. At the default `maxBlocksToMatch: 128` a fully matching prompt built up to 127 of them per request, each unsized so it regrew its buckets as pods went in.

The intermediate map is not needed. A pod is still matching at block `i` exactly when it has matched every earlier block, that is when `podScores[pod] == i`, so `podScores` is its own active set. The loop now counts survivors instead of rebuilding a set, and stops on the same condition as before.

Two smaller things in the same function. `podScores` is now sized from the first block's owners, which bound it, since only a pod holding the first block can ever score. And the `len(activePods) == 0` check at the top of the loop is removed: the set starts non-empty and the loop already breaks whenever the intersection empties, so it never fired.

go1.26.6 linux/amd64, `-count=6`, medians. `match` is how far the shared prefix runs before the intersection empties:

```
pods  match     before                              after
  2    100%     33041 ns   33032 B   263 allocs      9850 ns     520 B    9 allocs
  8    100%     67961 ns   33968 B   278 allocs     35102 ns    1456 B   24 allocs
 32    100%    624594 ns  447894 B  1222 allocs    132239 ns    4544 B   71 allocs
  8     30%     21646 ns   10992 B   100 allocs     11654 ns    1472 B   25 allocs
 32     30%    191406 ns  136192 B   414 allocs     42166 ns    4560 B   72 allocs
```

An allocation profile of the 32 pod case on main puts the two lines that create and fill that map at 97.3% of the bytes and 87.6% of the objects this function allocates, which is why removing it matters more than the sizing does.

Results are unchanged. The scores and the longest-match return were checked against the previous implementation across 200k randomised block and owner combinations, including repeated block hashes, hashes absent from the map, nil owner slices and zero-block prompts.

`BenchmarkCalculatePodScores` is added so the table above can be re-run against either side.

**Which issue(s) this PR fixes**:

Fixes #1648

**Special notes for your reviewer**:

#1293 changes this function's signature and adds a parallel weighted score map, but leaves the per-block intersection map as it is, so the two changes are independent and this one carries over to the weighted version unchanged. Whichever lands first the other rebases.

**Does this PR introduce a user-facing change?**

```release-note
NONE
```