### PR TITLE
fix(autoscaler): validate replica range for all target types

### DIFF
--- a/pkg/autoscaler/webhook/autoscalingpolicy_validator.go
+++ b/pkg/autoscaler/webhook/autoscalingpolicy_validator.go
@@ -147,14 +147,28 @@ func (v *AutoscalingPolicyValidator) validateTarget(policy *registryv1.Autoscali
 
 	switch {
 	case policy.Spec.HomogeneousTarget != nil:
+		homogeneousPath := specPath.Child("homogeneousTarget")
 		allErrs = append(allErrs, validateTargetRef(
 			&policy.Spec.HomogeneousTarget.Target.TargetRef,
-			specPath.Child("homogeneousTarget").Child("target").Child("targetRef"))...)
+			homogeneousPath.Child("target").Child("targetRef"))...)
+		if policy.Spec.HomogeneousTarget.MinReplicas > policy.Spec.HomogeneousTarget.MaxReplicas {
+			allErrs = append(allErrs, field.Invalid(
+				homogeneousPath.Child("minReplicas"),
+				policy.Spec.HomogeneousTarget.MinReplicas,
+				"minReplicas must be <= maxReplicas"))
+		}
 	case policy.Spec.HeterogeneousTarget != nil:
 		for idx, param := range policy.Spec.HeterogeneousTarget.Params {
+			paramPath := specPath.Child("heterogeneousTarget").Child("params").Index(idx)
 			allErrs = append(allErrs, validateTargetRef(
 				&param.Target.TargetRef,
-				specPath.Child("heterogeneousTarget").Child("params").Index(idx).Child("target").Child("targetRef"))...)
+				paramPath.Child("target").Child("targetRef"))...)
+			if param.MinReplicas > param.MaxReplicas {
+				allErrs = append(allErrs, field.Invalid(
+					paramPath.Child("minReplicas"),
+					param.MinReplicas,
+					"minReplicas must be <= maxReplicas"))
+			}
 		}
 	case policy.Spec.DisaggregatedTarget != nil:
 		allErrs = append(allErrs, validateTargetRef(

--- a/pkg/autoscaler/webhook/autoscalingpolicy_validator_test.go
+++ b/pkg/autoscaler/webhook/autoscalingpolicy_validator_test.go
@@ -174,6 +174,89 @@ func TestValidateAutoscalingPolicy_NoErrors(t *testing.T) {
 	assert.Empty(t, errorMsg)
 }
 
+func TestValidateAutoscalingPolicy_HomogeneousTarget(t *testing.T) {
+	validator := NewAutoscalingPolicyValidator()
+
+	basePolicy := &registryv1.AutoscalingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "homogeneous-policy", Namespace: "default"},
+		Spec: registryv1.AutoscalingPolicySpec{
+			TolerancePercent: 10,
+			Metrics: []registryv1.AutoscalingPolicyMetric{
+				{Name: "cpu", TargetValue: resource.MustParse("80")},
+			},
+			HomogeneousTarget: &registryv1.HomogeneousTarget{
+				Target: registryv1.Target{
+					TargetRef: corev1.ObjectReference{Kind: registryv1.ModelServingKind.Kind, Name: "test-target"},
+				},
+				MinReplicas: 1,
+				MaxReplicas: 8,
+			},
+		},
+	}
+
+	minLessThanMax := basePolicy.DeepCopy()
+	allowed, msg := validator.validateAutoscalingPolicy(minLessThanMax)
+	assert.True(t, allowed, msg)
+
+	minEqualsMax := basePolicy.DeepCopy()
+	minEqualsMax.Spec.HomogeneousTarget.MinReplicas = 4
+	minEqualsMax.Spec.HomogeneousTarget.MaxReplicas = 4
+	allowed, msg = validator.validateAutoscalingPolicy(minEqualsMax)
+	assert.True(t, allowed, msg)
+
+	minGreaterThanMax := basePolicy.DeepCopy()
+	minGreaterThanMax.Spec.HomogeneousTarget.MinReplicas = 5
+	minGreaterThanMax.Spec.HomogeneousTarget.MaxReplicas = 2
+	allowed, msg = validator.validateAutoscalingPolicy(minGreaterThanMax)
+	assert.False(t, allowed)
+	assert.Contains(t, msg, "minReplicas must be <= maxReplicas")
+}
+
+func TestValidateAutoscalingPolicy_HeterogeneousTarget(t *testing.T) {
+	validator := NewAutoscalingPolicyValidator()
+
+	basePolicy := &registryv1.AutoscalingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "heterogeneous-policy", Namespace: "default"},
+		Spec: registryv1.AutoscalingPolicySpec{
+			TolerancePercent: 10,
+			Metrics: []registryv1.AutoscalingPolicyMetric{
+				{Name: "cpu", TargetValue: resource.MustParse("80")},
+			},
+			HeterogeneousTarget: &registryv1.HeterogeneousTarget{
+				Params: []registryv1.HeterogeneousTargetParam{
+					{
+						Target:      registryv1.Target{TargetRef: corev1.ObjectReference{Kind: registryv1.ModelServingKind.Kind, Name: "h100-target"}},
+						MinReplicas: 0,
+						MaxReplicas: 4,
+					},
+					{
+						Target:      registryv1.Target{TargetRef: corev1.ObjectReference{Kind: registryv1.ModelServingKind.Kind, Name: "a100-target"}},
+						MinReplicas: 1,
+						MaxReplicas: 8,
+					},
+				},
+			},
+		},
+	}
+
+	minLessThanMax := basePolicy.DeepCopy()
+	allowed, msg := validator.validateAutoscalingPolicy(minLessThanMax)
+	assert.True(t, allowed, msg)
+
+	minEqualsMax := basePolicy.DeepCopy()
+	minEqualsMax.Spec.HeterogeneousTarget.Params[1].MinReplicas = 8
+	minEqualsMax.Spec.HeterogeneousTarget.Params[1].MaxReplicas = 8
+	allowed, msg = validator.validateAutoscalingPolicy(minEqualsMax)
+	assert.True(t, allowed, msg)
+
+	minGreaterThanMax := basePolicy.DeepCopy()
+	minGreaterThanMax.Spec.HeterogeneousTarget.Params[1].MinReplicas = 5
+	minGreaterThanMax.Spec.HeterogeneousTarget.Params[1].MaxReplicas = 2
+	allowed, msg = validator.validateAutoscalingPolicy(minGreaterThanMax)
+	assert.False(t, allowed)
+	assert.Contains(t, msg, "minReplicas must be <= maxReplicas")
+}
+
 func TestValidateAutoscalingPolicy_DisaggregatedTarget(t *testing.T) {
 	validator := NewAutoscalingPolicyValidator()
 


### PR DESCRIPTION
## What this PR does / why we need it

The autoscaler currently validates `minReplicas <= maxReplicas` only for Disaggregated targets. Homogeneous and Heterogeneous targets can accept an invalid replica range where `minReplicas > maxReplicas`.

This change applies the same validation to Homogeneous and Heterogeneous targets, ensuring all supported target types reject invalid replica ranges consistently.

For Heterogeneous targets, the invalid range can propagate into the scaling logic and allow a backend's replica count to bypass its configured `maxReplicas` limit.

The change also adds regression tests covering `minReplicas < maxReplicas`, `minReplicas == maxReplicas`, and `minReplicas > maxReplicas` for the affected target types.

## Which issue(s) this PR fixes

Fixes #1668

## Bug evidence (required for bug-related PRs)

The production path is:

AutoscalingPolicy validation → `validateTarget()` → target-specific validation → autoscaling optimization → replica restoration.

For Homogeneous and Heterogeneous targets, `validateTarget()` previously did not enforce `minReplicas <= maxReplicas`. A configuration such as:

```yaml
minReplicas: 5
maxReplicas: 2
```

was therefore accepted.

For Heterogeneous targets, this invalid range can reach `RestoreReplicasOfEachBackend`, where a backend's replica count is initialized from `MinReplicas`. When the backend is not subsequently included in the scaling order, the configured `MaxReplicas` is not re-applied, allowing the resulting replica count to exceed the configured maximum.

The fix rejects the invalid configuration during validation, before it reaches the downstream scaling logic.

## Special notes for your reviewer

The existing Disaggregated validation is reused as the model for Homogeneous and Heterogeneous targets. No API or CRD changes are required.

Regression tests cover valid and invalid replica ranges for the target types.

## Does this PR introduce a user-facing change?

No. Existing valid configurations continue to work unchanged. Invalid configurations with `minReplicas > maxReplicas` are now rejected consistently across all target types.

```release-note
NONE
```
