### PR TITLE
router: make the random score plugin safe for concurrent requests

### DIFF
--- a/pkg/kthena-router/scheduler/plugins/random.go
+++ b/pkg/kthena-router/scheduler/plugins/random.go
@@ -18,7 +18,6 @@ package plugins
 
 import (
 	"math/rand"
-	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -36,18 +35,11 @@ var _ framework.ScorePlugin = &Random{}
 // It is primarily intended for testing purposes to validate scheduler behavior with random pod selection.
 type Random struct {
 	name string
-	rng  *rand.Rand
 }
 
 func NewRandom(pluginArg runtime.RawExtension) *Random {
-	// Create a new random number generator with a time-based seed
-	// to ensure different random sequences across different instances
-	source := rand.NewSource(time.Now().UnixNano())
-	rng := rand.New(source)
-
 	return &Random{
 		name: RandomPluginName,
-		rng:  rng,
 	}
 }
 
@@ -63,9 +55,11 @@ func (r *Random) Score(ctx *framework.Context, pods []*datastore.PodInfo) map[*d
 		return scoreResults
 	}
 
-	// Assign random scores between 0 and 100 to each pod
+	// Assign random scores between 0 and 100 to each pod. The top-level rand
+	// functions are safe for concurrent use, unlike a shared *rand.Rand: the
+	// single plugin instance serves every request goroutine.
 	for _, pod := range pods {
-		score := r.rng.Intn(101) // Generate random number between 0-100 (inclusive)
+		score := rand.Intn(101) // Generate random number between 0-100 (inclusive)
 		scoreResults[pod] = score
 	}
 

--- a/pkg/kthena-router/scheduler/plugins/random_test.go
+++ b/pkg/kthena-router/scheduler/plugins/random_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package plugins
 
 import (
+	"sync"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -87,4 +88,31 @@ func TestRandom_Score(t *testing.T) {
 	if allSame {
 		t.Log("Warning: All scores were identical across two runs, which is unlikely but possible")
 	}
+}
+
+// TestRandom_ConcurrentScore exercises Score from multiple goroutines, the way
+// concurrent requests reach the single plugin instance the router builds once.
+func TestRandom_ConcurrentScore(t *testing.T) {
+	plugin := NewRandom(runtime.RawExtension{})
+	ctx := &framework.Context{}
+	pods := []*datastore.PodInfo{
+		{Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1"}}},
+		{Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod2"}}},
+	}
+
+	var wg sync.WaitGroup
+	for g := 0; g < 8; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 50; i++ {
+				scores := plugin.Score(ctx, pods)
+				if len(scores) != len(pods) {
+					t.Errorf("expected %d scores, got %d", len(pods), len(scores))
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The random score plugin shares one `*rand.Rand` across every request. `NewRandom` seeds a generator once (`rand.NewSource(time.Now().UnixNano())`, `random.go` L45) and the router builds a single plugin instance for its lifetime (`factory.go` L78 via `NewScheduler`, `router.go` L199, no reload path), so `Score` calls `r.rng.Intn` on every request goroutine with no synchronization. Two concurrent requests race on the generator's internal state. The plugin runs standalone by design (`handleRandomPluginConflicts` removes it when other score plugins are enabled), so concurrent request traffic is its normal operating mode.

The fix drops the shared generator and calls the top-level `rand.Intn`, which is safe for concurrent use and auto-seeded since Go 1.20. Same pattern as #784, which moved `selectFromWeightedSlice` to the global `rand.Intn`.

**Which issue(s) this PR fixes**:

None. Per the review guidance on #1623, small fixes do not need a separate issue.

**Bug evidence (required for bug-related PRs)**:

The `math/rand` documentation for `NewSource` states: "Unlike the default Source used by top-level functions, this source is not safe for concurrent use by multiple goroutines." The pre-fix code uses exactly that source from every request goroutine through one shared instance, with no lock anywhere in the plugin.

`TestRandom_ConcurrentScore` (added here) drives `Score` from 8 goroutines against one plugin instance, so `go test -race` exercises the shared-generator access pattern directly. One honest caveat: my local Windows toolchain cannot run the race detector (32-bit gcc, no cgo), so I could not attach its output; happy to paste a Linux run if wanted.

**Special notes for your reviewer**:

Scoring behavior is unchanged, still uniform ints in [0, 100]; the diff removes the field and seeding and swaps one call.
