### PR TITLE
fix(router): prevent OOM by enforcing size limits on HTTP request bodies

### DIFF
--- a/pkg/kthena-router/common/types.go
+++ b/pkg/kthena-router/common/types.go
@@ -20,6 +20,9 @@ const (
 	UserIdKey         = "user_id"
 	TokenUsageKey     = "token_usage"
 	RawRequestBodyKey = "raw_request_body"
+
+	// MaxRequestBodyBytes is the maximum allowed size (10MB) for incoming HTTP requests
+	MaxRequestBodyBytes = int64(10 * 1024 * 1024)
 )
 
 // Message represents a single message in a chat conversation

--- a/pkg/kthena-router/handlers/request.go
+++ b/pkg/kthena-router/handlers/request.go
@@ -22,6 +22,8 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+
+	"github.com/volcano-sh/kthena/pkg/kthena-router/common"
 )
 
 // OpenAI-compatible APIs can use different request body shapes.
@@ -33,8 +35,8 @@ type OpenAIRequestBody struct {
 
 // Function to parse the OpenAI request body
 func ParseOpenAIRequestBody(r *http.Request) (string, error) {
-	// Read the request body
-	body, err := io.ReadAll(r.Body)
+	// Read the request body with size limit to prevent OOM
+	body, err := io.ReadAll(io.LimitReader(r.Body, common.MaxRequestBodyBytes))
 	if err != nil {
 		return "", err
 	}

--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -699,7 +699,7 @@ func upstreamTimeoutFor(ms *v1alpha1.ModelServer) time.Duration {
 }
 
 func ParseModelRequest(c *gin.Context) (ModelRequest, error) {
-	bodyBytes, err := io.ReadAll(c.Request.Body)
+	bodyBytes, err := io.ReadAll(io.LimitReader(c.Request.Body, common.MaxRequestBodyBytes))
 	if err != nil {
 		c.AbortWithStatusJSON(http.StatusInternalServerError, err.Error())
 		return nil, err
@@ -844,7 +844,7 @@ func (r *Router) proxy(
 	// request across loop iterations sends an empty body to subsequent pods.
 	var bodyBytes []byte
 	if req.Body != nil {
-		b, err := io.ReadAll(req.Body)
+		b, err := io.ReadAll(io.LimitReader(req.Body, common.MaxRequestBodyBytes))
 		req.Body.Close()
 		if err != nil {
 			return fmt.Errorf("failed to read request body: %w", err)

--- a/pkg/kthena-router/webhook/utils.go
+++ b/pkg/kthena-router/webhook/utils.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 
 	networkingv1alpha1 "github.com/volcano-sh/kthena/pkg/apis/networking/v1alpha1"
+	"github.com/volcano-sh/kthena/pkg/kthena-router/common"
 	admissionv1 "k8s.io/api/admission/v1"
 	"k8s.io/klog/v2"
 )
@@ -38,7 +39,7 @@ func parseAdmissionReviewFromRequest(r *http.Request) (*admissionv1.AdmissionRev
 	var body []byte
 	if r.Body != nil {
 		defer r.Body.Close()
-		data, err := io.ReadAll(r.Body)
+		data, err := io.ReadAll(io.LimitReader(r.Body, common.MaxRequestBodyBytes))
 		if err != nil {
 			return nil, fmt.Errorf("failed to read request body: %v", err)
 		}


### PR DESCRIPTION
## Description
Fixes #1641 

This PR addresses a critical Denial of Service (DoS) vulnerability where unbounded user requests could exhaust router memory and cause the pod to crash (OOMKilled). 

Previously, several HTTP handlers used `io.ReadAll` directly on uncontrolled input streams without enforcing a maximum payload size. This PR mitigates the vulnerability by wrapping the incoming request bodies in an `io.LimitReader` configured with a strict 10MB limit before reading them into memory.

## Changes Made
- **`pkg/kthena-router/router/router.go`**: Wrapped `c.Request.Body` and `req.Body` with `io.LimitReader` (10MB) in `ParseModelRequest` and `proxyModelEndpoint`.
- **`pkg/kthena-router/handlers/request.go`**: Wrapped `r.Body` with `io.LimitReader` (10MB) in `ParseOpenAIRequestBody`.
- **`pkg/kthena-router/webhook/utils.go`**: Wrapped `r.Body` with `io.LimitReader` (10MB) in `parseAdmissionReviewFromRequest`.