### PR TITLE
cli: honor KUBECONFIG when loading the kubeconfig

### DIFF
--- a/cli/kthena/cmd/create.go
+++ b/cli/kthena/cmd/create.go
@@ -225,8 +225,10 @@ func askForConfirmation(question string) bool {
 }
 
 func applyResources(yamlContent string) error {
-	// Load kubeconfig
-	config, err := clientcmd.BuildConfigFromFlags("", clientcmd.RecommendedHomeFile)
+	// Load kubeconfig with kubectl's precedence: KUBECONFIG first, then ~/.kube/config.
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, &clientcmd.ConfigOverrides{})
+	config, err := kubeConfig.ClientConfig()
 	if err != nil {
 		return fmt.Errorf("failed to load kubeconfig: %v", err)
 	}

--- a/cli/kthena/cmd/create.go
+++ b/cli/kthena/cmd/create.go
@@ -33,7 +33,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
-	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/yaml"
 )
 
@@ -226,9 +225,7 @@ func askForConfirmation(question string) bool {
 
 func applyResources(yamlContent string) error {
 	// Load kubeconfig with kubectl's precedence: KUBECONFIG first, then ~/.kube/config.
-	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
-	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, &clientcmd.ConfigOverrides{})
-	config, err := kubeConfig.ClientConfig()
+	config, err := newKubeConfig().ClientConfig()
 	if err != nil {
 		return fmt.Errorf("failed to load kubeconfig: %v", err)
 	}

--- a/cli/kthena/cmd/get.go
+++ b/cli/kthena/cmd/get.go
@@ -210,12 +210,19 @@ func runGetTemplate(cmd *cobra.Command, args []string) error {
 	return w.Flush()
 }
 
+// newKubeConfig builds the deferred client config with kubectl's precedence:
+// the KUBECONFIG path list first, then ~/.kube/config. Every CLI entry point
+// that talks to the cluster should load through this one helper.
+func newKubeConfig() clientcmd.ClientConfig {
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, &clientcmd.ConfigOverrides{})
+}
+
 // getKthenaClient builds a kthena clientset and also returns the namespace
 // from the current kubeconfig context so callers can fall back to it when
 // the user hasn't passed -n/--namespace explicitly.
 func getKthenaClient() (client *versioned.Clientset, contextNamespace string, err error) {
-	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
-	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, &clientcmd.ConfigOverrides{})
+	kubeConfig := newKubeConfig()
 
 	restConfig, err := kubeConfig.ClientConfig()
 	if err != nil {

--- a/cli/kthena/cmd/get.go
+++ b/cli/kthena/cmd/get.go
@@ -214,7 +214,7 @@ func runGetTemplate(cmd *cobra.Command, args []string) error {
 // from the current kubeconfig context so callers can fall back to it when
 // the user hasn't passed -n/--namespace explicitly.
 func getKthenaClient() (client *versioned.Clientset, contextNamespace string, err error) {
-	loadingRules := &clientcmd.ClientConfigLoadingRules{ExplicitPath: clientcmd.RecommendedHomeFile}
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, &clientcmd.ConfigOverrides{})
 
 	restConfig, err := kubeConfig.ClientConfig()

--- a/cli/kthena/cmd/get_test.go
+++ b/cli/kthena/cmd/get_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package cmd
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -201,4 +203,36 @@ func TestGetModelBoosterStatus(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+// TestGetKthenaClient_HonorsKubeconfigEnv verifies the CLI resolves the
+// kubeconfig the way kubectl does: a file named by KUBECONFIG wins over
+// the home-directory default.
+func TestGetKthenaClient_HonorsKubeconfigEnv(t *testing.T) {
+	kubeconfig := `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://127.0.0.1:6553
+  name: env-cluster
+contexts:
+- context:
+    cluster: env-cluster
+    namespace: kubeconfig-env-namespace
+    user: env-user
+  name: env-context
+current-context: env-context
+users:
+- name: env-user
+  user: {}
+`
+	path := filepath.Join(t.TempDir(), "config")
+	if err := os.WriteFile(path, []byte(kubeconfig), 0o600); err != nil {
+		t.Fatalf("failed to write kubeconfig: %v", err)
+	}
+	t.Setenv("KUBECONFIG", path)
+
+	_, contextNamespace, err := getKthenaClient()
+	assert.NoError(t, err)
+	assert.Equal(t, "kubeconfig-env-namespace", contextNamespace)
 }

--- a/cmd/kthena-router/app/controller.go
+++ b/cmd/kthena-router/app/controller.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
 	inferencev1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -40,6 +39,7 @@ import (
 	kthenaInformers "github.com/volcano-sh/kthena/client-go/informers/externalversions"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/controller"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/datastore"
+	"github.com/volcano-sh/kthena/pkg/kube"
 )
 
 type Controller interface {
@@ -53,7 +53,7 @@ type aggregatedController struct {
 var _ Controller = &aggregatedController{}
 
 func startControllers(store datastore.Store, stop <-chan struct{}, enableGatewayAPI bool, defaultPort string, enableGatewayAPIInferenceExtension bool, kubeAPIQPS float32, kubeAPIBurst int) Controller {
-	cfg, err := clientcmd.BuildConfigFromFlags("", "")
+	cfg, err := kube.BuildConfig("", "")
 	if err != nil {
 		klog.Fatalf("Error building kubeconfig: %s", err.Error())
 	}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -25,6 +25,7 @@ import (
 
 	clientset "github.com/volcano-sh/kthena/client-go/clientset/versioned"
 	autoscaler "github.com/volcano-sh/kthena/pkg/autoscaler/controller"
+	"github.com/volcano-sh/kthena/pkg/kube"
 	modelbooster "github.com/volcano-sh/kthena/pkg/model-booster-controller/controller"
 	"github.com/volcano-sh/kthena/pkg/model-booster-controller/utils"
 	modelserving "github.com/volcano-sh/kthena/pkg/model-serving-controller/controller"
@@ -32,7 +33,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/klog/v2"
@@ -52,7 +52,7 @@ const (
 )
 
 func SetupController(ctx context.Context, cc Config) {
-	config, err := clientcmd.BuildConfigFromFlags(cc.MasterURL, cc.Kubeconfig)
+	config, err := kube.BuildConfig(cc.MasterURL, cc.Kubeconfig)
 	if err != nil {
 		klog.Fatalf("build client config: %v", err)
 	}

--- a/pkg/kube/config.go
+++ b/pkg/kube/config.go
@@ -1,0 +1,43 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kube
+
+import (
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+// BuildConfig returns a rest config with kubectl's loading semantics.
+// When neither masterURL nor kubeconfigPath is given it prefers the
+// in-cluster config, then falls back to the kubeconfig chain: the
+// KUBECONFIG path list first, then ~/.kube/config. An explicit
+// kubeconfigPath is used as the only kubeconfig file, and masterURL
+// overrides the server address from whichever config was loaded.
+func BuildConfig(masterURL, kubeconfigPath string) (*rest.Config, error) {
+	if masterURL == "" && kubeconfigPath == "" {
+		if config, err := rest.InClusterConfig(); err == nil {
+			return config, nil
+		}
+	}
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	loadingRules.ExplicitPath = kubeconfigPath
+	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		loadingRules,
+		&clientcmd.ConfigOverrides{ClusterInfo: clientcmdapi.Cluster{Server: masterURL}},
+	).ClientConfig()
+}

--- a/pkg/kube/config_test.go
+++ b/pkg/kube/config_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kube
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeKubeconfig(t *testing.T, name, server string) string {
+	t.Helper()
+	content := fmt.Sprintf(`apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: %s
+  name: test-cluster
+contexts:
+- context:
+    cluster: test-cluster
+    user: test-user
+  name: test-context
+current-context: test-context
+users:
+- name: test-user
+  user: {}
+`, server)
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("failed to write kubeconfig: %v", err)
+	}
+	return path
+}
+
+// forceOutOfCluster clears the in-cluster env so BuildConfig takes the
+// kubeconfig path regardless of where the test runs.
+func forceOutOfCluster(t *testing.T) {
+	t.Helper()
+	t.Setenv("KUBERNETES_SERVICE_HOST", "")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "")
+}
+
+func TestBuildConfig_HonorsKubeconfigEnv(t *testing.T) {
+	forceOutOfCluster(t)
+	envPath := writeKubeconfig(t, "env-config", "https://from-env.example.com")
+	t.Setenv("KUBECONFIG", envPath)
+
+	config, err := BuildConfig("", "")
+	if err != nil {
+		t.Fatalf("BuildConfig failed: %v", err)
+	}
+	if config.Host != "https://from-env.example.com" {
+		t.Errorf("expected host from KUBECONFIG, got %q", config.Host)
+	}
+}
+
+func TestBuildConfig_ExplicitPathWinsOverEnv(t *testing.T) {
+	forceOutOfCluster(t)
+	envPath := writeKubeconfig(t, "env-config", "https://from-env.example.com")
+	t.Setenv("KUBECONFIG", envPath)
+	explicitPath := writeKubeconfig(t, "explicit-config", "https://from-flag.example.com")
+
+	config, err := BuildConfig("", explicitPath)
+	if err != nil {
+		t.Fatalf("BuildConfig failed: %v", err)
+	}
+	if config.Host != "https://from-flag.example.com" {
+		t.Errorf("expected host from the explicit path, got %q", config.Host)
+	}
+}

--- a/test/e2e/utils/config.go
+++ b/test/e2e/utils/config.go
@@ -25,25 +25,19 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/volcano-sh/kthena/pkg/kube"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 	lwsclientset "sigs.k8s.io/lws/client-go/clientset/versioned"
 )
 
 // GetKubeConfig returns a Kubernetes REST config.
-// It tries in-cluster config first, then falls back to kubeconfig file.
+// It tries in-cluster config first, then falls back to the kubeconfig
+// chain: the KUBECONFIG path list first, then ~/.kube/config.
 func GetKubeConfig() (*rest.Config, error) {
-	// Try in-cluster config first
-	config, err := rest.InClusterConfig()
-	if err == nil {
-		return config, nil
-	}
-
-	// Fall back to kubeconfig
-	return clientcmd.BuildConfigFromFlags("", clientcmd.RecommendedHomeFile)
+	return kube.BuildConfig("", "")
 }
 
 // GetKubeClient returns a Kubernetes clientset.


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The CLI has pinned the kubeconfig to `~/.kube/config` since its first client, so `KUBECONFIG` is ignored everywhere: `getKthenaClient` (serving every `get` and `describe` subcommand) sets `ClientConfigLoadingRules{ExplicitPath: clientcmd.RecommendedHomeFile}`, and `applyResources` in `create.go` uses `BuildConfigFromFlags("", clientcmd.RecommendedHomeFile)`. There is also no `--kubeconfig` flag, so a user whose config lives where `KUBECONFIG` points cannot use the CLI at all, and a user whose `KUBECONFIG` selects a non-default config silently operates on the wrong cluster while `kubectl` in the same shell uses the right one.

The fix switches both sites to `clientcmd.NewDefaultClientConfigLoadingRules()`, which is client-go's kubectl-parity loader: it reads the `KUBECONFIG` path list first and falls back to `~/.kube/config`.

**Which issue(s) this PR fixes**:

None. Per the review guidance on #1623, small fixes do not need a separate issue.

**Bug evidence (required for bug-related PRs)**:

client-go v0.34.2, `tools/clientcmd/loader.go`:

- An explicit path is the only file considered, and a missing one is a hard error: `if len(rules.ExplicitPath) > 0 { if _, err := os.Stat(rules.ExplicitPath); os.IsNotExist(err) { return nil, err } ... }` (L207-211), with `GetLoadingPrecedence` returning `[]string{rules.ExplicitPath}` alone (L330-331).
- `NewDefaultClientConfigLoadingRules` reads `os.Getenv(RecommendedConfigPathEnvVar)` and builds the chain from it (L159-168), which is the precedence kubectl documents.

So today, with `KUBECONFIG=/work/cluster.yaml` and no `~/.kube/config`, every `kthena get`/`describe`/`create` fails with "failed to load kubeconfig" while `kubectl` works; with both files present, the CLI silently targets whatever `~/.kube/config` points at.

`TestGetKthenaClient_HonorsKubeconfigEnv` (added here) writes a kubeconfig to a temp file, sets `KUBECONFIG` to it, and asserts the client loads and resolves that file's context namespace. On the pre-fix code it fails in either environment: with a home config present the namespace comes from the wrong file, and without one the load errors.

**Special notes for your reviewer**:

The `resolveGetNamespace` precedence from #1602 is unchanged; this makes the file-selection half match the same kubectl semantics.
