### PR TITLE
helm: honor the controller manager webhook toggle

### DIFF
--- a/charts/kthena/charts/workload/templates/kthena-controller-manager/component/deployment.yaml
+++ b/charts/kthena/charts/workload/templates/kthena-controller-manager/component/deployment.yaml
@@ -23,6 +23,7 @@ spec:
           image: "{{ .Values.controllerManager.image.repository }}:{{ .Values.controllerManager.image.tag }}"
           args:
             {{- toYaml .Values.controllerManager.image.args | nindent 12 }}
+            - --enable-webhook={{ .Values.controllerManager.webhook.enabled }}
             - --cert-secret-name={{ .Values.controllerManager.webhook.tls.certSecretName }}
             - --service-name={{ .Values.controllerManager.webhook.tls.serviceName }}
             {{- if .Values.controllerManager.controllers }}
@@ -58,6 +59,7 @@ spec:
             - name: webhook-certs
               mountPath: /etc/tls
               readOnly: true
+          {{- if .Values.controllerManager.webhook.enabled }}
           livenessProbe:
             httpGet:
               path: /healthz
@@ -72,6 +74,7 @@ spec:
               scheme: HTTPS
             initialDelaySeconds: 5
             periodSeconds: 10
+          {{- end }}
       volumes:
         - name: webhook-certs
           secret:

--- a/charts/kthena/charts/workload/values.yaml
+++ b/charts/kthena/charts/workload/values.yaml
@@ -13,7 +13,7 @@ controllerManager:
     # node: edit by CI. No need to modify manually
     tag: latest
     pullPolicy: IfNotPresent
-    # set --enable-webhook false to disable webhook, default is true
+    # to turn the webhook off, set controllerManager.webhook.enabled to false
     args: [ "--v=2" ]
   resource:
     limits:


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

There is currently no working way to turn the controller manager webhook off.

1. `controllerManager.webhook.enabled=false` removes the ValidatingWebhookConfiguration, the MutatingWebhookConfiguration and the webhook Service, but the value never reaches the binary. The chart does not pass `--enable-webhook`, so the flag keeps its default of true ([main.go#L71](https://github.com/volcano-sh/kthena/blob/172e0211878c456fdf354cfeb7e602a1bd1e072d/cmd/kthena-controller-manager/main.go#L71)) and the container still runs the whole webhook setup: it generates and stores the certificate Secret, logs that it is skipping the CA bundle update for both configurations because they are gone, and then serves the webhook on 8443 ([secret.go#L115-L117](https://github.com/volcano-sh/kthena/blob/172e0211878c456fdf354cfeb7e602a1bd1e072d/pkg/webhook/cert/secret.go#L115-L117)). The networking subchart already wires this flag for the router ([deployment.yaml#L30](https://github.com/volcano-sh/kthena/blob/172e0211878c456fdf354cfeb7e602a1bd1e072d/charts/kthena/charts/networking/templates/kthena-router/component/deployment.yaml#L30)); the workload subchart never did.

2. `values.yaml` points at `image.args` instead, suggesting `--enable-webhook false` ([values.yaml#L16](https://github.com/volcano-sh/kthena/blob/172e0211878c456fdf354cfeb7e602a1bd1e072d/charts/kthena/charts/workload/values.yaml#L16)). That form does not disable anything. pflag gives bool flags `NoOptDefVal = "true"` ([bool.go#L54-L57](https://github.com/spf13/pflag/blob/v1.0.7/bool.go#L54-L57)), so `--enable-webhook false` sets the flag to true and leaves `false` as a positional argument that `pflag.Parse()` never reads ([main.go#L89](https://github.com/volcano-sh/kthena/blob/172e0211878c456fdf354cfeb7e602a1bd1e072d/cmd/kthena-controller-manager/main.go#L89)).

3. The form that does work, `--enable-webhook=false`, stops the webhook server, and then the pod probes have nothing to talk to. `/healthz` is registered only on the webhook mux ([main.go#L198](https://github.com/volcano-sh/kthena/blob/172e0211878c456fdf354cfeb7e602a1bd1e072d/cmd/kthena-controller-manager/main.go#L198)), which only runs when the flag is true ([main.go#L107-L113](https://github.com/volcano-sh/kthena/blob/172e0211878c456fdf354cfeb7e602a1bd1e072d/cmd/kthena-controller-manager/main.go#L107-L113)), while both probes target `/healthz` on 8443 unconditionally ([deployment.yaml#L61-L74](https://github.com/volcano-sh/kthena/blob/172e0211878c456fdf354cfeb7e602a1bd1e072d/charts/kthena/charts/workload/templates/kthena-controller-manager/component/deployment.yaml#L61-L74)). Readiness never passes and liveness restarts the container once it hits the failure threshold, over and over.

This wires the value that already exists through to the binary, and keeps the probes only when the webhook actually runs, which is what the networking subchart does for the router today. It also corrects the `values.yaml` comment so it points at the value rather than at an argument form that does nothing.

**Which issue(s) this PR fixes**:

N/A, small chart fix.

**Bug evidence (required for bug-related PRs)**:

`helm template kthena charts/kthena --set workload.controllerManager.webhook.enabled=false` on 172e021, controller manager container, before this change:

```yaml
args:
  - --v=2
  - --cert-secret-name=kthena-controller-manager-webhook-certs
  - --service-name=kthena-controller-manager-webhook
...
livenessProbe:
  httpGet:
    path: /healthz
    port: 8443
    scheme: HTTPS
readinessProbe:
  httpGet:
    path: /healthz
    port: 8443
    scheme: HTTPS
```

No `--enable-webhook` reaches the container, so the webhook server keeps running even though every webhook manifest was removed.

The argument form `values.yaml` suggests, checked against pflag v1.0.7 as the binary uses it:

```
["--enable-webhook" "false"]  -> enableWebhook=true   leftover=["false"]
["--enable-webhook=false"]    -> enableWebhook=false  leftover=[]
[]                            -> enableWebhook=true   leftover=[]
```

So the documented workaround leaves the webhook enabled, and the corrected form disables it and leaves both probes pointing at a port nothing listens on.

Same helm command with this change: the container gets `--enable-webhook=false` and carries no probes, while the router deployment in the same render keeps its own `--enable-webhook=true` and its own probes.

A default install is unchanged except for one argument that matches the binary default:

```
$ diff before.yaml after.yaml
751a752
>             - --enable-webhook=true
```

`helm lint charts/kthena` passes.

**Special notes for your reviewer**:

Three notes on the shape of the fix.

The new argument is appended after `controllerManager.image.args`, so if someone already carries `--enable-webhook` in those args the chart value now wins. That only changes behavior for a setup that cannot work today anyway: the space separated form never disabled anything, and the `=` form left the pod restarting. I also updated the comment in `values.yaml` that pointed at the argument, since it documented a form that has no effect.

With the webhook off the container is left without probes. Another option is to serve `/healthz` from an endpoint that runs regardless of the webhook, so a probe can stay in both cases. That is a code change rather than a chart change, so I kept this PR to the chart. Glad to send that version instead if you would rather have it.

I left `--cert-secret-name`, `--service-name`, the cert volume and the 8443 containerPort in place when the webhook is off. With the flag false `setupWebhook` never runs, so none of them are read, and the volume is `optional: true`. Removing them felt out of scope for this fix, happy to gate them too if you would prefer.

**Does this PR introduce a user-facing change?**:

```release-note
Fixed the workload chart so that setting `controllerManager.webhook.enabled` to false disables the controller manager webhook instead of leaving it running, and no longer leaves the pod with probes pointing at a webhook server that is not listening.
```
