### PR TITLE
feat(router): support HTTPRoute header and redirect filters

### DIFF
--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -61,6 +61,7 @@ const (
 	GatewayListenerNameKey = "gatewayListenerName"
 	GatewayListenerPortKey = "gatewayListenerPort"
 	PromptKey              = "promptKey" // store parsed ChatMessage, which will be reused
+	httpRouteMatchKey      = "httpRouteMatch"
 
 	successfulRequestFinishReason = "successful_request"
 	failedRequestFinishReason     = "request_failed"
@@ -276,6 +277,9 @@ func (r *Router) HandlerFunc() gin.HandlerFunc {
 		if c.Request.Method == http.MethodGet &&
 			(c.Request.URL.Path == "/v1/models" || c.Request.URL.Path == "/models") {
 			r.ListModels(c)
+			return
+		}
+		if !strings.HasPrefix(c.Request.URL.Path, "/v1/") && r.handleHTTPRouteRedirect(c) {
 			return
 		}
 
@@ -745,7 +749,7 @@ func (r *Router) getPodsAndServer(modelServerName types.NamespacedName) ([]*data
 // It returns whether a route matched, the selected InferencePool, and an error
 // when a matched rule has no eligible InferencePool backend.
 func (r *Router) handleHTTPRoute(c *gin.Context, gatewayKey string) (bool, types.NamespacedName, error) {
-	matchResult, matched := r.findHTTPRouteMatch(c, gatewayKey)
+	matchResult, matched := r.getHTTPRouteMatch(c, gatewayKey)
 	if !matched {
 		return false, types.NamespacedName{}, nil
 	}
@@ -768,16 +772,125 @@ func (r *Router) handleHTTPRoute(c *gin.Context, gatewayKey string) (bool, types
 	inferencePoolKey := fmt.Sprintf("%s/%s", inferencePoolName.Namespace, inferencePoolName.Name)
 	accesslog.SetGatewayAPIInfo(c, "", "", inferencePoolKey)
 
-	// Apply HTTPURLRewriteFilter from the same rule that matched the request.
-	if matchResult.rule.Filters != nil {
-		for _, filter := range matchResult.rule.Filters {
-			if filter.Type == gatewayv1.HTTPRouteFilterURLRewrite && filter.URLRewrite != nil {
+	for _, filter := range matchResult.rule.Filters {
+		switch filter.Type {
+		case gatewayv1.HTTPRouteFilterRequestHeaderModifier:
+			if filter.RequestHeaderModifier != nil {
+				applyRequestHeaderModifier(c.Request, filter.RequestHeaderModifier)
+			}
+		case gatewayv1.HTTPRouteFilterURLRewrite:
+			if filter.URLRewrite != nil {
 				r.applyURLRewrite(c, filter.URLRewrite)
 			}
 		}
 	}
 
 	return true, inferencePoolName, nil
+}
+
+func (r *Router) getHTTPRouteMatch(c *gin.Context, gatewayKey string) (httpRouteMatchResult, bool) {
+	if value, exists := c.Get(httpRouteMatchKey); exists {
+		matchResult, ok := value.(httpRouteMatchResult)
+		return matchResult, ok
+	}
+	matchResult, matched := r.findHTTPRouteMatch(c, gatewayKey)
+	if matched {
+		c.Set(httpRouteMatchKey, matchResult)
+	}
+	return matchResult, matched
+}
+
+func (r *Router) handleHTTPRouteRedirect(c *gin.Context) bool {
+	gatewayKey := c.GetString(GatewayKey)
+	if gatewayKey == "" {
+		return false
+	}
+	matchResult, matched := r.getHTTPRouteMatch(c, gatewayKey)
+	if !matched {
+		return false
+	}
+	for _, filter := range matchResult.rule.Filters {
+		if filter.Type != gatewayv1.HTTPRouteFilterRequestRedirect || filter.RequestRedirect == nil {
+			continue
+		}
+		httpRouteKey := fmt.Sprintf("%s/%s", matchResult.route.Namespace, matchResult.route.Name)
+		accesslog.SetGatewayAPIInfo(c, gatewayKey, httpRouteKey, "")
+		r.applyRequestRedirect(c, matchResult.matchedPrefix, filter.RequestRedirect)
+		return true
+	}
+	return false
+}
+
+func applyRequestHeaderModifier(request *http.Request, modifier *gatewayv1.HTTPHeaderFilter) {
+	for _, header := range modifier.Set {
+		request.Header.Set(string(header.Name), header.Value)
+	}
+	for _, header := range modifier.Add {
+		request.Header.Add(string(header.Name), header.Value)
+	}
+	for _, name := range modifier.Remove {
+		request.Header.Del(string(name))
+	}
+}
+
+func (r *Router) applyRequestRedirect(c *gin.Context, matchedPrefix string, redirect *gatewayv1.HTTPRequestRedirectFilter) {
+	redirectURL := *c.Request.URL
+	scheme := "http"
+	if c.Request.TLS != nil {
+		scheme = "https"
+	}
+	if redirect.Scheme != nil {
+		scheme = string(*redirect.Scheme)
+	}
+
+	hostname := normalizeHTTPRouteHost(c.Request.Host)
+	if redirect.Hostname != nil {
+		hostname = string(*redirect.Hostname)
+	}
+
+	port := c.GetInt(GatewayListenerPortKey)
+	if redirect.Scheme != nil {
+		port = 80
+		if scheme == "https" {
+			port = 443
+		}
+	}
+	if redirect.Port != nil {
+		port = int(*redirect.Port)
+	}
+	if port == 0 {
+		if _, value, err := net.SplitHostPort(c.Request.Host); err == nil {
+			port, _ = strconv.Atoi(value)
+		}
+	}
+
+	redirectURL.Scheme = scheme
+	redirectURL.Host = hostname
+	if (scheme == "http" && port != 0 && port != 80) || (scheme == "https" && port != 0 && port != 443) {
+		redirectURL.Host = net.JoinHostPort(hostname, strconv.Itoa(port))
+	} else if strings.Contains(hostname, ":") {
+		redirectURL.Host = "[" + hostname + "]"
+	}
+	if redirect.Path != nil {
+		switch redirect.Path.Type {
+		case gatewayv1.FullPathHTTPPathModifier:
+			if redirect.Path.ReplaceFullPath != nil {
+				redirectURL.Path = *redirect.Path.ReplaceFullPath
+			}
+		case gatewayv1.PrefixMatchHTTPPathModifier:
+			if redirect.Path.ReplacePrefixMatch != nil {
+				redirectURL.Path = *redirect.Path.ReplacePrefixMatch + strings.TrimPrefix(redirectURL.Path, matchedPrefix)
+			}
+		}
+		redirectURL.RawPath = ""
+	}
+
+	statusCode := http.StatusFound
+	if redirect.StatusCode != nil {
+		statusCode = int(*redirect.StatusCode)
+	}
+	c.Redirect(statusCode, redirectURL.String())
+	c.Abort()
 }
 
 // applyURLRewrite applies HTTPURLRewriteFilter to the request

--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -61,6 +61,7 @@ const (
 	GatewayListenerNameKey = "gatewayListenerName"
 	GatewayListenerPortKey = "gatewayListenerPort"
 	PromptKey              = "promptKey" // store parsed ChatMessage, which will be reused
+	httpRouteMatchKey      = "httpRouteMatch"
 
 	successfulRequestFinishReason = "successful_request"
 	failedRequestFinishReason     = "request_failed"
@@ -276,6 +277,9 @@ func (r *Router) HandlerFunc() gin.HandlerFunc {
 		if c.Request.Method == http.MethodGet &&
 			(c.Request.URL.Path == "/v1/models" || c.Request.URL.Path == "/models") {
 			r.ListModels(c)
+			return
+		}
+		if r.handleHTTPRouteRedirect(c) {
 			return
 		}
 
@@ -745,7 +749,7 @@ func (r *Router) getPodsAndServer(modelServerName types.NamespacedName) ([]*data
 // It returns whether a route matched, the selected InferencePool, and an error
 // when a matched rule has no eligible InferencePool backend.
 func (r *Router) handleHTTPRoute(c *gin.Context, gatewayKey string) (bool, types.NamespacedName, error) {
-	matchResult, matched := r.findHTTPRouteMatch(c, gatewayKey)
+	matchResult, matched := r.getHTTPRouteMatch(c, gatewayKey)
 	if !matched {
 		return false, types.NamespacedName{}, nil
 	}
@@ -768,16 +772,138 @@ func (r *Router) handleHTTPRoute(c *gin.Context, gatewayKey string) (bool, types
 	inferencePoolKey := fmt.Sprintf("%s/%s", inferencePoolName.Namespace, inferencePoolName.Name)
 	accesslog.SetGatewayAPIInfo(c, "", "", inferencePoolKey)
 
-	// Apply HTTPURLRewriteFilter from the same rule that matched the request.
-	if matchResult.rule.Filters != nil {
-		for _, filter := range matchResult.rule.Filters {
-			if filter.Type == gatewayv1.HTTPRouteFilterURLRewrite && filter.URLRewrite != nil {
+	for _, filter := range matchResult.rule.Filters {
+		switch filter.Type {
+		case gatewayv1.HTTPRouteFilterRequestHeaderModifier:
+			if filter.RequestHeaderModifier != nil {
+				applyRequestHeaderModifier(c.Request, filter.RequestHeaderModifier)
+			}
+		case gatewayv1.HTTPRouteFilterURLRewrite:
+			if filter.URLRewrite != nil {
 				r.applyURLRewrite(c, filter.URLRewrite)
 			}
 		}
 	}
 
 	return true, inferencePoolName, nil
+}
+
+func (r *Router) getHTTPRouteMatch(c *gin.Context, gatewayKey string) (httpRouteMatchResult, bool) {
+	if value, exists := c.Get(httpRouteMatchKey); exists {
+		matchResult, ok := value.(httpRouteMatchResult)
+		return matchResult, ok
+	}
+	matchResult, matched := r.findHTTPRouteMatch(c, gatewayKey)
+	if matched {
+		c.Set(httpRouteMatchKey, matchResult)
+	}
+	return matchResult, matched
+}
+
+func (r *Router) handleHTTPRouteRedirect(c *gin.Context) bool {
+	gatewayKey := c.GetString(GatewayKey)
+	if gatewayKey == "" {
+		return false
+	}
+	matchResult, matched := r.getHTTPRouteMatch(c, gatewayKey)
+	if !matched {
+		return false
+	}
+	for _, filter := range matchResult.rule.Filters {
+		if filter.Type != gatewayv1.HTTPRouteFilterRequestRedirect || filter.RequestRedirect == nil {
+			continue
+		}
+		httpRouteKey := fmt.Sprintf("%s/%s", matchResult.route.Namespace, matchResult.route.Name)
+		accesslog.SetGatewayAPIInfo(c, gatewayKey, httpRouteKey, "")
+		r.applyRequestRedirect(c, matchResult.matchedPrefix, filter.RequestRedirect)
+		return true
+	}
+	return false
+}
+
+func applyRequestHeaderModifier(request *http.Request, modifier *gatewayv1.HTTPHeaderFilter) {
+	for _, header := range modifier.Set {
+		request.Header.Set(string(header.Name), header.Value)
+	}
+	for _, header := range modifier.Add {
+		request.Header.Add(string(header.Name), header.Value)
+	}
+	for _, name := range modifier.Remove {
+		request.Header.Del(string(name))
+	}
+}
+
+func (r *Router) applyRequestRedirect(c *gin.Context, matchedPrefix string, redirect *gatewayv1.HTTPRequestRedirectFilter) {
+	redirectURL := *c.Request.URL
+	scheme := "http"
+	if c.Request.TLS != nil {
+		scheme = "https"
+	}
+	if redirect.Scheme != nil {
+		scheme = string(*redirect.Scheme)
+	}
+
+	hostname := normalizeHTTPRouteHost(c.Request.Host)
+	if redirect.Hostname != nil {
+		hostname = string(*redirect.Hostname)
+	}
+
+	port := c.GetInt(GatewayListenerPortKey)
+	if redirect.Scheme != nil {
+		port = 80
+		if scheme == "https" {
+			port = 443
+		}
+	}
+	if redirect.Port != nil {
+		port = int(*redirect.Port)
+	}
+	if port == 0 {
+		if _, value, err := net.SplitHostPort(c.Request.Host); err == nil {
+			port, _ = strconv.Atoi(value)
+		}
+	}
+
+	redirectURL.Scheme = scheme
+	redirectURL.Host = hostname
+	if (scheme == "http" && port != 0 && port != 80) || (scheme == "https" && port != 0 && port != 443) {
+		redirectURL.Host = net.JoinHostPort(hostname, strconv.Itoa(port))
+	} else if strings.Contains(hostname, ":") {
+		redirectURL.Host = "[" + hostname + "]"
+	}
+	if redirect.Path != nil {
+		switch redirect.Path.Type {
+		case gatewayv1.FullPathHTTPPathModifier:
+			if redirect.Path.ReplaceFullPath != nil {
+				redirectURL.Path = *redirect.Path.ReplaceFullPath
+			}
+		case gatewayv1.PrefixMatchHTTPPathModifier:
+			if redirect.Path.ReplacePrefixMatch != nil {
+				redirectURL.Path = replacePrefixMatchPath(redirectURL.Path, matchedPrefix, *redirect.Path.ReplacePrefixMatch)
+			}
+		}
+		redirectURL.RawPath = ""
+	}
+
+	statusCode := http.StatusFound
+	if redirect.StatusCode != nil {
+		statusCode = int(*redirect.StatusCode)
+	}
+	c.Redirect(statusCode, redirectURL.String())
+	c.Abort()
+}
+
+func replacePrefixMatchPath(requestPath, matchedPrefix, replacement string) string {
+	remainder := strings.TrimPrefix(requestPath, matchedPrefix)
+	if matchedPrefix == "/" && remainder != "" {
+		remainder = "/" + remainder
+	}
+
+	replacedPath := strings.TrimRight(replacement, "/") + remainder
+	if replacedPath == "" {
+		return "/"
+	}
+	return replacedPath
 }
 
 // applyURLRewrite applies HTTPURLRewriteFilter to the request

--- a/pkg/kthena-router/router/router_test.go
+++ b/pkg/kthena-router/router/router_test.go
@@ -576,6 +576,223 @@ func TestRouter_HandleHTTPRoute_UsesMatchedRuleURLRewrite(t *testing.T) {
 	assert.Equal(t, "/right/chat", c.Request.URL.Path)
 }
 
+func TestRouter_HandleHTTPRoute_RequestHeaderModifier(t *testing.T) {
+	pathType := gatewayv1.PathMatchPathPrefix
+	pathValue := "/chat"
+	gatewayKind := gatewayv1.Kind("Gateway")
+	poolGroup := inferencePoolBackendGroup
+	poolKind := inferencePoolBackendKind
+	store := datastore.New()
+	router := &Router{store: store}
+	route := &gatewayv1.HTTPRoute{
+		ObjectMeta: v1.ObjectMeta{Name: "route", Namespace: "default"},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{{Name: "gw", Kind: &gatewayKind}},
+			},
+			Rules: []gatewayv1.HTTPRouteRule{{
+				Matches: []gatewayv1.HTTPRouteMatch{{
+					Path: &gatewayv1.HTTPPathMatch{Type: &pathType, Value: &pathValue},
+				}},
+				Filters: []gatewayv1.HTTPRouteFilter{{
+					Type: gatewayv1.HTTPRouteFilterRequestHeaderModifier,
+					RequestHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+						Set: []gatewayv1.HTTPHeader{{
+							Name:  "X-Set",
+							Value: "new",
+						}},
+						Add: []gatewayv1.HTTPHeader{{
+							Name:  "X-Add",
+							Value: "second",
+						}},
+						Remove: []string{"X-Remove"},
+					},
+				}},
+				BackendRefs: []gatewayv1.HTTPBackendRef{{
+					BackendRef: gatewayv1.BackendRef{
+						BackendObjectReference: gatewayv1.BackendObjectReference{
+							Group: &poolGroup,
+							Kind:  &poolKind,
+							Name:  "pool",
+						},
+					},
+				}},
+			}},
+		},
+	}
+	assert.NoError(t, store.AddOrUpdateHTTPRoute(route))
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request, _ = http.NewRequest(http.MethodPost, "/chat/completions", nil)
+	c.Request.Header.Set("X-Set", "old")
+	c.Request.Header.Set("X-Add", "first")
+	c.Request.Header.Set("X-Remove", "value")
+
+	matched, pool, err := router.handleHTTPRoute(c, "default/gw")
+	assert.NoError(t, err)
+	assert.True(t, matched)
+	assert.Equal(t, types.NamespacedName{Namespace: "default", Name: "pool"}, pool)
+	assert.Equal(t, "new", c.Request.Header.Get("X-Set"))
+	assert.Equal(t, []string{"first", "second"}, c.Request.Header.Values("X-Add"))
+	assert.Empty(t, c.Request.Header.Get("X-Remove"))
+}
+
+func TestRouter_HandlerFunc_HTTPRouteRequestRedirect(t *testing.T) {
+	router, store, backend := setupTestRouter(t, nil)
+	defer backend.Close()
+
+	pathType := gatewayv1.PathMatchPathPrefix
+	pathValue := "/old"
+	redirectPathType := gatewayv1.FullPathHTTPPathModifier
+	replacement := "/new"
+	gatewayKind := gatewayv1.Kind("Gateway")
+	route := &gatewayv1.HTTPRoute{
+		ObjectMeta: v1.ObjectMeta{Name: "redirect", Namespace: "default"},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{{Name: "gw", Kind: &gatewayKind}},
+			},
+			Rules: []gatewayv1.HTTPRouteRule{{
+				Matches: []gatewayv1.HTTPRouteMatch{{
+					Path: &gatewayv1.HTTPPathMatch{Type: &pathType, Value: &pathValue},
+				}},
+				Filters: []gatewayv1.HTTPRouteFilter{{
+					Type: gatewayv1.HTTPRouteFilterRequestRedirect,
+					RequestRedirect: &gatewayv1.HTTPRequestRedirectFilter{
+						Path: &gatewayv1.HTTPPathModifier{
+							Type:            redirectPathType,
+							ReplaceFullPath: &replacement,
+						},
+					},
+				}},
+			}},
+		},
+	}
+	assert.NoError(t, store.AddOrUpdateHTTPRoute(route))
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Set(GatewayKey, "default/gw")
+	c.Set(GatewayListenerPortKey, 80)
+	c.Request, _ = http.NewRequest(http.MethodGet, "http://old.example.com/old?stream=true", nil)
+
+	router.HandlerFunc()(c)
+
+	assert.True(t, c.IsAborted())
+	assert.Equal(t, http.StatusFound, w.Code)
+	assert.Equal(t, "http://old.example.com/new?stream=true", w.Header().Get("Location"))
+
+	scheme := "https"
+	hostname := gatewayv1.PreciseHostname("new.example.com")
+	port := gatewayv1.PortNumber(8443)
+	statusCode := http.StatusMovedPermanently
+	redirectPathType = gatewayv1.PrefixMatchHTTPPathModifier
+	configuredRedirect := route.Spec.Rules[0].Filters[0].RequestRedirect
+	configuredRedirect.Scheme = &scheme
+	configuredRedirect.Hostname = &hostname
+	configuredRedirect.Port = &port
+	configuredRedirect.StatusCode = &statusCode
+	configuredRedirect.Path = &gatewayv1.HTTPPathModifier{
+		Type:               redirectPathType,
+		ReplacePrefixMatch: &replacement,
+	}
+	assert.NoError(t, store.AddOrUpdateHTTPRoute(route))
+
+	w = httptest.NewRecorder()
+	c, _ = gin.CreateTestContext(w)
+	c.Set(GatewayKey, "default/gw")
+	c.Set(GatewayListenerPortKey, 80)
+	c.Request, _ = http.NewRequest(http.MethodGet, "http://old.example.com/old/chat?stream=true", nil)
+
+	router.HandlerFunc()(c)
+
+	assert.True(t, c.IsAborted())
+	assert.Equal(t, http.StatusMovedPermanently, w.Code)
+	assert.Equal(t, "https://new.example.com:8443/new/chat?stream=true", w.Header().Get("Location"))
+
+	pathValue = "/"
+	assert.NoError(t, store.AddOrUpdateHTTPRoute(route))
+
+	w = httptest.NewRecorder()
+	c, _ = gin.CreateTestContext(w)
+	c.Set(GatewayKey, "default/gw")
+	c.Set(GatewayListenerPortKey, 80)
+	c.Request, _ = http.NewRequest(http.MethodPost, "http://old.example.com/v1/chat/completions", nil)
+
+	router.HandlerFunc()(c)
+
+	assert.True(t, c.IsAborted())
+	assert.Equal(t, http.StatusMovedPermanently, c.Writer.Status())
+	assert.Equal(t, "https://new.example.com:8443/new/v1/chat/completions", w.Header().Get("Location"))
+}
+
+func TestReplacePrefixMatchPath(t *testing.T) {
+	tests := []struct {
+		name          string
+		requestPath   string
+		matchedPrefix string
+		replacement   string
+		expected      string
+	}{
+		{
+			name:          "replace prefix",
+			requestPath:   "/foo/bar",
+			matchedPrefix: "/foo",
+			replacement:   "/xyz",
+			expected:      "/xyz/bar",
+		},
+		{
+			name:          "ignore replacement trailing slash",
+			requestPath:   "/foo/bar",
+			matchedPrefix: "/foo",
+			replacement:   "/xyz/",
+			expected:      "/xyz/bar",
+		},
+		{
+			name:          "preserve request trailing slash",
+			requestPath:   "/foo/",
+			matchedPrefix: "/foo",
+			replacement:   "/xyz",
+			expected:      "/xyz/",
+		},
+		{
+			name:          "empty replacement",
+			requestPath:   "/foo/bar",
+			matchedPrefix: "/foo",
+			replacement:   "",
+			expected:      "/bar",
+		},
+		{
+			name:          "empty replacement of full path",
+			requestPath:   "/foo",
+			matchedPrefix: "/foo",
+			replacement:   "",
+			expected:      "/",
+		},
+		{
+			name:          "replace root prefix",
+			requestPath:   "/foo",
+			matchedPrefix: "/",
+			replacement:   "/xyz",
+			expected:      "/xyz/foo",
+		},
+		{
+			name:          "replace path with root",
+			requestPath:   "/foo",
+			matchedPrefix: "/foo",
+			replacement:   "/",
+			expected:      "/",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, replacePrefixMatchPath(tt.requestPath, tt.matchedPrefix, tt.replacement))
+		})
+	}
+}
+
 func TestRouter_HandleHTTPRoute_HostnameMatch(t *testing.T) {
 	pathType := gatewayv1.PathMatchPathPrefix
 	kind := gatewayv1.Kind("Gateway")

--- a/pkg/kthena-router/router/router_test.go
+++ b/pkg/kthena-router/router/router_test.go
@@ -576,6 +576,142 @@ func TestRouter_HandleHTTPRoute_UsesMatchedRuleURLRewrite(t *testing.T) {
 	assert.Equal(t, "/right/chat", c.Request.URL.Path)
 }
 
+func TestRouter_HandleHTTPRoute_RequestHeaderModifier(t *testing.T) {
+	pathType := gatewayv1.PathMatchPathPrefix
+	pathValue := "/chat"
+	gatewayKind := gatewayv1.Kind("Gateway")
+	poolGroup := inferencePoolBackendGroup
+	poolKind := inferencePoolBackendKind
+	store := datastore.New()
+	router := &Router{store: store}
+	route := &gatewayv1.HTTPRoute{
+		ObjectMeta: v1.ObjectMeta{Name: "route", Namespace: "default"},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{{Name: "gw", Kind: &gatewayKind}},
+			},
+			Rules: []gatewayv1.HTTPRouteRule{{
+				Matches: []gatewayv1.HTTPRouteMatch{{
+					Path: &gatewayv1.HTTPPathMatch{Type: &pathType, Value: &pathValue},
+				}},
+				Filters: []gatewayv1.HTTPRouteFilter{{
+					Type: gatewayv1.HTTPRouteFilterRequestHeaderModifier,
+					RequestHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+						Set: []gatewayv1.HTTPHeader{{
+							Name:  "X-Set",
+							Value: "new",
+						}},
+						Add: []gatewayv1.HTTPHeader{{
+							Name:  "X-Add",
+							Value: "second",
+						}},
+						Remove: []string{"X-Remove"},
+					},
+				}},
+				BackendRefs: []gatewayv1.HTTPBackendRef{{
+					BackendRef: gatewayv1.BackendRef{
+						BackendObjectReference: gatewayv1.BackendObjectReference{
+							Group: &poolGroup,
+							Kind:  &poolKind,
+							Name:  "pool",
+						},
+					},
+				}},
+			}},
+		},
+	}
+	assert.NoError(t, store.AddOrUpdateHTTPRoute(route))
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request, _ = http.NewRequest(http.MethodPost, "/chat/completions", nil)
+	c.Request.Header.Set("X-Set", "old")
+	c.Request.Header.Set("X-Add", "first")
+	c.Request.Header.Set("X-Remove", "value")
+
+	matched, pool, err := router.handleHTTPRoute(c, "default/gw")
+	assert.NoError(t, err)
+	assert.True(t, matched)
+	assert.Equal(t, types.NamespacedName{Namespace: "default", Name: "pool"}, pool)
+	assert.Equal(t, "new", c.Request.Header.Get("X-Set"))
+	assert.Equal(t, []string{"first", "second"}, c.Request.Header.Values("X-Add"))
+	assert.Empty(t, c.Request.Header.Get("X-Remove"))
+}
+
+func TestRouter_HandlerFunc_HTTPRouteRequestRedirect(t *testing.T) {
+	router, store, backend := setupTestRouter(t, nil)
+	defer backend.Close()
+
+	pathType := gatewayv1.PathMatchPathPrefix
+	pathValue := "/old"
+	redirectPathType := gatewayv1.FullPathHTTPPathModifier
+	replacement := "/new"
+	gatewayKind := gatewayv1.Kind("Gateway")
+	route := &gatewayv1.HTTPRoute{
+		ObjectMeta: v1.ObjectMeta{Name: "redirect", Namespace: "default"},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{{Name: "gw", Kind: &gatewayKind}},
+			},
+			Rules: []gatewayv1.HTTPRouteRule{{
+				Matches: []gatewayv1.HTTPRouteMatch{{
+					Path: &gatewayv1.HTTPPathMatch{Type: &pathType, Value: &pathValue},
+				}},
+				Filters: []gatewayv1.HTTPRouteFilter{{
+					Type: gatewayv1.HTTPRouteFilterRequestRedirect,
+					RequestRedirect: &gatewayv1.HTTPRequestRedirectFilter{
+						Path: &gatewayv1.HTTPPathModifier{
+							Type:            redirectPathType,
+							ReplaceFullPath: &replacement,
+						},
+					},
+				}},
+			}},
+		},
+	}
+	assert.NoError(t, store.AddOrUpdateHTTPRoute(route))
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Set(GatewayKey, "default/gw")
+	c.Set(GatewayListenerPortKey, 80)
+	c.Request, _ = http.NewRequest(http.MethodGet, "http://old.example.com/old?stream=true", nil)
+
+	router.HandlerFunc()(c)
+
+	assert.True(t, c.IsAborted())
+	assert.Equal(t, http.StatusFound, w.Code)
+	assert.Equal(t, "http://old.example.com/new?stream=true", w.Header().Get("Location"))
+
+	scheme := "https"
+	hostname := gatewayv1.PreciseHostname("new.example.com")
+	port := gatewayv1.PortNumber(8443)
+	statusCode := http.StatusMovedPermanently
+	redirectPathType = gatewayv1.PrefixMatchHTTPPathModifier
+	configuredRedirect := route.Spec.Rules[0].Filters[0].RequestRedirect
+	configuredRedirect.Scheme = &scheme
+	configuredRedirect.Hostname = &hostname
+	configuredRedirect.Port = &port
+	configuredRedirect.StatusCode = &statusCode
+	configuredRedirect.Path = &gatewayv1.HTTPPathModifier{
+		Type:               redirectPathType,
+		ReplacePrefixMatch: &replacement,
+	}
+	assert.NoError(t, store.AddOrUpdateHTTPRoute(route))
+
+	w = httptest.NewRecorder()
+	c, _ = gin.CreateTestContext(w)
+	c.Set(GatewayKey, "default/gw")
+	c.Set(GatewayListenerPortKey, 80)
+	c.Request, _ = http.NewRequest(http.MethodGet, "http://old.example.com/old/chat?stream=true", nil)
+
+	router.HandlerFunc()(c)
+
+	assert.True(t, c.IsAborted())
+	assert.Equal(t, http.StatusMovedPermanently, w.Code)
+	assert.Equal(t, "https://new.example.com:8443/new/chat?stream=true", w.Header().Get("Location"))
+}
+
 func TestRouter_HandleHTTPRoute_HostnameMatch(t *testing.T) {
 	pathType := gatewayv1.PathMatchPathPrefix
 	kind := gatewayv1.Kind("Gateway")


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement

**What this PR does / why we need it**:

Adds support for `RequestHeaderModifier` and `RequestRedirect` filters on HTTPRoute rules.

Redirect-only routes are handled before request parsing and backend selection, so they no longer fail when no InferencePool backend is configured.

**Which issue(s) this PR fixes**:

Fixes #1579

**Bug evidence (required for bug-related PRs)**:

N/A

**Special notes for your reviewer**:

Added router tests for header set/add/remove and redirect hostname, path, scheme, port, status code, and query preservation.

**Does this PR introduce a user-facing change?**:

```release-note
Support RequestHeaderModifier and RequestRedirect filters on HTTPRoute rules.
```