### PR TITLE
router: reuse tokenizer HTTP client

### DIFF
--- a/pkg/kthena-router/scheduler/plugins/tokenization/remote_client.go
+++ b/pkg/kthena-router/scheduler/plugins/tokenization/remote_client.go
@@ -39,13 +39,20 @@ type httpClient struct {
 }
 
 func newHTTPClient(baseURL string) *httpClient {
+	return newHTTPClientWithRetryClient(baseURL, newRetryableHTTPClient())
+}
+
+func newRetryableHTTPClient() *retryablehttp.Client {
 	retryClient := retryablehttp.NewClient()
 	retryClient.RetryMax = defaultMaxRetries
 	retryClient.RetryWaitMin = 1 * time.Second
 	retryClient.RetryWaitMax = 1 * time.Second
 	retryClient.HTTPClient.Timeout = defaultTimeout
 	retryClient.Logger = nil
+	return retryClient
+}
 
+func newHTTPClientWithRetryClient(baseURL string, retryClient *retryablehttp.Client) *httpClient {
 	return &httpClient{
 		client:  retryClient,
 		baseURL: baseURL,

--- a/pkg/kthena-router/scheduler/plugins/tokenization/remote_client.go
+++ b/pkg/kthena-router/scheduler/plugins/tokenization/remote_client.go
@@ -38,10 +38,6 @@ type httpClient struct {
 	baseURL string
 }
 
-func newHTTPClient(baseURL string) *httpClient {
-	return newHTTPClientWithRetryClient(baseURL, newRetryableHTTPClient())
-}
-
 func newRetryableHTTPClient() *retryablehttp.Client {
 	retryClient := retryablehttp.NewClient()
 	retryClient.RetryMax = defaultMaxRetries
@@ -52,7 +48,7 @@ func newRetryableHTTPClient() *retryablehttp.Client {
 	return retryClient
 }
 
-func newHTTPClientWithRetryClient(baseURL string, retryClient *retryablehttp.Client) *httpClient {
+func newHTTPClient(baseURL string, retryClient *retryablehttp.Client) *httpClient {
 	return &httpClient{
 		client:  retryClient,
 		baseURL: baseURL,

--- a/pkg/kthena-router/scheduler/plugins/tokenization/tokenization_test.go
+++ b/pkg/kthena-router/scheduler/plugins/tokenization/tokenization_test.go
@@ -19,6 +19,8 @@ package tokenization
 import (
 	"encoding/json"
 	"fmt"
+	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -199,6 +201,45 @@ func TestTokenizerManagerRejectsOutOfRangePort(t *testing.T) {
 
 	if tokenizer := manager.GetTokenizer("test-model", []*datastore.PodInfo{pod}); tokenizer != nil {
 		t.Fatalf("expected no tokenizer for an out-of-range endpoint port, got %T", tokenizer)
+	}
+}
+
+func TestTokenizerManagerReusesHTTPConnections(t *testing.T) {
+	const requests = 20
+
+	var newConnections atomic.Int32
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"count":  3,
+			"tokens": []int{1, 2, 3},
+		})
+	}))
+	server.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+		if state == http.StateNew {
+			newConnections.Add(1)
+		}
+	}
+	server.Start()
+	defer server.Close()
+
+	address := server.Listener.Addr().(*net.TCPAddr)
+	manager := NewTokenizerManager(TokenizerManagerConfig{
+		EndpointPorts: map[string]int{EngineVLLM: address.Port},
+	})
+	defer manager.client.HTTPClient.CloseIdleConnections()
+	pod := testutil.PodInfoWithEngine("pod-vllm", "default", address.IP.String(), EngineVLLM)
+	prompt := &common.ChatMessage{Text: "hello"}
+
+	for range requests {
+		if _, err := manager.TokenizePrompt("test-model", prompt, []*datastore.PodInfo{pod}); err != nil {
+			t.Fatalf("TokenizePrompt failed: %v", err)
+		}
+	}
+
+	if got := newConnections.Load(); got != 1 {
+		t.Fatalf("new TCP connections after %d sequential requests = %d, want 1", requests, got)
 	}
 }
 

--- a/pkg/kthena-router/scheduler/plugins/tokenization/tokenizer.go
+++ b/pkg/kthena-router/scheduler/plugins/tokenization/tokenizer.go
@@ -16,17 +16,22 @@ limitations under the License.
 
 package tokenization
 
-import (
-	"context"
-)
+import "context"
 
 type remoteTokenizerImpl struct {
 	config  RemoteTokenizerConfig
 	client  *httpClient
 	adapter engineAdapter
+	// ownsClient distinguishes standalone tokenizers from the short-lived
+	// wrappers created by TokenizerManager around its shared client.
+	ownsClient bool
 }
 
 func NewRemoteTokenizer(config RemoteTokenizerConfig) (Tokenizer, error) {
+	return newRemoteTokenizer(config, nil, true)
+}
+
+func newRemoteTokenizer(config RemoteTokenizerConfig, client *httpClient, ownsClient bool) (Tokenizer, error) {
 	engine, err := normalizeEngine(config.Engine)
 	if err != nil {
 		return nil, err
@@ -40,11 +45,14 @@ func NewRemoteTokenizer(config RemoteTokenizerConfig) (Tokenizer, error) {
 		adapter = newVLLMAdapter(config.Model)
 	}
 
-	client := newHTTPClient(config.Endpoint)
+	if client == nil {
+		client = newHTTPClient(config.Endpoint)
+	}
 	return &remoteTokenizerImpl{
-		config:  config,
-		client:  client,
-		adapter: adapter,
+		config:     config,
+		client:     client,
+		adapter:    adapter,
+		ownsClient: ownsClient,
 	}, nil
 }
 
@@ -98,7 +106,7 @@ func (t *remoteTokenizerImpl) GetEndpoint() string {
 }
 
 func (t *remoteTokenizerImpl) Close() error {
-	if t.client != nil {
+	if t.ownsClient && t.client != nil {
 		t.client.Close()
 	}
 	return nil

--- a/pkg/kthena-router/scheduler/plugins/tokenization/tokenizer.go
+++ b/pkg/kthena-router/scheduler/plugins/tokenization/tokenizer.go
@@ -46,7 +46,7 @@ func newRemoteTokenizer(config RemoteTokenizerConfig, client *httpClient, ownsCl
 	}
 
 	if client == nil {
-		client = newHTTPClient(config.Endpoint)
+		client = newHTTPClient(config.Endpoint, newRetryableHTTPClient())
 	}
 	return &remoteTokenizerImpl{
 		config:     config,

--- a/pkg/kthena-router/scheduler/plugins/tokenization/tokenizer_manager.go
+++ b/pkg/kthena-router/scheduler/plugins/tokenization/tokenizer_manager.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-retryablehttp"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/common"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/datastore"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/metrics"
@@ -41,11 +42,15 @@ type TokenizerManagerConfig struct {
 
 type TokenizerManager struct {
 	config TokenizerManagerConfig
+	// client owns the connection pool shared by the short-lived tokenizer
+	// wrappers created for individual scheduling requests.
+	client *retryablehttp.Client
 }
 
 func NewTokenizerManager(config TokenizerManagerConfig) *TokenizerManager {
 	return &TokenizerManager{
 		config: config,
+		client: newRetryableHTTPClient(),
 	}
 }
 
@@ -97,7 +102,8 @@ func (m *TokenizerManager) createTokenizerFromPods(model string, pods []*datasto
 			ReturnTokenStrings: false,
 		}
 
-		tok, err := NewRemoteTokenizer(config)
+		client := newHTTPClientWithRetryClient(endpoint, m.client)
+		tok, err := newRemoteTokenizer(config, client, false)
 		if err != nil {
 			klog.Warningf("Failed to create %s tokenizer for model %s at %s: %v", engine, model, endpoint, err)
 			continue

--- a/pkg/kthena-router/scheduler/plugins/tokenization/tokenizer_manager.go
+++ b/pkg/kthena-router/scheduler/plugins/tokenization/tokenizer_manager.go
@@ -102,7 +102,7 @@ func (m *TokenizerManager) createTokenizerFromPods(model string, pods []*datasto
 			ReturnTokenStrings: false,
 		}
 
-		client := newHTTPClientWithRetryClient(endpoint, m.client)
+		client := newHTTPClient(endpoint, m.client)
 		tok, err := newRemoteTokenizer(config, client, false)
 		if err != nil {
 			klog.Warningf("Failed to create %s tokenizer for model %s at %s: %v", engine, model, endpoint, err)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Reuse one retryable HTTP client, and therefore one pooled transport, for all remote tokenizers created by a `TokenizerManager`. Standalone tokenizers continue to own and close their own client.

This avoids creating a new connection pool for every KV-cache-aware scheduling request, preserves HTTP keep-alive reuse, and prevents idle transports from retaining connections and file descriptors until their timeouts expire. A regression test exercises the manager through a real HTTP server and verifies that 20 sequential tokenization requests reuse one TCP connection.

**Which issue(s) this PR fixes**:
Fixes #1686

**Bug evidence (required for bug-related PRs)**:

The production path starts in the KV-cache-aware scheduler, which tokenizes each request while scoring backends:
https://github.com/volcano-sh/kthena/blob/f5b8fd7bc54b8de4a2b769266c8618182a06f37c/pkg/kthena-router/scheduler/plugins/kvcache_aware.go#L200-L224

`TokenizerManager.TokenizePrompt` obtains a tokenizer for every call, and `GetTokenizer` constructs a new remote tokenizer:
https://github.com/volcano-sh/kthena/blob/f5b8fd7bc54b8de4a2b769266c8618182a06f37c/pkg/kthena-router/scheduler/plugins/tokenization/tokenizer_manager.go#L53-L103

Before this change, every such construction created a fresh `retryablehttp.Client` and pooled HTTP transport:
https://github.com/volcano-sh/kthena/blob/f5b8fd7bc54b8de4a2b769266c8618182a06f37c/pkg/kthena-router/scheduler/plugins/tokenization/remote_client.go#L41-L50

Reproduction: run a local tokenizer HTTP endpoint that records `http.ConnState`, configure `TokenizerManager` to use it, and make 20 sequential `TokenizePrompt` calls. Before the fix, 20 new TCP connections remain open after the calls. With this change, the same production manager path opens one connection and reuses it for all 20 requests. The added regression test covers this behavior.

**Special notes for your reviewer**:

AI assistance was used to investigate the production call path, draft the implementation, and add the regression test. The author reviewed the changes and validation results.

Validation:
- `go test ./pkg/kthena-router/scheduler/plugins/tokenization -run 'TestTokenizerManagerReusesHTTPConnections|TestTokenizerManager|TestRemoteTokenizer' -count=20`
- `go test ./pkg/kthena-router/scheduler/plugins ./pkg/kthena-router/scheduler/plugins/tokenization`
- `go test ./pkg/kthena-router/...`
- `go vet ./pkg/kthena-router/scheduler/plugins/tokenization`
- The new regression test also passed 50 consecutive runs.
- `make lint` was attempted, but the Windows checkout reports repository-wide gofmt failures in untouched files because of line-ending handling. The changed files pass gofmt and `git diff --check`.
- `make test` was attempted, but `controller-gen` on this Windows environment reports `pkg/apis/networking` as containing no Go files. The router test suite above passes.
- Race testing is unavailable in this environment because its C compiler does not support 64-bit cgo mode.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
