### PR TITLE
fix(router): prevent retrying already-written responses in proxyToPDDisaggregated

### DIFF
--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -1447,6 +1447,9 @@ func (r *Router) proxyToPDDisaggregated(
 		if err != nil {
 			klog.Errorf("proxy failed for prefill pod %s, decode pod %s: %v",
 				prefillPod.Name, decodePod.Name, err)
+			if c.Writer.Written() {
+				return err
+			}
 			continue
 		}
 
@@ -1469,7 +1472,9 @@ func (r *Router) proxyToPDDisaggregated(
 		return nil
 	}
 
-	c.AbortWithStatusJSON(http.StatusInternalServerError, "all prefill/decode attempts failed")
+	if !c.Writer.Written() {
+		c.AbortWithStatusJSON(http.StatusInternalServerError, "all prefill/decode attempts failed")
+	}
 	return fmt.Errorf("all prefill/decode attempts failed")
 }
 

--- a/pkg/kthena-router/router/router_test.go
+++ b/pkg/kthena-router/router/router_test.go
@@ -54,6 +54,7 @@ import (
 	"github.com/volcano-sh/kthena/pkg/kthena-router/datastore"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/metrics"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/providers"
+	"github.com/volcano-sh/kthena/pkg/kthena-router/scheduler/framework"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/utils"
 )
 
@@ -3072,4 +3073,151 @@ func TestRouter_HandlerFunc_UnknownModel_RejectsBeforeQueueing(t *testing.T) {
 			}
 		})
 	}
+}
+
+type mockKVConnector struct {
+	calls        atomic.Int32
+	proxyHandler func(c *gin.Context, reqBody map[string]interface{}, prefillAddr, decodeAddr string, hooks *connectors.OnFlightHooks) (int, error)
+}
+
+func (m *mockKVConnector) Name() string {
+	return "mock"
+}
+
+func (m *mockKVConnector) Proxy(c *gin.Context, reqBody map[string]interface{}, prefillAddr, decodeAddr string, hooks *connectors.OnFlightHooks) (int, error) {
+	m.calls.Add(1)
+	if m.proxyHandler != nil {
+		return m.proxyHandler(c, reqBody, prefillAddr, decodeAddr, hooks)
+	}
+	return 0, nil
+}
+
+func TestRouter_ProxyToPDDisaggregated_DoesNotRetryWhenResponseWritten(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	store := datastore.New()
+	router := NewRouter(store, "../scheduler/testdata/configmap.yaml")
+
+	pod1 := &corev1.Pod{
+		ObjectMeta: v1.ObjectMeta{Name: "pod-1", Namespace: "default"},
+		Status:     corev1.PodStatus{PodIP: "10.0.0.1"},
+	}
+	pod2 := &corev1.Pod{
+		ObjectMeta: v1.ObjectMeta{Name: "pod-2", Namespace: "default"},
+		Status:     corev1.PodStatus{PodIP: "10.0.0.2"},
+	}
+	info1 := &datastore.PodInfo{Pod: pod1}
+	info2 := &datastore.PodInfo{Pod: pod2}
+
+	ctx := &framework.Context{
+		Model:       "test-model",
+		PrefillPods: []*datastore.PodInfo{info1, info2},
+		DecodePods:  []*datastore.PodInfo{info1, info2},
+	}
+
+	mockConnector := &mockKVConnector{
+		proxyHandler: func(c *gin.Context, reqBody map[string]interface{}, prefillAddr, decodeAddr string, hooks *connectors.OnFlightHooks) (int, error) {
+			// Simulate response headers / chunks being written before error occurs
+			c.Writer.WriteHeader(http.StatusOK)
+			_, _ = c.Writer.Write([]byte("data: partial response\n\n"))
+			return 5, fmt.Errorf("decode connection reset mid-stream")
+		},
+	}
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request, _ = http.NewRequest("POST", "/v1/chat/completions", bytes.NewBufferString(`{"model":"test-model"}`))
+
+	err := router.proxyToPDDisaggregated(c, c.Request, ctx, mockConnector, ModelRequest{"model": "test-model"}, 8000)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "decode connection reset mid-stream")
+	assert.Equal(t, int32(1), mockConnector.calls.Load(), "must not retry to second pod pair when response was already written to client")
+	assert.Equal(t, http.StatusOK, w.Code, "status code must remain 200 without attempting to overwrite with 500 JSON")
+}
+
+func TestRouter_ProxyToPDDisaggregated_RetriesWhenResponseNotWritten(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	store := datastore.New()
+	router := NewRouter(store, "../scheduler/testdata/configmap.yaml")
+
+	pod1 := &corev1.Pod{
+		ObjectMeta: v1.ObjectMeta{Name: "pod-1", Namespace: "default"},
+		Status:     corev1.PodStatus{PodIP: "10.0.0.1"},
+	}
+	pod2 := &corev1.Pod{
+		ObjectMeta: v1.ObjectMeta{Name: "pod-2", Namespace: "default"},
+		Status:     corev1.PodStatus{PodIP: "10.0.0.2"},
+	}
+	info1 := &datastore.PodInfo{Pod: pod1}
+	info2 := &datastore.PodInfo{Pod: pod2}
+
+	ctx := &framework.Context{
+		Model:       "test-model",
+		PrefillPods: []*datastore.PodInfo{info1, info2},
+		DecodePods:  []*datastore.PodInfo{info1, info2},
+	}
+
+	var mockConnector *mockKVConnector
+	mockConnector = &mockKVConnector{
+		proxyHandler: func(c *gin.Context, reqBody map[string]interface{}, prefillAddr, decodeAddr string, hooks *connectors.OnFlightHooks) (int, error) {
+			if mockConnector.calls.Load() == 1 {
+				// First attempt fails without writing any headers/body
+				return 0, fmt.Errorf("prefill connection refused")
+			}
+			// Second attempt succeeds
+			c.Writer.WriteHeader(http.StatusOK)
+			_, _ = c.Writer.Write([]byte(`{"choices":[{"message":{"content":"ok"}}]}`))
+			return 10, nil
+		},
+	}
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request, _ = http.NewRequest("POST", "/v1/chat/completions", bytes.NewBufferString(`{"model":"test-model"}`))
+
+	err := router.proxyToPDDisaggregated(c, c.Request, ctx, mockConnector, ModelRequest{"model": "test-model"}, 8000)
+
+	assert.NoError(t, err)
+	assert.Equal(t, int32(2), mockConnector.calls.Load(), "must retry to second pod pair when response was not written")
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestRouter_ProxyToPDDisaggregated_AllAttemptsFailWithoutWrite(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	store := datastore.New()
+	router := NewRouter(store, "../scheduler/testdata/configmap.yaml")
+
+	pod1 := &corev1.Pod{
+		ObjectMeta: v1.ObjectMeta{Name: "pod-1", Namespace: "default"},
+		Status:     corev1.PodStatus{PodIP: "10.0.0.1"},
+	}
+	pod2 := &corev1.Pod{
+		ObjectMeta: v1.ObjectMeta{Name: "pod-2", Namespace: "default"},
+		Status:     corev1.PodStatus{PodIP: "10.0.0.2"},
+	}
+	info1 := &datastore.PodInfo{Pod: pod1}
+	info2 := &datastore.PodInfo{Pod: pod2}
+
+	ctx := &framework.Context{
+		Model:       "test-model",
+		PrefillPods: []*datastore.PodInfo{info1, info2},
+		DecodePods:  []*datastore.PodInfo{info1, info2},
+	}
+
+	mockConnector := &mockKVConnector{
+		proxyHandler: func(c *gin.Context, reqBody map[string]interface{}, prefillAddr, decodeAddr string, hooks *connectors.OnFlightHooks) (int, error) {
+			return 0, fmt.Errorf("connection refused")
+		},
+	}
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request, _ = http.NewRequest("POST", "/v1/chat/completions", bytes.NewBufferString(`{"model":"test-model"}`))
+
+	err := router.proxyToPDDisaggregated(c, c.Request, ctx, mockConnector, ModelRequest{"model": "test-model"}, 8000)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "all prefill/decode attempts failed")
+	assert.Equal(t, int32(2), mockConnector.calls.Load())
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }

--- a/pkg/kthena-router/router/router_test.go
+++ b/pkg/kthena-router/router/router_test.go
@@ -3092,10 +3092,8 @@ func (m *mockKVConnector) Proxy(c *gin.Context, reqBody map[string]interface{}, 
 	return 0, nil
 }
 
-func TestRouter_ProxyToPDDisaggregated_DoesNotRetryWhenResponseWritten(t *testing.T) {
+func TestRouter_ProxyToPDDisaggregated_RetryBehavior(t *testing.T) {
 	gin.SetMode(gin.TestMode)
-	store := datastore.New()
-	router := NewRouter(store, "../scheduler/testdata/configmap.yaml")
 
 	pod1 := &corev1.Pod{
 		ObjectMeta: v1.ObjectMeta{Name: "pod-1", Namespace: "default"},
@@ -3108,116 +3106,92 @@ func TestRouter_ProxyToPDDisaggregated_DoesNotRetryWhenResponseWritten(t *testin
 	info1 := &datastore.PodInfo{Pod: pod1}
 	info2 := &datastore.PodInfo{Pod: pod2}
 
-	ctx := &framework.Context{
-		Model:       "test-model",
-		PrefillPods: []*datastore.PodInfo{info1, info2},
-		DecodePods:  []*datastore.PodInfo{info1, info2},
-	}
-
-	mockConnector := &mockKVConnector{
-		proxyHandler: func(c *gin.Context, reqBody map[string]interface{}, prefillAddr, decodeAddr string, hooks *connectors.OnFlightHooks) (int, error) {
-			// Simulate response headers / chunks being written before error occurs
-			c.Writer.WriteHeader(http.StatusOK)
-			_, _ = c.Writer.Write([]byte("data: partial response\n\n"))
-			return 5, fmt.Errorf("decode connection reset mid-stream")
+	tests := []struct {
+		name            string
+		proxyHandler    func(connector *mockKVConnector) func(c *gin.Context, reqBody map[string]interface{}, prefillAddr, decodeAddr string, hooks *connectors.OnFlightHooks) (int, error)
+		wantErr         bool
+		wantErrContains string
+		wantCalls       int32
+		wantStatus      int
+		callsMsg        string
+	}{
+		{
+			name: "does not retry when response written",
+			proxyHandler: func(*mockKVConnector) func(c *gin.Context, reqBody map[string]interface{}, prefillAddr, decodeAddr string, hooks *connectors.OnFlightHooks) (int, error) {
+				return func(c *gin.Context, reqBody map[string]interface{}, prefillAddr, decodeAddr string, hooks *connectors.OnFlightHooks) (int, error) {
+					// Simulate response headers / chunks being written before error occurs
+					c.Writer.WriteHeader(http.StatusOK)
+					_, _ = c.Writer.Write([]byte("data: partial response\n\n"))
+					return 5, fmt.Errorf("decode connection reset mid-stream")
+				}
+			},
+			wantErr:         true,
+			wantErrContains: "decode connection reset mid-stream",
+			wantCalls:       1,
+			wantStatus:      http.StatusOK,
+			callsMsg:        "must not retry to second pod pair when response was already written to client",
+		},
+		{
+			name: "retries when response not written",
+			proxyHandler: func(connector *mockKVConnector) func(c *gin.Context, reqBody map[string]interface{}, prefillAddr, decodeAddr string, hooks *connectors.OnFlightHooks) (int, error) {
+				return func(c *gin.Context, reqBody map[string]interface{}, prefillAddr, decodeAddr string, hooks *connectors.OnFlightHooks) (int, error) {
+					if connector.calls.Load() == 1 {
+						// First attempt fails without writing any headers/body
+						return 0, fmt.Errorf("prefill connection refused")
+					}
+					// Second attempt succeeds
+					c.Writer.WriteHeader(http.StatusOK)
+					_, _ = c.Writer.Write([]byte(`{"choices":[{"message":{"content":"ok"}}]}`))
+					return 10, nil
+				}
+			},
+			wantErr:    false,
+			wantCalls:  2,
+			wantStatus: http.StatusOK,
+			callsMsg:   "must retry to second pod pair when response was not written",
+		},
+		{
+			name: "all attempts fail without write",
+			proxyHandler: func(*mockKVConnector) func(c *gin.Context, reqBody map[string]interface{}, prefillAddr, decodeAddr string, hooks *connectors.OnFlightHooks) (int, error) {
+				return func(c *gin.Context, reqBody map[string]interface{}, prefillAddr, decodeAddr string, hooks *connectors.OnFlightHooks) (int, error) {
+					return 0, fmt.Errorf("connection refused")
+				}
+			},
+			wantErr:         true,
+			wantErrContains: "all prefill/decode attempts failed",
+			wantCalls:       2,
+			wantStatus:      http.StatusInternalServerError,
 		},
 	}
 
-	w := httptest.NewRecorder()
-	c, _ := gin.CreateTestContext(w)
-	c.Request, _ = http.NewRequest("POST", "/v1/chat/completions", bytes.NewBufferString(`{"model":"test-model"}`))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := datastore.New()
+			router := NewRouter(store, "../scheduler/testdata/configmap.yaml")
 
-	err := router.proxyToPDDisaggregated(c, c.Request, ctx, mockConnector, ModelRequest{"model": "test-model"}, 8000)
-
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "decode connection reset mid-stream")
-	assert.Equal(t, int32(1), mockConnector.calls.Load(), "must not retry to second pod pair when response was already written to client")
-	assert.Equal(t, http.StatusOK, w.Code, "status code must remain 200 without attempting to overwrite with 500 JSON")
-}
-
-func TestRouter_ProxyToPDDisaggregated_RetriesWhenResponseNotWritten(t *testing.T) {
-	gin.SetMode(gin.TestMode)
-	store := datastore.New()
-	router := NewRouter(store, "../scheduler/testdata/configmap.yaml")
-
-	pod1 := &corev1.Pod{
-		ObjectMeta: v1.ObjectMeta{Name: "pod-1", Namespace: "default"},
-		Status:     corev1.PodStatus{PodIP: "10.0.0.1"},
-	}
-	pod2 := &corev1.Pod{
-		ObjectMeta: v1.ObjectMeta{Name: "pod-2", Namespace: "default"},
-		Status:     corev1.PodStatus{PodIP: "10.0.0.2"},
-	}
-	info1 := &datastore.PodInfo{Pod: pod1}
-	info2 := &datastore.PodInfo{Pod: pod2}
-
-	ctx := &framework.Context{
-		Model:       "test-model",
-		PrefillPods: []*datastore.PodInfo{info1, info2},
-		DecodePods:  []*datastore.PodInfo{info1, info2},
-	}
-
-	var mockConnector *mockKVConnector
-	mockConnector = &mockKVConnector{
-		proxyHandler: func(c *gin.Context, reqBody map[string]interface{}, prefillAddr, decodeAddr string, hooks *connectors.OnFlightHooks) (int, error) {
-			if mockConnector.calls.Load() == 1 {
-				// First attempt fails without writing any headers/body
-				return 0, fmt.Errorf("prefill connection refused")
+			ctx := &framework.Context{
+				Model:       "test-model",
+				PrefillPods: []*datastore.PodInfo{info1, info2},
+				DecodePods:  []*datastore.PodInfo{info1, info2},
 			}
-			// Second attempt succeeds
-			c.Writer.WriteHeader(http.StatusOK)
-			_, _ = c.Writer.Write([]byte(`{"choices":[{"message":{"content":"ok"}}]}`))
-			return 10, nil
-		},
+
+			mockConnector := &mockKVConnector{}
+			mockConnector.proxyHandler = tt.proxyHandler(mockConnector)
+
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request, _ = http.NewRequest("POST", "/v1/chat/completions", bytes.NewBufferString(`{"model":"test-model"}`))
+
+			err := router.proxyToPDDisaggregated(c, c.Request, ctx, mockConnector, ModelRequest{"model": "test-model"}, 8000)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrContains)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantCalls, mockConnector.calls.Load(), tt.callsMsg)
+			assert.Equal(t, tt.wantStatus, w.Code)
+		})
 	}
-
-	w := httptest.NewRecorder()
-	c, _ := gin.CreateTestContext(w)
-	c.Request, _ = http.NewRequest("POST", "/v1/chat/completions", bytes.NewBufferString(`{"model":"test-model"}`))
-
-	err := router.proxyToPDDisaggregated(c, c.Request, ctx, mockConnector, ModelRequest{"model": "test-model"}, 8000)
-
-	assert.NoError(t, err)
-	assert.Equal(t, int32(2), mockConnector.calls.Load(), "must retry to second pod pair when response was not written")
-	assert.Equal(t, http.StatusOK, w.Code)
-}
-
-func TestRouter_ProxyToPDDisaggregated_AllAttemptsFailWithoutWrite(t *testing.T) {
-	gin.SetMode(gin.TestMode)
-	store := datastore.New()
-	router := NewRouter(store, "../scheduler/testdata/configmap.yaml")
-
-	pod1 := &corev1.Pod{
-		ObjectMeta: v1.ObjectMeta{Name: "pod-1", Namespace: "default"},
-		Status:     corev1.PodStatus{PodIP: "10.0.0.1"},
-	}
-	pod2 := &corev1.Pod{
-		ObjectMeta: v1.ObjectMeta{Name: "pod-2", Namespace: "default"},
-		Status:     corev1.PodStatus{PodIP: "10.0.0.2"},
-	}
-	info1 := &datastore.PodInfo{Pod: pod1}
-	info2 := &datastore.PodInfo{Pod: pod2}
-
-	ctx := &framework.Context{
-		Model:       "test-model",
-		PrefillPods: []*datastore.PodInfo{info1, info2},
-		DecodePods:  []*datastore.PodInfo{info1, info2},
-	}
-
-	mockConnector := &mockKVConnector{
-		proxyHandler: func(c *gin.Context, reqBody map[string]interface{}, prefillAddr, decodeAddr string, hooks *connectors.OnFlightHooks) (int, error) {
-			return 0, fmt.Errorf("connection refused")
-		},
-	}
-
-	w := httptest.NewRecorder()
-	c, _ := gin.CreateTestContext(w)
-	c.Request, _ = http.NewRequest("POST", "/v1/chat/completions", bytes.NewBufferString(`{"model":"test-model"}`))
-
-	err := router.proxyToPDDisaggregated(c, c.Request, ctx, mockConnector, ModelRequest{"model": "test-model"}, 8000)
-
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "all prefill/decode attempts failed")
-	assert.Equal(t, int32(2), mockConnector.calls.Load())
-	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

In Kthena Router's PD disaggregated proxy path (`proxyToPDDisaggregated` in `pkg/kthena-router/router/router.go`), when a connector proxy operation fails mid-stream after response headers (such as `HTTP/1.1 200 OK`) and initial chunks (e.g. SSE streaming data) have already been flushed to the downstream client, the retry loop previously executed `continue` without checking whether the response was already committed (`c.Writer.Written()`).

This caused the router to dispatch a second prefill/decode request to the next prefill/decode pod pair and attempt to write a duplicate set of HTTP headers and completion chunks to the same downstream client connection. This resulted in:
1. Gin `[GIN-debug] [WARNING] Headers were already written` warnings.
2. Stream corruption and interleaved duplicate completions for downstream clients.
3. Invalid 500 JSON errors written over active HTTP response streams if all retries failed.

This PR aligns `proxyToPDDisaggregated` with standard aggregated `proxy()` by:
1. Checking `if c.Writer.Written() { return err }` upon encountering a proxy error in `proxyToPDDisaggregated`.
2. Guarding the final `c.AbortWithStatusJSON` call with `if !c.Writer.Written()`.
3. Adding regression unit tests covering:
   - `TestRouter_ProxyToPDDisaggregated_DoesNotRetryWhenResponseWritten`: Verifies no retry is attempted and headers are preserved when an error occurs mid-stream after writing.
   - `TestRouter_ProxyToPDDisaggregated_RetriesWhenResponseNotWritten`: Verifies pod failover retry succeeds normally when a failure occurs before any response headers or body bytes are written.
   - `TestRouter_ProxyToPDDisaggregated_AllAttemptsFailWithoutWrite`: Verifies 500 JSON abort is emitted when all attempts fail cleanly without writing.

**Which issue(s) this PR fixes**:

Fixes #1684

**Bug evidence (required for bug-related PRs)**:

- Production execution path:
  1. Standard aggregated proxying in `proxy()` guards retries against already-written responses:
     https://github.com/volcano-sh/kthena/blob/3cc057284c34469fcb0ed22a12dac84b1d120719/pkg/kthena-router/router/router.go#L880-L885
  2. `proxyToPDDisaggregated()` in `router.go` omitted this check on error:
     https://github.com/volcano-sh/kthena/blob/3cc057284c34469fcb0ed22a12dac84b1d120719/pkg/kthena-router/router/router.go#L1447-L1451
  3. Verified with regression unit tests in `pkg/kthena-router/router/router_test.go`.

**Special notes for your reviewer**:

All unit tests in `pkg/kthena-router/...` pass cleanly.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
