### PR TITLE
docs: highlight Kthena's lightweight and modular architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ The two components talk to Kubernetes, not to each other, so you can mix and mat
 
 | You want to...               | Install               | Notes                                                                                                  |
 | ---------------------------- | --------------------- | ------------------------------------------------------------------------------------------------------ |
-| Manage model workloads only  | `workload` subchart   | Use `ModelServing` / `AutoScalingPolicy` and expose pods with your own gateway or `Service`.           |
+| Manage model workloads only  | `workload` subchart   | Use `ModelServing` / `AutoscalingPolicy` and expose pods with your own gateway or `Service`.           |
 | Route inference traffic only | `networking` subchart | Point `ModelServer` at any pods — Deployments, StatefulSets, or workloads managed by another operator. |
 | Full platform                | Both subcharts        | Required for the one-stop `ModelBooster` API, which cascades into both CRD groups.                     |
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Kthena is deliberately **lightweight and composable**. The entire platform is tw
 ### **Lightweight & Modular**
 - **Small footprint**: Two self-contained Go binaries with a minimal dependency surface — quick to install, cheap to run, and simple to upgrade.
 - **Independently deployable planes**: The controller manager (workload) and the router (networking) are separate Helm subcharts with separate CRD groups and release lifecycles. Deploy either one alone, or both together.
-- **No runtime coupling**: Each component reconciles against the Kubernetes API rather than against the other, so a partial install is a first-class scenario, not a degraded mode.
+- **No runtime coupling**: Each component talks only to the Kubernetes API, never to the other, so a partial install is a first-class scenario, not a degraded mode.
 - **Bring your own stack**: Keep your existing API gateway, ingress, and observability tooling — Kthena plugs into them instead of replacing them.
 - **Opt-in capabilities**: Gang scheduling (Volcano), webhooks, Gateway API support, and TLS are all optional, so a minimal install stays minimal.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </p>
 
 <p align="center">
-  <strong>The Enterprise-Grade LLM Serving Platform That Makes AI Infrastructure Simple, Scalable, and Cost-Efficient</strong>
+  <strong>The Lightweight, Modular, Enterprise-Grade LLM Serving Platform That Makes AI Infrastructure Simple, Scalable, and Cost-Efficient</strong>
 </p>
 
 <p align="center">
@@ -23,11 +23,20 @@
 
 ## Overview
 
-**Kthena** is a Kubernetes-native LLM inference platform that transforms how organizations deploy and manage Large Language Models in production. Built with declarative model lifecycle management and intelligent request routing, it provides high performance and enterprise-grade scalability for LLM inference workloads.
+**Kthena** is a lightweight, Kubernetes-native LLM inference platform that transforms how organizations deploy and manage Large Language Models in production. Built with declarative model lifecycle management and intelligent request routing, it provides high performance and enterprise-grade scalability for LLM inference workloads.
 
 The platform extends Kubernetes with purpose-built Custom Resource Definitions (CRDs) for managing LLM workloads, supporting multiple inference engines (vLLM, SGLang, Triton) and advanced serving patterns like prefill-decode disaggregation. Kthena's architecture separates control plane operations (model lifecycle, autoscaling policies) from data plane traffic routing through an intelligent router, enabling teams to manage complex LLM deployments with familiar cloud-native patterns while delivering cost-driven autoscaling, heterogeneous accelerators support, and multi-backend inference engines.
 
+Kthena is deliberately **lightweight and composable**. The entire platform is two self-contained Go binaries with a small dependency surface, and its two planes are fully decoupled: install the **workload controllers** to manage the model lifecycle, install the **router** to handle inference traffic, or install both. Each side stands on its own and neither depends on the other at runtime — adopt just the piece you need today, and add the other whenever you're ready.
+
 ## Key Features
+
+### **Lightweight & Modular**
+- **Small footprint**: Two self-contained Go binaries with a minimal dependency surface — quick to install, cheap to run, and simple to upgrade.
+- **Independently deployable planes**: The controller manager (workload) and the router (networking) are separate Helm subcharts with separate CRD groups and release lifecycles. Deploy either one alone, or both together.
+- **No runtime coupling**: Each component reconciles against the Kubernetes API rather than against the other, so a partial install is a first-class scenario, not a degraded mode.
+- **Bring your own stack**: Keep your existing API gateway, ingress, and observability tooling — Kthena plugs into them instead of replacing them.
+- **Opt-in capabilities**: Gang scheduling (Volcano), webhooks, Gateway API support, and TLS are all optional, so a minimal install stays minimal.
 
 ### **Production-Ready LLM Serving**
 Deploy and scale Large Language Models with enterprise-grade reliability, supporting vLLM, SGLang, Triton, and TorchServe inference engines through consistent Kubernetes-native APIs.
@@ -52,12 +61,34 @@ Gang scheduling ensures atomic scheduling of distributed inference groups like x
 
 ## Architecture
 
-Kthena implements a Kubernetes-native architecture with separate control plane and data plane components, each of which can be deployed and used alone. The platform manages LLM inference workloads through CRDs and provides intelligent request routing through a dedicated router. It contains the following key components:
+Kthena implements a Kubernetes-native architecture with a clear split between the control plane and the data plane. Each plane is an independent component with its own CRD group, its own Helm subchart, and its own release lifecycle — **either one can be deployed and used on its own**. It contains the following key components:
 
 - **Kthena-controller-manager**: 
   The control plane component governing the LLM inference lifecycle. It continuously reconciles Kthena CRDs to deploy, scale, and upgrade inference replicas across the cluster while exposing advanced scheduling policies that integrate directly with the [Volcano scheduler](https://github.com/volcano-sh/volcano/).   
 - **Kthena-router**:
   The data plane entry point for inference traffic. It classifies each request by model name, custom headers, or URI patterns, then applies load-balancing policies and traffic controls to dispatch requests to the right inference instance. Native support for prefill–decode disaggregation routing while keeping high throughput and low latency.
+
+### Modular Deployment
+
+The two components talk to Kubernetes, not to each other, so you can mix and match:
+
+| You want to...               | Install               | Notes                                                                                                  |
+| ---------------------------- | --------------------- | ------------------------------------------------------------------------------------------------------ |
+| Manage model workloads only  | `workload` subchart   | Use `ModelServing` / `AutoScalingPolicy` and expose pods with your own gateway or `Service`.           |
+| Route inference traffic only | `networking` subchart | Point `ModelServer` at any pods — Deployments, StatefulSets, or workloads managed by another operator. |
+| Full platform                | Both subcharts        | Required for the one-stop `ModelBooster` API, which cascades into both CRD groups.                     |
+
+```bash
+# Workload controllers only (no router)
+helm install kthena oci://ghcr.io/volcano-sh/charts/kthena \
+  --namespace kthena-system --create-namespace \
+  --set networking.enabled=false
+
+# Router only (no workload controllers)
+helm install kthena oci://ghcr.io/volcano-sh/charts/kthena \
+  --namespace kthena-system --create-namespace \
+  --set workload.enabled=false
+```
 
 For more details, please refer to [Kthena Architecture](https://kthena.volcano.sh/docs/architecture/architecture)
 
@@ -67,7 +98,7 @@ For more details, please refer to [Kthena Architecture](https://kthena.volcano.s
 
 ## Getting Started
 
-Get up and running with Kthena in minutes. This [guide](docs/kthena/docs/getting-started/quick-start.md) will walk you through installing the platform and deploying your first LLM model.
+Get up and running with Kthena in minutes. This [guide](docs/kthena/docs/getting-started/quick-start.md) will walk you through installing the platform and deploying your first LLM model. You can install the full platform, or only the component you need — see [Modular Deployment](#modular-deployment) and the [installation guide](docs/kthena/docs/getting-started/installation.md).
 
 ### Install from code
 

--- a/docs/kthena/docs/architecture/architecture.mdx
+++ b/docs/kthena/docs/architecture/architecture.mdx
@@ -6,7 +6,7 @@ import requestPipeline from '../assets/diagrams/architecture/request_pipeline.sv
 
 Kthena follows a **two-plane architecture** that cleanly separates *what you declare* from *how requests flow*. The **Control Plane** reconciles your CRDs into a running system; the **Data Plane** routes every inference request through a model-aware pipeline to the right pod at the right time.
 
-The two planes are **independently deployable**. They share no in-process state and never call each other — both reconcile purely against the Kubernetes API. Each plane is a single self-contained Go binary packaged as its own Helm subchart with its own CRD group, so you can run either one alone. See [Modular Deployment](#modular-deployment) below.
+The two planes are **independently deployable**. They share no in-process state and never call each other — both interact only with the Kubernetes API. Each plane is a single self-contained Go binary packaged as its own Helm subchart with its own CRD group, so you can run either one alone. See [Modular Deployment](#modular-deployment) below.
 
 <LightboxImage src={architectureOverview} alt="Architecture Overview"/>
 

--- a/docs/kthena/docs/architecture/architecture.mdx
+++ b/docs/kthena/docs/architecture/architecture.mdx
@@ -102,7 +102,7 @@ Kthena is intentionally lightweight: the whole platform is two self-contained Go
 
 | Subchart | Binary | CRD group | Owns |
 |---|---|---|---|
-| `workload` | `kthena-controller-manager` | `workload.serving.volcano.sh` | `ModelServing`, `ModelBooster`, `AutoScalingPolicy`, `AutoScalingPolicyBinding` |
+| `workload` | `kthena-controller-manager` | `workload.serving.volcano.sh` | `ModelServing`, `ModelBooster`, `AutoscalingPolicy` |
 | `networking` | `kthena-router` | `networking.serving.volcano.sh` | `ModelRoute`, `ModelServer`, `ExternalModelProvider` |
 
 Because the planes are decoupled, three deployment shapes are supported:

--- a/docs/kthena/docs/architecture/architecture.mdx
+++ b/docs/kthena/docs/architecture/architecture.mdx
@@ -6,6 +6,8 @@ import requestPipeline from '../assets/diagrams/architecture/request_pipeline.sv
 
 Kthena follows a **two-plane architecture** that cleanly separates *what you declare* from *how requests flow*. The **Control Plane** reconciles your CRDs into a running system; the **Data Plane** routes every inference request through a model-aware pipeline to the right pod at the right time.
 
+The two planes are **independently deployable**. They share no in-process state and never call each other — both reconcile purely against the Kubernetes API. Each plane is a single self-contained Go binary packaged as its own Helm subchart with its own CRD group, so you can run either one alone. See [Modular Deployment](#modular-deployment) below.
+
 <LightboxImage src={architectureOverview} alt="Architecture Overview"/>
 
 ---
@@ -91,6 +93,25 @@ The scheduler at Stage 5 is the heart of Kthena's intelligent routing. It mirror
 | **GPU Cache** | Considers GPU memory utilization to avoid requests preemption. |
 
 **PD-Aware Scheduling:** When the request targets a disaggregated PD group, the scheduler first scores decode pods, then pairs each with a compatible prefill pod in the same group — ensuring KV-cache locality and minimal data transfer.
+
+---
+
+## Modular Deployment
+
+Kthena is intentionally lightweight: the whole platform is two self-contained Go binaries with a minimal dependency surface, packaged as two Helm subcharts that map one-to-one onto the two planes.
+
+| Subchart | Binary | CRD group | Owns |
+|---|---|---|---|
+| `workload` | `kthena-controller-manager` | `workload.serving.volcano.sh` | `ModelServing`, `ModelBooster`, `AutoScalingPolicy`, `AutoScalingPolicyBinding` |
+| `networking` | `kthena-router` | `networking.serving.volcano.sh` | `ModelRoute`, `ModelServer`, `ExternalModelProvider` |
+
+Because the planes are decoupled, three deployment shapes are supported:
+
+- **Control plane only** (`--set networking.enabled=false`) — Use Kthena purely as a workload manager. Declare `ModelServing` for role-based, gang-scheduled, topology-aware replicas and let autoscaling policies drive capacity, while traffic keeps flowing through your existing gateway or a plain `Service`.
+- **Data plane only** (`--set workload.enabled=false`) — Use the router as a standalone, model-aware LLM gateway. `ModelServer` discovers backends via a label `workloadSelector`, so the pods behind it can come from a Deployment, a StatefulSet, another operator, or an external provider such as OpenAI. No Kthena workload CRDs required.
+- **Full platform** (default) — Both subcharts installed. This is required for the one-stop `ModelBooster` API, which cascades into both CRD groups, and for end-to-end features that span planes such as PD-aware routing driven by `ModelServing` roles.
+
+Each subchart installs only its own CRDs, RBAC, and webhooks, so a component-scoped installation leaves no unused resources behind. See the [installation guide](../getting-started/installation.md#component-scoped-installation) for the exact commands.
 
 ---
 

--- a/docs/kthena/docs/architecture/kthena-router.md
+++ b/docs/kthena/docs/architecture/kthena-router.md
@@ -14,6 +14,8 @@ Our goal is to deliver a lightweight, user-friendly, and extensible LLM inferenc
 
 Kthena Router is deployed as a standalone binary that can seamlessly integrate with existing gateway infrastructure or serve as a direct traffic entry point for handling AI workloads independently.
 
+It is fully decoupled from the Kthena controller manager: the router only needs the `networking.serving.volcano.sh` CRDs (`ModelRoute`, `ModelServer`, `ExternalModelProvider`) and discovers backend pods through a label selector. This means it can front pods managed by a plain Deployment, a StatefulSet, another operator, or a Kthena `ModelServing` — install it alone with `--set workload.enabled=false` (see [Component-Scoped Installation](../getting-started/installation.md#component-scoped-installation)).
+
 For backend model access, the router supports both external public AI service providers (such as OpenAI, Google Gemini) and privately deployed models within the cluster.
 
 For privately deployed models in particular, the router supports mainstream inference frameworks including vLLM, SGLang, and others. By continuously monitoring the metrics interfaces of inference engines running on model pods, it obtains real-time model status information, including currently loaded LoRA details, KV cache utilization, and other key metrics. This information enables intelligent routing decisions that significantly improve inference service throughput while reducing latency.

--- a/docs/kthena/docs/getting-started/installation.md
+++ b/docs/kthena/docs/getting-started/installation.md
@@ -73,6 +73,47 @@ You can also download the Helm chart package from [GitHub releases](https://gith
 
 ## Configuration Options
 
+### Component-Scoped Installation
+
+Kthena is modular: the **workload** controllers and the **networking** router are separate Helm subcharts with separate CRD groups, and neither depends on the other at runtime. Install only what you need — a component-scoped install brings in just that component's CRDs, RBAC, and webhooks.
+
+| Subchart     | Component                                                  | CRDs installed                                                                  |
+| :----------- | :--------------------------------------------------------- | :------------------------------------------------------------------------------ |
+| `workload`   | `kthena-controller-manager` (model lifecycle, autoscaling) | `ModelServing`, `ModelBooster`, `AutoScalingPolicy`, `AutoScalingPolicyBinding` |
+| `networking` | `kthena-router` (inference traffic routing)                | `ModelRoute`, `ModelServer`, `ExternalModelProvider`                            |
+
+**Workload controllers only** — manage model workloads with Kthena while keeping your existing gateway for traffic:
+
+```bash
+helm install kthena oci://ghcr.io/volcano-sh/charts/kthena \
+  --namespace kthena-system --create-namespace \
+  --set networking.enabled=false
+```
+
+**Router only** — use Kthena Router as a standalone, model-aware LLM gateway in front of pods managed by Deployments, StatefulSets, another operator, or external providers:
+
+```bash
+helm install kthena oci://ghcr.io/volcano-sh/charts/kthena \
+  --namespace kthena-system --create-namespace \
+  --set workload.enabled=false
+```
+
+:::note
+The one-stop `ModelBooster` API cascades into both CRD groups, so it requires **both** subcharts to be installed. With a component-scoped install, use the fine-grained CRDs of that component directly.
+:::
+
+You can enable the other component later with `helm upgrade --set <subchart>.enabled=true`. Note that Helm does not install files under a chart's `crds/` directory during an upgrade, so apply the newly enabled component's CRDs yourself first:
+
+```bash
+# Fetch and unpack the chart, then apply the CRDs of the component you are enabling
+helm pull oci://ghcr.io/volcano-sh/charts/kthena --version v1.0.0 --untar
+kubectl apply --server-side -f kthena/charts/networking/crds/
+
+helm upgrade kthena oci://ghcr.io/volcano-sh/charts/kthena \
+  --namespace kthena-system --reuse-values \
+  --set networking.enabled=true
+```
+
 ### Helm Values
 
 You can customize the installation by providing values:
@@ -88,7 +129,9 @@ helm install kthena oci://ghcr.io/volcano-sh/charts/kthena \
 ### Common Configuration Parameters
 
 | Parameter                             | Description                                                    | Default |
-|:--------------------------------------|:---------------------------------------------------------------|:--------|
+| :------------------------------------ | :------------------------------------------------------------- | :------ |
+| `workload.enabled`                    | Install the workload controllers and their CRDs                | `true`  |
+| `networking.enabled`                  | Install the Kthena Router and its CRDs                         | `true`  |
 | `workload.controllerManager.replicas` | Number of controller manager replicas                          | `1`     |
 | `networking.kthenaRouter.replicas`    | Number of router replicas                                      | `1`     |
 | `networking.kthenaRouter.tls.enabled` | Enable TLS for the router                                      | `false` |

--- a/docs/kthena/docs/getting-started/installation.md
+++ b/docs/kthena/docs/getting-started/installation.md
@@ -105,10 +105,16 @@ The one-stop `ModelBooster` API cascades into both CRD groups, so it requires **
 You can enable the other component later with `helm upgrade --set <subchart>.enabled=true`. Note that Helm does not install files under a chart's `crds/` directory during an upgrade, so apply the newly enabled component's CRDs yourself first:
 
 ```bash
-# Fetch and unpack the chart, then apply the CRDs of the component you are enabling
-helm pull oci://ghcr.io/volcano-sh/charts/kthena --version v1.0.0 --untar
-kubectl apply --server-side -f kthena/charts/networking/crds/
+# 1. Fetch and unpack the chart. Replace <chart-version> with the chart version
+#    you have installed — `helm list -n kthena-system` shows it.
+helm pull oci://ghcr.io/volcano-sh/charts/kthena --version <chart-version> --untar
 
+# 2. Apply the CRDs of the subchart you are enabling: use `networking` for the
+#    router, or `workload` for the controllers.
+kubectl apply --server-side -f kthena/charts/<subchart>/crds/
+
+# 3. Enable the subchart. This example turns on the router; use
+#    `--set workload.enabled=true` to turn on the controllers instead.
 helm upgrade kthena oci://ghcr.io/volcano-sh/charts/kthena \
   --namespace kthena-system --reuse-values \
   --set networking.enabled=true

--- a/docs/kthena/docs/getting-started/installation.md
+++ b/docs/kthena/docs/getting-started/installation.md
@@ -77,10 +77,10 @@ You can also download the Helm chart package from [GitHub releases](https://gith
 
 Kthena is modular: the **workload** controllers and the **networking** router are separate Helm subcharts with separate CRD groups, and neither depends on the other at runtime. Install only what you need — a component-scoped install brings in just that component's CRDs, RBAC, and webhooks.
 
-| Subchart     | Component                                                  | CRDs installed                                                                  |
-| :----------- | :--------------------------------------------------------- | :------------------------------------------------------------------------------ |
-| `workload`   | `kthena-controller-manager` (model lifecycle, autoscaling) | `ModelServing`, `ModelBooster`, `AutoScalingPolicy`, `AutoScalingPolicyBinding` |
-| `networking` | `kthena-router` (inference traffic routing)                | `ModelRoute`, `ModelServer`, `ExternalModelProvider`                            |
+| Subchart     | Component                                                  | CRDs installed                                       |
+| :----------- | :--------------------------------------------------------- | :--------------------------------------------------- |
+| `workload`   | `kthena-controller-manager` (model lifecycle, autoscaling) | `ModelServing`, `ModelBooster`, `AutoscalingPolicy`  |
+| `networking` | `kthena-router` (inference traffic routing)                | `ModelRoute`, `ModelServer`, `ExternalModelProvider` |
 
 **Workload controllers only** — manage model workloads with Kthena while keeping your existing gateway for traffic:
 

--- a/docs/kthena/docs/intro.md
+++ b/docs/kthena/docs/intro.md
@@ -33,7 +33,7 @@ Kthena ships as **two independent, self-contained components** — workload cont
 Kthena is built to be adopted incrementally and to stay out of your way.
 
 - **Small footprint** — Two self-contained Go binaries with a minimal dependency surface, quick to install and simple to upgrade.
-- **Independently deployable planes** — The **workload** controllers (`ModelServing`, `AutoScalingPolicy`) and the **networking** router (`ModelRoute`, `ModelServer`) are separate Helm subcharts with separate CRD groups and separate release lifecycles.
+- **Independently deployable planes** — The **workload** controllers (`ModelServing`, `AutoscalingPolicy`) and the **networking** router (`ModelRoute`, `ModelServer`) are separate Helm subcharts with separate CRD groups and separate release lifecycles.
 - **No cross-plane runtime coupling** — Each component talks only to the Kubernetes API, never to the other. Run the router in front of workloads managed by Deployments or another operator; or run the controllers and expose pods through your own gateway.
 - **Opt-in extras** — Gang scheduling (Volcano), webhooks, Gateway API support, and TLS are all optional, so a minimal install stays minimal.
 

--- a/docs/kthena/docs/intro.md
+++ b/docs/kthena/docs/intro.md
@@ -34,7 +34,7 @@ Kthena is built to be adopted incrementally and to stay out of your way.
 
 - **Small footprint** — Two self-contained Go binaries with a minimal dependency surface, quick to install and simple to upgrade.
 - **Independently deployable planes** — The **workload** controllers (`ModelServing`, `AutoScalingPolicy`) and the **networking** router (`ModelRoute`, `ModelServer`) are separate Helm subcharts with separate CRD groups and separate release lifecycles.
-- **No cross-plane runtime coupling** — Each component reconciles against the Kubernetes API, not against the other. Run the router in front of workloads managed by Deployments or another operator; or run the controllers and expose pods through your own gateway.
+- **No cross-plane runtime coupling** — Each component talks only to the Kubernetes API, never to the other. Run the router in front of workloads managed by Deployments or another operator; or run the controllers and expose pods through your own gateway.
 - **Opt-in extras** — Gang scheduling (Volcano), webhooks, Gateway API support, and TLS are all optional, so a minimal install stays minimal.
 
 See [Installation](./getting-started/installation.md#component-scoped-installation) for component-scoped install commands.

--- a/docs/kthena/docs/intro.md
+++ b/docs/kthena/docs/intro.md
@@ -4,7 +4,9 @@ sidebar_position: 1
 
 # Kthena
 
-**Kthena** is a Kubernetes-native AI serving platform that turns a cluster into a production-grade inference cloud. Instead of stitching together load balancers, autoscalers, and model servers by hand, you declare *what* you want — models, traffic rules, scaling targets — and Kthena's control plane reconciles the rest.
+**Kthena** is a lightweight, Kubernetes-native AI serving platform that turns a cluster into an enterprise-grade inference cloud. Instead of stitching together load balancers, autoscalers, and model servers by hand, you declare *what* you want — models, traffic rules, scaling targets — and Kthena's control plane reconciles the rest.
+
+Kthena ships as **two independent, self-contained components** — workload controllers and a router. Install one, the other, or both; each is useful on its own.
 
 > **Declarative CRDs. Any engine. Every scale.**
 > Deploy with a single `ModelBooster` for a one-stop experience, or compose fine-grained primitives — `ModelRoute`, `ModelServer`, `ModelServing`, `AutoScalingPolicy`, and `AutoScalingPolicyBinding` — for full control. From a single-GPU/NPU prototype to a multi-node, prefill/decode disaggregated fleet.
@@ -13,16 +15,29 @@ sidebar_position: 1
 
 ## Why Kthena?
 
-| Challenge                             | Kthena's Answer                                                                                                                         |
-| ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| Managing multiple inference engines   | Unified CRD layer that abstracts vLLM, SGLang, Triton, and TorchServe behind a consistent API                                           |
-| Balancing latency vs. throughput      | Request-level scheduler with pluggable scoring — KV-cache awareness, prefix-cache matching, LoRA affinity, least-request, least-latency |
-| Scaling large models cost-effectively | Prefill/Decode disaggregation with independent scaling ratios and cost-aware autoscaling                                                |
-| Safe model updates in production      | Rolling upgrades with partition control, canary releases, and automated failover                                                        |
+| Challenge                                   | Kthena's Answer                                                                                                                         |
+| ------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| Heavy platforms with sprawling dependencies | Two self-contained Go binaries with a minimal dependency surface — fast to install, cheap to run, simple to upgrade                     |
+| Adopting only part of a platform            | Fully decoupled planes: deploy the workload controllers, the router, or both — neither depends on the other at runtime                  |
+| Managing multiple inference engines         | Unified CRD layer that abstracts vLLM, SGLang, Triton, and TorchServe behind a consistent API                                           |
+| Balancing latency vs. throughput            | Request-level scheduler with pluggable scoring — KV-cache awareness, prefix-cache matching, LoRA affinity, least-request, least-latency |
+| Scaling large models cost-effectively       | Prefill/Decode disaggregation with independent scaling ratios and cost-aware autoscaling                                                |
+| Safe model updates in production            | Rolling upgrades with partition control, canary releases, and automated failover                                                        |
 
 ---
 
 ## Key Features
+
+### Lightweight & Modular
+
+Kthena is built to be adopted incrementally and to stay out of your way.
+
+- **Small footprint** — Two self-contained Go binaries with a minimal dependency surface, quick to install and simple to upgrade.
+- **Independently deployable planes** — The **workload** controllers (`ModelServing`, `AutoScalingPolicy`) and the **networking** router (`ModelRoute`, `ModelServer`) are separate Helm subcharts with separate CRD groups and separate release lifecycles.
+- **No cross-plane runtime coupling** — Each component reconciles against the Kubernetes API, not against the other. Run the router in front of workloads managed by Deployments or another operator; or run the controllers and expose pods through your own gateway.
+- **Opt-in extras** — Gang scheduling (Volcano), webhooks, Gateway API support, and TLS are all optional, so a minimal install stays minimal.
+
+See [Installation](./getting-started/installation.md#component-scoped-installation) for component-scoped install commands.
 
 ### Multi-Backend Inference Engine
 


### PR DESCRIPTION
### What type of PR is this?
/kind documentation

### What this PR does / why we need it

Kthena's controller manager (`workload` subchart) and router (`networking` subchart) are already fully decoupled — they have separate CRD groups, separate Helm subcharts, separate release lifecycles, and no runtime dependency on each other. Each reconciles against the Kubernetes API rather than against the other, so either one can be deployed and used on its own.

The docs did not make this clear, and there was no guidance on how to adopt only the component you need. This PR polishes the README and related docs to highlight Kthena's lightweight footprint and modular architecture.

Changes:

- **README.md** — Add a `Lightweight & Modular` feature section and a `Modular Deployment` subsection under Architecture with component-scoped Helm commands; update the tagline and Overview.
- **docs/kthena/docs/intro.md** — Add a `Lightweight & Modular` feature section and two new rows to the *Why Kthena?* table.
- **docs/kthena/docs/architecture/architecture.mdx** — Add a `Modular Deployment` section describing the subchart/binary/CRD-group mapping and the three supported deployment shapes (control plane only, data plane only, full platform).
- **docs/kthena/docs/architecture/kthena-router.md** — Note that the router only requires the `networking.serving.volcano.sh` CRDs and can front pods managed by a Deployment, StatefulSet, or another operator.
- **docs/kthena/docs/getting-started/installation.md** — Add a `Component-Scoped Installation` section, and document `workload.enabled` / `networking.enabled` in the common parameters table.

No functional/code changes — documentation only.

### Which issue(s) this PR fixes

N/A

### Special notes for your reviewer

The claims in the docs were verified against the actual chart behavior:

```bash
helm template kthena charts/kthena --set networking.enabled=false   # no router resources rendered
helm template kthena charts/kthena --set workload.enabled=false     # no controller-manager resources rendered
```

The `helm upgrade` caveat in the installation guide reflects that Helm does not install files under a chart's `crds/` directory during an upgrade, so enabling a previously-disabled subchart requires applying its CRDs first.

The Docusaurus build was not run locally (Node/npm unavailable in this environment); please let CI validate `make test-docs`.

This PR was drafted with AI assistance; all content was reviewed and the chart behavior claims were verified manually.

### Does this PR introduce a user-facing change?

```release-note
NONE
```
