### PR TITLE
yfix(router): match nested subdomains for wildcard listeners

### DIFF
--- a/cmd/kthena-router/app/router.go
+++ b/cmd/kthena-router/app/router.go
@@ -460,8 +460,8 @@ func wildcardHostnameMatch(pattern, hostname string) bool {
 	}
 
 	prefix := hostnameLower[:len(hostnameLower)-len(suffix)]
-	// Gateway wildcard hostnames represent exactly one leading label.
-	return prefix != "" && !strings.Contains(prefix, ".")
+	// Gateway wildcard hostnames use suffix matching.
+	return prefix != ""
 }
 
 // listenerConfigKey creates a unique key for a listener config for comparison

--- a/cmd/kthena-router/app/router_listener_test.go
+++ b/cmd/kthena-router/app/router_listener_test.go
@@ -73,10 +73,10 @@ func TestWildcardHostnameMatch(t *testing.T) {
 			want:     true,
 		},
 		{
-			name:     "multi label subdomain should not match",
+			name:     "multi label subdomain match",
 			pattern:  "*.example.com",
 			hostname: "a.b.example.com",
-			want:     false,
+			want:     true,
 		},
 		{
 			name:     "apex hostname should not match",


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Allows Gateway wildcard listeners to match nested subdomains. Gateway API defines `*.example.com` as a suffix match, so it must match both `bar.example.com` and `foo.bar.example.com`.

The current matcher applies single-label TLS wildcard behavior and rejects the second case.

**Which issue(s) this PR fixes**:

Fixes #1658

**Bug evidence (required for bug-related PRs)**:

Minimal configuration:

```yaml
listeners:
- name: http
  hostname: "*.example.com"
  port: 8081
  protocol: HTTP
  Request: curl -H 'Host: foo.bar.example.com' \
  http://<router-address>:8081/v1/models
```

Before this change, the listener middleware returns:
404 {"message":"No matching listener found"}

Production path:
The listener handler reads Request.Host and calls findBestMatchingListener:
https://github.com/volcano-sh/kthena/blob/4340d9d07240d7a7d6947e61c756b061a647d594/cmd/kthena-router/app/router.go#L228-L267
Wildcard listeners are selected here:
https://github.com/volcano-sh/kthena/blob/4340d9d07240d7a7d6947e61c756b061a647d594/cmd/kthena-router/app/router.go#L395-L448
The matcher rejects prefixes containing a dot:
https://github.com/volcano-sh/kthena/blob/4340d9d07240d7a7d6947e61c756b061a647d594/cmd/kthena-router/app/router.go#L450-L464
This change removes that single-label restriction. The existing table test now covers a.b.example.com.

**Special notes for your reviewer**:
Gateway listener hostname matching uses suffix semantics. This is different from TLS certificate wildcard matching. The change is limited to the existing matcher and its regression test.

**Does this PR introduce a user-facing change?**:

```release-note
Fixed Gateway wildcard listeners rejecting nested subdomains.
```
