### PR TITLE
fix(helm): read the Redis password from the key the Secret actually has

### DIFF
--- a/charts/kthena/README.md
+++ b/charts/kthena/README.md
@@ -248,7 +248,7 @@ metadata:
   namespace: kthena-system
 type: Opaque
 data:
-  password: "base64-encoded-password"
+  REDIS_PASSWORD: "base64-encoded-password"
 ```
 
 For detailed information about when Redis is required and deployment instructions, see [examples/redis/README.md](../../examples/redis/README.md).

--- a/charts/kthena/charts/networking/templates/kthena-router/component/deployment.yaml
+++ b/charts/kthena/charts/networking/templates/kthena-router/component/deployment.yaml
@@ -85,7 +85,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: redis-secret
-                  key: password
+                  key: REDIS_PASSWORD
                   optional: true
             # Scheduling strategy: user fairness and session boost are mutually exclusive
             {{- if .Values.kthenaRouter.fairness.enabled }}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The router Deployment sourced `REDIS_PASSWORD` from the `redis-secret` key `password`. Nothing in the repository creates that key. `examples/redis/redis-standalone.yaml` creates the Secret with the key `REDIS_PASSWORD`, and the ModelBooster wires the runtime containers to the same Secret with that key. Only the chart used `password`.

Because the reference is `optional: true`, the missing key was silent. The router started with an empty password, and against a password-protected Redis the startup ping failed with `NOAUTH`.

Two consumers are affected, and one of them is not gated on any plugin:

- `cmd/kthena-router/app/server.go` builds the Redis on-flight counter whenever `REDIS_HOST` is set, so cross-router in-flight tracking silently degrades to a local counter on any Redis-configured router.
- `scheduler/plugins/kvcache_aware.go` holds a nil client, so kvcache-aware scoring is loaded and does nothing.

Verified on kind with Kubernetes v1.32.0, installing this chart against a `--requirepass` Redis created from `examples/redis/redis-standalone.yaml`. Same cluster, same Secret, only the key differs:

```text
key: password
  environment variable REDIS_PASSWORD is not set, using default value:
  Redis connection failed: NOAUTH Authentication required.
  REDIS_HOST is set but Redis connection failed; falling back to local on-flight counter
  KVCacheAware: Redis client is nil — kvcache-aware scoring will not work

key: REDIS_PASSWORD
  Redis connection successfully
  Redis on-flight counter enabled: cross-router in-flight tracking active
  KVCacheAware: Redis client initialized successfully
```

Aligning the chart rather than the Go code keeps the change on one side, since the runnable example and `model_serving.go` already agree on `REDIS_PASSWORD`. `charts/kthena/README.md` documented `password` and is updated to match.

**Which issue(s) this PR fixes**:

Fixes #1682

**Special notes for your reviewer**:

`git grep "key: password"` now returns nothing, and every tracked file that names this Secret key uses `REDIS_PASSWORD`: the chart and its README, both copies of the Redis example and their READMEs, `utils/redis.go`, `python/kthena/runtime/redis_client.py` and the e2e testdata. Versioned docs under `docs/kthena/versioned_docs/` are frozen release snapshots and are deliberately untouched.

Existing clusters that created the Secret with a `password` key keep working only if they add `REDIS_PASSWORD`; that is the same key the runtime sidecars have always required, so a cluster where both halves worked already has it.

**Does this PR introduce a user-facing change?**

```release-note
Fixed the Helm router reading the Redis password from a `redis-secret` key that is never created, which silently disabled cross-router in-flight tracking and kvcache-aware scoring against a password-protected Redis.
```

---