### PR TITLE
fix(router): make HTTPConnector and NIXLConnector stateless to prevent data races and request corruption

### DIFF
--- a/pkg/kthena-router/connectors/connectors_test.go
+++ b/pkg/kthena-router/connectors/connectors_test.go
@@ -17,8 +17,8 @@ limitations under the License.
 package connectors
 
 import (
-	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -85,33 +85,33 @@ func TestFactory(t *testing.T) {
 	}
 }
 
-// Helper function to parse request body
-func parseRequestBody(req *http.Request) (map[string]interface{}, error) {
-	if req == nil || req.Body == nil {
-		return nil, nil
-	}
-
-	body, err := io.ReadAll(req.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	// Reset the body for potential future reads
-	req.Body = io.NopCloser(bytes.NewBuffer(body))
-
-	var result map[string]interface{}
-	err = json.Unmarshal(body, &result)
-	return result, err
-}
-
 func TestHTTPConnectorProxy(t *testing.T) {
 	// Test non-streaming request
 	t.Run("NonStreamingRequest", func(t *testing.T) {
+		var prefillReceivedBody map[string]interface{}
+		var decodeReceivedBody map[string]interface{}
+
+		prefillServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			b, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(b, &prefillReceivedBody)
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer prefillServer.Close()
+
+		decodeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			b, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(b, &decodeReceivedBody)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"ok"}}],"usage":{"completion_tokens":5}}`))
+		}))
+		defer decodeServer.Close()
+
 		connector := NewHTTPConnector()
 
-		// Create a proper test context with a valid HTTP request
 		req, _ := http.NewRequest("POST", "/v1/chat/completions", nil)
-		c, _ := gin.CreateTestContext(httptest.NewRecorder())
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
 		c.Request = req
 
 		reqBody := map[string]interface{}{
@@ -125,79 +125,81 @@ func TestHTTPConnectorProxy(t *testing.T) {
 			},
 		}
 
-		// The HTTP connector does support the Proxy method, but it will fail
-		// because the test addresses don't exist and the prefill/decode calls will fail
-		_, err := connector.Proxy(c, reqBody, "localhost:8000", "localhost:8001", nil)
-		if err == nil {
-			t.Error("Expected HTTP connector Proxy to return error due to network/connection issues")
+		prefillHost := prefillServer.Listener.Addr().String()
+		decodeHost := decodeServer.Listener.Addr().String()
+
+		tokens, err := connector.Proxy(c, reqBody, prefillHost, decodeHost, nil)
+		if err != nil {
+			t.Fatalf("Unexpected error from Proxy: %v", err)
+		}
+		if tokens != 5 {
+			t.Errorf("Expected 5 output tokens, got %d", tokens)
 		}
 
-		// Verify that prefill and decode requests were built
-		httpConn := connector.(*HTTPConnector)
-		if httpConn.prefillRequest == nil {
-			t.Error("Expected prefill request to be built")
+		// Verify prefill request body fields
+		if maxTokens, ok := prefillReceivedBody["max_tokens"]; !ok {
+			t.Error("Expected prefill request to have max_tokens field")
+		} else if maxTokensFloat, ok := maxTokens.(float64); !ok || maxTokensFloat != 1.0 {
+			t.Errorf("Expected prefill request max_tokens to be 1, got %v", maxTokens)
 		}
-		if httpConn.decodeRequest == nil {
-			t.Error("Expected decode request to be built")
+		if _, hasStream := prefillReceivedBody["stream"]; hasStream {
+			t.Error("Expected prefill request to not have stream field")
 		}
-
-		// Verify request body fields
-		if httpConn.prefillRequest != nil {
-			prefillBody, err := parseRequestBody(httpConn.prefillRequest)
-			if err != nil {
-				t.Errorf("Failed to parse prefill request body: %v", err)
-			} else {
-				// Prefill request should have max_tokens set to 1
-				if maxTokens, ok := prefillBody["max_tokens"]; !ok {
-					t.Error("Expected prefill request to have max_tokens field")
-				} else if maxTokensFloat, ok := maxTokens.(float64); !ok || maxTokensFloat != 1.0 {
-					t.Errorf("Expected prefill request max_tokens to be 1, got %v", maxTokens)
-				}
-				// Prefill request should not have stream field
-				if _, hasStream := prefillBody["stream"]; hasStream {
-					t.Error("Expected prefill request to not have stream field")
-				}
-				// Prefill request should not have stream_options field
-				if _, hasStreamOptions := prefillBody["stream_options"]; hasStreamOptions {
-					t.Error("Expected prefill request to not have stream_options field")
-				}
-				// Should still have model and messages
-				if model, ok := prefillBody["model"]; !ok || model != "test-model" {
-					t.Errorf("Expected prefill request to have model 'test-model', got %v", model)
-				}
-			}
+		if _, hasStreamOptions := prefillReceivedBody["stream_options"]; hasStreamOptions {
+			t.Error("Expected prefill request to not have stream_options field")
+		}
+		if model, ok := prefillReceivedBody["model"]; !ok || model != "test-model" {
+			t.Errorf("Expected prefill request to have model 'test-model', got %v", model)
 		}
 
-		if httpConn.decodeRequest != nil {
-			decodeBody, err := parseRequestBody(httpConn.decodeRequest)
-			if err != nil {
-				t.Errorf("Failed to parse decode request body: %v", err)
-			} else {
-				// Decode request should have include_usage set for non-streaming requests
-				if includeUsage, ok := decodeBody["include_usage"]; !ok || includeUsage != true {
-					t.Errorf("Expected decode request include_usage to be true, got %v", includeUsage)
-				}
-				// Should preserve original max_tokens
-				if maxTokens, ok := decodeBody["max_tokens"]; !ok {
-					t.Error("Expected decode request to have max_tokens field")
-				} else if maxTokensFloat, ok := maxTokens.(float64); !ok || maxTokensFloat != 100.0 {
-					t.Errorf("Expected decode request max_tokens to be 100, got %v", maxTokens)
-				}
-				// Should still have model and messages
-				if model, ok := decodeBody["model"]; !ok || model != "test-model" {
-					t.Errorf("Expected decode request to have model 'test-model', got %v", model)
-				}
-			}
+		// Verify decode request body fields
+		if includeUsage, ok := decodeReceivedBody["include_usage"]; !ok || includeUsage != true {
+			t.Errorf("Expected decode request include_usage to be true, got %v", includeUsage)
+		}
+		if maxTokens, ok := decodeReceivedBody["max_tokens"]; !ok {
+			t.Error("Expected decode request to have max_tokens field")
+		} else if maxTokensFloat, ok := maxTokens.(float64); !ok || maxTokensFloat != 100.0 {
+			t.Errorf("Expected decode request max_tokens to be 100, got %v", maxTokens)
+		}
+		if model, ok := decodeReceivedBody["model"]; !ok || model != "test-model" {
+			t.Errorf("Expected decode request to have model 'test-model', got %v", model)
 		}
 	})
 
 	// Test streaming request
 	t.Run("StreamingRequest", func(t *testing.T) {
+		var prefillReceivedBody map[string]interface{}
+		var decodeReceivedBody map[string]interface{}
+
+		prefillServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			b, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(b, &prefillReceivedBody)
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer prefillServer.Close()
+
+		decodeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			b, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(b, &decodeReceivedBody)
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			flusher, _ := w.(http.Flusher)
+			_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{\"content\":\"hello\"}}],\"usage\":{\"completion_tokens\":1}}\n\n"))
+			if flusher != nil {
+				flusher.Flush()
+			}
+			_, _ = w.Write([]byte("data: [DONE]\n\n"))
+			if flusher != nil {
+				flusher.Flush()
+			}
+		}))
+		defer decodeServer.Close()
+
 		connector := NewHTTPConnector()
 
-		// Create a proper test context with a valid HTTP request
 		req, _ := http.NewRequest("POST", "/v1/chat/completions", nil)
-		c, _ := gin.CreateTestContext(httptest.NewRecorder())
+		rec := CreateTestResponseRecorder()
+		c, _ := gin.CreateTestContext(rec)
 		c.Request = req
 
 		reqBody := map[string]interface{}{
@@ -212,19 +214,12 @@ func TestHTTPConnectorProxy(t *testing.T) {
 			},
 		}
 
-		// The HTTP connector will fail due to network issues
-		_, err := connector.Proxy(c, reqBody, "localhost:8000", "localhost:8001", nil)
-		if err == nil {
-			t.Error("Expected HTTP connector Proxy to return error due to network/connection issues")
-		}
+		prefillHost := prefillServer.Listener.Addr().String()
+		decodeHost := decodeServer.Listener.Addr().String()
 
-		// Verify that prefill and decode requests were built
-		httpConn := connector.(*HTTPConnector)
-		if httpConn.prefillRequest == nil {
-			t.Error("Expected prefill request to be built")
-		}
-		if httpConn.decodeRequest == nil {
-			t.Error("Expected decode request to be built")
+		_, err := connector.Proxy(c, reqBody, prefillHost, decodeHost, nil)
+		if err != nil {
+			t.Fatalf("Unexpected error from Proxy: %v", err)
 		}
 
 		// For streaming requests, verify that token usage context was set
@@ -232,63 +227,56 @@ func TestHTTPConnectorProxy(t *testing.T) {
 			t.Error("Expected token usage to be set in context for streaming request")
 		}
 
-		// Verify request body fields for streaming request
-		if httpConn.prefillRequest != nil {
-			prefillBody, err := parseRequestBody(httpConn.prefillRequest)
-			if err != nil {
-				t.Errorf("Failed to parse prefill request body: %v", err)
-			} else {
-				// Prefill request should have max_tokens set to 1
-				if maxTokens, ok := prefillBody["max_tokens"]; !ok {
-					t.Error("Expected prefill request to have max_tokens field")
-				} else if maxTokensFloat, ok := maxTokens.(float64); !ok || maxTokensFloat != 1.0 {
-					t.Errorf("Expected prefill request max_tokens to be 1, got %v", maxTokens)
-				}
-				// Prefill request should not have stream field (removed for prefill)
-				if _, hasStream := prefillBody["stream"]; hasStream {
-					t.Error("Expected prefill request to not have stream field")
-				}
-				// Prefill request should not have stream_options field (removed for prefill)
-				if _, hasStreamOptions := prefillBody["stream_options"]; hasStreamOptions {
-					t.Error("Expected prefill request to not have stream_options field")
-				}
-			}
+		// Verify prefill request body fields
+		if maxTokens, ok := prefillReceivedBody["max_tokens"]; !ok {
+			t.Error("Expected prefill request to have max_tokens field")
+		} else if maxTokensFloat, ok := maxTokens.(float64); !ok || maxTokensFloat != 1.0 {
+			t.Errorf("Expected prefill request max_tokens to be 1, got %v", maxTokens)
+		}
+		if _, hasStream := prefillReceivedBody["stream"]; hasStream {
+			t.Error("Expected prefill request to not have stream field")
 		}
 
-		if httpConn.decodeRequest != nil {
-			decodeBody, err := parseRequestBody(httpConn.decodeRequest)
-			if err != nil {
-				t.Errorf("Failed to parse decode request body: %v", err)
-			} else {
-				// Decode request should preserve stream field
-				if stream, ok := decodeBody["stream"]; !ok || stream != true {
-					t.Errorf("Expected decode request stream to be true, got %v", stream)
-				}
-				// Decode request should have stream_options with include_usage added
-				if streamOptions, ok := decodeBody["stream_options"]; !ok {
-					t.Error("Expected decode request to have stream_options")
-				} else if opts, isMap := streamOptions.(map[string]interface{}); !isMap {
-					t.Error("Expected stream_options to be a map")
-				} else if includeUsage, ok := opts["include_usage"]; !ok || includeUsage != true {
-					t.Errorf("Expected stream_options include_usage to be true, got %v", includeUsage)
-				}
-				// Should preserve original max_tokens
-				if maxTokens, ok := decodeBody["max_tokens"]; !ok {
-					t.Error("Expected decode request to have max_tokens field")
-				} else if maxTokensFloat, ok := maxTokens.(float64); !ok || maxTokensFloat != 100.0 {
-					t.Errorf("Expected decode request max_tokens to be 100, got %v", maxTokens)
-				}
-			}
+		// Verify decode request body fields
+		if stream, ok := decodeReceivedBody["stream"]; !ok || stream != true {
+			t.Errorf("Expected decode request stream to be true, got %v", stream)
+		}
+		if streamOptions, ok := decodeReceivedBody["stream_options"]; !ok {
+			t.Error("Expected decode request to have stream_options")
+		} else if opts, isMap := streamOptions.(map[string]interface{}); !isMap {
+			t.Error("Expected stream_options to be a map")
+		} else if includeUsage, ok := opts["include_usage"]; !ok || includeUsage != true {
+			t.Errorf("Expected stream_options include_usage to be true, got %v", includeUsage)
 		}
 	})
 
 	// Test streaming request with existing stream_options
 	t.Run("StreamingRequestWithStreamOptions", func(t *testing.T) {
+		var decodeReceivedBody map[string]interface{}
+
+		prefillServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer prefillServer.Close()
+
+		decodeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			b, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(b, &decodeReceivedBody)
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			flusher, _ := w.(http.Flusher)
+			_, _ = w.Write([]byte("data: [DONE]\n\n"))
+			if flusher != nil {
+				flusher.Flush()
+			}
+		}))
+		defer decodeServer.Close()
+
 		connector := NewHTTPConnector()
 
-		// Create a proper test context with a valid HTTP request
 		req, _ := http.NewRequest("POST", "/v1/chat/completions", nil)
-		c, _ := gin.CreateTestContext(httptest.NewRecorder())
+		rec := CreateTestResponseRecorder()
+		c, _ := gin.CreateTestContext(rec)
 		c.Request = req
 
 		reqBody := map[string]interface{}{
@@ -306,19 +294,12 @@ func TestHTTPConnectorProxy(t *testing.T) {
 			},
 		}
 
-		// The HTTP connector will fail due to network issues
-		_, err := connector.Proxy(c, reqBody, "localhost:8000", "localhost:8001", nil)
-		if err == nil {
-			t.Error("Expected HTTP connector Proxy to return error due to network/connection issues")
-		}
+		prefillHost := prefillServer.Listener.Addr().String()
+		decodeHost := decodeServer.Listener.Addr().String()
 
-		// Verify that prefill and decode requests were built
-		httpConn := connector.(*HTTPConnector)
-		if httpConn.prefillRequest == nil {
-			t.Error("Expected prefill request to be built")
-		}
-		if httpConn.decodeRequest == nil {
-			t.Error("Expected decode request to be built")
+		_, err := connector.Proxy(c, reqBody, prefillHost, decodeHost, nil)
+		if err != nil {
+			t.Fatalf("Unexpected error from Proxy: %v", err)
 		}
 
 		// For streaming requests with existing stream_options, token usage should not be added to context
@@ -326,31 +307,42 @@ func TestHTTPConnectorProxy(t *testing.T) {
 			t.Error("Did not expect token usage to be set in context when stream_options already exists")
 		}
 
-		// Verify request body fields when stream_options already exists
-		if httpConn.decodeRequest != nil {
-			decodeBody, err := parseRequestBody(httpConn.decodeRequest)
-			if err != nil {
-				t.Errorf("Failed to parse decode request body: %v", err)
-			} else {
-				// Decode request should preserve existing stream_options
-				if streamOptions, ok := decodeBody["stream_options"]; !ok {
-					t.Error("Expected decode request to preserve existing stream_options")
-				} else if opts, isMap := streamOptions.(map[string]interface{}); !isMap {
-					t.Error("Expected stream_options to be a map")
-				} else if includeUsage, ok := opts["include_usage"]; !ok || includeUsage != true {
-					t.Errorf("Expected existing stream_options include_usage to be preserved as true, got %v", includeUsage)
-				}
-			}
+		// Verify decode request body preserves existing stream_options
+		if streamOptions, ok := decodeReceivedBody["stream_options"]; !ok {
+			t.Error("Expected decode request to preserve existing stream_options")
+		} else if opts, isMap := streamOptions.(map[string]interface{}); !isMap {
+			t.Error("Expected stream_options to be a map")
+		} else if includeUsage, ok := opts["include_usage"]; !ok || includeUsage != true {
+			t.Errorf("Expected existing stream_options include_usage to be preserved as true, got %v", includeUsage)
 		}
 	})
 
 	// Test max_completion_tokens handling
 	t.Run("MaxCompletionTokensHandling", func(t *testing.T) {
+		var prefillReceivedBody map[string]interface{}
+		var decodeReceivedBody map[string]interface{}
+
+		prefillServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			b, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(b, &prefillReceivedBody)
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer prefillServer.Close()
+
+		decodeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			b, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(b, &decodeReceivedBody)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"ok"}}]}`))
+		}))
+		defer decodeServer.Close()
+
 		connector := NewHTTPConnector()
 
-		// Create a proper test context with a valid HTTP request
 		req, _ := http.NewRequest("POST", "/v1/chat/completions", nil)
-		c, _ := gin.CreateTestContext(httptest.NewRecorder())
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
 		c.Request = req
 
 		reqBody := map[string]interface{}{
@@ -364,168 +356,106 @@ func TestHTTPConnectorProxy(t *testing.T) {
 			},
 		}
 
-		// The HTTP connector will fail due to network issues
-		_, err := connector.Proxy(c, reqBody, "localhost:8000", "localhost:8001", nil)
-		if err == nil {
-			t.Error("Expected HTTP connector Proxy to return error due to network/connection issues")
+		prefillHost := prefillServer.Listener.Addr().String()
+		decodeHost := decodeServer.Listener.Addr().String()
+
+		_, err := connector.Proxy(c, reqBody, prefillHost, decodeHost, nil)
+		if err != nil {
+			t.Fatalf("Unexpected error from Proxy: %v", err)
 		}
 
-		// Verify that both prefill and decode requests were built
-		httpConn := connector.(*HTTPConnector)
-		if httpConn.prefillRequest == nil {
-			t.Error("Expected prefill request to be built")
+		// Verify prefill request handling of max_completion_tokens
+		if maxTokens, ok := prefillReceivedBody["max_tokens"]; !ok {
+			t.Error("Expected prefill request to have max_tokens field")
+		} else if maxTokensFloat, ok := maxTokens.(float64); !ok || maxTokensFloat != 1.0 {
+			t.Errorf("Expected prefill request max_tokens to be 1, got %v", maxTokens)
 		}
-		if httpConn.decodeRequest == nil {
-			t.Error("Expected decode request to be built")
-		}
-
-		// Both requests should have content
-		if httpConn.prefillRequest.ContentLength == 0 {
-			t.Error("Expected prefill request to have a body")
-		}
-		if httpConn.decodeRequest.ContentLength == 0 {
-			t.Error("Expected decode request to have a body")
+		if maxCompletionTokens, ok := prefillReceivedBody["max_completion_tokens"]; !ok {
+			t.Error("Expected prefill request to have max_completion_tokens field")
+		} else if maxCompletionTokensFloat, ok := maxCompletionTokens.(float64); !ok || maxCompletionTokensFloat != 1.0 {
+			t.Errorf("Expected prefill request max_completion_tokens to be 1, got %v", maxCompletionTokens)
 		}
 
-		// Verify request body fields for max_completion_tokens handling
-		if httpConn.prefillRequest != nil {
-			prefillBody, err := parseRequestBody(httpConn.prefillRequest)
-			if err != nil {
-				t.Errorf("Failed to parse prefill request body: %v", err)
-			} else {
-				// Prefill request should have max_tokens set to 1
-				if maxTokens, ok := prefillBody["max_tokens"]; !ok {
-					t.Error("Expected prefill request to have max_tokens field")
-				} else if maxTokensFloat, ok := maxTokens.(float64); !ok || maxTokensFloat != 1.0 {
-					t.Errorf("Expected prefill request max_tokens to be 1, got %v", maxTokens)
-				}
-				// Prefill request should have max_completion_tokens set to 1
-				if maxCompletionTokens, ok := prefillBody["max_completion_tokens"]; !ok {
-					t.Error("Expected prefill request to have max_completion_tokens field")
-				} else if maxCompletionTokensFloat, ok := maxCompletionTokens.(float64); !ok || maxCompletionTokensFloat != 1.0 {
-					t.Errorf("Expected prefill request max_completion_tokens to be 1, got %v", maxCompletionTokens)
-				}
-			}
-		}
-
-		if httpConn.decodeRequest != nil {
-			decodeBody, err := parseRequestBody(httpConn.decodeRequest)
-			if err != nil {
-				t.Errorf("Failed to parse decode request body: %v", err)
-			} else {
-				// Decode request should preserve original max_completion_tokens
-				if maxCompletionTokens, ok := decodeBody["max_completion_tokens"]; !ok {
-					t.Error("Expected decode request to have max_completion_tokens field")
-				} else if maxCompletionTokensFloat, ok := maxCompletionTokens.(float64); !ok || maxCompletionTokensFloat != 50.0 {
-					t.Errorf("Expected decode request max_completion_tokens to be 50, got %v", maxCompletionTokens)
-				}
-				// Decode request should have include_usage for non-streaming
-				if includeUsage, ok := decodeBody["include_usage"]; !ok || includeUsage != true {
-					t.Errorf("Expected decode request include_usage to be true, got %v", includeUsage)
-				}
-			}
+		// Verify decode request preserves original max_completion_tokens
+		if maxCompletionTokens, ok := decodeReceivedBody["max_completion_tokens"]; !ok {
+			t.Error("Expected decode request to have max_completion_tokens field")
+		} else if maxCompletionTokensFloat, ok := maxCompletionTokens.(float64); !ok || maxCompletionTokensFloat != 50.0 {
+			t.Errorf("Expected decode request max_completion_tokens to be 50, got %v", maxCompletionTokens)
 		}
 	})
+}
 
-	// Test request body modifications in detail
-	t.Run("RequestBodyModifications", func(t *testing.T) {
-		connector := NewHTTPConnector()
+// TestHTTPConnector_ConcurrentThreadSafety verifies that concurrent requests through
+// the same HTTPConnector instance do not race or corrupt each other's payloads.
+func TestHTTPConnector_ConcurrentThreadSafety(t *testing.T) {
+	prefillServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer prefillServer.Close()
 
-		// Create a proper test context with a valid HTTP request
-		req, _ := http.NewRequest("POST", "/v1/chat/completions", nil)
-		c, _ := gin.CreateTestContext(httptest.NewRecorder())
-		c.Request = req
+	decodeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		model, _ := body["model"].(string)
 
-		originalReqBody := map[string]interface{}{
-			"model":      "test-model",
-			"stream":     true,
-			"max_tokens": 200,
-			"stream_options": map[string]interface{}{
-				"some_other_option": "value",
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		resp := map[string]interface{}{
+			"model": model,
+			"choices": []map[string]interface{}{
+				{"message": map[string]string{"content": "response for " + model}},
 			},
-			"messages": []interface{}{
-				map[string]interface{}{
-					"role":    "user",
-					"content": "test message",
+			"usage": map[string]int{"completion_tokens": 1},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer decodeServer.Close()
+
+	connector := NewHTTPConnector()
+	prefillAddr := prefillServer.Listener.Addr().String()
+	decodeAddr := decodeServer.Listener.Addr().String()
+
+	const concurrency = 10
+	errCh := make(chan error, concurrency)
+
+	for i := 0; i < concurrency; i++ {
+		go func(id int) {
+			modelName := fmt.Sprintf("model-%d", id)
+			req, _ := http.NewRequest("POST", "/v1/chat/completions", nil)
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			c.Request = req
+
+			reqBody := map[string]interface{}{
+				"model":      modelName,
+				"max_tokens": 50 + id,
+				"messages": []interface{}{
+					map[string]interface{}{"role": "user", "content": fmt.Sprintf("msg-%d", id)},
 				},
-			},
-		}
-
-		// Make a copy of the original to verify it gets modified
-		reqBodyCopy := make(map[string]interface{})
-		for k, v := range originalReqBody {
-			reqBodyCopy[k] = v
-		}
-
-		// The HTTP connector will fail due to network issues
-		_, err := connector.Proxy(c, reqBodyCopy, "localhost:8000", "localhost:8001", nil)
-		if err == nil {
-			t.Error("Expected HTTP connector Proxy to return error due to network/connection issues")
-		}
-
-		// Verify that the original request body was modified correctly
-		httpConn := connector.(*HTTPConnector)
-
-		// Check prefill request body
-		if httpConn.prefillRequest != nil {
-			prefillBody, err := parseRequestBody(httpConn.prefillRequest)
-			if err != nil {
-				t.Errorf("Failed to parse prefill request body: %v", err)
-			} else {
-				// Should have modified max_tokens to 1
-				if maxTokens, ok := prefillBody["max_tokens"]; !ok {
-					t.Error("Expected prefill request to have max_tokens field")
-				} else if maxTokensFloat, ok := maxTokens.(float64); !ok || maxTokensFloat != 1.0 {
-					t.Errorf("Expected prefill request max_tokens to be 1, got %v", maxTokens)
-				}
-
-				// Should have removed stream field
-				if _, hasStream := prefillBody["stream"]; hasStream {
-					t.Error("Expected prefill request to not have stream field")
-				}
-
-				// Should have removed stream_options field
-				if _, hasStreamOptions := prefillBody["stream_options"]; hasStreamOptions {
-					t.Error("Expected prefill request to not have stream_options field")
-				}
 			}
-		}
 
-		// Check decode request body
-		if httpConn.decodeRequest != nil {
-			decodeBody, err := parseRequestBody(httpConn.decodeRequest)
+			_, err := connector.Proxy(c, reqBody, prefillAddr, decodeAddr, nil)
 			if err != nil {
-				t.Errorf("Failed to parse decode request body: %v", err)
-			} else {
-				// Should preserve stream field
-				if stream, ok := decodeBody["stream"]; !ok || stream != true {
-					t.Errorf("Expected decode request stream to be true, got %v", stream)
-				}
-
-				// Should preserve original max_tokens
-				if maxTokens, ok := decodeBody["max_tokens"]; !ok {
-					t.Error("Expected decode request to have max_tokens field")
-				} else if maxTokensFloat, ok := maxTokens.(float64); !ok || maxTokensFloat != 200.0 {
-					t.Errorf("Expected decode request max_tokens to be 200, got %v", maxTokens)
-				}
-
-				// Should have stream_options with include_usage added
-				if streamOptions, ok := decodeBody["stream_options"]; !ok {
-					t.Error("Expected decode request to have stream_options")
-				} else if opts, isMap := streamOptions.(map[string]interface{}); !isMap {
-					t.Error("Expected stream_options to be a map")
-				} else {
-					// Should have include_usage added
-					if includeUsage, ok := opts["include_usage"]; !ok || includeUsage != true {
-						t.Errorf("Expected stream_options include_usage to be true, got %v", includeUsage)
-					}
-					// Note: Original stream_options are replaced, not preserved
-					// This is the current behavior of buildDecodeRequest
-					if len(opts) != 1 {
-						t.Errorf("Expected stream_options to only contain include_usage, got %+v", opts)
-					}
-				}
+				errCh <- fmt.Errorf("goroutine %d failed: %w", id, err)
+				return
 			}
+
+			var respBody map[string]interface{}
+			if err := json.Unmarshal(rec.Body.Bytes(), &respBody); err != nil {
+				errCh <- fmt.Errorf("goroutine %d unmarshal error: %w", id, err)
+				return
+			}
+			if respBody["model"] != modelName {
+				errCh <- fmt.Errorf("goroutine %d received response for model %v, expected %s", id, respBody["model"], modelName)
+				return
+			}
+			errCh <- nil
+		}(i)
+	}
+
+	for i := 0; i < concurrency; i++ {
+		if err := <-errCh; err != nil {
+			t.Errorf("Concurrent request error: %v", err)
 		}
-	})
+	}
 }

--- a/pkg/kthena-router/connectors/http.go
+++ b/pkg/kthena-router/connectors/http.go
@@ -27,10 +27,7 @@ import (
 
 // HTTPConnector implements simple HTTP-based KV transfer
 // Many kv connectors like LMCache, MoonCakeStore can use this
-type HTTPConnector struct {
-	prefillRequest *http.Request
-	decodeRequest  *http.Request
-}
+type HTTPConnector struct{}
 
 // NewHTTPConnector creates a new HTTP connector with default configuration
 func NewHTTPConnector() KVConnector {
@@ -71,10 +68,10 @@ func (h *HTTPConnector) Proxy(c *gin.Context, reqBody map[string]interface{}, pr
 	}
 
 	decodeBody := cloneReqBody(reqBody)
-	h.decodeRequest = BuildDecodeRequest(c, c.Request, decodeBody)
+	decodeRequest := BuildDecodeRequest(c, c.Request, decodeBody)
 
 	prefillBody := cloneReqBody(reqBody)
-	h.prefillRequest = buildPrefillRequest(c.Request, prefillBody)
+	prefillRequest := buildPrefillRequest(c.Request, prefillBody)
 
 	// --- Prefill phase ---
 	if metricsRecorder != nil {
@@ -85,7 +82,7 @@ func (h *HTTPConnector) Proxy(c *gin.Context, reqBody map[string]interface{}, pr
 		hooks.IncrPrefill()
 	}
 
-	err := h.prefill(h.prefillRequest, prefillAddr)
+	err := h.prefill(prefillRequest, prefillAddr)
 
 	if hooks != nil && hooks.DecrPrefill != nil {
 		hooks.DecrPrefill()
@@ -112,7 +109,7 @@ func (h *HTTPConnector) Proxy(c *gin.Context, reqBody map[string]interface{}, pr
 		hooks.IncrDecode()
 	}
 
-	result, decodeErr := h.decode(c, h.decodeRequest, decodeAddr)
+	result, decodeErr := h.decode(c, decodeRequest, decodeAddr)
 
 	if hooks != nil && hooks.DecrDecode != nil {
 		hooks.DecrDecode()

--- a/pkg/kthena-router/connectors/nixl.go
+++ b/pkg/kthena-router/connectors/nixl.go
@@ -33,9 +33,7 @@ import (
 
 // NIXLConnector implements high-performance distributed in-memory KV cache using NIXL
 type NIXLConnector struct {
-	name              string
-	prefillRequest    *http.Request
-	decodeRequestBody map[string]interface{}
+	name string
 }
 
 // NewNIXLConnector creates a new NIXL connector
@@ -62,9 +60,9 @@ func (n *NIXLConnector) Proxy(c *gin.Context, reqBody map[string]interface{}, pr
 
 	req := c.Request
 	prefillBody := cloneReqBody(reqBody)
-	n.prefillRequest = n.buildPrefillRequest(req, prefillBody)
+	prefillRequest := n.buildPrefillRequest(req, prefillBody)
 	decodeBody := cloneReqBody(reqBody)
-	n.decodeRequestBody = AddTokenUsage(c, decodeBody)
+	decodeRequestBody := AddTokenUsage(c, decodeBody)
 
 	// --- Prefill phase ---
 	if metricsRecorder != nil {
@@ -76,7 +74,7 @@ func (n *NIXLConnector) Proxy(c *gin.Context, reqBody map[string]interface{}, pr
 	}
 
 	// 1. send prefill request
-	kvTransferParams, err := n.prefill(n.prefillRequest, prefillAddr)
+	kvTransferParams, err := n.prefill(prefillRequest, prefillAddr)
 
 	if hooks != nil && hooks.DecrPrefill != nil {
 		hooks.DecrPrefill()
@@ -104,7 +102,7 @@ func (n *NIXLConnector) Proxy(c *gin.Context, reqBody map[string]interface{}, pr
 	}
 
 	// 2. send decode request
-	decodeReq := n.buildDecodeRequest(c, n.decodeRequestBody, kvTransferParams)
+	decodeReq := n.buildDecodeRequest(c, decodeRequestBody, kvTransferParams)
 	result, decodeErr := n.decode(c, decodeReq, decodeAddr)
 
 	if hooks != nil && hooks.DecrDecode != nil {

--- a/pkg/kthena-router/connectors/nixl_test.go
+++ b/pkg/kthena-router/connectors/nixl_test.go
@@ -32,11 +32,34 @@ import (
 func TestNIXLConnectorProxy(t *testing.T) {
 	// Test non-streaming request
 	t.Run("NonStreamingRequest", func(t *testing.T) {
+		var prefillReceivedBody map[string]interface{}
+		var decodeReceivedBody map[string]interface{}
+
+		prefillServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			b, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(b, &prefillReceivedBody)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"kv_transfer_params": map[string]interface{}{"remote_host": "10.0.0.1"},
+			})
+		}))
+		defer prefillServer.Close()
+
+		decodeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			b, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(b, &decodeReceivedBody)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"ok"}}],"usage":{"completion_tokens":3}}`))
+		}))
+		defer decodeServer.Close()
+
 		connector := NewNIXLConnector()
 
-		// Create a proper test context with a valid HTTP request
 		req, _ := http.NewRequest("POST", "/v1/chat/completions", nil)
-		c, _ := gin.CreateTestContext(httptest.NewRecorder())
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
 		c.Request = req
 
 		reqBody := map[string]interface{}{
@@ -50,88 +73,103 @@ func TestNIXLConnectorProxy(t *testing.T) {
 			},
 		}
 
-		// The NIXL connector will fail due to network issues (prefill request)
-		_, err := connector.Proxy(c, reqBody, "localhost:8000", "localhost:8001", nil)
-		if err == nil {
-			t.Error("Expected NIXL connector Proxy to return error due to network/connection issues")
-		}
+		prefillHost := prefillServer.Listener.Addr().String()
+		decodeHost := decodeServer.Listener.Addr().String()
 
-		// Verify that prefill request was built
-		nixlConn := connector.(*NIXLConnector)
-		if nixlConn.prefillRequest == nil {
-			t.Error("Expected prefill request to be built")
+		tokens, err := connector.Proxy(c, reqBody, prefillHost, decodeHost, nil)
+		if err != nil {
+			t.Fatalf("Unexpected error from Proxy: %v", err)
+		}
+		if tokens != 3 {
+			t.Errorf("Expected 3 output tokens, got %d", tokens)
 		}
 
 		// Verify prefill request body
-		if nixlConn.prefillRequest != nil {
-			prefillBody, err := parseRequestBody(nixlConn.prefillRequest)
-			if err != nil {
-				t.Errorf("Failed to parse prefill request body: %v", err)
-			} else {
-				// Prefill request should have max_tokens set to 1
-				if maxTokens, ok := prefillBody["max_tokens"]; !ok {
-					t.Error("Expected prefill request to have max_tokens field")
-				} else if maxTokensFloat, ok := maxTokens.(float64); !ok || maxTokensFloat != 1.0 {
-					t.Errorf("Expected prefill request max_tokens to be 1, got %v", maxTokens)
-				}
+		if maxTokens, ok := prefillReceivedBody["max_tokens"]; !ok {
+			t.Error("Expected prefill request to have max_tokens field")
+		} else if maxTokensFloat, ok := maxTokens.(float64); !ok || maxTokensFloat != 1.0 {
+			t.Errorf("Expected prefill request max_tokens to be 1, got %v", maxTokens)
+		}
+		if _, hasStream := prefillReceivedBody["stream"]; hasStream {
+			t.Error("Expected prefill request to not have stream field")
+		}
+		if _, hasStreamOptions := prefillReceivedBody["stream_options"]; hasStreamOptions {
+			t.Error("Expected prefill request to not have stream_options field")
+		}
 
-				// Prefill request should not have stream field
-				if _, hasStream := prefillBody["stream"]; hasStream {
-					t.Error("Expected prefill request to not have stream field")
-				}
-
-				// Prefill request should not have stream_options field
-				if _, hasStreamOptions := prefillBody["stream_options"]; hasStreamOptions {
-					t.Error("Expected prefill request to not have stream_options field")
-				}
-
-				// Should have kv_transfer_params for NIXL
-				if kvTransferParams, ok := prefillBody["kv_transfer_params"]; !ok {
-					t.Error("Expected prefill request to have kv_transfer_params field")
-				} else if params, isMap := kvTransferParams.(map[string]interface{}); !isMap {
-					t.Error("Expected kv_transfer_params to be a map")
-				} else {
-					// Verify NIXL-specific kv_transfer_params
-					if doRemoteDecode, ok := params["do_remote_decode"]; !ok || doRemoteDecode != true {
-						t.Errorf("Expected do_remote_decode to be true, got %v", doRemoteDecode)
-					}
-					if doRemotePrefill, ok := params["do_remote_prefill"]; !ok || doRemotePrefill != false {
-						t.Errorf("Expected do_remote_prefill to be false, got %v", doRemotePrefill)
-					}
-				}
-
-				// Should still have model and messages
-				if model, ok := prefillBody["model"]; !ok || model != "test-model" {
-					t.Errorf("Expected prefill request to have model 'test-model', got %v", model)
-				}
+		// Should have kv_transfer_params for NIXL in prefill request
+		if kvTransferParams, ok := prefillReceivedBody["kv_transfer_params"]; !ok {
+			t.Error("Expected prefill request to have kv_transfer_params field")
+		} else if params, isMap := kvTransferParams.(map[string]interface{}); !isMap {
+			t.Error("Expected kv_transfer_params to be a map")
+		} else {
+			if doRemoteDecode, ok := params["do_remote_decode"]; !ok || doRemoteDecode != true {
+				t.Errorf("Expected do_remote_decode to be true, got %v", doRemoteDecode)
+			}
+			if doRemotePrefill, ok := params["do_remote_prefill"]; !ok || doRemotePrefill != false {
+				t.Errorf("Expected do_remote_prefill to be false, got %v", doRemotePrefill)
 			}
 		}
 
-		// Verify decode request body was prepared (but not executed due to prefill failure)
-		if nixlConn.decodeRequestBody == nil {
-			t.Error("Expected decode request body to be prepared")
-		} else {
-			fmt.Println("Decode request body:", nixlConn.decodeRequestBody)
-			// Decode request should have include_usage set for non-streaming requests
-			if includeUsage, ok := nixlConn.decodeRequestBody["include_usage"]; !ok || includeUsage != true {
-				t.Errorf("Expected decode request body include_usage to be true, got %v", includeUsage)
-			}
-			// Should preserve original max_tokens
-			if maxTokens, ok := nixlConn.decodeRequestBody["max_tokens"]; !ok {
-				t.Error("Expected decode request body to have max_tokens field")
-			} else if maxTokens, ok := maxTokens.(int); !ok || maxTokens != 100 {
-				t.Errorf("Expected decode request body max_tokens to be 100, got %v", maxTokens)
-			}
+		if model, ok := prefillReceivedBody["model"]; !ok || model != "test-model" {
+			t.Errorf("Expected prefill request to have model 'test-model', got %v", model)
+		}
+
+		// Verify decode request body
+		if includeUsage, ok := decodeReceivedBody["include_usage"]; !ok || includeUsage != true {
+			t.Errorf("Expected decode request body include_usage to be true, got %v", includeUsage)
+		}
+		if maxTokens, ok := decodeReceivedBody["max_tokens"]; !ok {
+			t.Error("Expected decode request body to have max_tokens field")
+		} else if maxTokensFloat, ok := maxTokens.(float64); !ok || maxTokensFloat != 100.0 {
+			t.Errorf("Expected decode request body max_tokens to be 100, got %v", maxTokens)
+		}
+		// Verify kv_transfer_params was relayed to decode
+		if kvParams, ok := decodeReceivedBody["kv_transfer_params"]; !ok {
+			t.Error("Expected decode request body to have relayed kv_transfer_params")
+		} else if m, ok := kvParams.(map[string]interface{}); !ok || m["remote_host"] != "10.0.0.1" {
+			t.Errorf("Expected remote_host 10.0.0.1, got %v", kvParams)
 		}
 	})
 
 	// Test streaming request
 	t.Run("StreamingRequest", func(t *testing.T) {
+		var prefillReceivedBody map[string]interface{}
+		var decodeReceivedBody map[string]interface{}
+
+		prefillServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			b, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(b, &prefillReceivedBody)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"kv_transfer_params": map[string]interface{}{"remote_host": "10.0.0.2"},
+			})
+		}))
+		defer prefillServer.Close()
+
+		decodeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			b, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(b, &decodeReceivedBody)
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			flusher, _ := w.(http.Flusher)
+			_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{\"content\":\"hello\"}}],\"usage\":{\"completion_tokens\":1}}\n\n"))
+			if flusher != nil {
+				flusher.Flush()
+			}
+			_, _ = w.Write([]byte("data: [DONE]\n\n"))
+			if flusher != nil {
+				flusher.Flush()
+			}
+		}))
+		defer decodeServer.Close()
+
 		connector := NewNIXLConnector()
 
-		// Create a proper test context with a valid HTTP request
 		req, _ := http.NewRequest("POST", "/v1/chat/completions", nil)
-		c, _ := gin.CreateTestContext(httptest.NewRecorder())
+		rec := CreateTestResponseRecorder()
+		c, _ := gin.CreateTestContext(rec)
 		c.Request = req
 
 		reqBody := map[string]interface{}{
@@ -146,16 +184,12 @@ func TestNIXLConnectorProxy(t *testing.T) {
 			},
 		}
 
-		// The NIXL connector will fail due to network issues
-		_, err := connector.Proxy(c, reqBody, "localhost:8000", "localhost:8001", nil)
-		if err == nil {
-			t.Error("Expected NIXL connector Proxy to return error due to network/connection issues")
-		}
+		prefillHost := prefillServer.Listener.Addr().String()
+		decodeHost := decodeServer.Listener.Addr().String()
 
-		// Verify that prefill request was built
-		nixlConn := connector.(*NIXLConnector)
-		if nixlConn.prefillRequest == nil {
-			t.Error("Expected prefill request to be built")
+		_, err := connector.Proxy(c, reqBody, prefillHost, decodeHost, nil)
+		if err != nil {
+			t.Fatalf("Unexpected error from Proxy: %v", err)
 		}
 
 		// For streaming requests, verify that token usage context was set
@@ -163,66 +197,58 @@ func TestNIXLConnectorProxy(t *testing.T) {
 			t.Error("Expected token usage to be set in context for streaming request")
 		}
 
-		// Verify prefill request body for streaming request
-		if nixlConn.prefillRequest != nil {
-			prefillBody, err := parseRequestBody(nixlConn.prefillRequest)
-			if err != nil {
-				t.Errorf("Failed to parse prefill request body: %v", err)
-			} else {
-				// Prefill request should have max_tokens set to 1
-				if maxTokens, ok := prefillBody["max_tokens"]; !ok {
-					t.Error("Expected prefill request to have max_tokens field")
-				} else if maxTokensFloat, ok := maxTokens.(float64); !ok || maxTokensFloat != 1.0 {
-					t.Errorf("Expected prefill request max_tokens to be 1, got %v", maxTokens)
-				}
-
-				// Prefill request should not have stream field (removed for prefill)
-				if _, hasStream := prefillBody["stream"]; hasStream {
-					t.Error("Expected prefill request to not have stream field")
-				}
-
-				// Prefill request should not have stream_options field (removed for prefill)
-				if _, hasStreamOptions := prefillBody["stream_options"]; hasStreamOptions {
-					t.Error("Expected prefill request to not have stream_options field")
-				}
-
-				// Should have NIXL-specific kv_transfer_params
-				if kvTransferParams, ok := prefillBody["kv_transfer_params"]; !ok {
-					t.Error("Expected prefill request to have kv_transfer_params field")
-				} else if params, isMap := kvTransferParams.(map[string]interface{}); !isMap {
-					t.Error("Expected kv_transfer_params to be a map")
-				} else {
-					if doRemoteDecode, ok := params["do_remote_decode"]; !ok || doRemoteDecode != true {
-						t.Errorf("Expected do_remote_decode to be true, got %v", doRemoteDecode)
-					}
-				}
-			}
+		// Verify prefill request body
+		if maxTokens, ok := prefillReceivedBody["max_tokens"]; !ok {
+			t.Error("Expected prefill request to have max_tokens field")
+		} else if maxTokensFloat, ok := maxTokens.(float64); !ok || maxTokensFloat != 1.0 {
+			t.Errorf("Expected prefill request max_tokens to be 1, got %v", maxTokens)
+		}
+		if _, hasStream := prefillReceivedBody["stream"]; hasStream {
+			t.Error("Expected prefill request to not have stream field")
 		}
 
 		// Verify decode request body
-		if nixlConn.decodeRequestBody != nil {
-			// Decode request should preserve stream field
-			if stream, ok := nixlConn.decodeRequestBody["stream"]; !ok || stream != true {
-				t.Errorf("Expected decode request body stream to be true, got %v", stream)
-			}
-			// Decode request should have stream_options with include_usage added
-			if streamOptions, ok := nixlConn.decodeRequestBody["stream_options"]; !ok {
-				t.Error("Expected decode request body to have stream_options")
-			} else if opts, isMap := streamOptions.(map[string]interface{}); !isMap {
-				t.Error("Expected stream_options to be a map")
-			} else if includeUsage, ok := opts["include_usage"]; !ok || includeUsage != true {
-				t.Errorf("Expected stream_options include_usage to be true, got %v", includeUsage)
-			}
+		if stream, ok := decodeReceivedBody["stream"]; !ok || stream != true {
+			t.Errorf("Expected decode request body stream to be true, got %v", stream)
+		}
+		if streamOptions, ok := decodeReceivedBody["stream_options"]; !ok {
+			t.Error("Expected decode request body to have stream_options")
+		} else if opts, isMap := streamOptions.(map[string]interface{}); !isMap {
+			t.Error("Expected stream_options to be a map")
+		} else if includeUsage, ok := opts["include_usage"]; !ok || includeUsage != true {
+			t.Errorf("Expected stream_options include_usage to be true, got %v", includeUsage)
 		}
 	})
 
 	// Test streaming request with existing stream_options
 	t.Run("StreamingRequestWithStreamOptions", func(t *testing.T) {
+		var decodeReceivedBody map[string]interface{}
+
+		prefillServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"kv_transfer_params": nil})
+		}))
+		defer prefillServer.Close()
+
+		decodeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			b, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(b, &decodeReceivedBody)
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			flusher, _ := w.(http.Flusher)
+			_, _ = w.Write([]byte("data: [DONE]\n\n"))
+			if flusher != nil {
+				flusher.Flush()
+			}
+		}))
+		defer decodeServer.Close()
+
 		connector := NewNIXLConnector()
 
-		// Create a proper test context with a valid HTTP request
 		req, _ := http.NewRequest("POST", "/v1/chat/completions", nil)
-		c, _ := gin.CreateTestContext(httptest.NewRecorder())
+		rec := CreateTestResponseRecorder()
+		c, _ := gin.CreateTestContext(rec)
 		c.Request = req
 
 		reqBody := map[string]interface{}{
@@ -240,10 +266,12 @@ func TestNIXLConnectorProxy(t *testing.T) {
 			},
 		}
 
-		// The NIXL connector will fail due to network issues
-		_, err := connector.Proxy(c, reqBody, "localhost:8000", "localhost:8001", nil)
-		if err == nil {
-			t.Error("Expected NIXL connector Proxy to return error due to network/connection issues")
+		prefillHost := prefillServer.Listener.Addr().String()
+		decodeHost := decodeServer.Listener.Addr().String()
+
+		_, err := connector.Proxy(c, reqBody, prefillHost, decodeHost, nil)
+		if err != nil {
+			t.Fatalf("Unexpected error from Proxy: %v", err)
 		}
 
 		// For streaming requests with existing stream_options, token usage should not be added to context
@@ -252,25 +280,43 @@ func TestNIXLConnectorProxy(t *testing.T) {
 		}
 
 		// Verify decode request body preserves existing stream_options
-		nixlConn := connector.(*NIXLConnector)
-		if nixlConn.decodeRequestBody != nil {
-			if streamOptions, ok := nixlConn.decodeRequestBody["stream_options"]; !ok {
-				t.Error("Expected decode request body to preserve existing stream_options")
-			} else if opts, isMap := streamOptions.(map[string]interface{}); !isMap {
-				t.Error("Expected stream_options to be a map")
-			} else if includeUsage, ok := opts["include_usage"]; !ok || includeUsage != true {
-				t.Errorf("Expected existing stream_options include_usage to be preserved as true, got %v", includeUsage)
-			}
+		if streamOptions, ok := decodeReceivedBody["stream_options"]; !ok {
+			t.Error("Expected decode request body to preserve existing stream_options")
+		} else if opts, isMap := streamOptions.(map[string]interface{}); !isMap {
+			t.Error("Expected stream_options to be a map")
+		} else if includeUsage, ok := opts["include_usage"]; !ok || includeUsage != true {
+			t.Errorf("Expected existing stream_options include_usage to be preserved as true, got %v", includeUsage)
 		}
 	})
 
 	// Test max_completion_tokens handling
 	t.Run("MaxCompletionTokensHandling", func(t *testing.T) {
+		var prefillReceivedBody map[string]interface{}
+		var decodeReceivedBody map[string]interface{}
+
+		prefillServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			b, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(b, &prefillReceivedBody)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"kv_transfer_params": nil})
+		}))
+		defer prefillServer.Close()
+
+		decodeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			b, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(b, &decodeReceivedBody)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"ok"}}]}`))
+		}))
+		defer decodeServer.Close()
+
 		connector := NewNIXLConnector()
 
-		// Create a proper test context with a valid HTTP request
 		req, _ := http.NewRequest("POST", "/v1/chat/completions", nil)
-		c, _ := gin.CreateTestContext(httptest.NewRecorder())
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
 		c.Request = req
 
 		reqBody := map[string]interface{}{
@@ -284,98 +330,124 @@ func TestNIXLConnectorProxy(t *testing.T) {
 			},
 		}
 
-		// The NIXL connector will fail due to network issues
-		_, err := connector.Proxy(c, reqBody, "localhost:8000", "localhost:8001", nil)
-		if err == nil {
-			t.Error("Expected NIXL connector Proxy to return error due to network/connection issues")
+		prefillHost := prefillServer.Listener.Addr().String()
+		decodeHost := decodeServer.Listener.Addr().String()
+
+		_, err := connector.Proxy(c, reqBody, prefillHost, decodeHost, nil)
+		if err != nil {
+			t.Fatalf("Unexpected error from Proxy: %v", err)
 		}
 
 		// Verify prefill request handling of max_completion_tokens
-		nixlConn := connector.(*NIXLConnector)
-		if nixlConn.prefillRequest != nil {
-			prefillBody, err := parseRequestBody(nixlConn.prefillRequest)
-			if err != nil {
-				t.Errorf("Failed to parse prefill request body: %v", err)
-			} else {
-				// Prefill request should have max_tokens set to 1
-				if maxTokens, ok := prefillBody["max_tokens"]; !ok {
-					t.Error("Expected prefill request to have max_tokens field")
-				} else if maxTokensFloat, ok := maxTokens.(float64); !ok || maxTokensFloat != 1.0 {
-					t.Errorf("Expected prefill request max_tokens to be 1, got %v", maxTokens)
-				}
-				// Prefill request should have max_completion_tokens set to 1
-				if maxCompletionTokens, ok := prefillBody["max_completion_tokens"]; !ok {
-					t.Error("Expected prefill request to have max_completion_tokens field")
-				} else if maxCompletionTokensFloat, ok := maxCompletionTokens.(float64); !ok || maxCompletionTokensFloat != 1.0 {
-					t.Errorf("Expected prefill request max_completion_tokens to be 1, got %v", maxCompletionTokens)
-				}
-			}
+		if maxTokens, ok := prefillReceivedBody["max_tokens"]; !ok {
+			t.Error("Expected prefill request to have max_tokens field")
+		} else if maxTokensFloat, ok := maxTokens.(float64); !ok || maxTokensFloat != 1.0 {
+			t.Errorf("Expected prefill request max_tokens to be 1, got %v", maxTokens)
+		}
+		if maxCompletionTokens, ok := prefillReceivedBody["max_completion_tokens"]; !ok {
+			t.Error("Expected prefill request to have max_completion_tokens field")
+		} else if maxCompletionTokensFloat, ok := maxCompletionTokens.(float64); !ok || maxCompletionTokensFloat != 1.0 {
+			t.Errorf("Expected prefill request max_completion_tokens to be 1, got %v", maxCompletionTokens)
 		}
 
 		// Verify decode request preserves original max_completion_tokens
-		if nixlConn.decodeRequestBody != nil {
-			if maxCompletionTokens, ok := nixlConn.decodeRequestBody["max_completion_tokens"]; !ok {
-				t.Error("Expected decode request body to have max_completion_tokens field")
-			} else if maxCompletionTokens, ok := maxCompletionTokens.(int); !ok || maxCompletionTokens != 50 {
-				t.Errorf("Expected decode request body max_completion_tokens to be 50, got %v", maxCompletionTokens)
-			}
+		if maxCompletionTokens, ok := decodeReceivedBody["max_completion_tokens"]; !ok {
+			t.Error("Expected decode request body to have max_completion_tokens field")
+		} else if maxCompletionTokensFloat, ok := maxCompletionTokens.(float64); !ok || maxCompletionTokensFloat != 50.0 {
+			t.Errorf("Expected decode request body max_completion_tokens to be 50, got %v", maxCompletionTokens)
 		}
 	})
+}
 
-	// Test NIXL-specific kv_transfer_params structure
-	t.Run("KVTransferParamsStructure", func(t *testing.T) {
-		connector := NewNIXLConnector()
+// TestNIXLConnector_ConcurrentThreadSafety verifies that concurrent requests through
+// the same NIXLConnector instance do not race or corrupt each other's payloads.
+func TestNIXLConnector_ConcurrentThreadSafety(t *testing.T) {
+	prefillServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		model, _ := body["model"].(string)
 
-		// Create a proper test context with a valid HTTP request
-		req, _ := http.NewRequest("POST", "/v1/chat/completions", nil)
-		c, _ := gin.CreateTestContext(httptest.NewRecorder())
-		c.Request = req
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"kv_transfer_params": map[string]interface{}{"assigned_model": model},
+		})
+	}))
+	defer prefillServer.Close()
 
-		reqBody := map[string]interface{}{
-			"model": "test-model",
-			"messages": []interface{}{
-				map[string]interface{}{
-					"role":    "user",
-					"content": "test message",
-				},
+	decodeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		model, _ := body["model"].(string)
+
+		// Verify relayed kv_transfer_params matches the request model
+		kvParams, _ := body["kv_transfer_params"].(map[string]interface{})
+		if kvParams == nil || kvParams["assigned_model"] != model {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"error":"model mismatch: req=%s, kv=%v"}`, model, kvParams)))
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		resp := map[string]interface{}{
+			"model": model,
+			"choices": []map[string]interface{}{
+				{"message": map[string]string{"content": "response for " + model}},
 			},
+			"usage": map[string]int{"completion_tokens": 1},
 		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer decodeServer.Close()
 
-		// The NIXL connector will fail due to network issues
-		_, err := connector.Proxy(c, reqBody, "localhost:8000", "localhost:8001", nil)
-		if err == nil {
-			t.Error("Expected NIXL connector Proxy to return error due to network/connection issues")
-		}
+	connector := NewNIXLConnector()
+	prefillAddr := prefillServer.Listener.Addr().String()
+	decodeAddr := decodeServer.Listener.Addr().String()
 
-		// Verify detailed kv_transfer_params structure in prefill request
-		nixlConn := connector.(*NIXLConnector)
-		if nixlConn.prefillRequest != nil {
-			prefillBody, err := parseRequestBody(nixlConn.prefillRequest)
-			if err != nil {
-				t.Errorf("Failed to parse prefill request body: %v", err)
-			} else {
-				if kvTransferParams, ok := prefillBody["kv_transfer_params"]; !ok {
-					t.Error("Expected prefill request to have kv_transfer_params field")
-				} else if params, isMap := kvTransferParams.(map[string]interface{}); !isMap {
-					t.Error("Expected kv_transfer_params to be a map")
-				} else {
-					// Verify all expected NIXL kv_transfer_params fields
-					expectedFields := map[string]interface{}{
-						"do_remote_decode":  true,
-						"do_remote_prefill": false,
-					}
+	const concurrency = 10
+	errCh := make(chan error, concurrency)
 
-					for field, expectedValue := range expectedFields {
-						if actualValue, ok := params[field]; !ok {
-							t.Errorf("Expected kv_transfer_params to have field '%s'", field)
-						} else if actualValue != expectedValue {
-							t.Errorf("Expected kv_transfer_params['%s'] to be %v, got %v", field, expectedValue, actualValue)
-						}
-					}
-				}
+	for i := 0; i < concurrency; i++ {
+		go func(id int) {
+			modelName := fmt.Sprintf("nixl-model-%d", id)
+			req, _ := http.NewRequest("POST", "/v1/chat/completions", nil)
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			c.Request = req
+
+			reqBody := map[string]interface{}{
+				"model":      modelName,
+				"max_tokens": 50 + id,
+				"messages": []interface{}{
+					map[string]interface{}{"role": "user", "content": fmt.Sprintf("msg-%d", id)},
+				},
 			}
+
+			_, err := connector.Proxy(c, reqBody, prefillAddr, decodeAddr, nil)
+			if err != nil {
+				errCh <- fmt.Errorf("goroutine %d failed: %w", id, err)
+				return
+			}
+
+			var respBody map[string]interface{}
+			if err := json.Unmarshal(rec.Body.Bytes(), &respBody); err != nil {
+				errCh <- fmt.Errorf("goroutine %d unmarshal error: %w", id, err)
+				return
+			}
+			if respBody["model"] != modelName {
+				errCh <- fmt.Errorf("goroutine %d received response for model %v, expected %s", id, respBody["model"], modelName)
+				return
+			}
+			errCh <- nil
+		}(i)
+	}
+
+	for i := 0; i < concurrency; i++ {
+		if err := <-errCh; err != nil {
+			t.Errorf("Concurrent request error: %v", err)
 		}
-	})
+	}
 }
 
 // TestNIXLConnectorRetryBodyNotDrained checks that calling Proxy() twice on the


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

In `HTTPConnector` (`pkg/kthena-router/connectors/http.go`) and `NIXLConnector` (`pkg/kthena-router/connectors/nixl.go`), mutable per-request state (`prefillRequest`, `decodeRequest`, and `decodeRequestBody`) were maintained as struct fields on the connector instances.

When Kthena Router operates in PD disaggregation mode, connector singletons created via `r.connectorFactory.GetConnector(connectorType)` are shared across concurrent requests. When two or more requests are routed through `HTTPConnector`, `NIXLConnector`, or `MoonCakeConnector` concurrently, multiple goroutines concurrently mutate and read `h.decodeRequest`, `h.prefillRequest`, `n.prefillRequest`, and `n.decodeRequestBody` on the shared connector instance without synchronization. This causes a data race and request payload corruption, where one request's decode phase sends another concurrent request's prompt and parameters to the decode engine.

This PR makes `HTTPConnector` and `NIXLConnector` completely stateless by:
1. Removing per-request struct fields (`prefillRequest`, `decodeRequest`, `decodeRequestBody`) from `HTTPConnector` and `NIXLConnector`.
2. Maintaining request objects as local variables within `Proxy()` and passing them directly into `prefill()` and `decode()`.
3. Adding concurrent regression unit tests (`TestHTTPConnector_ConcurrentThreadSafety` and `TestNIXLConnector_ConcurrentThreadSafety`) that simulate concurrent requests through a shared connector instance to verify thread safety and payload isolation.

**Which issue(s) this PR fixes**:

Fixes #1656

**Bug evidence (required for bug-related PRs)**:

- Production execution path:
  1. `proxyToPDDisaggregated` obtains the connector singleton from factory:
     https://github.com/volcano-sh/kthena/blob/713a4a5814526d19b45781a742ea3521d9657065/pkg/kthena-router/router/router.go#L1363
  2. `HTTPConnector.Proxy` writes to struct fields `h.decodeRequest` and `h.prefillRequest`:
     https://github.com/volcano-sh/kthena/blob/713a4a5814526d19b45781a742ea3521d9657065/pkg/kthena-router/connectors/http.go#L74-L77
  3. `NIXLConnector.Proxy` writes to struct fields `n.prefillRequest` and `n.decodeRequestBody`:
     https://github.com/volcano-sh/kthena/blob/713a4a5814526d19b45781a742ea3521d9657065/pkg/kthena-router/connectors/nixl.go#L65-L67
  4. Concurrent request goroutines overwrite these shared fields prior to the decode phase dispatching `decodeRequest` / `decodeRequestBody`.

- Verified by concurrent regression unit tests running concurrent goroutines through shared connector instances.

**Special notes for your reviewer**:

All unit tests in `pkg/kthena-router/...` pass cleanly.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
