### PR TITLE
router: widen upstream forwarding transport connection pool

### DIFF
--- a/pkg/kthena-router/common/transport.go
+++ b/pkg/kthena-router/common/transport.go
@@ -1,0 +1,61 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"net"
+	"net/http"
+	"time"
+)
+
+// Fallback values mirroring http.DefaultTransport, used only when Clone() is
+// unavailable (DefaultTransport is not *http.Transport).
+const (
+	pooledMaxIdleConns        = 100
+	pooledIdleConnTimeout     = 90 * time.Second
+	pooledDialTimeout         = 30 * time.Second
+	pooledDialKeepAlive       = 30 * time.Second
+	pooledTLSHandshakeTimeout = 10 * time.Second
+)
+
+// NewPooledTransport clones http.DefaultTransport and widens only the per-host
+// idle pool. The stdlib default (DefaultMaxIdleConnsPerHost=2) churns
+// connections under high concurrency against a single upstream pod, surfacing
+// as EOF/500 on streaming responses that cannot be retried once begun. Other
+// fields are left at the stdlib defaults Clone() already carries.
+func NewPooledTransport(maxIdleConnsPerHost int) *http.Transport {
+	base, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		return &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+			DialContext: (&net.Dialer{
+				Timeout:   pooledDialTimeout,
+				KeepAlive: pooledDialKeepAlive,
+			}).DialContext,
+			ForceAttemptHTTP2:     true,
+			MaxIdleConns:          pooledMaxIdleConns,
+			MaxIdleConnsPerHost:   maxIdleConnsPerHost,
+			IdleConnTimeout:       pooledIdleConnTimeout,
+			TLSHandshakeTimeout:   pooledTLSHandshakeTimeout,
+			ExpectContinueTimeout: time.Second,
+		}
+	}
+
+	t := base.Clone()
+	t.MaxIdleConnsPerHost = maxIdleConnsPerHost
+	return t
+}

--- a/pkg/kthena-router/common/transport_test.go
+++ b/pkg/kthena-router/common/transport_test.go
@@ -1,0 +1,44 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const testMaxIdleConnsPerHost = 64
+
+func TestNewPooledTransportOverridesPerHostPool(t *testing.T) {
+	transport := NewPooledTransport(testMaxIdleConnsPerHost)
+	assert.Equal(t, testMaxIdleConnsPerHost, transport.MaxIdleConnsPerHost)
+	assert.NotNil(t, transport.DialContext)
+}
+
+// DefaultTransport stores 0 in MaxIdleConnsPerHost and applies
+// DefaultMaxIdleConnsPerHost(=2) internally, so compare against the constant.
+func TestNewPooledTransportWiderThanStdlibDefault(t *testing.T) {
+	assert.Greater(t, NewPooledTransport(testMaxIdleConnsPerHost).MaxIdleConnsPerHost,
+		http.DefaultMaxIdleConnsPerHost)
+}
+
+// Streaming prefill/decode must not be cut off mid-flight.
+func TestNewPooledTransportNoResponseHeaderTimeout(t *testing.T) {
+	assert.Zero(t, NewPooledTransport(testMaxIdleConnsPerHost).ResponseHeaderTimeout)
+}

--- a/pkg/kthena-router/connectors/nixl.go
+++ b/pkg/kthena-router/connectors/nixl.go
@@ -137,7 +137,7 @@ func (n *NIXLConnector) prefill(req *http.Request, prefillAddr string, timeout t
 		defer cancel()
 		req = req.WithContext(ctx)
 	}
-	resp, err := http.DefaultTransport.RoundTrip(req)
+	resp, err := upstreamTransport.RoundTrip(req)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kthena-router/connectors/nixl.go
+++ b/pkg/kthena-router/connectors/nixl.go
@@ -129,7 +129,7 @@ func (n *NIXLConnector) prefill(req *http.Request, prefillAddr string) (interfac
 	klog.V(4).Infof("%s prefill: sending to %s", n.name, req.URL.String())
 
 	// Send prefill request
-	resp, err := http.DefaultTransport.RoundTrip(req)
+	resp, err := upstreamTransport.RoundTrip(req)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kthena-router/connectors/transport.go
+++ b/pkg/kthena-router/connectors/transport.go
@@ -55,7 +55,7 @@ func roundTrip(req *http.Request, timeout time.Duration) (*http.Response, error)
 		req = req.WithContext(ctx)
 	}
 
-	resp, err := http.DefaultTransport.RoundTrip(req)
+	resp, err := upstreamTransport.RoundTrip(req)
 	if err != nil {
 		cancel()
 		return nil, err

--- a/pkg/kthena-router/connectors/transport.go
+++ b/pkg/kthena-router/connectors/transport.go
@@ -32,7 +32,7 @@ import (
 )
 
 func prefillerProxy(_ *gin.Context, req *http.Request) error {
-	resp, err := http.DefaultTransport.RoundTrip(req)
+	resp, err := upstreamTransport.RoundTrip(req)
 	if err != nil {
 		return fmt.Errorf("prefill request failed: %w", err)
 	}
@@ -47,7 +47,7 @@ func prefillerProxy(_ *gin.Context, req *http.Request) error {
 }
 
 func decoderProxy(c *gin.Context, req *http.Request) (int, error) {
-	resp, err := http.DefaultTransport.RoundTrip(req)
+	resp, err := upstreamTransport.RoundTrip(req)
 	if err != nil {
 		return 0, fmt.Errorf("decode request failed: %w", err)
 	}

--- a/pkg/kthena-router/connectors/upstream_transport.go
+++ b/pkg/kthena-router/connectors/upstream_transport.go
@@ -17,67 +17,13 @@ limitations under the License.
 package connectors
 
 import (
-	"net"
-	"net/http"
-	"time"
+	"github.com/volcano-sh/kthena/pkg/kthena-router/common"
 )
 
-const (
-	// upstreamMaxIdleConnsPerHost widens http.DefaultTransport's per-host idle
-	// pool (default 2) for PD-disaggregated forwarding (prefillerProxy,
-	// decoderProxy, NIXLConnector.prefill). The default of 2 causes connection
-	// churn under high concurrency that surfaces as EOF/500 on streaming
-	// decode responses, which cannot be retried once the first byte is written.
-	upstreamMaxIdleConnsPerHost = 64
-	upstreamMaxIdleConns        = 100
-	upstreamIdleConnTimeout     = 90 * time.Second
-	upstreamDialTimeout         = 30 * time.Second
-	upstreamDialKeepAlive       = 30 * time.Second
-	upstreamTLSHandshakeTimeout = 10 * time.Second
-)
+// upstreamMaxIdleConnsPerHost widens the per-host idle pool over the stdlib
+// default of 2; see common.NewPooledTransport.
+const upstreamMaxIdleConnsPerHost = 64
 
 // upstreamTransport is the shared RoundTripper for PD-disaggregated forwarding
-// to upstream pods (prefillerProxy, decoderProxy, NIXLConnector.prefill).
-//
-// It clones http.DefaultTransport and only widens the per-host idle pool, so
-// hot prefill/decode pods reuse pooled connections under high concurrency
-// instead of rebuilding them on every request. A wider pool here is essential
-// because the PD retry loop cannot retry a decode once streaming has begun,
-// so connection churn that triggers EOF propagates directly to the client.
-var upstreamTransport = newUpstreamTransport()
-
-// newUpstreamTransport builds a transport tuned for high-concurrency PD
-// forwarding. Kept as a constructor so the configuration is testable in
-// isolation.
-func newUpstreamTransport() *http.Transport {
-	base, ok := http.DefaultTransport.(*http.Transport)
-	if !ok {
-		// Fall back to a fully-specified transport when the default has been
-		// replaced with a non-*http.Transport RoundTripper.
-		return &http.Transport{
-			Proxy: http.ProxyFromEnvironment,
-			DialContext: (&net.Dialer{
-				Timeout:   upstreamDialTimeout,
-				KeepAlive: upstreamDialKeepAlive,
-			}).DialContext,
-			ForceAttemptHTTP2:     true,
-			MaxIdleConns:          upstreamMaxIdleConns,
-			MaxIdleConnsPerHost:   upstreamMaxIdleConnsPerHost,
-			IdleConnTimeout:       upstreamIdleConnTimeout,
-			TLSHandshakeTimeout:   upstreamTLSHandshakeTimeout,
-			ExpectContinueTimeout: time.Second,
-		}
-	}
-
-	t := base.Clone()
-	t.MaxIdleConnsPerHost = upstreamMaxIdleConnsPerHost
-	t.MaxIdleConns = upstreamMaxIdleConns
-	t.IdleConnTimeout = upstreamIdleConnTimeout
-	t.TLSHandshakeTimeout = upstreamTLSHandshakeTimeout
-	t.DialContext = (&net.Dialer{
-		Timeout:   upstreamDialTimeout,
-		KeepAlive: upstreamDialKeepAlive,
-	}).DialContext
-	t.ForceAttemptHTTP2 = true
-	return t
-}
+// (prefillerProxy, decoderProxy, NIXLConnector.prefill).
+var upstreamTransport = common.NewPooledTransport(upstreamMaxIdleConnsPerHost)

--- a/pkg/kthena-router/connectors/upstream_transport.go
+++ b/pkg/kthena-router/connectors/upstream_transport.go
@@ -1,0 +1,83 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package connectors
+
+import (
+	"net"
+	"net/http"
+	"time"
+)
+
+const (
+	// upstreamMaxIdleConnsPerHost widens http.DefaultTransport's per-host idle
+	// pool (default 2) for PD-disaggregated forwarding (prefillerProxy,
+	// decoderProxy, NIXLConnector.prefill). The default of 2 causes connection
+	// churn under high concurrency that surfaces as EOF/500 on streaming
+	// decode responses, which cannot be retried once the first byte is written.
+	upstreamMaxIdleConnsPerHost = 64
+	upstreamMaxIdleConns        = 100
+	upstreamIdleConnTimeout     = 90 * time.Second
+	upstreamDialTimeout         = 30 * time.Second
+	upstreamDialKeepAlive       = 30 * time.Second
+	upstreamTLSHandshakeTimeout = 10 * time.Second
+)
+
+// upstreamTransport is the shared RoundTripper for PD-disaggregated forwarding
+// to upstream pods (prefillerProxy, decoderProxy, NIXLConnector.prefill).
+//
+// It clones http.DefaultTransport and only widens the per-host idle pool, so
+// hot prefill/decode pods reuse pooled connections under high concurrency
+// instead of rebuilding them on every request. A wider pool here is essential
+// because the PD retry loop cannot retry a decode once streaming has begun,
+// so connection churn that triggers EOF propagates directly to the client.
+var upstreamTransport = newUpstreamTransport()
+
+// newUpstreamTransport builds a transport tuned for high-concurrency PD
+// forwarding. Kept as a constructor so the configuration is testable in
+// isolation.
+func newUpstreamTransport() *http.Transport {
+	base, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		// Fall back to a fully-specified transport when the default has been
+		// replaced with a non-*http.Transport RoundTripper.
+		return &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+			DialContext: (&net.Dialer{
+				Timeout:   upstreamDialTimeout,
+				KeepAlive: upstreamDialKeepAlive,
+			}).DialContext,
+			ForceAttemptHTTP2:     true,
+			MaxIdleConns:          upstreamMaxIdleConns,
+			MaxIdleConnsPerHost:   upstreamMaxIdleConnsPerHost,
+			IdleConnTimeout:       upstreamIdleConnTimeout,
+			TLSHandshakeTimeout:   upstreamTLSHandshakeTimeout,
+			ExpectContinueTimeout: time.Second,
+		}
+	}
+
+	t := base.Clone()
+	t.MaxIdleConnsPerHost = upstreamMaxIdleConnsPerHost
+	t.MaxIdleConns = upstreamMaxIdleConns
+	t.IdleConnTimeout = upstreamIdleConnTimeout
+	t.TLSHandshakeTimeout = upstreamTLSHandshakeTimeout
+	t.DialContext = (&net.Dialer{
+		Timeout:   upstreamDialTimeout,
+		KeepAlive: upstreamDialKeepAlive,
+	}).DialContext
+	t.ForceAttemptHTTP2 = true
+	return t
+}

--- a/pkg/kthena-router/connectors/upstream_transport_test.go
+++ b/pkg/kthena-router/connectors/upstream_transport_test.go
@@ -17,45 +17,14 @@ limitations under the License.
 package connectors
 
 import (
-	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-// TestUpstreamTransportPoolConfiguration asserts the PD-disaggregated
-// forwarding transport widens the per-host idle pool. The stdlib default of 2
-// churns connections under high concurrency, which surfaces as EOF/500 on
-// streaming decode responses that cannot be retried once begun.
-func TestUpstreamTransportPoolConfiguration(t *testing.T) {
-	transport := newUpstreamTransport()
-
-	assert.Equal(t, upstreamMaxIdleConnsPerHost, transport.MaxIdleConnsPerHost,
-		"MaxIdleConnsPerHost must be widened beyond the stdlib default of 2")
-	assert.Equal(t, upstreamMaxIdleConns, transport.MaxIdleConns)
-	assert.Equal(t, upstreamIdleConnTimeout, transport.IdleConnTimeout)
-	assert.Equal(t, upstreamTLSHandshakeTimeout, transport.TLSHandshakeTimeout)
-	assert.NotNil(t, transport.DialContext, "DialContext must be configured")
-	assert.True(t, transport.ForceAttemptHTTP2, "ForceAttemptHTTP2 should be enabled")
-	assert.Zero(t, transport.ResponseHeaderTimeout,
-		"no ResponseHeaderTimeout: streaming decode must not be cut off mid-flight")
-}
-
-// TestUpstreamTransportWiderThanStdlibDefault is the behavioural guard: the
-// per-host pool must exceed http.DefaultTransport's default of 2.
-func TestUpstreamTransportWiderThanStdlibDefault(t *testing.T) {
-	defaultTransport, ok := http.DefaultTransport.(*http.Transport)
-	if !ok || defaultTransport == nil {
-		t.Skip("http.DefaultTransport is not *http.Transport in this environment")
-	}
-	assert.Greater(t, newUpstreamTransport().MaxIdleConnsPerHost, defaultTransport.MaxIdleConnsPerHost,
-		"upstream pool must be wider than the stdlib default of 2")
-}
-
-// TestUpstreamTransportSingletonInitialized guards the package-level singleton
-// shared by prefillerProxy, decoderProxy and NIXLConnector.prefill.
+// TestUpstreamTransportSingletonInitialized guards the package-level singleton;
+// pool config is covered by common.TestNewPooledTransport*.
 func TestUpstreamTransportSingletonInitialized(t *testing.T) {
 	assert.NotNil(t, upstreamTransport)
-	assert.Equal(t, upstreamMaxIdleConnsPerHost, upstreamTransport.MaxIdleConnsPerHost,
-		"package-level singleton must carry the widened pool configuration")
+	assert.Equal(t, upstreamMaxIdleConnsPerHost, upstreamTransport.MaxIdleConnsPerHost)
 }

--- a/pkg/kthena-router/connectors/upstream_transport_test.go
+++ b/pkg/kthena-router/connectors/upstream_transport_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package connectors
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestUpstreamTransportPoolConfiguration asserts the PD-disaggregated
+// forwarding transport widens the per-host idle pool. The stdlib default of 2
+// churns connections under high concurrency, which surfaces as EOF/500 on
+// streaming decode responses that cannot be retried once begun.
+func TestUpstreamTransportPoolConfiguration(t *testing.T) {
+	transport := newUpstreamTransport()
+
+	assert.Equal(t, upstreamMaxIdleConnsPerHost, transport.MaxIdleConnsPerHost,
+		"MaxIdleConnsPerHost must be widened beyond the stdlib default of 2")
+	assert.Equal(t, upstreamMaxIdleConns, transport.MaxIdleConns)
+	assert.Equal(t, upstreamIdleConnTimeout, transport.IdleConnTimeout)
+	assert.Equal(t, upstreamTLSHandshakeTimeout, transport.TLSHandshakeTimeout)
+	assert.NotNil(t, transport.DialContext, "DialContext must be configured")
+	assert.True(t, transport.ForceAttemptHTTP2, "ForceAttemptHTTP2 should be enabled")
+	assert.Zero(t, transport.ResponseHeaderTimeout,
+		"no ResponseHeaderTimeout: streaming decode must not be cut off mid-flight")
+}
+
+// TestUpstreamTransportWiderThanStdlibDefault is the behavioural guard: the
+// per-host pool must exceed http.DefaultTransport's default of 2.
+func TestUpstreamTransportWiderThanStdlibDefault(t *testing.T) {
+	defaultTransport, ok := http.DefaultTransport.(*http.Transport)
+	if !ok || defaultTransport == nil {
+		t.Skip("http.DefaultTransport is not *http.Transport in this environment")
+	}
+	assert.Greater(t, newUpstreamTransport().MaxIdleConnsPerHost, defaultTransport.MaxIdleConnsPerHost,
+		"upstream pool must be wider than the stdlib default of 2")
+}
+
+// TestUpstreamTransportSingletonInitialized guards the package-level singleton
+// shared by prefillerProxy, decoderProxy and NIXLConnector.prefill.
+func TestUpstreamTransportSingletonInitialized(t *testing.T) {
+	assert.NotNil(t, upstreamTransport)
+	assert.Equal(t, upstreamMaxIdleConnsPerHost, upstreamTransport.MaxIdleConnsPerHost,
+		"package-level singleton must carry the widened pool configuration")
+}

--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -1342,7 +1342,7 @@ func doRequest(
 		req = req.WithContext(ctx)
 	}
 
-	resp, err := http.DefaultTransport.RoundTrip(req)
+	resp, err := proxyTransport.RoundTrip(req)
 	if err != nil {
 		cancel()
 		return nil, err

--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -1320,7 +1320,7 @@ func doRequest(
 		req = req.WithContext(ctx)
 	}
 
-	resp, err := http.DefaultTransport.RoundTrip(req)
+	resp, err := proxyTransport.RoundTrip(req)
 	if err != nil {
 		cancel()
 		return nil, err

--- a/pkg/kthena-router/router/transport.go
+++ b/pkg/kthena-router/router/transport.go
@@ -17,78 +17,13 @@ limitations under the License.
 package router
 
 import (
-	"net"
-	"net/http"
-	"time"
+	"github.com/volcano-sh/kthena/pkg/kthena-router/common"
 )
 
-const (
-	// maxIdleConnsPerHost overrides http.DefaultTransport's default of 2.
-	// Under high concurrency against a single upstream pod, the default of 2
-	// forces frequent connection churn (dial/close/re-dial) that surfaces as
-	// unexpected EOF / 500 on streaming responses, which cannot be retried
-	// against another pod once the first byte is written. 64 keeps a deep idle
-	// pool per host so hot pods reuse pooled connections instead of rebuilding.
-	maxIdleConnsPerHost = 64
-	// maxIdleConns caps the total idle pool across all hosts, matching the
-	// value used by the external provider transport
-	// (see providers.newProviderTransportBaseline).
-	maxIdleConns = 100
-	// idleConnTimeout reuses http.DefaultTransport's default so stale idle
-	// connections still close when traffic drops.
-	idleConnTimeout = 90 * time.Second
-	// dialTimeout and dialKeepAlive mirror http.DefaultTransport's dialer so
-	// connection establishment behaviour is unchanged.
-	dialTimeout   = 30 * time.Second
-	dialKeepAlive = 30 * time.Second
-	// tlsHandshakeTimeout mirrors http.DefaultTransport's default.
-	tlsHandshakeTimeout = 10 * time.Second
-)
+// maxIdleConnsPerHost widens the per-host idle pool over the stdlib default of
+// 2; see common.NewPooledTransport.
+const maxIdleConnsPerHost = 64
 
-// proxyTransport is the shared RoundTripper for forwarding inference requests
-// to upstream model-server pods (doRequest and the PD decode path).
-//
-// It clones http.DefaultTransport so the standard library's robust default
-// transport behaviour is preserved, then only widens the per-host idle
-// connection pool. The default MaxIdleConnsPerHost of 2 is the bottleneck
-// under high concurrency: extra concurrent requests rebuild connections on
-// every cycle, which surfaces as EOF/500 once a streaming response has begun
-// (streaming responses cannot be retried against another pod).
-var proxyTransport = newProxyTransport()
-
-// newProxyTransport builds a transport tuned for high-concurrency upstream
-// forwarding. A dedicated constructor (instead of an inline var initializer)
-// keeps the configuration testable in isolation.
-func newProxyTransport() *http.Transport {
-	base, ok := http.DefaultTransport.(*http.Transport)
-	if !ok {
-		// Fall back to a fully-specified transport when the default has been
-		// replaced with a non-*http.Transport RoundTripper (e.g. in tests or
-		// by an embedding binary). Mirrors providers.newProviderTransportBaseline.
-		return &http.Transport{
-			Proxy: http.ProxyFromEnvironment,
-			DialContext: (&net.Dialer{
-				Timeout:   dialTimeout,
-				KeepAlive: dialKeepAlive,
-			}).DialContext,
-			ForceAttemptHTTP2:     true,
-			MaxIdleConns:          maxIdleConns,
-			MaxIdleConnsPerHost:   maxIdleConnsPerHost,
-			IdleConnTimeout:       idleConnTimeout,
-			TLSHandshakeTimeout:   tlsHandshakeTimeout,
-			ExpectContinueTimeout: time.Second,
-		}
-	}
-
-	t := base.Clone()
-	t.MaxIdleConnsPerHost = maxIdleConnsPerHost
-	t.MaxIdleConns = maxIdleConns
-	t.IdleConnTimeout = idleConnTimeout
-	t.TLSHandshakeTimeout = tlsHandshakeTimeout
-	t.DialContext = (&net.Dialer{
-		Timeout:   dialTimeout,
-		KeepAlive: dialKeepAlive,
-	}).DialContext
-	t.ForceAttemptHTTP2 = true
-	return t
-}
+// proxyTransport forwards inference requests to upstream pods (doRequest, PD
+// decode path).
+var proxyTransport = common.NewPooledTransport(maxIdleConnsPerHost)

--- a/pkg/kthena-router/router/transport.go
+++ b/pkg/kthena-router/router/transport.go
@@ -1,0 +1,94 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package router
+
+import (
+	"net"
+	"net/http"
+	"time"
+)
+
+const (
+	// maxIdleConnsPerHost overrides http.DefaultTransport's default of 2.
+	// Under high concurrency against a single upstream pod, the default of 2
+	// forces frequent connection churn (dial/close/re-dial) that surfaces as
+	// unexpected EOF / 500 on streaming responses, which cannot be retried
+	// against another pod once the first byte is written. 64 keeps a deep idle
+	// pool per host so hot pods reuse pooled connections instead of rebuilding.
+	maxIdleConnsPerHost = 64
+	// maxIdleConns caps the total idle pool across all hosts, matching the
+	// value used by the external provider transport
+	// (see providers.newProviderTransportBaseline).
+	maxIdleConns = 100
+	// idleConnTimeout reuses http.DefaultTransport's default so stale idle
+	// connections still close when traffic drops.
+	idleConnTimeout = 90 * time.Second
+	// dialTimeout and dialKeepAlive mirror http.DefaultTransport's dialer so
+	// connection establishment behaviour is unchanged.
+	dialTimeout   = 30 * time.Second
+	dialKeepAlive = 30 * time.Second
+	// tlsHandshakeTimeout mirrors http.DefaultTransport's default.
+	tlsHandshakeTimeout = 10 * time.Second
+)
+
+// proxyTransport is the shared RoundTripper for forwarding inference requests
+// to upstream model-server pods (doRequest and the PD decode path).
+//
+// It clones http.DefaultTransport so the standard library's robust default
+// transport behaviour is preserved, then only widens the per-host idle
+// connection pool. The default MaxIdleConnsPerHost of 2 is the bottleneck
+// under high concurrency: extra concurrent requests rebuild connections on
+// every cycle, which surfaces as EOF/500 once a streaming response has begun
+// (streaming responses cannot be retried against another pod).
+var proxyTransport = newProxyTransport()
+
+// newProxyTransport builds a transport tuned for high-concurrency upstream
+// forwarding. A dedicated constructor (instead of an inline var initializer)
+// keeps the configuration testable in isolation.
+func newProxyTransport() *http.Transport {
+	base, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		// Fall back to a fully-specified transport when the default has been
+		// replaced with a non-*http.Transport RoundTripper (e.g. in tests or
+		// by an embedding binary). Mirrors providers.newProviderTransportBaseline.
+		return &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+			DialContext: (&net.Dialer{
+				Timeout:   dialTimeout,
+				KeepAlive: dialKeepAlive,
+			}).DialContext,
+			ForceAttemptHTTP2:     true,
+			MaxIdleConns:          maxIdleConns,
+			MaxIdleConnsPerHost:   maxIdleConnsPerHost,
+			IdleConnTimeout:       idleConnTimeout,
+			TLSHandshakeTimeout:   tlsHandshakeTimeout,
+			ExpectContinueTimeout: time.Second,
+		}
+	}
+
+	t := base.Clone()
+	t.MaxIdleConnsPerHost = maxIdleConnsPerHost
+	t.MaxIdleConns = maxIdleConns
+	t.IdleConnTimeout = idleConnTimeout
+	t.TLSHandshakeTimeout = tlsHandshakeTimeout
+	t.DialContext = (&net.Dialer{
+		Timeout:   dialTimeout,
+		KeepAlive: dialKeepAlive,
+	}).DialContext
+	t.ForceAttemptHTTP2 = true
+	return t
+}

--- a/pkg/kthena-router/router/transport_test.go
+++ b/pkg/kthena-router/router/transport_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package router
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestProxyTransportPoolConfiguration asserts the upstream forwarding
+// transport widens the per-host idle pool so high-concurrency requests
+// against a single pod reuse pooled connections instead of churning. This
+// guards against regressions silently dropping the override back to the
+// stdlib default of 2.
+func TestProxyTransportPoolConfiguration(t *testing.T) {
+	transport := newProxyTransport()
+
+	assert.Equal(t, maxIdleConnsPerHost, transport.MaxIdleConnsPerHost,
+		"MaxIdleConnsPerHost must be widened beyond the stdlib default of 2")
+	assert.Equal(t, maxIdleConns, transport.MaxIdleConns)
+	assert.Equal(t, idleConnTimeout, transport.IdleConnTimeout)
+	assert.Equal(t, tlsHandshakeTimeout, transport.TLSHandshakeTimeout)
+	assert.NotNil(t, transport.DialContext, "DialContext must be configured")
+	assert.True(t, transport.ForceAttemptHTTP2, "ForceAttemptHTTP2 should be enabled")
+	assert.Zero(t, transport.ResponseHeaderTimeout,
+		"no ResponseHeaderTimeout: streaming prefill must not be cut off mid-flight")
+}
+
+// TestProxyTransportWiderThanStdlibDefault is the behavioural guard: the
+// entire point of this PR is that the per-host pool exceeds
+// http.DefaultTransport's default of 2.
+func TestProxyTransportWiderThanStdlibDefault(t *testing.T) {
+	defaultTransport, ok := http.DefaultTransport.(*http.Transport)
+	if !ok || defaultTransport == nil {
+		t.Skip("http.DefaultTransport is not *http.Transport in this environment")
+	}
+	assert.Greater(t, newProxyTransport().MaxIdleConnsPerHost, defaultTransport.MaxIdleConnsPerHost,
+		"upstream pool must be wider than the stdlib default of 2")
+}
+
+// TestProxyTransportSingletonInitialized guards the package-level singleton:
+// if it is ever left as a nil/round-tripper stub, doRequest would panic on
+// the first request.
+func TestProxyTransportSingletonInitialized(t *testing.T) {
+	assert.NotNil(t, proxyTransport)
+	assert.Equal(t, maxIdleConnsPerHost, proxyTransport.MaxIdleConnsPerHost,
+		"package-level singleton must carry the widened pool configuration")
+}

--- a/pkg/kthena-router/router/transport_test.go
+++ b/pkg/kthena-router/router/transport_test.go
@@ -17,48 +17,14 @@ limitations under the License.
 package router
 
 import (
-	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-// TestProxyTransportPoolConfiguration asserts the upstream forwarding
-// transport widens the per-host idle pool so high-concurrency requests
-// against a single pod reuse pooled connections instead of churning. This
-// guards against regressions silently dropping the override back to the
-// stdlib default of 2.
-func TestProxyTransportPoolConfiguration(t *testing.T) {
-	transport := newProxyTransport()
-
-	assert.Equal(t, maxIdleConnsPerHost, transport.MaxIdleConnsPerHost,
-		"MaxIdleConnsPerHost must be widened beyond the stdlib default of 2")
-	assert.Equal(t, maxIdleConns, transport.MaxIdleConns)
-	assert.Equal(t, idleConnTimeout, transport.IdleConnTimeout)
-	assert.Equal(t, tlsHandshakeTimeout, transport.TLSHandshakeTimeout)
-	assert.NotNil(t, transport.DialContext, "DialContext must be configured")
-	assert.True(t, transport.ForceAttemptHTTP2, "ForceAttemptHTTP2 should be enabled")
-	assert.Zero(t, transport.ResponseHeaderTimeout,
-		"no ResponseHeaderTimeout: streaming prefill must not be cut off mid-flight")
-}
-
-// TestProxyTransportWiderThanStdlibDefault is the behavioural guard: the
-// entire point of this PR is that the per-host pool exceeds
-// http.DefaultTransport's default of 2.
-func TestProxyTransportWiderThanStdlibDefault(t *testing.T) {
-	defaultTransport, ok := http.DefaultTransport.(*http.Transport)
-	if !ok || defaultTransport == nil {
-		t.Skip("http.DefaultTransport is not *http.Transport in this environment")
-	}
-	assert.Greater(t, newProxyTransport().MaxIdleConnsPerHost, defaultTransport.MaxIdleConnsPerHost,
-		"upstream pool must be wider than the stdlib default of 2")
-}
-
-// TestProxyTransportSingletonInitialized guards the package-level singleton:
-// if it is ever left as a nil/round-tripper stub, doRequest would panic on
-// the first request.
+// TestProxyTransportSingletonInitialized guards the package-level singleton;
+// pool config is covered by common.TestNewPooledTransport*.
 func TestProxyTransportSingletonInitialized(t *testing.T) {
 	assert.NotNil(t, proxyTransport)
-	assert.Equal(t, maxIdleConnsPerHost, proxyTransport.MaxIdleConnsPerHost,
-		"package-level singleton must carry the widened pool configuration")
+	assert.Equal(t, maxIdleConnsPerHost, proxyTransport.MaxIdleConnsPerHost)
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind enhancement

**What this PR does / why we need it:**

The router's inference-forwarding paths all use http.DefaultTransport, whose MaxIdleConnsPerHost of 2 saturates under high concurrency against a single hot pod, so extra concurrent requests rebuild the TCP connection on every cycle and this surfaces as unexpected EOF or 500 on streaming responses that cannot be retried against another pod once the first byte has been written (router.go only retries while c.Writer.Written() is false). This PR introduces per-package shared transports that clone http.DefaultTransport and widen the per-host idle pool: router.proxyTransport is used by doRequest and connectors.upstreamTransport is used by the PD prefillerProxy, decoderProxy and NIXLConnector.prefill. MaxIdleConnsPerHost is raised to 64 with MaxIdleConns 100 and IdleConnTimeout 90s, so hot pods reuse a deep idle connection pool instead of churning. The configuration is hardcoded to match the existing HTTP tuning convention in the repo (providers already hardcodes its transport baseline and does not set MaxIdleConnsPerHost either).

Source refs (v1.0.0):
- doRequest: https://github.com/volcano-sh/kthena/blob/v1.0.0/pkg/kthena-router/router/router.go#L948
- streaming retry guard: https://github.com/volcano-sh/kthena/blob/v1.0.0/pkg/kthena-router/router/router.go#L721
- PD prefillerProxy: https://github.com/volcano-sh/kthena/blob/v1.0.0/pkg/kthena-router/connectors/transport.go#L35
- PD decoderProxy: https://github.com/volcano-sh/kthena/blob/v1.0.0/pkg/kthena-router/connectors/transport.go#L50
- NIXL prefill: https://github.com/volcano-sh/kthena/blob/v1.0.0/pkg/kthena-router/connectors/nixl.go#L132
- existing baseline with no per-host override: https://github.com/volcano-sh/kthena/blob/v1.0.0/pkg/kthena-router/providers/adapter.go#L397

**Which issue(s) this PR fixes:**
Fixes #1653

**Bug evidence (required for bug-related PRs):**
N/A — this is an enhancement, not a bug PR. The connection-pool churn is the remaining suspected cause after the recoveryPolicy=None mitigation in load testing, but a minimal reproducer that isolates connection-pool churn (single hot pod, high concurrency, recoveryPolicy=None) has not yet been captured, so this PR is framed as an enhancement rather than a bug fix to avoid overclaiming causation.

**Special notes for your reviewer:**

Disclosure: parts of this PR's code and this description were drafted with generative AI assistance, and all code was reviewed and tested (go test ./pkg/kthena-router/router/... ./pkg/kthena-router/connectors/... and golangci-lint pass) and signed off by the author; no AI co-author or co-sign trailer is added per
the repo's AI policy.

Scope notes: only the forwarding paths are touched (doRequest plus the PD connectors) while metrics scrape, tokenizer and the external provider transport already have their own clients and are intentionally left untouched; no ResponseHeaderTimeout or client.Timeout is added in this PR because adding one risks cutting off streaming prefill mid-flight and is left for a follow-up; parameters are hardcoded rather than env-configurable to match the existing HTTP tuning convention in the repo.

**Does this PR introduce a user-facing change?**:
```release-note
NONE