### PR TITLE
proposal: coordinated proportional Role rolling updates

### DIFF
--- a/docs/proposal/coordinated-role-rolling-update.md
+++ b/docs/proposal/coordinated-role-rolling-update.md
@@ -1,7 +1,7 @@
 ---
 title: Coordinated Proportional Role Rolling Update
 authors:
-- haoeeeee
+- "@haoeeeee"
 reviewers:
 - TBD
 approvers:
@@ -15,76 +15,106 @@ creation-date: 2026-08-17
 
 ### Summary
 
-Kthena supports `RoleRollingUpdate`, but the current controller calculates `partition` and `maxUnavailable` independently for every Role in every ServingGroup. If several cooperating Roles change in one ModelServing revision, a fast Role can advance much further than a slow Role. The controller also has no Role dependency graph, so an upstream Role may be replaced and become ready before the new revision of its downstream dependency is ready.
+Kthena supports `RoleRollingUpdate` for replacing changed Role replicas inside a ServingGroup. The existing controller calculates each Role's rolling candidates independently. For a ServingGroup whose Roles cooperate in one request path, independent replacement can create a large difference between their target-version capacities.
 
-This proposal adds optional, per-ServingGroup coordination to `RoleRollingUpdate`. Users select the participating Roles, define a maximum percentage-point skew between their normalized ready progress, and optionally define a dependency DAG. The controller continues to use each Role's existing `partition` and `maxUnavailable` as local safety limits, then applies a second, cross-Role filter before deleting or creating a rollout candidate.
+This proposal adds optional coordination to `RoleRollingUpdate`. Users configure:
 
-Dependencies are a startup gate, not a permanent progress order. For `A -> B -> C`, the internal B and C stages may prestart together while A remains on the old revision. A starts only after both B and C have target-revision `RoleRunning` capacity. After a Role has a target-revision Ready replica, `maxSkew` coordinates later progress without maintaining `progress_A <= progress_B <= progress_C`. Every reconcile derives progress and in-flight reservations from Role state, Pod labels, and readiness.
+- the Roles participating in one coordination domain;
+- `maxSkew`, which limits the percentage-point difference in normalized rollout progress;
+- a Role dependency DAG, which describes the version call topology.
 
-### Applicability Prerequisite
+For every reconcile, the controller builds one snapshot for all participating Roles in a ServingGroup, calculates a temporary `coordinationPartition` for each Role, and combines it with the Role's configured partition:
 
-This proposal applies only when the user explicitly selects:
+```text
+effectivePartition = max(userPartition, coordinationPartition)
+```
+
+The existing Role rolling-update path then uses `effectivePartition` and `maxUnavailable` to perform deletion and recreation.
+
+For a dependency chain `A -> B -> C`, A is the rollout root. B and C can prestart within the `maxSkew` limit. A starts after B and C have eligible target-version `RoleRunning` capacity. At rollout completion, an old A keeps at least one old B, and an old B keeps at least one old C.
+
+### Motivation
+
+Consider one ServingGroup with:
+
+```text
+A: 100 replicas
+B:  50 replicas
+C:  10 replicas
+
+A depends on B
+B depends on C
+```
+
+The target revision changes all three Roles. The application routes new-version requests through the new-version dependency chain.
+
+Independent Role rolling updates can produce two problems:
+
+1. A large Role can accumulate much more target-version Ready capacity than another Role, so the dependency chain has unbalanced processing capacity.
+2. A target-version upstream Role can become reachable before its target-version dependency has Ready capacity.
+
+The coordinated rollout maintains proportional target-version capacity and establishes the new dependency chain before exposing its root.
+
+#### Goals
+
+- Coordinate selected Roles independently inside each ServingGroup.
+- Express rollout progress as target-version `RoleRunning` replicas divided by update-eligible replicas.
+- Bound proportional progress with a percentage `maxSkew`.
+- Support different replica counts and user partitions across Roles.
+- Allow internal dependency Roles to prestart together.
+- Start each rollout root after its complete dependency closure has target-version Ready capacity.
+- Preserve the old-version dependency chain until old callers have exited.
+- Reuse the existing Role partition, `maxUnavailable`, deletion, recreation, and readiness mechanisms.
+- Reconstruct rollout decisions from Kubernetes resources after controller restart.
+- Report the current coordination blocker through ModelServing status.
+
+### Proposal
+
+#### Applicability
+
+Coordination is enabled under `RoleRollingUpdate`:
 
 ```yaml
 spec:
   rolloutStrategy:
     type: RoleRollingUpdate
+    roleCoordination:
+      maxSkew: 10%
 ```
 
-Users still submit the target A/B/C configuration through `ModelServing.spec.template.roles`, because Roles are embedded in the ServingGroup template. The configuration location does not determine the execution unit; `rolloutStrategy.type` does:
+Users continue to submit Role templates through `ModelServing.spec.template.roles`. With `RoleRollingUpdate`, the controller compares Role template hashes and replaces changed Role replicas inside each existing ServingGroup. Coordination is calculated separately for every ServingGroup.
 
-- With `RoleRollingUpdate`, the controller enters each ServingGroup, compares per-Role `RoleTemplateHash` values, and replaces only changed Role replicas. This proposal coordinates those Role-level candidates.
-- With `ServingGroupRollingUpdate`, or with the default strategy when `rolloutStrategy` is omitted, the controller deletes and recreates an outdated ServingGroup as a whole. It does not calculate independent A/B/C progress and this proposal does not apply.
+#### API Design
 
-Updating A, B, and C in one ModelServing update therefore gives the controller one shared target Spec; they become three coordinated rollout objects only under explicit `RoleRollingUpdate`. This proposal neither changes strategy selection nor converts a ServingGroup rollout into a Role rollout automatically.
+```go
+type RolloutStrategy struct {
+    Type RolloutStrategyType `json:"type"`
 
-### Motivation
+    RollingUpdateConfiguration *RollingUpdateConfiguration
+        `json:"rollingUpdateConfiguration,omitempty"`
 
-Consider one ServingGroup containing three Roles:
+    RoleCoordination *RoleCoordination
+        `json:"roleCoordination,omitempty"`
+}
 
-```text
-A depends on B
-B depends on C
+type RoleCoordination struct {
+    // Empty selects every Role in spec.template.roles.
+    Roles []string `json:"roles,omitempty"`
+
+    // Maximum percentage-point difference in normalized rollout progress.
+    MaxSkew *intstr.IntOrString `json:"maxSkew"`
+
+    // Version call topology used for root startup and old-chain retention.
+    Dependencies []RoleRolloutDependency `json:"dependencies,omitempty"`
+}
+
+type RoleRolloutDependency struct {
+    Role      string   `json:"role"`
+    DependsOn []string `json:"dependsOn"`
+}
 ```
 
-The application guarantees version-aware routing: new A calls new B, and new B calls new C. That guarantee alone does not make an uncoordinated rollout safe. In the first reconcile, the current Role rolling update can independently select one replica from A, B, and C. If new A and B become Ready before new C, traffic can reach new A and then fail because the required new C endpoint is not Ready.
-
-Updating only C until completion is also undesirable. New C receives no new-version traffic before B advances, and a large excess of new C replicas may be idle. The required behavior is:
-
-1. keep normalized new-version Ready progress approximately proportional across selected Roles;
-2. keep an upstream entry Role on the old revision until its dependency closure has target-revision Ready capacity;
-3. retain existing per-Role availability and partition semantics;
-4. allow slow or failed dependencies to stop upstream progress safely.
-
-The current implementation cannot provide these properties because `rolesToDeleteForRoleRollingUpdate` loops over Role specs and calculates each Role's `maxScaleDown` independently. `RoleRunning` is already a useful readiness signal: a Role replica becomes Running only after its entry Pod and all worker Pods are Running and Ready. This proposal builds coordination on that existing signal instead of introducing a separate readiness definition.
-
-#### Goals
-
-- Coordinate Role rolling updates independently inside each ServingGroup.
-- Define progress as the percentage of update-eligible Role replicas that are both on the target Role template hash and `RoleRunning`.
-- Limit the progress difference among selected active Roles with a user-supplied percentage such as `10%`.
-- Allow users to define an acyclic Role dependency graph for rollout ordering.
-- Keep an upstream entry Role from starting until every Role in its dependency closure has at least one target-version `RoleRunning` replica, while allowing internal dependency stages to prestart together.
-- Preserve each Role's current `maxUnavailable` and `partition` behavior.
-- Reserve in-flight work so asynchronous deletion, creation, scheduling, and readiness cannot oversubscribe the skew budget.
-- Remain compatible with the current informer, workqueue, and repeated-reconcile architecture.
-- Reconstruct coordination state from current objects after controller restarts.
-- Define validation, failure behavior, and a complete test plan.
-
-#### Non-Goals
-
-- Implement business request routing or verify that new A actually calls only new B.
-- Change initial ModelServing creation ordering. Dependencies in this proposal apply only to coordinated Role rolling updates.
-- Coordinate rollout progress across different ServingGroups. Each ServingGroup has an independent coordinator.
-- Replace the existing Role `maxUnavailable` or `partition` fields.
-- Coordinate replica-only scaling, failure recovery, or Role addition/removal as proportional rolling-update work. When a replica increase and a Role template change are submitted together, creating target-version replicas is part of the rollout and is therefore coordinated.
-- Automatically roll back a revision when rollout progress stalls.
-- Turn Pod readiness on or off, mutate readiness gates, or change Service endpoint selection.
-- Guarantee runtime dependency health after an upstream replica has already completed rollout. Ordinary recovery policy handles later failures.
-
-### Proposal
-
-Coordination is opt-in and only valid with `rolloutStrategy.type: RoleRollingUpdate`.
+Example:
 
 ```yaml
 apiVersion: workload.serving.volcano.sh/v1alpha1
@@ -95,14 +125,8 @@ spec:
   rolloutStrategy:
     type: RoleRollingUpdate
     roleCoordination:
-      # Optional. Omission selects all Roles in spec.template.roles.
       roles: [a, b, c]
-
-      # Percentage points of normalized rollout progress. Percent only.
       maxSkew: 10%
-
-      # Rollout-only startup dependency graph. "a dependsOn b" means b
-      # must have one target-revision RoleRunning replica before a starts.
       dependencies:
       - role: a
         dependsOn: [b]
@@ -112,177 +136,134 @@ spec:
   template:
     roles:
     - name: a
-      replicas: 4
+      replicas: 100
       maxUnavailable: 1
       partition: 0
-      # templates omitted
     - name: b
-      replicas: 4
+      replicas: 50
       maxUnavailable: 1
       partition: 0
     - name: c
-      replicas: 4
+      replicas: 10
       maxUnavailable: 1
       partition: 0
 ```
 
-The `roles` list scopes one coordination domain:
+The `roles` list defines one coordination domain:
 
-- omitted or empty: all Roles in `spec.template.roles`;
-- specified: exactly those Roles participate in progress skew and dependency ordering;
-- an unchanged selected Role is treated as complete for the current revision and does not block changed Roles;
-- a non-selected Role retains the existing independent Role rollout behavior;
-- a dependency endpoint must be in the selected set.
+- an empty list selects all Roles in `spec.template.roles`;
+- a non-empty list selects the named Roles;
+- selected Roles share one `maxSkew` calculation;
+- each selected Role keeps its own `partition` and `maxUnavailable`.
 
-#### User Stories
+The webhook validates:
 
-##### Proportional PD rollout
+- `roleCoordination` is used with `RoleRollingUpdate`;
+- `maxSkew` is a percentage in the range `(0%, 100%]`;
+- at least two Roles participate;
+- all Role names exist;
+- Role names and dependency edges are unique;
+- dependency endpoints belong to the selected Role set;
+- the dependency graph contains no self-edge or cycle.
 
-A ServingGroup has 10 prefill and 20 decode Role replicas. Both templates change. With `maxSkew: 10%`, the controller prevents one Role from accumulating substantially more target-hash Ready capacity than the other while both still have rollout work.
+### Design Details
 
-##### Dependency-safe three-stage rollout
+#### Overall Flow
 
-A, B, and C each have four replicas, `maxUnavailable: 1`, `maxSkew: 10%`, and dependencies A -> B -> C. Each Role's first integer step is 25%. Startup proceeds as follows:
+For each non-deleting ServingGroup, one reconcile performs the following work:
 
-```text
-B and C each start one replacement; A remains old
-    -> B and C reach target hash and RoleRunning
-    -> A starts one replacement
-```
+1. Resolve the participating Roles and their target Role template hashes.
+2. Resolve each Role's `userPartition` and rollout ordinal range.
+3. Classify current Role replicas as target Ready, target in-flight, or old.
+4. Calculate normalized Ready progress and the `maxSkew` allowance.
+5. Apply rollout-root startup and old-version dependency constraints.
+6. Calculate `coordinationPartition` and `effectivePartition` for every participating Role.
+7. Pass the allowed ordinal range to the existing Role rolling-update logic.
+8. Apply the existing per-Role `maxUnavailable` budget.
+9. Delete admitted old Role replicas and recreate their target-version replacements through the existing paths.
+10. Reconcile again when deletion, creation, or readiness changes the observed state.
 
-After these first Ready replicas exist, all three Roles are unlocked. Later selection is based on `maxSkew` and deterministic candidate ordering; it does not have to repeat C/B/A order. New A cannot start before compatible new B and C capacity exists.
+Each reconcile uses the complete cross-Role snapshot before admitting new rollout work.
 
-##### Different Role replica counts
+#### Per-Role State
 
-A has 2 replicas, B has 4, and C has 10. With `maxSkew: 10%` and a zero Ready baseline, their per-Role integer start limits are `ceil(0.1*2)=1`, `ceil(0.1*4)=1`, and `ceil(0.1*10)=1`. A's first replica is an unavoidable local 50% step, but that does not inflate B or C to a global 50% bound.
-
-##### Different partitions
-
-A has four replicas with `partition: 2`; B and C have four replicas with no partition. A's rollout target contains only A-2 and A-3. Its denominator is therefore two, not four. Once those two replicas are updated and Ready, A's coordinated progress is 100%, while A-0 and A-1 intentionally remain old. B and C may still reach 100% of their own four-replica targets; A's partition does not implicitly partition B or C.
-
-##### Concurrent scale-up and template update
-
-If only a Role's replica count changes, the existing scaling path continues to handle that change without proportional coordination. If a participating Role's replica count and template change in the same update, however, every additional target-version replica introduces new-version capacity and is a rollout start. Its creation is admitted by the same dependency and `maxSkew` checks as a delete-first replacement. This prevents an upstream scale-up from creating target-version A replicas before compatible target-version B and C capacity is Ready.
-
-Scale-down retains the existing behavior. After the desired count changes, the coordinator recalculates the denominator and observed progress from the new desired count and gates subsequent rollout starts. It does not undo or delay a user-requested scale-down.
-
-### API Design
-
-```go
-type RolloutStrategy struct {
-    Type RolloutStrategyType `json:"type"`
-
-    // Used only by ServingGroupRollingUpdate.
-    RollingUpdateConfiguration *RollingUpdateConfiguration `json:"rollingUpdateConfiguration,omitempty"`
-
-    // Used only by RoleRollingUpdate.
-    RoleCoordination *RoleCoordination `json:"roleCoordination,omitempty"`
-}
-
-type RoleCoordination struct {
-    // Empty means all Roles.
-    Roles []string `json:"roles,omitempty"`
-
-    // Required. Percentage strings only, for example "10%".
-    MaxSkew *intstr.IntOrString `json:"maxSkew"`
-
-    Dependencies []RoleRolloutDependency `json:"dependencies,omitempty"`
-}
-
-type RoleRolloutDependency struct {
-    Role      string   `json:"role"`
-    DependsOn []string `json:"dependsOn"`
-}
-
-```
-
-Dependency ordering has one fixed meaning: an upstream entry Role waits for target-revision `RoleRunning` capacity across its dependency closure. Internal stages may prestart together while all of their upstream dependents remain unstarted. Once a Role has a target-revision Ready replica, dependency edges do not impose a continuing progress order. The API intentionally does not expose a scheduled-only readiness mode.
-
-#### Validation and defaulting
-
-The webhook must enforce:
-
-- When `roleCoordination` is present, `rolloutStrategy.type` must explicitly equal `RoleRollingUpdate`; the default `ServingGroupRollingUpdate` selected when the strategy is omitted is not valid.
-- `roleCoordination.maxSkew` is required and must be a percentage string in `(0%, 100%]`; integer values are rejected.
-- Role names in `roles`, `role`, and `dependsOn` exist in `spec.template.roles`.
-- Names are unique; self-dependencies and duplicate dependency edges are rejected.
-- The dependency graph is acyclic.
-- Every dependency endpoint belongs to the effective selected Role set.
-- At least two Roles are selected; a single Role provides no coordination benefit.
-- Existing Role-level `partition` and `maxUnavailable` syntax validation remains unchanged.
-
-Coordination does not introduce a `maxUnavailable` default. If it is omitted, the existing Role rolling logic supplies all outdated replicas as local candidates, and the coordinator may still reduce that set through skew and dependency constraints. Operators should configure `maxUnavailable` when they require an explicit per-Role availability bound.
-
-### Progress Model
-
-All calculations are performed independently for each ServingGroup and target ModelServing revision.
-
-For participating Role `r`:
+For a participating Role `r`:
 
 ```text
 D_r = desired Role replica count
-P_r = resolved partition count
-T_r = max(D_r - P_r, 0)              update-eligible target replicas
-R_r = eligible replicas with target RoleTemplateHash and RoleRunning
-I_r = eligible rollout work already reserved but not Ready
+P_r = resolved user partition
+T_r = max(D_r - P_r, 0)
 
-readyProgress_r    = R_r / T_r
-reservedProgress_r = min(R_r + I_r, T_r) / T_r
+R_r = target-hash replicas in RoleRunning
+I_r = admitted target-version work that is not RoleRunning
+O_r = old-hash replicas that still exist
 ```
+
+The rollout ordinal range is:
+
+```text
+[P_r, D_r)
+```
+
+Only replicas in this range contribute to `T_r`, `R_r`, `I_r`, and target-version dependency Ready capacity.
+
+Replicas below `P_r` remain protected by the user partition. Replicas at or above `D_r` belong to ordinary scale-down. Old-hash replicas that still exist contribute to `O_r` while they can remain part of the old-version request path.
 
 `I_r` includes:
 
-- Role replicas in `RoleDeleting` because of this rollout;
-- target-hash Role replicas that are not `RoleRunning`;
-- stable replacement slots missing between an admitted delete-first action and successful recreation.
+- an old Role replica whose rollout deletion is in progress;
+- a target-hash Role replica that has not reached `RoleRunning`;
+- a missing replacement ordinal between deletion completion and target-version recreation.
 
-An ordinal that is absent only because the desired replica count increased is not reserved before its target-version creation is admitted. After admission, the created target-hash replica is observable and consumes `I_r` until it becomes `RoleRunning`.
+The in-flight count reserves already admitted work across asynchronous deletion, creation, scheduling, and readiness.
 
-Counting in-flight work is essential. If the controller selected A, B, and C using only Ready progress, A and B could become Ready faster than C and exceed a decision made when all progress values were zero. Reservation prevents repeated reconciles from admitting more work than the coordination budget already committed.
+#### Rollout Progress
 
-Only ordinals greater than or equal to the resolved Role partition contribute to `T_r`, `R_r`, or `I_r`. Protected replicas remain available but are outside the rollout target.
-
-If a selected Role's template did not change, it is excluded from the active skew minimum, while its current target-hash Ready replicas may still satisfy a dependency. If `T_r` is zero for a changed dependency Role, it cannot provide target-revision Ready capacity and its dependents remain blocked.
-
-#### Percentage semantics
-
-`maxSkew: 10%` means a target difference of ten percentage points before conversion to integer replica limits:
+The coordinator calculates two normalized values:
 
 ```text
-progress_r <= minimum Ready progress + 0.10
+readyProgress_r =
+    R_r / T_r
+
+startedProgress_r =
+    min(R_r + I_r, T_r) / T_r
 ```
 
-It does not mean:
+Ready progress supplies the common baseline. Started progress consumes the allowance already granted to a Role.
 
-- ten replica instances;
-- ten percent of the larger Role's raw replica count;
-- a relative error such as `progress_a / progress_b`.
+A selected Role participates in the active baseline while its template changed and its update-eligible rollout still has work in progress. Completed and unchanged Roles leave the active minimum. Their eligible target-version Ready replicas can still satisfy a rollout-root dependency.
 
-The only permitted overshoot is the local integer quantization described below. The implementation should use integer cross-multiplication or fixed-point basis points rather than floating-point comparison.
+#### maxSkew
 
-#### Per-Role integer limits
-
-A Role with `T_r` eligible replicas advances in increments of `1/T_r`. The controller must not increase one global effective skew to the coarsest Role's step, because that would grant unrelated large Roles extra work.
-
-For every reconcile, define:
+`maxSkew` is expressed as percentage points of normalized progress. For each reconcile:
 
 ```text
-readyBaseline = min(readyProgress_r) across active participating Roles
-ratioLimit    = min(1, readyBaseline + configuredSkew)
-allowedStarted_r = min(T_r, ceil(ratioLimit * T_r))
+readyBaseline =
+    minimum readyProgress across active participating Roles
+
+ratioLimit =
+    min(1, readyBaseline + maxSkew)
+
+allowedStarted_r =
+    min(T_r, ceil(ratioLimit * T_r))
 ```
 
-Ready progress itself is not rounded: the controller compares `R_r / T_r` as an exact ratio using integer cross-multiplication. Rounding is applied only when the ratio limit is converted to an integer number of started replicas, and that conversion uses `ceil`. Rounding down could produce zero at startup for a small Role; for example, `floor(10% * 4) = 0` would prevent a four-replica Role from ever starting. The ceiling permits one replica for that Role without increasing any other Role's limit.
+The per-Role ceiling converts the percentage allowance to a replica count. Each Role keeps its own integer step.
 
-A candidate for Role `r` is skew-eligible only when:
+With A=100, B=50, C=10, and `maxSkew: 10%`:
 
-```text
-R_r + I_r + 1 <= allowedStarted_r
-```
+| State | Ready progress A/B/C | Allowed started total A/B/C |
+| --- | --- | --- |
+| Initial | 0% / 0% / 0% | 10 / 5 / 1 |
+| B=5 and C=1 Ready | 0% / 10% / 10% | 10 / 5 / 1 |
+| A=10 Ready | 10% / 10% / 10% | 20 / 10 / 2 |
+| A=20, B=10, C=2 Ready | 20% / 20% / 20% | 30 / 15 / 3 |
 
-For A/B/C with 8, 4, and 10 eligible replicas, a `10%` limit at a zero Ready baseline permits 1, 1, and 1 started replica respectively: 12.5%, 25%, and 10%. B's unavoidable 25% integer step does not raise A or C to a 25% global limit. Implementations use integer cross-multiplication rather than floating point.
+The table shows the percentage relationship across unequal replica counts. The startup dependency rule blocks A in the first row, so initial target-version work is admitted only for B and C. Each Role's §maxUnavailable§ can further reduce the number acted on in one reconcile.
 
-### Dependency Semantics
+The implementation compares ratios with integer cross-multiplication and converts the configured percentage to fixed-point integer units.
+
+#### Dependency Graph
 
 An edge:
 
@@ -291,294 +272,382 @@ An edge:
   dependsOn: [b]
 ```
 
-means that B is a rollout prerequisite of A.
+describes a version call from A to B.
 
-Before A's first replacement is admitted, every dependency B must have at least one eligible target-revision `RoleRunning` replica. A dependency that is merely created or scheduled does not unlock A.
+The graph provides two coordination rules:
 
-After A is unlocked, the edge no longer compares A and B progress. A may advance ahead of B when A's own candidate remains inside the shared `maxSkew` limit. No ordinal pairing such as A-3 to B-3 is required.
+1. rollout-root startup;
+2. old-version dependency retention.
 
-The dependency gate is checked when rollout work is admitted, before deleting the old upstream Role replica. It does not change Kubernetes Pod readiness. Consequently, the required downstream new-version capacity already exists before the upstream replacement can be created and become reachable.
+##### Rollout roots
 
-Among currently eligible candidates, the Role with the lowest started progress is preferred, followed by Role order in the ModelServing spec and descending Role ordinal. Dependency order affects eligibility only while a Role is locked; it does not remain a priority after startup unlock.
+A rollout root is a selected Role whose name does not appear in another selected Role's `dependsOn` list.
 
-### Reconcile Algorithm
-
-The existing `syncModelServing` order remains conceptually unchanged:
-
-```text
-sync ServingGroup count
-sync Role count and missing Pods
-manage rolling update
-sync Services
-update status
-```
-
-Coordination changes Role rollout admission in two places: target-version creation during a concurrent scale-up in `syncRoleReplicas`, and delete-first replacement selection in `manageRollingUpdate`.
-
-#### Phase 1: build a snapshot
-
-For each non-deleting ServingGroup:
-
-1. Resolve selected Roles and determine which Role templates changed in the current revision.
-2. Calculate the target Role template hash for every Role.
-3. Resolve per-Role partition and eligible ordinals.
-4. Classify eligible replicas as old Ready, old unavailable, deleting, target Creating, or target Running.
-5. Calculate `T`, `R`, `I`, Ready progress, started progress, the shared Ready baseline, and each Role's `allowedStarted` integer limit.
-6. Generate target-version scale-up candidates and local outdated candidates using the existing scaling and `maxUnavailable` rules.
-
-Replica-only scaling remains owned by the existing `syncRoleReplicas` path and is not coordinated. When a replica increase and template change occur together, missing ordinals that would be created with the target Role hash are rollout-start candidates and must be admitted before creation. Target-version replicas created by an admitted scale-up contribute to `R` when `RoleRunning` and to `I` otherwise. Missing replacement slots created by an admitted delete-first update remain reserved as in-flight work; unadmitted scale-up slots do not.
-
-#### Phase 2: filter and select candidates
-
-The coordinator repeatedly evaluates rollout-start candidates using a simulated reservation snapshot. A candidate may create an additional target-version replica during concurrent scale-up or delete an outdated replica for delete-first replacement:
+For:
 
 ```text
-selected = []
-
-while candidates remain:
-    eligible = candidates that satisfy all of:
-      1. the existing local scaling or rolling-update rule allows the action
-      2. Role partition allows the ordinal
-      3. Role maxUnavailable/local budget allows a delete-first candidate
-      4. projected R + I does not exceed this Role's allowedStarted limit
-      5. dependency Ready gate is satisfied
-
-    if eligible is empty:
-        break
-
-    choose the candidate with:
-      1. lowest projected/reserved Role progress
-      2. Role order in spec
-      3. highest replica ordinal
-
-    append candidate to the corresponding create or delete selection
-    increment the simulated in-flight reservation for its Role
+A -> B -> C
 ```
 
-The simulated increment prevents one reconcile from selecting an unlimited number of replicas before informer events report `RoleDeleting`.
+A is the rollout root. Its transitive dependency closure is `{B, C}`. B and C are internal Roles.
 
-After selection, the existing `scaleUpRoles` path creates admitted target-version scale-up replicas, while the existing `DeleteRole` path performs admitted delete-first replacements. Deletion-completion events remove the logical Role from the datastore and enqueue the ModelServing. The next reconcile recreates the missing Role with the target hash. A target-hash non-Running Role consumes both the local `maxUnavailable` budget, where applicable, and the cross-Role reservation until it becomes `RoleRunning`.
+Before the first target-version A replacement is admitted, B and C must each have at least one target-hash `RoleRunning` replica inside their own `[P, D)` range. B and C can prestart together under `maxSkew`.
 
-#### Phase 3: event-driven continuation
-
-The Pod handler already changes a Role to `RoleRunning` only after its entry Pod and all worker Pods are Running and Ready. The current `syncModelServing` function itself has no whole-ServingGroup Ready gate: whenever a ModelServing is enqueued, it runs the normal reconcile. The subtle issue is the current Ready-event path. `handleReadyPod` updates an individual Role to `RoleRunning`, but that path normally calls `enqueueModelServing` only after `checkServingGroupReady` reports that the whole ServingGroup is Ready. Delete completion, spec changes, retries, or other events may still enqueue earlier, so this is not a hard semantic barrier; it is a missing immediate enqueue for an intermediate Role Ready transition.
-
-Coordinated rollout therefore additionally enqueues the ModelServing whenever a participating Role replica transitions to `RoleRunning`, while retaining the existing ServingGroup status update. This lets the first Ready dependency unlock its dependent and lets later Ready progress release new skew capacity promptly.
-
-The controller still does not wait inside reconcile:
+For a graph containing only:
 
 ```text
-reconcile -> select/delete -> return
-Pod/Service delete events -> enqueue
-reconcile -> recreate -> return
-Pod Ready events -> RoleRunning -> enqueue
-reconcile -> select the next allowed work
+B -> C
 ```
 
-After restart, Pod revision/hash labels, Role status reconstruction, desired counts, and missing slots reproduce the same constraints.
+B is the rollout root and waits for target-version C Ready capacity.
 
-### Interaction with Existing Features
+The first-start state is reconstructed from `R_r + I_r`. A root with `R_r + I_r = 0` applies the startup check. Once target-version work for that root has started, subsequent progress is coordinated by `maxSkew`.
 
-#### maxUnavailable
+##### Old-version dependency retention
 
-`maxUnavailable` remains a local availability constraint for one Role. Coordination is an additional global filter:
+Every direct edge also protects the old-version request path.
+
+For `A -> B -> C`:
+
+- while an old A replica exists, B retains at least one old replica;
+- while an old B replica exists, C retains at least one old replica.
+
+With zero user partitions, the old-version completion order is:
 
 ```text
-final candidates = local maxUnavailable candidates
-                 intersect partition-eligible candidates
-                 intersect skew-allowed candidates
-                 intersect dependency-allowed candidates
+A completes
+    -> B can remove its final old replica
+        -> C can remove its final old replica
 ```
 
-Coordination may reduce the number selected by the existing logic but never increases it.
+The retention rule uses observed old replicas. A terminating old replica contributes to `O_r` until its Pods have disappeared.
 
-#### partition
+If a Role's `userPartition` already preserves one or more old replicas, that boundary satisfies the retention requirement. A partition-protected old caller also keeps its direct old dependency for the same lifetime.
 
-Partition is resolved separately for every Role and affects only that Role's denominator. A partition on A never stops B or C from completing their own rollout. Protected old replicas remain old after coordinated rollout completes.
+#### Effective Partition
 
-#### ordinary scaling
+The coordinator maintains three partition values:
 
-A replica-only update continues through the existing scaling path without dependency or skew admission. When the desired count and template of a participating Role change together, target-version scale-up creation is admitted as rollout work because it can expose the new Role version to traffic. Scale-down remains an ordinary scaling action; once it changes `D_r`, subsequent coordination uses the new `T_r`, Ready progress, and reserved progress. If scale-down creates an observed skew greater than the configured limit, the coordinator does not undo the scale-down and admits no additional work for the leading Role until the other Roles catch up.
+- `userPartition`: the Role partition supplied by the user;
+- `coordinationPartition`: the temporary boundary calculated for the current snapshot;
+- `effectivePartition`: the boundary passed to the Role rolling-update executor.
 
-#### recovery policy
+The initial coordination boundary comes from `maxSkew`:
 
-Intentional deletion continues to be identified by `RoleDeleting`, so it must not be treated as a failure-recovery event. A later failure after rollout admission follows the configured RecoveryPolicy. The coordinator does not retract already Ready upstream replicas.
+```text
+coordinationPartition_r =
+    D_r - allowedStarted_r
+```
 
-#### new template changes during rollout
+The dependency rules then adjust the same boundary:
 
-The latest ModelServing spec remains authoritative. A new target hash starts a new reconciliation target. Previously created replicas that no longer match become outdated again.
+```text
+if r is a rollout root,
+   R_r + I_r = 0,
+   and a Role in r's dependency closure has R = 0:
+    coordinationPartition_r = D_r
 
-### Failure and Blocking Behavior
+if D_r > 0 and a direct dependent d has O_d > 0:
+    coordinationPartition_r =
+        max(coordinationPartition_r, 1)
+```
 
-#### Slow or failed dependency
+The final boundary is:
 
-If new C remains Creating:
+```text
+effectivePartition_r =
+    max(userPartition_r, coordinationPartition_r)
+```
 
-- C consumes its local and reserved budget;
-- B may consume its initial skew budget while all upstream Roles remain unstarted;
-- A cannot start until both B and C have target-revision `RoleRunning` replicas;
-- B and C cannot consume more than their per-Role integer limits derived from `maxSkew`;
-- old A replicas remain serving.
+The existing rolling-update path selects outdated Role replicas in:
 
-The rollout is intentionally stalled rather than exposing an incompatible upstream chain.
+```text
+[effectivePartition_r, D_r)
+```
 
-#### Unschedulable replicas
+and applies the Role's `maxUnavailable` budget to that range. Existing descending ordinal ordering remains in use.
 
-Unschedulable target replicas remain in-flight and do not release budget. Existing Kubernetes Pod events explain scheduling failure, and the rollout remains waiting for Role readiness.
+The rollout denominator continues to use:
 
-#### Dependency cycle or missing Role
+```text
+T_r = D_r - userPartition_r
+```
 
-These are admission errors and never reach the controller.
+This keeps normalized progress stable while `coordinationPartition` changes between reconciles.
 
-#### No eligible dependency replica
+#### Example: A, B, and C
 
-If a changed dependency is fully protected by partition, it cannot provide target-revision Ready capacity and dependent rollout remains blocked. The controller does not bypass the dependency.
+Assume each Role has ten replicas, `maxUnavailable: 1`, `partition: 0`, and `maxSkew: 10%`.
 
-#### Inconsistent or legacy hash data
+Startup:
 
-The existing ControllerRevision fallback is used to infer missing Role template hashes. If a hash cannot be resolved, the controller conservatively does not count the replica as target Ready and logs the unresolved comparison.
+| Role | maxSkew boundary | Dependency adjustment | effectivePartition |
+| --- | ---: | ---: | ---: |
+| A | 9 | A is a blocked root: 10 | 10 |
+| B | 9 | old A retention: at least 1 | 9 |
+| C | 9 | old B retention: at least 1 | 9 |
+
+B and C each replace one replica. When both replacements become `RoleRunning`, A's startup adjustment is released and A can replace one replica.
+
+Middle:
+
+- the Ready baseline advances as target replicas become `RoleRunning`;
+- `allowedStarted` grows independently for A, B, and C from the same percentage limit;
+- dependency edges impose no continuous A/B/C progress ordering.
+
+Completion:
+
+```text
+effective partitions near the tail
+
+A = 0
+B = 1
+C = 1
+
+old A disappears  -> B may use 0
+old B disappears  -> C may use 0
+```
+
+#### Interaction with Existing Role Rolling Update
+
+The current `rolesToDeleteForRoleRollingUpdate` path calculates outdated replicas and each Role's local `maxUnavailable` allowance. Coordination adds one cross-Role calculation before the final delete list is returned:
+
+```text
+current Role objects
+    -> build all participating Role states
+    -> calculate coordinationPartition
+    -> calculate effectivePartition
+    -> filter outdated ordinals to [effectivePartition, D)
+    -> apply existing maxUnavailable
+    -> DeleteRole
+    -> existing scaleUpRoles recreates the target replica
+```
+
+Replica-only scaling continues through the existing scaling logic.
+
+When a replica increase and template change are submitted together, creation of additional target-version ordinals is admitted through the same `effectivePartition`. A rollout-root scale-up therefore waits for its dependency closure, and every participating Role consumes its `maxSkew` allowance.
+
+Scale-down continues through the existing scaling logic. The new desired count immediately defines `D_r`, so scale-down excess at or above `D_r` leaves progress and dependency Ready calculations.
+
+`maxUnavailable` remains a per-Role availability budget. The coordinator determines the rollout range, and `maxUnavailable` determines how many replicas inside that range can be deleted.
+
+#### Reconcile Continuation
+
+The controller completes one bounded amount of work and returns from reconcile. Later resource state changes enqueue the ModelServing again.
+
+A participating Role replica becomes `RoleRunning` after its entry Pod and all worker Pods are Running and Ready. That transition enqueues the ModelServing so the next reconcile can:
+
+- unlock a rollout root;
+- advance the Ready baseline;
+- admit the next proportional work;
+- release an old-version retention boundary.
+
+#### Controller Restart
+
+The controller rebuilds coordination state from:
+
+- the current ModelServing spec;
+- current and target ControllerRevisions;
+- Role and Pod revision/hash labels;
+- Pod Ready conditions;
+- Pod deletion timestamps;
+- current and missing Role ordinals.
+
+The startup path lists existing Pods, rebuilds the datastore, and enqueues existing ModelServings. The first reconcile recalculates `coordinationPartition` and `effectivePartition`.
+
+Restart-state classification:
+
+| Observed state | Reconstructed state |
+| --- | --- |
+| target-hash Role is `RoleRunning` | Ready progress |
+| target-hash Role exists and is not `RoleRunning` | in-flight work |
+| old-hash Pods are terminating | in-flight replacement and old-version presence |
+| an ordinal in current `[P, D)` is missing after delete-first admission | in-flight replacement awaiting recreation |
+| a missing ordinal belongs to a requested scale-up | scale-up work awaiting admission |
+| an ordinal is at or above current `D` | scale-down excess |
+
+Terminating old Pods are read from the Pod informer cache so old-version dependency retention survives datastore reconstruction.
 
 ### Status and Observability
 
-This change does not add a new public status or metric API. Operators can inspect existing Pod Ready conditions, Role template-hash labels, Role lifecycle events, and controller logs. `status.updatedReplicas` remains ServingGroup-level and is not Role rollout progress.
+The proposal adds a ModelServing condition through the existing `status.conditions` field:
 
-### Controller Integration
+```go
+const ModelServingCoordinatedRoleRolloutBlocked ModelServingConditionType =
+    "CoordinatedRoleRolloutBlocked"
+```
 
-The implementation introduces a compact per-Role snapshot and a pure selection function so algorithm tests do not require Kubernetes clients:
+The condition is `True` when a participating Role still has rollout work and is waiting on a coordination constraint or admitted target-version readiness.
+
+Supported reasons:
+
+- `DependencyNotReady`;
+- `MaxSkewLimitReached`;
+- `OldVersionDependencyPresent`;
+- `TargetReplicaNotReady`.
+
+Example:
+
+```yaml
+status:
+  conditions:
+  - type: CoordinatedRoleRolloutBlocked
+    status: "True"
+    reason: DependencyNotReady
+    message: "ServingGroup example-0: root role a is waiting for target-version RoleRunning capacity from roles b and c"
+    observedGeneration: 12
+```
+
+Current blockers are ordered by ServingGroup ordinal, Role declaration order, and fixed reason priority. The first blocker supplies the condition reason, and the message summarizes the affected Roles.
+
+The controller sets the condition to `False` with `ProgressAvailable` or `RolloutComplete` when the corresponding state is observed. Kubernetes Events record blocker changes and rollout resumption.
+
+### Failure and Blocking Behavior
+
+#### Slow or failed target replica
+
+A target replica in Creating, pending scheduling, or waiting for Pod Ready remains in `I_r`. Its reserved allowance stays occupied. The blocker condition reports `TargetReplicaNotReady`.
+
+#### Dependency readiness
+
+A rollout root remains at `coordinationPartition = D` while a Role in its dependency closure has no eligible target-version `RoleRunning` replica. The blocker condition reports `DependencyNotReady` and identifies the dependency Roles.
+
+#### maxSkew limit
+
+A Role whose `R_r + I_r` reaches `allowedStarted_r` waits for the shared Ready baseline to advance. The blocker condition reports `MaxSkewLimitReached`.
+
+#### Old-version retention
+
+A dependency at its final old replica keeps an effective partition of at least one while an old direct caller exists. The blocker condition reports `OldVersionDependencyPresent`.
+
+#### Partition-limited dependency
+
+A dependency with no eligible target-version ordinal remains unable to satisfy a rollout-root Ready requirement. Its user partition remains authoritative and the root remains blocked.
+
+#### Single-replica dependency
+
+With delete-first replacement, a one-replica dependency can require the same replica for the old chain and for creation of new-version capacity. The rollout remains blocked at that boundary and reports the current dependency reason.
+
+### Implementation
+
+The implementation adds a per-ServingGroup coordinator with a pure calculation interface:
 
 ```go
 type coordinatedRoleState struct {
-    roleName  string
-    specIndex int
-    target    int
-    ready     int
-    inFlight int
-    active    bool
-    candidates []roleToDelete
+    roleName string
+
+    desired       int
+    userPartition int
+    target        int
+    ready         int
+    inFlight      int
+    oldReplicas   int
+    active        bool
 }
 
-func selectCoordinatedRoleCandidates(
+type coordinatedRoleDecision struct {
+    effectivePartitions map[string]int
+    blockers             []coordinatedRoleBlocker
+}
+
+func coordinatedRolePartitions(
     states []coordinatedRoleState,
     coordination *RoleCoordination,
-) ([]roleToDelete, error)
+) (coordinatedRoleDecision, error)
 ```
 
-Expected code touch points:
+Main code changes:
 
-- API types and generated clients/deepcopy/CRDs.
-- ModelServing webhook validation/defaulting.
-- `syncRoleReplicas` and `scaleUpRoles`: admit target-version creation when a replica increase and template change occur together.
-- `rolesToDeleteForRoleRollingUpdate`: build all Role candidates first instead of immediately concatenating independent selections.
-- `buildCoordinatedRoleState`: classify target Ready and admitted in-flight replicas without reserving unadmitted scale-up slots.
-- `handleReadyPod`: enqueue on participating Role transition to Running.
+- API types, generated clients, deepcopy code, and CRDs for `roleCoordination`;
+- webhook validation for Role selection, `maxSkew`, and dependency DAGs;
+- Role-state construction from datastore Roles, Pods, hashes, readiness, and ordinals;
+- `rolesToDeleteForRoleRollingUpdate` integration for `effectivePartition`;
+- `scaleUpRoles` integration for concurrent template update and scale-up;
+- immediate ModelServing enqueue on participating Role `RoleRunning` transitions;
+- ModelServing condition and Event updates for coordination blockers.
 
-The existing `DeleteRole`, role recreation, ControllerRevision, Pod hash labels, and workqueue retry paths remain in use.
+Existing `DeleteRole`, `CreatePodsByRole`, ControllerRevision, Role template hash, and per-Role `maxUnavailable` execution remain the rollout mechanisms.
 
 ### Risks and Mitigations
 
-#### Rollout throughput reduction
+#### Integer progress granularity
 
-Ready-based startup gating delays an upstream entry Role until its dependency closure is Ready and can be slower than independent rollout. Internal dependency stages may prestart together. After all Roles are unlocked, `maxSkew` and each Role's `maxUnavailable` determine throughput.
+Small Roles have coarse progress steps. Per-Role ceiling conversion permits one local step while retaining the configured percentage baseline for every other Role.
 
-#### Deadlock from discrete replica counts
+#### Repeated reconciliation
 
-Strict percentage inequalities can be impossible for small Roles. Per-Role ceiling conversion provides one-replica liveness without inflating every Role's budget. Coordinator tests cover mixed replica counts.
+In-flight reservations include deleting, missing, Creating, and waiting-for-Ready work. Repeated reconciles calculate the same or a stricter admission boundary from the observed snapshot.
 
-#### Stale informer observations
+#### Informer convergence
 
-Candidate admission uses conservative in-flight reservations and simulated increments. Operations are idempotent, and RoleDeleting/target-Creating/missing replacement slots remain reserved across reconciles.
+Terminating Pods and missing ordinals are classified conservatively. Reconciliation resumes as informer state converges.
 
-#### Misconfigured dependency direction
+#### Long-running blockers
 
-API documentation states that `A dependsOn B` makes B a startup prerequisite of A. Webhook DAG validation and examples reduce ambiguity.
-
-#### Feature interaction complexity
-
-The coordinator only admits actions that already passed existing Role scaling or rolling-update rules. Existing paths continue to own creation, deletion, readiness, and recovery.
+The ModelServing condition records the blocking ServingGroup, Role, reason, and relevant progress data. Events record transitions between blocker states.
 
 ### Test Plan
 
 #### Unit tests
 
-- Percent parsing and rejection of absolute `maxSkew`.
-- Role selection defaulting and explicit subset behavior.
-- Dependency existence, duplicate, self-edge, and cycle validation.
-- Progress calculation with target hash, `RoleRunning`, Creating, Deleting, and missing replacement slots.
-- Per-Role partition denominator and different partitions across Roles.
-- Unchanged selected Roles and fully partitioned changed dependencies.
-- Per-Role integer limits for equal and unequal replica counts.
-- Ceiling conversion from percentage limits to integer replica counts, including small Roles whose floor would be zero.
-- Quantization of a small Role does not inflate other Roles' limits.
-- Ready-based startup dependency gating at equal and unequal replica counts.
-- Coordination preserves the existing behavior when `maxUnavailable` is omitted.
-- Candidate simulation prevents over-selection in one reconcile.
-- Deterministic selection order and descending ordinal behavior.
-- Existing `maxUnavailable` always remains an upper bound.
-- Controller restart snapshot produces the same decision.
-- Replica-only scale-up bypasses coordination.
-- Concurrent template update and scale-up cannot create a target-version dependent before its dependency is Ready or exceed the Role's skew allowance.
-- Scale-down changes the denominator and subsequent decisions use the new desired count.
+- Role selection and `maxSkew` validation.
+- Dependency existence, duplicate edge, self-edge, and cycle validation.
+- Rollout-root inference for chains, branches, multiple roots, and isolated Roles.
+- Exact ordinal range `[P, D)`.
+- Scale-down excess excluded from progress and dependency Ready capacity.
+- Ready and in-flight progress from Running, Creating, Deleting, terminating, and missing states.
+- Equal and unequal Role replica counts.
+- Per-Role ceiling conversion and small-Role quantization.
+- `A -> B -> C` internal prestart and root startup behavior.
+- `B -> C` root startup behavior.
+- Direct-edge old-version retention.
+- User partition combined with coordination partition.
+- Descending ordinal selection and `maxUnavailable`.
+- Deterministic blocker aggregation and condition transitions.
+- Restart reconstruction during deletion, missing replacement, creation, and readiness.
 
 #### Property and fuzz tests
 
-For random DAGs, replica counts, partitions, Ready states, and local budgets:
+For generated replica counts, partitions, Role states, and acyclic graphs:
 
-- selected candidates never violate local availability or partition;
-- projected reservations never exceed that Role's quantized integer limit;
-- dependency gating never admits a dependent before every dependency has a target-revision Ready replica;
-- selection is deterministic for the same snapshot;
-- repeated Ready transitions eventually complete when all creations succeed;
-- invalid graphs are always rejected.
+- `effectivePartition >= userPartition`;
+- projected started work stays within each Role's quantized allowance;
+- a rollout root starts after every Role in its closure has eligible Ready capacity;
+- target Ready replicas outside `[P, D)` never unlock a root;
+- an observed old caller retains its direct old dependency;
+- identical snapshots produce identical decisions;
+- generated invalid graphs fail validation.
 
 #### Integration tests
 
-- Spec update event enqueues a ModelServing and selects only dependency-allowed work.
-- Delete events preserve reservation through deletion/recreation gaps.
-- each participating RoleRunning transition enqueues reconciliation.
-- rate-limited retries do not duplicate deletions.
-- controller restart during Deleting and Creating reconstructs reservations.
-- a second template update during rollout switches target hashes safely.
-- concurrent scale-up creation follows the same dependency and skew admission as delete-first replacement.
+- A ModelServing spec update enters coordinated Role rolling update.
+- Deletion and recreation gaps preserve in-flight reservation.
+- Participating Role `RoleRunning` transitions trigger the next decision.
+- Controller restart reconstructs deleting and Creating work.
+- Terminating old Pods retain the old-version dependency boundary.
+- Status updates preserve existing conditions and update `CoordinatedRoleRolloutBlocked`.
+- Concurrent template update and scale-up uses the same effective partition.
 
 #### End-to-end tests
 
-- A/B/C equal replicas, delayed C readiness: B and C may prestart, while A waits until both dependencies have a target-revision Ready replica.
-- Different replica counts with configured skew below one Role's single-replica step.
-- Mixed partitions: A partially remains old while B/C complete.
-- One Role unschedulable: upstream stops and old capacity remains.
-- Explicit Role subset: selected Roles coordinate; unselected Role preserves legacy behavior.
-- Concurrent scale-up and template update: additional target-version replicas cannot bypass dependency or `maxSkew` admission.
+- Equal-replica A/B/C rollout with delayed C readiness.
+- A/B/C rollout completion in old-version order A, B, C.
+- Unequal A/B/C replica counts with `maxSkew: 10%`.
+- Different user partitions across Roles.
+- Unschedulable dependency with a visible blocker condition.
+- Explicit Role subset coordination.
+- Controller restart during delete, create, and readiness stages.
 
 ### Rollout Plan
 
-1. Add the opt-in alpha API and webhook validation.
-2. Add per-ServingGroup state construction and pure candidate selection.
-3. Integrate rollout-start admission into concurrent target-version scale-up and `RoleRollingUpdate`, and enqueue intermediate participating RoleRunning transitions.
-4. Add unit, controller, and end-to-end coverage with injected readiness delays.
+The feature is enabled by configuring `roleCoordination` under `RoleRollingUpdate`. ModelServings without `roleCoordination` continue through the existing independent Role rolling-update path.
 
-When `roleCoordination` is absent, the existing independent Role rolling update behavior remains unchanged.
+Implementation proceeds in four stages:
 
-### Alternatives
-
-#### Rely only on business-layer version routing
-
-Rejected as the controller can still make a new upstream Role reachable before any compatible downstream replica is Ready. Routing cannot select a nonexistent endpoint.
-
-#### Use only dependency order
-
-The invariant `progress_A <= progress_B <= progress_C` prevents upstream from leading, but by itself allows C to reach 100% while A remains at 0%. `maxSkew` is still needed to bound idle downstream progress.
-
-#### Use only maxSkew with simultaneous candidate admission
-
-Rejected because all Roles can be at zero when A, B, and C are admitted simultaneously. Different readiness latency can then expose A before C. The dependency Ready gate must constrain admission.
-
-#### Define skew as a raw replica-count difference
-
-Rejected because Roles commonly have different desired counts. A one-replica difference means 50% for a two-replica Role but 1% for a hundred-replica Role.
-
-#### Mutate Pod readiness until dependencies are Ready
-
-Rejected for the initial design. It couples rollout control to kubelet readiness and Service endpoint semantics, can hide otherwise healthy Pods, and still needs a policy for already Ready Pods when a dependency later fails. Candidate admission prevents the unsafe state earlier.
+1. add the API, generated artifacts, and webhook validation;
+2. add per-ServingGroup state construction and the pure coordination calculation;
+3. integrate effective partitions, Ready-triggered continuation, and status reporting;
+4. add unit, integration, and end-to-end coverage.
 
 ### References
 

--- a/docs/proposal/coordinated-role-rolling-update.md
+++ b/docs/proposal/coordinated-role-rolling-update.md
@@ -23,15 +23,15 @@ This proposal adds optional coordination to `RoleRollingUpdate`. Users configure
 - `maxSkew`, which limits the percentage-point difference in normalized rollout progress;
 - a Role dependency DAG, which describes the version call topology.
 
-For every reconcile, the controller builds one snapshot for all participating Roles in a ServingGroup, calculates a temporary `coordinationPartition` for each Role, and combines it with the Role's configured partition:
+For every reconcile, the controller builds one snapshot for all participating Roles in a ServingGroup and calculates the boundary passed to the existing Role rolling-update path:
 
 ```text
-effectivePartition = max(userPartition, coordinationPartition)
+effectivePartition = boundary required by userPartition, maxSkew, and dependency rules
 ```
 
-The existing Role rolling-update path then uses `effectivePartition` and `maxUnavailable` to perform deletion and recreation.
+`maxSkew` limits the replacement progress of replicas that existed before the update. The dependency rules delay a rollout root until its target-version dependency path is Ready and retain the old-version dependency path while old callers remain. The existing Role rolling-update path then uses `effectivePartition` and `maxUnavailable` to perform deletion and replacement.
 
-For a dependency chain `A -> B -> C`, A is the rollout root. B and C can prestart within the `maxSkew` limit. A starts after B and C have eligible target-version `RoleRunning` capacity. At rollout completion, an old A keeps at least one old B, and an old B keeps at least one old C.
+For a dependency chain `A -> B -> C`, A is the rollout root. B and C first establish target-version `RoleRunning` capacity, while their replacement progress remains governed by `maxSkew`. A then starts. At rollout completion, an old A keeps at least one old B, and an old B keeps at least one old C.
 
 ### Motivation
 
@@ -48,25 +48,21 @@ B depends on C
 
 The target revision changes all three Roles. The application routes new-version requests through the new-version dependency chain.
 
-Independent Role rolling updates can produce two problems:
+For example, a new Predict Role may require the vector schema produced by a new Embedding Role. Starting the new Predict Role before the new Embedding Role is Ready can make requests fail. This is rollout-time service compatibility rather than model sharding.
 
-1. A large Role can accumulate much more target-version Ready capacity than another Role, so the dependency chain has unbalanced processing capacity.
-2. A target-version upstream Role can become reachable before its target-version dependency has Ready capacity.
+The coordinated rollout addresses two requirements:
 
-The coordinated rollout maintains proportional target-version capacity and establishes the new dependency chain before exposing its root.
+1. Ready progress produced by stable old-replica replacement remains proportional across Roles with different replica counts.
+2. A target-version upstream Role starts after its target-version dependency has Ready capacity.
+
+The coordinated rollout maintains proportional stable-replacement progress and establishes the new dependency chain before exposing its root.
 
 #### Goals
 
-- Coordinate selected Roles independently inside each ServingGroup.
-- Express rollout progress as target-version `RoleRunning` replicas divided by update-eligible replicas.
-- Bound proportional progress with a percentage `maxSkew`.
-- Support different replica counts and user partitions across Roles.
-- Allow internal dependency Roles to prestart together.
-- Start each rollout root after its complete dependency closure has target-version Ready capacity.
-- Preserve the old-version dependency chain until old callers have exited.
-- Reuse the existing Role partition, `maxUnavailable`, deletion, recreation, and readiness mechanisms.
-- Reconstruct rollout decisions from Kubernetes resources after controller restart.
-- Report the current coordination blocker through ModelServing status.
+- Keep the old-replica replacement progress of selected Roles within a configured proportional bound, including Roles with different replica counts and partitions.
+- Establish the target-version dependency path before starting its rollout root, and preserve the old-version dependency path until old callers have exited.
+- Keep coordination optional and compatible with existing `RoleRollingUpdate` behavior.
+- Expose the current coordination constraint and waiting state.
 
 ### Proposal
 
@@ -142,19 +138,25 @@ spec:
     - name: b
       replicas: 50
       maxUnavailable: 1
+      maxSurge: 1
       partition: 0
     - name: c
       replicas: 10
       maxUnavailable: 1
+      maxSurge: 1
       partition: 0
 ```
+
+This proposal integrates with the Role-level `maxSurge` field proposed in #1626. Its default value is zero, and positive values provide temporary dependency bootstrap capacity. The dependency integration is implemented after that Role-level capability is available; without it, admission rejects a changed dependency that has no replacement or ordinary scale-up capacity for bootstrap.
 
 The `roles` list defines one coordination domain:
 
 - an empty list selects all Roles in `spec.template.roles`;
 - a non-empty list selects the named Roles;
 - selected Roles share one `maxSkew` calculation;
-- each selected Role keeps its own `partition` and `maxUnavailable`.
+- each selected Role keeps its own `partition`, `maxUnavailable`, and `maxSurge`.
+
+Roles outside the list retain the existing independent Role rolling behavior, allowing one request path to be coordinated within a ServingGroup that also contains unrelated Roles.
 
 The webhook validates:
 
@@ -164,106 +166,97 @@ The webhook validates:
 - all Role names exist;
 - Role names and dependency edges are unique;
 - dependency endpoints belong to the selected Role set;
-- the dependency graph contains no self-edge or cycle.
+- the dependency graph is a DAG;
+- on UPDATE, every changed target-version dependency has `partition < replicas` and provides target-version bootstrap capacity through replacement, ordinary scale-up, or positive `maxSurge` while required old-version capacity is retained.
+
+UPDATE validation reports the dependency Role and the capacity setting to adjust.
 
 ### Design Details
 
 #### Overall Flow
 
-For each non-deleting ServingGroup, one reconcile performs the following work:
+For each non-deleting ServingGroup, the controller completes one cross-Role coordination decision before changing any Role. The following six steps are also the order used by the detailed design below:
 
-1. Resolve the participating Roles and their target Role template hashes.
-2. Resolve each Role's `userPartition` and rollout ordinal range.
-3. Classify current Role replicas as target Ready, target in-flight, or old.
-4. Calculate normalized Ready progress and the `maxSkew` allowance.
-5. Apply rollout-root startup and old-version dependency constraints.
-6. Calculate `coordinationPartition` and `effectivePartition` for every participating Role.
-7. Pass the allowed ordinal range to the existing Role rolling-update logic.
-8. Apply the existing per-Role `maxUnavailable` budget.
-9. Delete admitted old Role replicas and recreate their target-version replacements through the existing paths.
-10. Reconcile again when deletion, creation, or readiness changes the observed state.
+1. **Build the snapshot.** Resolve the participating Roles, the pre-update and target desired counts, partitions, template hashes, existing Role replicas, and readiness.
+2. **Calculate proportional allowance.** Use normalized Ready progress and `maxSkew` to calculate how many replacements each Role may have started.
+3. **Apply dependencies.** Decide whether target-version work may start and whether a final old dependency replica must be retained.
+4. **Derive final limits.** Convert the proportional and dependency results into `effectivePartition` and `targetStartAllowed` for every Role.
+5. **Execute existing paths.** Apply those limits to Role scale synchronization and the existing rolling-delete path.
+6. **Observe and continue.** A later reconcile rebuilds the snapshot from the resulting deletion, creation, and Ready state and repeats the calculation.
 
-Each reconcile uses the complete cross-Role snapshot before admitting new rollout work.
+#### Step 1: Build the ServingGroup Snapshot
 
-#### Per-Role State
+For every selected Role, the state builder reads three inputs:
 
-For a participating Role `r`:
+- `previousDesired` from the pre-update ControllerRevision;
+- `desired` from the new Role spec; and
+- the resolved `userPartition`.
 
-```text
-D_r = desired Role replica count
-P_r = resolved user partition
-T_r = max(D_r - P_r, 0)
-
-R_r = target-hash replicas in RoleRunning
-I_r = admitted target-version work that is not RoleRunning
-O_r = old-hash replicas that still exist
-```
-
-The rollout ordinal range is:
+They define the stable population covered by proportional replacement:
 
 ```text
-[P_r, D_r)
+T = max(min(previousDesired, desired) - userPartition, 0)
 ```
 
-Only replicas in this range contribute to `T_r`, `R_r`, `I_r`, and target-version dependency Ready capacity.
+`T` is the number of pre-update stable slots covered by proportional replacement. It uses the smaller of the old and new desired counts, so ordinary scale-up capacity and scale-down excess stay outside the proportional denominator.
 
-Replicas below `P_r` remain protected by the user partition. Replicas at or above `D_r` belong to ordinary scale-down. Old-hash replicas that still exist contribute to `O_r` while they can remain part of the old-version request path.
+The proportional calculation keeps only three per-Role values. They are reconstructed on every reconcile and are not persisted in the API or status:
 
-`I_r` includes:
+| State | Meaning | Where it is used |
+| --- | --- | --- |
+| `T` | total pre-update stable slots to replace | Step 2 uses it as the progress denominator and replacement target |
+| `S` | slots whose replacement has started | Step 2 subtracts it from the allowed total so in-flight work is not admitted again |
+| `R` | started slots backed by target-version stable `RoleRunning` capacity | Step 2 uses `R/T` as normalized Ready progress |
 
-- an old Role replica whose rollout deletion is in progress;
-- a target-hash Role replica that has not reached `RoleRunning`;
-- a missing replacement ordinal between deletion completion and target-version recreation.
+`S` prevents already admitted deletion and recreation work from consuming the allowance again. `R` advances only when stable target-version capacity reaches `RoleRunning`. Their reconstruction from Role and Pod observations is described later in [State Reconstruction and Controller Restart](#state-reconstruction-and-controller-restart).
 
-The in-flight count reserves already admitted work across asynchronous deletion, creation, scheduling, and readiness.
+#### Step 2: Calculate the Proportional Allowance
 
-#### Rollout Progress
-
-The coordinator calculates two normalized values:
+A Role participates in the active `maxSkew` baseline while its template changed, `T > 0`, and `R < T`. An unchanged selected Role is already complete for proportional coordination, although its target-version Ready capacity may still satisfy a dependency. The normalized Ready progress of an active Role is:
 
 ```text
-readyProgress_r =
-    R_r / T_r
-
-startedProgress_r =
-    min(R_r + I_r, T_r) / T_r
+progress = R / T
 ```
 
-Ready progress supplies the common baseline. Started progress consumes the allowance already granted to a Role.
-
-A selected Role participates in the active baseline while its template changed and its update-eligible rollout still has work in progress. Completed and unchanged Roles leave the active minimum. Their eligible target-version Ready replicas can still satisfy a rollout-root dependency.
-
-#### maxSkew
-
-`maxSkew` is expressed as percentage points of normalized progress. For each reconcile:
+For each reconcile:
 
 ```text
-readyBaseline =
-    minimum readyProgress across active participating Roles
+if activeRoleCount <= 1:
+    ratioLimit = 1
+else:
+    readyBaseline = minimum progress across active Roles
+    ratioLimit = min(1, readyBaseline + maxSkew)
 
-ratioLimit =
-    min(1, readyBaseline + maxSkew)
-
-allowedStarted_r =
-    min(T_r, ceil(ratioLimit * T_r))
+allowedStarted = min(T, ceil(ratioLimit * T))
 ```
 
-The per-Role ceiling converts the percentage allowance to a replica count. Each Role keeps its own integer step.
+`allowedStarted` is the total number of replacements currently allowed to have started. This snapshot may admit at most `max(allowedStarted-S, 0)` additional replacements. The per-Role ceiling converts the percentage allowance to a replica count. Because rollout progress is discrete, the observed ratio can exceed the percentage boundary by at most one replica step for that Role.
+
+When zero or one Role remains active, there is no cross-Role difference to constrain. Dependency rules and the Role's `maxUnavailable` continue to control execution.
 
 With A=100, B=50, C=10, and `maxSkew: 10%`:
 
-| State | Ready progress A/B/C | Allowed started total A/B/C |
+| State | Ready progress A/B/C | `allowedStarted` for A/B/C |
 | --- | --- | --- |
 | Initial | 0% / 0% / 0% | 10 / 5 / 1 |
 | B=5 and C=1 Ready | 0% / 10% / 10% | 10 / 5 / 1 |
 | A=10 Ready | 10% / 10% / 10% | 20 / 10 / 2 |
 | A=20, B=10, C=2 Ready | 20% / 20% / 20% | 30 / 15 / 3 |
 
-The table shows the percentage relationship across unequal replica counts. The startup dependency rule blocks A in the first row, so initial target-version work is admitted only for B and C. Each Role's §maxUnavailable§ can further reduce the number acted on in one reconcile.
+The table shows the percentage relationship across unequal replica counts. In the first row, A waits for dependency startup while B and C receive the initial target-version work. Each Role's `maxUnavailable` can further reduce the number acted on in one reconcile.
 
 The implementation compares ratios with integer cross-multiplication and converts the configured percentage to fixed-point integer units.
 
-#### Dependency Graph
+#### Step 3: Apply the Dependency Rules
+
+Dependency coordination uses two additional per-Role states, separate from the proportional values above:
+
+| State | Meaning | Where it is used |
+| --- | --- | --- |
+| `targetState` | `NotStarted`, `Started`, or `Ready` | gates the first target-version start of a rollout root |
+| `hasOldVersion` | whether old-version capacity still exists | retains the final old replica on a dependency path |
+
+Replacement, ordinary scale-up, and surge capacity may update `targetState`, but only stable replacement capacity contributes to `T`, `S`, and `R`.
 
 An edge:
 
@@ -274,6 +267,8 @@ An edge:
 
 describes a version call from A to B.
 
+`dependsOn` describes target-version traffic compatibility, not an unconditional Pod-creation order for every edge. A Role may prestart while no target-version traffic can reach it. A rollout root is the first Role that can receive such traffic, so the controller holds that root until its complete dependency path is Ready.
+
 The graph provides two coordination rules:
 
 1. rollout-root startup;
@@ -281,7 +276,7 @@ The graph provides two coordination rules:
 
 ##### Rollout roots
 
-A rollout root is a selected Role whose name does not appear in another selected Role's `dependsOn` list.
+A rollout root is a selected Role with zero incoming dependency edges.
 
 For:
 
@@ -291,9 +286,9 @@ A -> B -> C
 
 A is the rollout root. Its transitive dependency closure is `{B, C}`. B and C are internal Roles.
 
-Before the first target-version A replacement is admitted, B and C must each have at least one target-hash `RoleRunning` replica inside their own `[P, D)` range. B and C can prestart together under `maxSkew`.
+Before the first target-version A start is admitted, B and C each reach `targetState=Ready`. A target-hash `RoleRunning` replica created by replacement, ordinary scale-up, or surge provides this state. B and C can prestart together, and their old-replica replacements advance proportional progress.
 
-For a graph containing only:
+For the graph:
 
 ```text
 B -> C
@@ -301,7 +296,7 @@ B -> C
 
 B is the rollout root and waits for target-version C Ready capacity.
 
-The first-start state is reconstructed from `R_r + I_r`. A root with `R_r + I_r = 0` applies the startup check. Once target-version work for that root has started, subsequent progress is coordinated by `maxSkew`.
+The root startup rule uses `targetState`. A root in `NotStarted` receives `targetStartAllowed=false` until every Role in its transitive dependency closure is `Ready`. Internal dependency Roles receive `targetStartAllowed=true` and can prestart together. After target-version replacement, ordinary scale-up, or surge work is admitted, the root enters `Started`; later reconciles continue its rollout through `maxSkew`.
 
 ##### Old-version dependency retention
 
@@ -320,118 +315,96 @@ A completes
         -> C can remove its final old replica
 ```
 
-The retention rule uses observed old replicas. A terminating old replica contributes to `O_r` until its Pods have disappeared.
+The retention rule uses `hasOldVersion`. A terminating old replica keeps this value true until its Pods have disappeared.
 
 If a Role's `userPartition` already preserves one or more old replicas, that boundary satisfies the retention requirement. A partition-protected old caller also keeps its direct old dependency for the same lifetime.
 
-#### Effective Partition
+Retention protects old-replica deletion, while target-version creation remains available. A dependency may create ordinary scale-up or surge capacity while its final old replica remains protected. This lets a one-replica dependency establish new-version capacity while preserving the old-version request path.
 
-The coordinator maintains three partition values:
+#### Step 4: Derive the Final Role Limits
 
-- `userPartition`: the Role partition supplied by the user;
-- `coordinationPartition`: the temporary boundary calculated for the current snapshot;
-- `effectivePartition`: the boundary passed to the Role rolling-update executor.
-
-The initial coordination boundary comes from `maxSkew`:
+The proportional allowance from Step 2 becomes the initial final boundary:
 
 ```text
-coordinationPartition_r =
-    D_r - allowedStarted_r
+effectivePartition = userPartition + T - allowedStarted
 ```
 
-The dependency rules then adjust the same boundary:
+This protects the part of the pre-update stable population that has not yet been admitted by `maxSkew`.
+
+The dependency rules from Step 3 then adjust the same value. A rollout root with `targetState=NotStarted` and `targetStartAllowed=false` uses `effectivePartition=userPartition+T`, which admits no old-replica replacement. Once its dependency closure is Ready, it uses the proportional boundary.
+
+Old-version retention applies the following boundary:
 
 ```text
-if r is a rollout root,
-   R_r + I_r = 0,
-   and a Role in r's dependency closure has R = 0:
-    coordinationPartition_r = D_r
-
-if D_r > 0 and a direct dependent d has O_d > 0:
-    coordinationPartition_r =
-        max(coordinationPartition_r, 1)
+if hasOldVersion and a direct caller hasOldVersion:
+    effectivePartition = max(effectivePartition, 1)
 ```
 
-The final boundary is:
+`userPartition` is already included once in the initial formula, so no later `max(userPartition, ...)` is required. The existing path keeps its current Role ordering, selects outdated replicas outside the first `effectivePartition` partition-protected Role replicas, and applies the Role's `maxUnavailable`. Existing descending ordinal ordering remains in use. `effectivePartition` therefore controls old-replica replacement, while `targetStartAllowed` controls target-version creation by ordinary scale-up and `maxSurge`.
+
+#### Step 5: Execute Through Existing Role Paths
+
+The controller builds the Step 1 snapshot and coordination decision once for the ServingGroup before running Role scale synchronization and rolling deletion. The same decision is passed to both paths:
 
 ```text
-effectivePartition_r =
-    max(userPartition_r, coordinationPartition_r)
-```
-
-The existing rolling-update path selects outdated Role replicas in:
-
-```text
-[effectivePartition_r, D_r)
-```
-
-and applies the Role's `maxUnavailable` budget to that range. Existing descending ordinal ordering remains in use.
-
-The rollout denominator continues to use:
-
-```text
-T_r = D_r - userPartition_r
-```
-
-This keeps normalized progress stable while `coordinationPartition` changes between reconciles.
-
-#### Example: A, B, and C
-
-Assume each Role has ten replicas, `maxUnavailable: 1`, `partition: 0`, and `maxSkew: 10%`.
-
-Startup:
-
-| Role | maxSkew boundary | Dependency adjustment | effectivePartition |
-| --- | ---: | ---: | ---: |
-| A | 9 | A is a blocked root: 10 | 10 |
-| B | 9 | old A retention: at least 1 | 9 |
-| C | 9 | old B retention: at least 1 | 9 |
-
-B and C each replace one replica. When both replacements become `RoleRunning`, A's startup adjustment is released and A can replace one replica.
-
-Middle:
-
-- the Ready baseline advances as target replicas become `RoleRunning`;
-- `allowedStarted` grows independently for A, B, and C from the same percentage limit;
-- dependency edges impose no continuous A/B/C progress ordering.
-
-Completion:
-
-```text
-effective partitions near the tail
-
-A = 0
-B = 1
-C = 1
-
-old A disappears  -> B may use 0
-old B disappears  -> C may use 0
-```
-
-#### Interaction with Existing Role Rolling Update
-
-The current `rolesToDeleteForRoleRollingUpdate` path calculates outdated replicas and each Role's local `maxUnavailable` allowance. Coordination adds one cross-Role calculation before the final delete list is returned:
-
-```text
-current Role objects
-    -> build all participating Role states
-    -> calculate coordinationPartition
-    -> calculate effectivePartition
-    -> filter outdated ordinals to [effectivePartition, D)
-    -> apply existing maxUnavailable
+ServingGroup snapshot
+    -> calculate effectivePartition and targetStartAllowed
+    -> syncRoleReplicas creates admitted target capacity
+    -> rolesToDeleteForRoleRollingUpdate applies effectivePartition
+    -> existing maxUnavailable selects the local delete count
     -> DeleteRole
-    -> existing scaleUpRoles recreates the target replica
+    -> later syncRoleReplicas fills the missing stable capacity
 ```
 
-Replica-only scaling continues through the existing scaling logic.
+During a template update, target-version Role capacity can come from three paths:
 
-When a replica increase and template change are submitted together, creation of additional target-version ordinals is admitted through the same `effectivePartition`. A rollout-root scale-up therefore waits for its dependency closure, and every participating Role consumes its `maxSkew` allowance.
+| Capacity source | How it is created | Proportional coordination | Dependency coordination |
+| --- | --- | --- | --- |
+| Rolling replacement | an old stable replica is deleted and recreated with the target template | contributes to `T`, `S`, and `R` | becomes dependency Ready at `RoleRunning` |
+| Ordinary scale-up | `desired` increases beyond `previousDesired` | stays outside `T`, `S`, and `R` | becomes dependency Ready at `RoleRunning` |
+| Temporary `maxSurge` | capacity is created above `desired`, up to `desired+maxSurge` | stays outside `T`, `S`, and `R` | becomes dependency Ready at `RoleRunning` and is reclaimed after rollout |
 
-Scale-down continues through the existing scaling logic. The new desired count immediately defines `D_r`, so scale-down excess at or above `D_r` leaves progress and dependency Ready calculations.
+`rolesToDeleteForRoleRollingUpdate` remains responsible for outdated detection, descending Role ordering, and the Role's `maxUnavailable`. Coordination only narrows its candidate set through `effectivePartition`.
 
-`maxUnavailable` remains a per-Role availability budget. The coordinator determines the rollout range, and `maxUnavailable` determines how many replicas inside that range can be deleted.
+For a simultaneous template update and ordinary scale-up, `syncRoleReplicas` creates target capacity toward `desired` after `targetStartAllowed` becomes true. The `desired-previousDesired` expansion amount stays outside proportional progress, while a resulting target-hash `RoleRunning` replica can make `targetState=Ready` for dependency startup.
 
-#### Reconcile Continuation
+For example, `previousDesired=10`, `desired=12`, and `userPartition=0` produce `T=10`, with two ordinary scale-up replicas outside `T`. The ten pre-update stable slots form the proportional denominator, independent of which ordinals the existing scale-up policy chooses.
+
+For a simultaneous scale-down, `min(previousDesired, desired)` excludes the removed excess from the proportional population. Existing scale-down policy reconciles that excess, while `T` remains the replacement denominator.
+
+`maxUnavailable` remains the per-Role availability budget after all coordination limits have been applied.
+
+##### Role maxSurge execution
+
+Role-level `maxSurge` uses count-based behavior. The coordinator first determines whether temporary capacity is still required:
+
+```text
+surgeRequired = updateableOldExists or dependencyRetentionIsBinding
+
+if targetStartAllowed and surgeRequired:
+    temporaryExpected = desired + maxSurge
+else:
+    temporaryExpected = desired
+```
+
+`dependencyRetentionIsBinding` is true only when dependency coordination, rather than `userPartition`, is retaining the final old replica. Normal Role scale synchronization creates capacity up to `temporaryExpected`. The controller does not label an individual Role as surge and does not infer surge identity from its ordinal. Eligible target-hash capacity that becomes `RoleRunning` can make `targetState=Ready` and unlock a dependent root.
+
+Old-replica deletion still follows `effectivePartition` and `maxUnavailable`. `maxSkew` still follows `R/T`; temporary capacity above `desired` is outside the stable target capacity used to derive `R`.
+
+While dependency retention is binding, the temporary expected count does not contract and the target-version capacity used to unlock the root remains available. After the caller's final old replica disappears, retention releases; the dependency's final old replica becomes updateable and is replaced. Only after updateable old work and the coordination retention are both gone does `temporaryExpected` return to `desired`. Existing Role scale-down scoring then selects any remaining target-version excess; ordinal does not determine which Role is removed.
+
+For one-replica Roles in `A -> B -> C`, `maxSurge: 1` on B and C permits the following sequence:
+
+1. Keep old B and old C for the old request path.
+2. Create target B and target C as admitted surge capacity.
+3. After target B and target C are `RoleRunning`, update A.
+4. After the final old A disappears, remove the final old B.
+5. After the final old B disappears, remove the final old C.
+6. Reclaim any capacity above the declared Role replica counts.
+
+For root A, delete-first replacement provides the target-version start. For a changed dependency, replacement or ordinary scale-up provides the target-version start when old capacity can be retained; `maxSurge` provides bootstrap capacity for the remaining single-capacity case.
+
+#### Step 6: Observe the Result and Continue
 
 The controller completes one bounded amount of work and returns from reconcile. Later resource state changes enqueue the ModelServing again.
 
@@ -442,31 +415,71 @@ A participating Role replica becomes `RoleRunning` after its entry Pod and all w
 - admit the next proportional work;
 - release an old-version retention boundary.
 
-#### Controller Restart
+#### Worked Example: A, B, and C
 
-The controller rebuilds coordination state from:
+Assume each Role has ten replicas, `maxUnavailable: 1`, `maxSurge: 0`, `partition: 0`, and `maxSkew: 10%`. Initially, every Role has `T=10` and `S=R=0`.
 
-- the current ModelServing spec;
-- current and target ControllerRevisions;
-- Role and Pod revision/hash labels;
-- Pod Ready conditions;
-- Pod deletion timestamps;
-- current and missing Role ordinals.
+The first proportional calculation gives `allowedStarted=1` and `effectivePartition=9` for every Role. Dependency startup then changes only A's result:
 
-The startup path lists existing Pods, rebuilds the datastore, and enqueues existing ModelServings. The first reconcile recalculates `coordinationPartition` and `effectivePartition`.
+| Role | Proportional boundary | Dependency result | `effectivePartition` |
+| --- | ---: | --- | ---: |
+| A | 9 | A is a `NotStarted` root, so protect all ten old slots | 10 |
+| B | 9 | Internal Role; this boundary already retains old B | 9 |
+| C | 9 | Internal Role; this boundary already retains old C | 9 |
 
-Restart-state classification:
+The existing rolling path can therefore replace one B and one C, while A has no delete candidate. Their in-flight work makes `S=1` for B and C. When both target replicas become `RoleRunning`, their `R` becomes 1 and their `targetState` becomes `Ready`. A's dependency closure is now Ready, so the next reconcile restores A's proportional boundary to 9 and admits one A replacement.
 
-| Observed state | Reconstructed state |
-| --- | --- |
-| target-hash Role is `RoleRunning` | Ready progress |
-| target-hash Role exists and is not `RoleRunning` | in-flight work |
-| old-hash Pods are terminating | in-flight replacement and old-version presence |
-| an ordinal in current `[P, D)` is missing after delete-first admission | in-flight replacement awaiting recreation |
-| a missing ordinal belongs to a requested scale-up | scale-up work awaiting admission |
-| an ordinal is at or above current `D` | scale-down excess |
+After A is started, all three Roles use the same Ready baseline. When every Role has `R=1`, `allowedStarted` becomes 2; when every Role has `R=2`, it becomes 3, and so on.
 
-Terminating old Pods are read from the Pod informer cache so old-version dependency retention survives datastore reconstruction.
+Near completion, `maxSkew` can produce:
+
+```text
+effectivePartition(A) = 0
+effectivePartition(B) = 1    # old A still keeps one old B
+effectivePartition(C) = 1    # old B still keeps one old C
+```
+
+After old A disappears, `hasOldVersion(A)=false` and B may use `effectivePartition=0`. After old B disappears, C may also use `effectivePartition=0`.
+
+#### State Reconstruction and Controller Restart
+
+No coordination state is persisted. Every reconcile derives it from the ModelServing spec, the pre-update and target ControllerRevisions, and the observed Roles and Pods.
+
+##### Proportional state
+
+- `T` is calculated from `previousDesired`, `desired`, and `userPartition`.
+- `S` is `T` minus the non-deleting old replicas that still occupy the updateable stable population. A slot remains started while its old replica is deleting, its stable capacity is missing, or its replacement is Creating.
+- `R` is the part of `S` backed by target-hash `RoleRunning` capacity inside the stable desired count. Before deriving it, the controller conservatively removes ordinary scale-up capacity and any current capacity above `desired` from the observed target Ready count. Those replicas can therefore never inflate proportional progress; an ambiguous snapshot may temporarily undercount `R` until scaling converges.
+
+Here, `remainingOldToUpdate` is the number of non-deleting old replicas still occupying the updateable stable population, `targetReady` is the observed target-hash `RoleRunning` count, and `observedNonDeleting` is the current non-deleting Role count. The count-based reconstruction is:
+
+```text
+S = T - min(T, remainingOldToUpdate)
+
+ordinaryScale       = max(desired - previousDesired, 0)
+temporaryExcess     = max(observedNonDeleting - desired, 0)
+replacementReady    = max(targetReady - ordinaryScale - temporaryExcess, 0)
+R                   = min(S, replacementReady)
+```
+
+Subtracting the full ordinary-scale and excess counts is conservative when individual origins are ambiguous: it can delay another admission, but cannot let scale-up, scale-down excess, or surge capacity consume `maxSkew` progress.
+
+##### Dependency state
+
+- `targetState` becomes `Started` when target-version replacement, ordinary scale-up, or admitted surge work exists. It becomes `Ready` when target-hash `RoleRunning` capacity remains after conservatively excluding scale-down excess above the currently admitted capacity limit.
+- `hasOldVersion` remains true while an old-hash Role or terminating old Pod still exists, or while a partition-protected old slot is temporarily missing and awaiting recovery. Terminating Pods are read from the Pod informer cache so the final-old-replica protection survives datastore reconstruction.
+
+```text
+dependencyExpected = desired + admittedSurge
+scaleDownExcess    = max(observedNonDeleting - dependencyExpected, 0)
+dependencyReady    = max(targetReady - scaleDownExcess, 0)
+```
+
+`admittedSurge` is the resolved `maxSurge` only while target startup is allowed and `surgeRequired` from Step 5 is true; otherwise it is zero. `dependencyReady > 0` sets `targetState=Ready`. This allows admitted surge capacity to unlock a root without letting replicas that are merely awaiting ordinary scale-down do so.
+
+Ordinary scale-up is derived as `max(desired-previousDesired, 0)`. Capacity above `desired` while `surgeRequired` is true is treated as temporary surge capacity. Revision and template-hash labels distinguish old and target versions; no individual Role ordinal is permanently classified as replacement, scale-up, or surge.
+
+After a controller restart, the startup path rebuilds the datastore and enqueues existing ModelServings. The first reconcile observes the same revisions, hashes, deletion state, missing capacity, and Ready conditions, reconstructs the values above, and resumes from the resulting limits.
 
 ### Status and Observability
 
@@ -477,14 +490,13 @@ const ModelServingCoordinatedRoleRolloutBlocked ModelServingConditionType =
     "CoordinatedRoleRolloutBlocked"
 ```
 
-The condition is `True` when a participating Role still has rollout work and is waiting on a coordination constraint or admitted target-version readiness.
+The condition is `True` when a participating Role still has rollout work and is waiting on a coordination constraint.
 
 Supported reasons:
 
 - `DependencyNotReady`;
 - `MaxSkewLimitReached`;
-- `OldVersionDependencyPresent`;
-- `TargetReplicaNotReady`.
+- `OldVersionDependencyPresent`.
 
 Example:
 
@@ -498,35 +510,21 @@ status:
     observedGeneration: 12
 ```
 
-Current blockers are ordered by ServingGroup ordinal, Role declaration order, and fixed reason priority. The first blocker supplies the condition reason, and the message summarizes the affected Roles.
+Current blockers are ordered by ServingGroup ordinal, Role declaration order, and fixed reason priority: `DependencyNotReady`, `OldVersionDependencyPresent`, and `MaxSkewLimitReached`. The first blocker supplies the condition reason, and the message summarizes the affected Roles.
 
 The controller sets the condition to `False` with `ProgressAvailable` or `RolloutComplete` when the corresponding state is observed. Kubernetes Events record blocker changes and rollout resumption.
 
-### Failure and Blocking Behavior
+### Blocking and Admission Behavior
 
-#### Slow or failed target replica
+An admitted replacement in deletion, creation, scheduling, or readiness stages contributes to `S`, reserving its proportional allowance. Stable target Ready capacity advances `R`. Existing Role and Pod status expose the readiness of admitted replicas; the coordination condition identifies the constraint that prevents additional work.
 
-A target replica in Creating, pending scheduling, or waiting for Pod Ready remains in `I_r`. Its reserved allowance stays occupied. The blocker condition reports `TargetReplicaNotReady`.
+| Situation | Controller behavior | Condition reason |
+| --- | --- | --- |
+| A root has `targetState=NotStarted` and its dependency closure is not target Ready | Keep its target start gated and identify the dependency Roles | `DependencyNotReady` |
+| A Role has `S >= allowedStarted` while `allowedStarted < T` | Preserve admitted work and wait for the shared Ready baseline | `MaxSkewLimitReached` |
+| Dependency retention raises `effectivePartition` | Retain the dependency's final old replica | `OldVersionDependencyPresent` |
 
-#### Dependency readiness
-
-A rollout root remains at `coordinationPartition = D` while a Role in its dependency closure has no eligible target-version `RoleRunning` replica. The blocker condition reports `DependencyNotReady` and identifies the dependency Roles.
-
-#### maxSkew limit
-
-A Role whose `R_r + I_r` reaches `allowedStarted_r` waits for the shared Ready baseline to advance. The blocker condition reports `MaxSkewLimitReached`.
-
-#### Old-version retention
-
-A dependency at its final old replica keeps an effective partition of at least one while an old direct caller exists. The blocker condition reports `OldVersionDependencyPresent`.
-
-#### Partition-limited dependency
-
-A dependency with no eligible target-version ordinal remains unable to satisfy a rollout-root Ready requirement. Its user partition remains authoritative and the root remains blocked.
-
-#### Single-replica dependency
-
-With delete-first replacement, a one-replica dependency can require the same replica for the old chain and for creation of new-version capacity. The rollout remains blocked at that boundary and reports the current dependency reason.
+Update admission verifies that each changed dependency can provide target-version capacity while retaining required old-version capacity. For a one-replica dependency, ordinary scale-up or positive `maxSurge` supplies the concurrent capacity. Validation identifies the dependency Role and directs the user to adjust `maxSurge`, `replicas`, or the rollout staging.
 
 ### Implementation
 
@@ -534,35 +532,49 @@ The implementation adds a per-ServingGroup coordinator with a pure calculation i
 
 ```go
 type coordinatedRoleState struct {
-    roleName string
-
-    desired       int
-    userPartition int
-    target        int
-    ready         int
-    inFlight      int
-    oldReplicas   int
-    active        bool
+    roleName       string
+    userPartition  int
+    totalToUpdate  int // T
+    startedCount   int // S
+    readyCount     int // R
+    targetState    targetVersionState
+    hasOldVersion  bool
+    active         bool
 }
+
+type targetVersionState string
+
+const (
+    targetNotStarted targetVersionState = "NotStarted"
+    targetStarted    targetVersionState = "Started"
+    targetReady      targetVersionState = "Ready"
+)
 
 type coordinatedRoleDecision struct {
     effectivePartitions map[string]int
+    targetStartAllowed   map[string]bool
+    temporaryExpected    map[string]int
     blockers             []coordinatedRoleBlocker
 }
 
-func coordinatedRolePartitions(
+func coordinateRoleRollout(
     states []coordinatedRoleState,
     coordination *RoleCoordination,
 ) (coordinatedRoleDecision, error)
 ```
 
+The state builder derives `totalToUpdate` from `previousDesired`, `desired`, and `userPartition`; the coordinator does not carry those extra intermediate values. `active` is true only for a changed Role with unfinished stable replacement work. `targetStartAllowed` is true for internal dependency Roles and for rollout roots whose dependency closure is Ready or whose target-version work has already started. `effectivePartitions` controls old-replica replacement, while `temporaryExpected` keeps admitted surge capacity until both updateable old work and dependency retention have cleared.
+
 Main code changes:
 
 - API types, generated clients, deepcopy code, and CRDs for `roleCoordination`;
-- webhook validation for Role selection, `maxSkew`, and dependency DAGs;
-- Role-state construction from datastore Roles, Pods, hashes, readiness, and ordinals;
+- admission parsing of the old and new ModelServing objects for update-time rollout feasibility validation;
+- webhook validation for Role selection, `maxSkew`, dependency DAGs, partition-limited target capacity, and insufficient bootstrap capacity on update;
+- flat Role-state construction for `T`, `S`, `R`, `targetState`, `hasOldVersion`, and `active` from the ControllerRevision, Role spec, datastore Roles, Pods, hashes, readiness, and current counts;
+- `syncModelServing` construction of one per-ServingGroup decision map before Role replica synchronization, passed to both `syncRoleReplicas` and `manageRollingUpdate`;
 - `rolesToDeleteForRoleRollingUpdate` integration for `effectivePartition`;
-- `scaleUpRoles` integration for concurrent template update and scale-up;
+- `scaleUpRoles` integration with dependency startup and `targetState` updates during a coordinated Role rollout;
+- `manageRoleReplicasPerGroup` integration with dependency-gated Role-level `maxSurge` expected counts and `targetState` updates;
 - immediate ModelServing enqueue on participating Role `RoleRunning` transitions;
 - ModelServing condition and Event updates for coordination blockers.
 
@@ -576,7 +588,11 @@ Small Roles have coarse progress steps. Per-Role ceiling conversion permits one 
 
 #### Repeated reconciliation
 
-In-flight reservations include deleting, missing, Creating, and waiting-for-Ready work. Repeated reconciles calculate the same or a stricter admission boundary from the observed snapshot.
+`S` reconstructs admitted delete-first replacement across deleting, missing, Creating, and Ready states. `targetState` reconstructs ordinary scale-up and surge work for dependency startup. Repeated reconciles calculate the same or a stricter admission boundary from the observed snapshot.
+
+#### Ordinary Scale-up and Surge Capacity
+
+Ordinary scale-up and temporary capacity contribute through `targetState`. After reaching `RoleRunning`, both provide dependency Ready capacity. Ordinary scale-up persists inside `desired`, while the expected count contracts to `desired` after eligible old replicas are gone. Replacement progress remains `R/T`.
 
 #### Informer convergence
 
@@ -590,18 +606,24 @@ The ModelServing condition records the blocking ServingGroup, Role, reason, and 
 
 #### Unit tests
 
-- Role selection and `maxSkew` validation.
-- Dependency existence, duplicate edge, self-edge, and cycle validation.
+- Role selection, `maxSkew`, and dependency DAG validation.
+- UPDATE capacity validation for changed dependencies, including `partition < replicas` and single-replica bootstrap through ordinary scale-up or positive `maxSurge`.
 - Rollout-root inference for chains, branches, multiple roots, and isolated Roles.
-- Exact ordinal range `[P, D)`.
-- Scale-down excess excluded from progress and dependency Ready capacity.
-- Ready and in-flight progress from Running, Creating, Deleting, terminating, and missing states.
+- `T=max(min(previousDesired,desired)-userPartition,0)` for equal, scale-up, and scale-down updates.
+- `S` and `R` construction from Running, Creating, Deleting, terminating, missing, ordinary scale-up, and temporary-capacity states.
+- Count-based distinction among ordinary scale-up, stable replacement Ready capacity, and temporary expected capacity without ordinal classification.
+- Ordinary scale-up and surge transitions through `targetState=Started` and `targetState=Ready`.
 - Equal and unequal Role replica counts.
+- Zero or one active replacement Role releases the cross-Role ratio limit.
 - Per-Role ceiling conversion and small-Role quantization.
 - `A -> B -> C` internal prestart and root startup behavior.
 - `B -> C` root startup behavior.
 - Direct-edge old-version retention.
-- User partition combined with coordination partition.
+- Derivation of `effectivePartition` from `userPartition`, `T`, `allowedStarted`, and dependency adjustments.
+- Ordinary scale-up and surge creation while the final old dependency replica is retained.
+- Root ordinary scale-up and surge creation after the dependency closure reaches `Ready`.
+- Surge creation up to the Role's `maxSurge`.
+- Surge capacity is reclaimed after eligible old replicas complete.
 - Descending ordinal selection and `maxUnavailable`.
 - Deterministic blocker aggregation and condition transitions.
 - Restart reconstruction during deletion, missing replacement, creation, and readiness.
@@ -611,12 +633,15 @@ The ModelServing condition records the blocking ServingGroup, Role, reason, and 
 For generated replica counts, partitions, Role states, and acyclic graphs:
 
 - `effectivePartition >= userPartition`;
-- projected started work stays within each Role's quantized allowance;
-- a rollout root starts after every Role in its closure has eligible Ready capacity;
-- target Ready replicas outside `[P, D)` never unlock a root;
+- new replacement admission is zero when `S >= allowedStarted`, and otherwise projected `S` stays within `allowedStarted`;
+- a rollout root starts after every Role in its closure reaches `targetState=Ready`;
+- target-hash RoleRunning capacity sets `targetState=Ready`, while `R <= S <= T`;
+- `T` remains derived solely from `previousDesired`, `desired`, and `userPartition` when ordinary scale-up or temporary excess exists;
+- scale-down capacity is reconciled through the desired range;
 - an observed old caller retains its direct old dependency;
+- a retained final old dependency allows admitted target scale-up and surge creation;
 - identical snapshots produce identical decisions;
-- generated invalid graphs fail validation.
+- graph validation covers generated DAGs and structural errors.
 
 #### Integration tests
 
@@ -624,9 +649,12 @@ For generated replica counts, partitions, Role states, and acyclic graphs:
 - Deletion and recreation gaps preserve in-flight reservation.
 - Participating Role `RoleRunning` transitions trigger the next decision.
 - Controller restart reconstructs deleting and Creating work.
+- Controller restart reconstructs the temporary expected count without creating capacity above `desired+maxSurge`.
 - Terminating old Pods retain the old-version dependency boundary.
 - Status updates preserve existing conditions and update `CoordinatedRoleRolloutBlocked`.
-- Concurrent template update and scale-up uses the same effective partition.
+- Concurrent template update and scale-up uses `R/T` for `maxSkew` and `targetState` for scale-up dependency startup.
+- Surge creation reaches the configured `maxSurge` through dependency startup.
+- A rollout root creates replacement, ordinary scale-up, or surge target capacity after its dependency closure reaches `Ready`.
 
 #### End-to-end tests
 
@@ -634,21 +662,25 @@ For generated replica counts, partitions, Role states, and acyclic graphs:
 - A/B/C rollout completion in old-version order A, B, C.
 - Unequal A/B/C replica counts with `maxSkew: 10%`.
 - Different user partitions across Roles.
-- Unschedulable dependency with a visible blocker condition.
+- One-replica B and C establish target Ready capacity through `maxSurge: 1` while old B and C remain available.
+- Admission reports the capacity requirement for a changed fully partitioned dependency.
+- Admission reports the bootstrap requirement for a one-replica dependency.
+- An unschedulable dependency produces a visible blocker condition.
 - Explicit Role subset coordination.
 - Controller restart during delete, create, and readiness stages.
 
 ### Rollout Plan
 
-The feature is enabled by configuring `roleCoordination` under `RoleRollingUpdate`. ModelServings without `roleCoordination` continue through the existing independent Role rolling-update path.
+Configuring `roleCoordination` under `RoleRollingUpdate` enables the feature. The existing independent Role rolling-update path remains the default behavior.
 
 Implementation proceeds in four stages:
 
 1. add the API, generated artifacts, and webhook validation;
 2. add per-ServingGroup state construction and the pure coordination calculation;
-3. integrate effective partitions, Ready-triggered continuation, and status reporting;
+3. integrate effective partitions, dependency-gated ordinary scale-up and `maxSurge`, Ready-triggered continuation, and status reporting;
 4. add unit, integration, and end-to-end coverage.
 
 ### References
 
 - [Kthena Role rolling update proposal](https://github.com/volcano-sh/kthena/blob/main/docs/proposal/role-rollingupdate.md)
+- [Kthena Role-level maxSurge implementation](https://github.com/volcano-sh/kthena/pull/1626)

--- a/docs/proposal/coordinated-role-rolling-update.md
+++ b/docs/proposal/coordinated-role-rolling-update.md
@@ -77,7 +77,7 @@ The current implementation cannot provide these properties because `rolesToDelet
 - Change initial ModelServing creation ordering. Dependencies in this proposal apply only to coordinated Role rolling updates.
 - Coordinate rollout progress across different ServingGroups. Each ServingGroup has an independent coordinator.
 - Replace the existing Role `maxUnavailable` or `partition` fields.
-- Coordinate ordinary scaling, failure recovery, or Role addition/removal as proportional rolling-update work.
+- Coordinate replica-only scaling, failure recovery, or Role addition/removal as proportional rolling-update work. When a replica increase and a Role template change are submitted together, creating target-version replicas is part of the rollout and is therefore coordinated.
 - Automatically roll back a revision when rollout progress stalls.
 - Turn Pod readiness on or off, mutate readiness gates, or change Service endpoint selection.
 - Guarantee runtime dependency health after an upstream replica has already completed rollout. Ordinary recovery policy handles later failures.
@@ -94,21 +94,20 @@ metadata:
 spec:
   rolloutStrategy:
     type: RoleRollingUpdate
-    roleRollingUpdateConfiguration:
-      coordination:
-        # Optional. Omission selects all Roles in spec.template.roles.
-        roles: [a, b, c]
+    roleCoordination:
+      # Optional. Omission selects all Roles in spec.template.roles.
+      roles: [a, b, c]
 
-        # Percentage points of normalized rollout progress. Percent only.
-        maxSkew: 10%
+      # Percentage points of normalized rollout progress. Percent only.
+      maxSkew: 10%
 
-        # Rollout-only startup dependency graph. "a dependsOn b" means b
-        # must have one target-revision RoleRunning replica before a starts.
-        dependencies:
-        - role: a
-          dependsOn: [b]
-        - role: b
-          dependsOn: [c]
+      # Rollout-only startup dependency graph. "a dependsOn b" means b
+      # must have one target-revision RoleRunning replica before a starts.
+      dependencies:
+      - role: a
+        dependsOn: [b]
+      - role: b
+        dependsOn: [c]
 
   template:
     roles:
@@ -161,6 +160,12 @@ A has 2 replicas, B has 4, and C has 10. With `maxSkew: 10%` and a zero Ready ba
 
 A has four replicas with `partition: 2`; B and C have four replicas with no partition. A's rollout target contains only A-2 and A-3. Its denominator is therefore two, not four. Once those two replicas are updated and Ready, A's coordinated progress is 100%, while A-0 and A-1 intentionally remain old. B and C may still reach 100% of their own four-replica targets; A's partition does not implicitly partition B or C.
 
+##### Concurrent scale-up and template update
+
+If only a Role's replica count changes, the existing scaling path continues to handle that change without proportional coordination. If a participating Role's replica count and template change in the same update, however, every additional target-version replica introduces new-version capacity and is a rollout start. Its creation is admitted by the same dependency and `maxSkew` checks as a delete-first replacement. This prevents an upstream scale-up from creating target-version A replicas before compatible target-version B and C capacity is Ready.
+
+Scale-down retains the existing behavior. After the desired count changes, the coordinator recalculates the denominator and observed progress from the new desired count and gates subsequent rollout starts. It does not undo or delay a user-requested scale-down.
+
 ### API Design
 
 ```go
@@ -171,14 +176,10 @@ type RolloutStrategy struct {
     RollingUpdateConfiguration *RollingUpdateConfiguration `json:"rollingUpdateConfiguration,omitempty"`
 
     // Used only by RoleRollingUpdate.
-    RoleRollingUpdateConfiguration *RoleRollingUpdateConfiguration `json:"roleRollingUpdateConfiguration,omitempty"`
+    RoleCoordination *RoleCoordination `json:"roleCoordination,omitempty"`
 }
 
-type RoleRollingUpdateConfiguration struct {
-    Coordination *RoleRollingUpdateCoordination `json:"coordination,omitempty"`
-}
-
-type RoleRollingUpdateCoordination struct {
+type RoleCoordination struct {
     // Empty means all Roles.
     Roles []string `json:"roles,omitempty"`
 
@@ -201,8 +202,8 @@ Dependency ordering has one fixed meaning: an upstream entry Role waits for targ
 
 The webhook must enforce:
 
-- When `roleRollingUpdateConfiguration.coordination` is present, `rolloutStrategy.type` must explicitly equal `RoleRollingUpdate`; the default `ServingGroupRollingUpdate` selected when the strategy is omitted is not valid.
-- `coordination.maxSkew` is required and must be a percentage string in `(0%, 100%]`; integer values are rejected.
+- When `roleCoordination` is present, `rolloutStrategy.type` must explicitly equal `RoleRollingUpdate`; the default `ServingGroupRollingUpdate` selected when the strategy is omitted is not valid.
+- `roleCoordination.maxSkew` is required and must be a percentage string in `(0%, 100%]`; integer values are rejected.
 - Role names in `roles`, `role`, and `dependsOn` exist in `spec.template.roles`.
 - Names are unique; self-dependencies and duplicate dependency edges are rejected.
 - The dependency graph is acyclic.
@@ -233,7 +234,9 @@ reservedProgress_r = min(R_r + I_r, T_r) / T_r
 
 - Role replicas in `RoleDeleting` because of this rollout;
 - target-hash Role replicas that are not `RoleRunning`;
-- stable replacement slots missing between deletion completion and successful recreation;
+- stable replacement slots missing between an admitted delete-first action and successful recreation.
+
+An ordinal that is absent only because the desired replica count increased is not reserved before its target-version creation is admitted. After admission, the created target-hash replica is observable and consumes `I_r` until it becomes `RoleRunning`.
 
 Counting in-flight work is essential. If the controller selected A, B, and C using only Ready progress, A and B could become Ready faster than C and exceed a decision made when all progress values were zero. Reservation prevents repeated reconciles from admitting more work than the coordination budget already committed.
 
@@ -268,6 +271,8 @@ readyBaseline = min(readyProgress_r) across active participating Roles
 ratioLimit    = min(1, readyBaseline + configuredSkew)
 allowedStarted_r = min(T_r, ceil(ratioLimit * T_r))
 ```
+
+Ready progress itself is not rounded: the controller compares `R_r / T_r` as an exact ratio using integer cross-multiplication. Rounding is applied only when the ratio limit is converted to an integer number of started replicas, and that conversion uses `ceil`. Rounding down could produce zero at startup for a small Role; for example, `floor(10% * 4) = 0` would prevent a four-replica Role from ever starting. The ceiling permits one replica for that Role without increasing any other Role's limit.
 
 A candidate for Role `r` is skew-eligible only when:
 
@@ -308,7 +313,7 @@ sync Services
 update status
 ```
 
-Coordination changes only the Role rolling-update decision inside `manageRollingUpdate`.
+Coordination changes Role rollout admission in two places: target-version creation during a concurrent scale-up in `syncRoleReplicas`, and delete-first replacement selection in `manageRollingUpdate`.
 
 #### Phase 1: build a snapshot
 
@@ -319,23 +324,24 @@ For each non-deleting ServingGroup:
 3. Resolve per-Role partition and eligible ordinals.
 4. Classify eligible replicas as old Ready, old unavailable, deleting, target Creating, or target Running.
 5. Calculate `T`, `R`, `I`, Ready progress, started progress, the shared Ready baseline, and each Role's `allowedStarted` integer limit.
-6. Generate local outdated candidates using the existing `maxUnavailable` logic.
+6. Generate target-version scale-up candidates and local outdated candidates using the existing scaling and `maxUnavailable` rules.
 
-Ordinary scaling remains owned by the existing `syncRoleReplicas` path and is not treated as coordinated rollout progress. The coordinator only filters outdated-role candidates produced by the existing rolling-update logic. Missing replacement slots for an active changed Role remain reserved as in-flight work.
+Replica-only scaling remains owned by the existing `syncRoleReplicas` path and is not coordinated. When a replica increase and template change occur together, missing ordinals that would be created with the target Role hash are rollout-start candidates and must be admitted before creation. Target-version replicas created by an admitted scale-up contribute to `R` when `RoleRunning` and to `I` otherwise. Missing replacement slots created by an admitted delete-first update remain reserved as in-flight work; unadmitted scale-up slots do not.
 
 #### Phase 2: filter and select candidates
 
-The coordinator repeatedly evaluates local candidates using a simulated reservation snapshot:
+The coordinator repeatedly evaluates rollout-start candidates using a simulated reservation snapshot. A candidate may create an additional target-version replica during concurrent scale-up or delete an outdated replica for delete-first replacement:
 
 ```text
 selected = []
 
 while candidates remain:
     eligible = candidates that satisfy all of:
-      1. Role partition allows the ordinal
-      2. Role maxUnavailable/local budget allows the candidate
-      3. projected R + I does not exceed this Role's allowedStarted limit
-      4. dependency Ready gate is satisfied
+      1. the existing local scaling or rolling-update rule allows the action
+      2. Role partition allows the ordinal
+      3. Role maxUnavailable/local budget allows a delete-first candidate
+      4. projected R + I does not exceed this Role's allowedStarted limit
+      5. dependency Ready gate is satisfied
 
     if eligible is empty:
         break
@@ -345,13 +351,13 @@ while candidates remain:
       2. Role order in spec
       3. highest replica ordinal
 
-    append candidate to selected
+    append candidate to the corresponding create or delete selection
     increment the simulated in-flight reservation for its Role
 ```
 
 The simulated increment prevents one reconcile from selecting an unlimited number of replicas before informer events report `RoleDeleting`.
 
-After selection, the existing `DeleteRole` path performs the actual delete. Deletion-completion events remove the logical Role from the datastore and enqueue the ModelServing. The next reconcile recreates the missing Role with the target hash. A target-hash non-Running Role consumes both the local `maxUnavailable` budget and the cross-Role reservation until it becomes `RoleRunning`.
+After selection, the existing `scaleUpRoles` path creates admitted target-version scale-up replicas, while the existing `DeleteRole` path performs admitted delete-first replacements. Deletion-completion events remove the logical Role from the datastore and enqueue the ModelServing. The next reconcile recreates the missing Role with the target hash. A target-hash non-Running Role consumes both the local `maxUnavailable` budget, where applicable, and the cross-Role reservation until it becomes `RoleRunning`.
 
 #### Phase 3: event-driven continuation
 
@@ -389,6 +395,10 @@ Coordination may reduce the number selected by the existing logic but never incr
 #### partition
 
 Partition is resolved separately for every Role and affects only that Role's denominator. A partition on A never stops B or C from completing their own rollout. Protected old replicas remain old after coordinated rollout completes.
+
+#### ordinary scaling
+
+A replica-only update continues through the existing scaling path without dependency or skew admission. When the desired count and template of a participating Role change together, target-version scale-up creation is admitted as rollout work because it can expose the new Role version to traffic. Scale-down remains an ordinary scaling action; once it changes `D_r`, subsequent coordination uses the new `T_r`, Ready progress, and reserved progress. If scale-down creates an observed skew greater than the configured limit, the coordinator does not undo the scale-down and admits no additional work for the leading Role until the other Roles catch up.
 
 #### recovery policy
 
@@ -449,7 +459,7 @@ type coordinatedRoleState struct {
 
 func selectCoordinatedRoleCandidates(
     states []coordinatedRoleState,
-    coordination *RoleRollingUpdateCoordination,
+    coordination *RoleCoordination,
 ) ([]roleToDelete, error)
 ```
 
@@ -457,8 +467,9 @@ Expected code touch points:
 
 - API types and generated clients/deepcopy/CRDs.
 - ModelServing webhook validation/defaulting.
+- `syncRoleReplicas` and `scaleUpRoles`: admit target-version creation when a replica increase and template change occur together.
 - `rolesToDeleteForRoleRollingUpdate`: build all Role candidates first instead of immediately concatenating independent selections.
-- `buildCoordinatedRoleState`: classify target Ready and in-flight replicas.
+- `buildCoordinatedRoleState`: classify target Ready and admitted in-flight replicas without reserving unadmitted scale-up slots.
 - `handleReadyPod`: enqueue on participating Role transition to Running.
 
 The existing `DeleteRole`, role recreation, ControllerRevision, Pod hash labels, and workqueue retry paths remain in use.
@@ -483,7 +494,7 @@ API documentation states that `A dependsOn B` makes B a startup prerequisite of 
 
 #### Feature interaction complexity
 
-The coordinator only filters candidates that already passed existing Role update rules. It does not own deletion, creation, readiness, or recovery.
+The coordinator only admits actions that already passed existing Role scaling or rolling-update rules. Existing paths continue to own creation, deletion, readiness, and recovery.
 
 ### Test Plan
 
@@ -496,6 +507,7 @@ The coordinator only filters candidates that already passed existing Role update
 - Per-Role partition denominator and different partitions across Roles.
 - Unchanged selected Roles and fully partitioned changed dependencies.
 - Per-Role integer limits for equal and unequal replica counts.
+- Ceiling conversion from percentage limits to integer replica counts, including small Roles whose floor would be zero.
 - Quantization of a small Role does not inflate other Roles' limits.
 - Ready-based startup dependency gating at equal and unequal replica counts.
 - Coordination preserves the existing behavior when `maxUnavailable` is omitted.
@@ -503,6 +515,9 @@ The coordinator only filters candidates that already passed existing Role update
 - Deterministic selection order and descending ordinal behavior.
 - Existing `maxUnavailable` always remains an upper bound.
 - Controller restart snapshot produces the same decision.
+- Replica-only scale-up bypasses coordination.
+- Concurrent template update and scale-up cannot create a target-version dependent before its dependency is Ready or exceed the Role's skew allowance.
+- Scale-down changes the denominator and subsequent decisions use the new desired count.
 
 #### Property and fuzz tests
 
@@ -523,6 +538,7 @@ For random DAGs, replica counts, partitions, Ready states, and local budgets:
 - rate-limited retries do not duplicate deletions.
 - controller restart during Deleting and Creating reconstructs reservations.
 - a second template update during rollout switches target hashes safely.
+- concurrent scale-up creation follows the same dependency and skew admission as delete-first replacement.
 
 #### End-to-end tests
 
@@ -531,15 +547,16 @@ For random DAGs, replica counts, partitions, Ready states, and local budgets:
 - Mixed partitions: A partially remains old while B/C complete.
 - One Role unschedulable: upstream stops and old capacity remains.
 - Explicit Role subset: selected Roles coordinate; unselected Role preserves legacy behavior.
+- Concurrent scale-up and template update: additional target-version replicas cannot bypass dependency or `maxSkew` admission.
 
 ### Rollout Plan
 
 1. Add the opt-in alpha API and webhook validation.
 2. Add per-ServingGroup state construction and pure candidate selection.
-3. Integrate candidate filtering into `RoleRollingUpdate` and enqueue intermediate participating RoleRunning transitions.
+3. Integrate rollout-start admission into concurrent target-version scale-up and `RoleRollingUpdate`, and enqueue intermediate participating RoleRunning transitions.
 4. Add unit, controller, and end-to-end coverage with injected readiness delays.
 
-When `coordination` is absent, the existing independent Role rolling update behavior remains unchanged.
+When `roleCoordination` is absent, the existing independent Role rolling update behavior remains unchanged.
 
 ### Alternatives
 

--- a/docs/proposal/coordinated-role-rolling-update.md
+++ b/docs/proposal/coordinated-role-rolling-update.md
@@ -1,0 +1,568 @@
+---
+title: Coordinated Proportional Role Rolling Update
+authors:
+- haoeeeee
+reviewers:
+- TBD
+approvers:
+- TBD
+
+creation-date: 2026-08-17
+
+---
+
+## Coordinated Proportional Role Rolling Update
+
+### Summary
+
+Kthena supports `RoleRollingUpdate`, but the current controller calculates `partition` and `maxUnavailable` independently for every Role in every ServingGroup. If several cooperating Roles change in one ModelServing revision, a fast Role can advance much further than a slow Role. The controller also has no Role dependency graph, so an upstream Role may be replaced and become ready before the new revision of its downstream dependency is ready.
+
+This proposal adds optional, per-ServingGroup coordination to `RoleRollingUpdate`. Users select the participating Roles, define a maximum percentage-point skew between their normalized ready progress, and optionally define a dependency DAG. The controller continues to use each Role's existing `partition` and `maxUnavailable` as local safety limits, then applies a second, cross-Role filter before deleting or creating a rollout candidate.
+
+Dependencies are a startup gate, not a permanent progress order. For `A -> B -> C`, the internal B and C stages may prestart together while A remains on the old revision. A starts only after both B and C have target-revision `RoleRunning` capacity. After a Role has a target-revision Ready replica, `maxSkew` coordinates later progress without maintaining `progress_A <= progress_B <= progress_C`. Every reconcile derives progress and in-flight reservations from Role state, Pod labels, and readiness.
+
+### Applicability Prerequisite
+
+This proposal applies only when the user explicitly selects:
+
+```yaml
+spec:
+  rolloutStrategy:
+    type: RoleRollingUpdate
+```
+
+Users still submit the target A/B/C configuration through `ModelServing.spec.template.roles`, because Roles are embedded in the ServingGroup template. The configuration location does not determine the execution unit; `rolloutStrategy.type` does:
+
+- With `RoleRollingUpdate`, the controller enters each ServingGroup, compares per-Role `RoleTemplateHash` values, and replaces only changed Role replicas. This proposal coordinates those Role-level candidates.
+- With `ServingGroupRollingUpdate`, or with the default strategy when `rolloutStrategy` is omitted, the controller deletes and recreates an outdated ServingGroup as a whole. It does not calculate independent A/B/C progress and this proposal does not apply.
+
+Updating A, B, and C in one ModelServing update therefore gives the controller one shared target Spec; they become three coordinated rollout objects only under explicit `RoleRollingUpdate`. This proposal neither changes strategy selection nor converts a ServingGroup rollout into a Role rollout automatically.
+
+### Motivation
+
+Consider one ServingGroup containing three Roles:
+
+```text
+A depends on B
+B depends on C
+```
+
+The application guarantees version-aware routing: new A calls new B, and new B calls new C. That guarantee alone does not make an uncoordinated rollout safe. In the first reconcile, the current Role rolling update can independently select one replica from A, B, and C. If new A and B become Ready before new C, traffic can reach new A and then fail because the required new C endpoint is not Ready.
+
+Updating only C until completion is also undesirable. New C receives no new-version traffic before B advances, and a large excess of new C replicas may be idle. The required behavior is:
+
+1. keep normalized new-version Ready progress approximately proportional across selected Roles;
+2. keep an upstream entry Role on the old revision until its dependency closure has target-revision Ready capacity;
+3. retain existing per-Role availability and partition semantics;
+4. allow slow or failed dependencies to stop upstream progress safely.
+
+The current implementation cannot provide these properties because `rolesToDeleteForRoleRollingUpdate` loops over Role specs and calculates each Role's `maxScaleDown` independently. `RoleRunning` is already a useful readiness signal: a Role replica becomes Running only after its entry Pod and all worker Pods are Running and Ready. This proposal builds coordination on that existing signal instead of introducing a separate readiness definition.
+
+#### Goals
+
+- Coordinate Role rolling updates independently inside each ServingGroup.
+- Define progress as the percentage of update-eligible Role replicas that are both on the target Role template hash and `RoleRunning`.
+- Limit the progress difference among selected active Roles with a user-supplied percentage such as `10%`.
+- Allow users to define an acyclic Role dependency graph for rollout ordering.
+- Keep an upstream entry Role from starting until every Role in its dependency closure has at least one target-version `RoleRunning` replica, while allowing internal dependency stages to prestart together.
+- Preserve each Role's current `maxUnavailable` and `partition` behavior.
+- Reserve in-flight work so asynchronous deletion, creation, scheduling, and readiness cannot oversubscribe the skew budget.
+- Remain compatible with the current informer, workqueue, and repeated-reconcile architecture.
+- Reconstruct coordination state from current objects after controller restarts.
+- Define validation, failure behavior, and a complete test plan.
+
+#### Non-Goals
+
+- Implement business request routing or verify that new A actually calls only new B.
+- Change initial ModelServing creation ordering. Dependencies in this proposal apply only to coordinated Role rolling updates.
+- Coordinate rollout progress across different ServingGroups. Each ServingGroup has an independent coordinator.
+- Replace the existing Role `maxUnavailable` or `partition` fields.
+- Coordinate ordinary scaling, failure recovery, or Role addition/removal as proportional rolling-update work.
+- Automatically roll back a revision when rollout progress stalls.
+- Turn Pod readiness on or off, mutate readiness gates, or change Service endpoint selection.
+- Guarantee runtime dependency health after an upstream replica has already completed rollout. Ordinary recovery policy handles later failures.
+
+### Proposal
+
+Coordination is opt-in and only valid with `rolloutStrategy.type: RoleRollingUpdate`.
+
+```yaml
+apiVersion: workload.serving.volcano.sh/v1alpha1
+kind: ModelServing
+metadata:
+  name: example
+spec:
+  rolloutStrategy:
+    type: RoleRollingUpdate
+    roleRollingUpdateConfiguration:
+      coordination:
+        # Optional. Omission selects all Roles in spec.template.roles.
+        roles: [a, b, c]
+
+        # Percentage points of normalized rollout progress. Percent only.
+        maxSkew: 10%
+
+        # Rollout-only startup dependency graph. "a dependsOn b" means b
+        # must have one target-revision RoleRunning replica before a starts.
+        dependencies:
+        - role: a
+          dependsOn: [b]
+        - role: b
+          dependsOn: [c]
+
+  template:
+    roles:
+    - name: a
+      replicas: 4
+      maxUnavailable: 1
+      partition: 0
+      # templates omitted
+    - name: b
+      replicas: 4
+      maxUnavailable: 1
+      partition: 0
+    - name: c
+      replicas: 4
+      maxUnavailable: 1
+      partition: 0
+```
+
+The `roles` list scopes one coordination domain:
+
+- omitted or empty: all Roles in `spec.template.roles`;
+- specified: exactly those Roles participate in progress skew and dependency ordering;
+- an unchanged selected Role is treated as complete for the current revision and does not block changed Roles;
+- a non-selected Role retains the existing independent Role rollout behavior;
+- a dependency endpoint must be in the selected set.
+
+#### User Stories
+
+##### Proportional PD rollout
+
+A ServingGroup has 10 prefill and 20 decode Role replicas. Both templates change. With `maxSkew: 10%`, the controller prevents one Role from accumulating substantially more target-hash Ready capacity than the other while both still have rollout work.
+
+##### Dependency-safe three-stage rollout
+
+A, B, and C each have four replicas, `maxUnavailable: 1`, `maxSkew: 10%`, and dependencies A -> B -> C. Each Role's first integer step is 25%. Startup proceeds as follows:
+
+```text
+B and C each start one replacement; A remains old
+    -> B and C reach target hash and RoleRunning
+    -> A starts one replacement
+```
+
+After these first Ready replicas exist, all three Roles are unlocked. Later selection is based on `maxSkew` and deterministic candidate ordering; it does not have to repeat C/B/A order. New A cannot start before compatible new B and C capacity exists.
+
+##### Different Role replica counts
+
+A has 2 replicas, B has 4, and C has 10. With `maxSkew: 10%` and a zero Ready baseline, their per-Role integer start limits are `ceil(0.1*2)=1`, `ceil(0.1*4)=1`, and `ceil(0.1*10)=1`. A's first replica is an unavoidable local 50% step, but that does not inflate B or C to a global 50% bound.
+
+##### Different partitions
+
+A has four replicas with `partition: 2`; B and C have four replicas with no partition. A's rollout target contains only A-2 and A-3. Its denominator is therefore two, not four. Once those two replicas are updated and Ready, A's coordinated progress is 100%, while A-0 and A-1 intentionally remain old. B and C may still reach 100% of their own four-replica targets; A's partition does not implicitly partition B or C.
+
+### API Design
+
+```go
+type RolloutStrategy struct {
+    Type RolloutStrategyType `json:"type"`
+
+    // Used only by ServingGroupRollingUpdate.
+    RollingUpdateConfiguration *RollingUpdateConfiguration `json:"rollingUpdateConfiguration,omitempty"`
+
+    // Used only by RoleRollingUpdate.
+    RoleRollingUpdateConfiguration *RoleRollingUpdateConfiguration `json:"roleRollingUpdateConfiguration,omitempty"`
+}
+
+type RoleRollingUpdateConfiguration struct {
+    Coordination *RoleRollingUpdateCoordination `json:"coordination,omitempty"`
+}
+
+type RoleRollingUpdateCoordination struct {
+    // Empty means all Roles.
+    Roles []string `json:"roles,omitempty"`
+
+    // Required. Percentage strings only, for example "10%".
+    MaxSkew *intstr.IntOrString `json:"maxSkew"`
+
+    Dependencies []RoleRolloutDependency `json:"dependencies,omitempty"`
+}
+
+type RoleRolloutDependency struct {
+    Role      string   `json:"role"`
+    DependsOn []string `json:"dependsOn"`
+}
+
+```
+
+Dependency ordering has one fixed meaning: an upstream entry Role waits for target-revision `RoleRunning` capacity across its dependency closure. Internal stages may prestart together while all of their upstream dependents remain unstarted. Once a Role has a target-revision Ready replica, dependency edges do not impose a continuing progress order. The API intentionally does not expose a scheduled-only readiness mode.
+
+#### Validation and defaulting
+
+The webhook must enforce:
+
+- When `roleRollingUpdateConfiguration.coordination` is present, `rolloutStrategy.type` must explicitly equal `RoleRollingUpdate`; the default `ServingGroupRollingUpdate` selected when the strategy is omitted is not valid.
+- `coordination.maxSkew` is required and must be a percentage string in `(0%, 100%]`; integer values are rejected.
+- Role names in `roles`, `role`, and `dependsOn` exist in `spec.template.roles`.
+- Names are unique; self-dependencies and duplicate dependency edges are rejected.
+- The dependency graph is acyclic.
+- Every dependency endpoint belongs to the effective selected Role set.
+- At least two Roles are selected; a single Role provides no coordination benefit.
+- Existing Role-level `partition` and `maxUnavailable` syntax validation remains unchanged.
+
+Coordination does not introduce a `maxUnavailable` default. If it is omitted, the existing Role rolling logic supplies all outdated replicas as local candidates, and the coordinator may still reduce that set through skew and dependency constraints. Operators should configure `maxUnavailable` when they require an explicit per-Role availability bound.
+
+### Progress Model
+
+All calculations are performed independently for each ServingGroup and target ModelServing revision.
+
+For participating Role `r`:
+
+```text
+D_r = desired Role replica count
+P_r = resolved partition count
+T_r = max(D_r - P_r, 0)              update-eligible target replicas
+R_r = eligible replicas with target RoleTemplateHash and RoleRunning
+I_r = eligible rollout work already reserved but not Ready
+
+readyProgress_r    = R_r / T_r
+reservedProgress_r = min(R_r + I_r, T_r) / T_r
+```
+
+`I_r` includes:
+
+- Role replicas in `RoleDeleting` because of this rollout;
+- target-hash Role replicas that are not `RoleRunning`;
+- stable replacement slots missing between deletion completion and successful recreation;
+
+Counting in-flight work is essential. If the controller selected A, B, and C using only Ready progress, A and B could become Ready faster than C and exceed a decision made when all progress values were zero. Reservation prevents repeated reconciles from admitting more work than the coordination budget already committed.
+
+Only ordinals greater than or equal to the resolved Role partition contribute to `T_r`, `R_r`, or `I_r`. Protected replicas remain available but are outside the rollout target.
+
+If a selected Role's template did not change, it is excluded from the active skew minimum, while its current target-hash Ready replicas may still satisfy a dependency. If `T_r` is zero for a changed dependency Role, it cannot provide target-revision Ready capacity and its dependents remain blocked.
+
+#### Percentage semantics
+
+`maxSkew: 10%` means a target difference of ten percentage points before conversion to integer replica limits:
+
+```text
+progress_r <= minimum Ready progress + 0.10
+```
+
+It does not mean:
+
+- ten replica instances;
+- ten percent of the larger Role's raw replica count;
+- a relative error such as `progress_a / progress_b`.
+
+The only permitted overshoot is the local integer quantization described below. The implementation should use integer cross-multiplication or fixed-point basis points rather than floating-point comparison.
+
+#### Per-Role integer limits
+
+A Role with `T_r` eligible replicas advances in increments of `1/T_r`. The controller must not increase one global effective skew to the coarsest Role's step, because that would grant unrelated large Roles extra work.
+
+For every reconcile, define:
+
+```text
+readyBaseline = min(readyProgress_r) across active participating Roles
+ratioLimit    = min(1, readyBaseline + configuredSkew)
+allowedStarted_r = min(T_r, ceil(ratioLimit * T_r))
+```
+
+A candidate for Role `r` is skew-eligible only when:
+
+```text
+R_r + I_r + 1 <= allowedStarted_r
+```
+
+For A/B/C with 8, 4, and 10 eligible replicas, a `10%` limit at a zero Ready baseline permits 1, 1, and 1 started replica respectively: 12.5%, 25%, and 10%. B's unavoidable 25% integer step does not raise A or C to a 25% global limit. Implementations use integer cross-multiplication rather than floating point.
+
+### Dependency Semantics
+
+An edge:
+
+```yaml
+- role: a
+  dependsOn: [b]
+```
+
+means that B is a rollout prerequisite of A.
+
+Before A's first replacement is admitted, every dependency B must have at least one eligible target-revision `RoleRunning` replica. A dependency that is merely created or scheduled does not unlock A.
+
+After A is unlocked, the edge no longer compares A and B progress. A may advance ahead of B when A's own candidate remains inside the shared `maxSkew` limit. No ordinal pairing such as A-3 to B-3 is required.
+
+The dependency gate is checked when rollout work is admitted, before deleting the old upstream Role replica. It does not change Kubernetes Pod readiness. Consequently, the required downstream new-version capacity already exists before the upstream replacement can be created and become reachable.
+
+Among currently eligible candidates, the Role with the lowest started progress is preferred, followed by Role order in the ModelServing spec and descending Role ordinal. Dependency order affects eligibility only while a Role is locked; it does not remain a priority after startup unlock.
+
+### Reconcile Algorithm
+
+The existing `syncModelServing` order remains conceptually unchanged:
+
+```text
+sync ServingGroup count
+sync Role count and missing Pods
+manage rolling update
+sync Services
+update status
+```
+
+Coordination changes only the Role rolling-update decision inside `manageRollingUpdate`.
+
+#### Phase 1: build a snapshot
+
+For each non-deleting ServingGroup:
+
+1. Resolve selected Roles and determine which Role templates changed in the current revision.
+2. Calculate the target Role template hash for every Role.
+3. Resolve per-Role partition and eligible ordinals.
+4. Classify eligible replicas as old Ready, old unavailable, deleting, target Creating, or target Running.
+5. Calculate `T`, `R`, `I`, Ready progress, started progress, the shared Ready baseline, and each Role's `allowedStarted` integer limit.
+6. Generate local outdated candidates using the existing `maxUnavailable` logic.
+
+Ordinary scaling remains owned by the existing `syncRoleReplicas` path and is not treated as coordinated rollout progress. The coordinator only filters outdated-role candidates produced by the existing rolling-update logic. Missing replacement slots for an active changed Role remain reserved as in-flight work.
+
+#### Phase 2: filter and select candidates
+
+The coordinator repeatedly evaluates local candidates using a simulated reservation snapshot:
+
+```text
+selected = []
+
+while candidates remain:
+    eligible = candidates that satisfy all of:
+      1. Role partition allows the ordinal
+      2. Role maxUnavailable/local budget allows the candidate
+      3. projected R + I does not exceed this Role's allowedStarted limit
+      4. dependency Ready gate is satisfied
+
+    if eligible is empty:
+        break
+
+    choose the candidate with:
+      1. lowest projected/reserved Role progress
+      2. Role order in spec
+      3. highest replica ordinal
+
+    append candidate to selected
+    increment the simulated in-flight reservation for its Role
+```
+
+The simulated increment prevents one reconcile from selecting an unlimited number of replicas before informer events report `RoleDeleting`.
+
+After selection, the existing `DeleteRole` path performs the actual delete. Deletion-completion events remove the logical Role from the datastore and enqueue the ModelServing. The next reconcile recreates the missing Role with the target hash. A target-hash non-Running Role consumes both the local `maxUnavailable` budget and the cross-Role reservation until it becomes `RoleRunning`.
+
+#### Phase 3: event-driven continuation
+
+The Pod handler already changes a Role to `RoleRunning` only after its entry Pod and all worker Pods are Running and Ready. The current `syncModelServing` function itself has no whole-ServingGroup Ready gate: whenever a ModelServing is enqueued, it runs the normal reconcile. The subtle issue is the current Ready-event path. `handleReadyPod` updates an individual Role to `RoleRunning`, but that path normally calls `enqueueModelServing` only after `checkServingGroupReady` reports that the whole ServingGroup is Ready. Delete completion, spec changes, retries, or other events may still enqueue earlier, so this is not a hard semantic barrier; it is a missing immediate enqueue for an intermediate Role Ready transition.
+
+Coordinated rollout therefore additionally enqueues the ModelServing whenever a participating Role replica transitions to `RoleRunning`, while retaining the existing ServingGroup status update. This lets the first Ready dependency unlock its dependent and lets later Ready progress release new skew capacity promptly.
+
+The controller still does not wait inside reconcile:
+
+```text
+reconcile -> select/delete -> return
+Pod/Service delete events -> enqueue
+reconcile -> recreate -> return
+Pod Ready events -> RoleRunning -> enqueue
+reconcile -> select the next allowed work
+```
+
+After restart, Pod revision/hash labels, Role status reconstruction, desired counts, and missing slots reproduce the same constraints.
+
+### Interaction with Existing Features
+
+#### maxUnavailable
+
+`maxUnavailable` remains a local availability constraint for one Role. Coordination is an additional global filter:
+
+```text
+final candidates = local maxUnavailable candidates
+                 intersect partition-eligible candidates
+                 intersect skew-allowed candidates
+                 intersect dependency-allowed candidates
+```
+
+Coordination may reduce the number selected by the existing logic but never increases it.
+
+#### partition
+
+Partition is resolved separately for every Role and affects only that Role's denominator. A partition on A never stops B or C from completing their own rollout. Protected old replicas remain old after coordinated rollout completes.
+
+#### recovery policy
+
+Intentional deletion continues to be identified by `RoleDeleting`, so it must not be treated as a failure-recovery event. A later failure after rollout admission follows the configured RecoveryPolicy. The coordinator does not retract already Ready upstream replicas.
+
+#### new template changes during rollout
+
+The latest ModelServing spec remains authoritative. A new target hash starts a new reconciliation target. Previously created replicas that no longer match become outdated again.
+
+### Failure and Blocking Behavior
+
+#### Slow or failed dependency
+
+If new C remains Creating:
+
+- C consumes its local and reserved budget;
+- B may consume its initial skew budget while all upstream Roles remain unstarted;
+- A cannot start until both B and C have target-revision `RoleRunning` replicas;
+- B and C cannot consume more than their per-Role integer limits derived from `maxSkew`;
+- old A replicas remain serving.
+
+The rollout is intentionally stalled rather than exposing an incompatible upstream chain.
+
+#### Unschedulable replicas
+
+Unschedulable target replicas remain in-flight and do not release budget. Existing Kubernetes Pod events explain scheduling failure, and the rollout remains waiting for Role readiness.
+
+#### Dependency cycle or missing Role
+
+These are admission errors and never reach the controller.
+
+#### No eligible dependency replica
+
+If a changed dependency is fully protected by partition, it cannot provide target-revision Ready capacity and dependent rollout remains blocked. The controller does not bypass the dependency.
+
+#### Inconsistent or legacy hash data
+
+The existing ControllerRevision fallback is used to infer missing Role template hashes. If a hash cannot be resolved, the controller conservatively does not count the replica as target Ready and logs the unresolved comparison.
+
+### Status and Observability
+
+This change does not add a new public status or metric API. Operators can inspect existing Pod Ready conditions, Role template-hash labels, Role lifecycle events, and controller logs. `status.updatedReplicas` remains ServingGroup-level and is not Role rollout progress.
+
+### Controller Integration
+
+The implementation introduces a compact per-Role snapshot and a pure selection function so algorithm tests do not require Kubernetes clients:
+
+```go
+type coordinatedRoleState struct {
+    roleName  string
+    specIndex int
+    target    int
+    ready     int
+    inFlight int
+    active    bool
+    candidates []roleToDelete
+}
+
+func selectCoordinatedRoleCandidates(
+    states []coordinatedRoleState,
+    coordination *RoleRollingUpdateCoordination,
+) ([]roleToDelete, error)
+```
+
+Expected code touch points:
+
+- API types and generated clients/deepcopy/CRDs.
+- ModelServing webhook validation/defaulting.
+- `rolesToDeleteForRoleRollingUpdate`: build all Role candidates first instead of immediately concatenating independent selections.
+- `buildCoordinatedRoleState`: classify target Ready and in-flight replicas.
+- `handleReadyPod`: enqueue on participating Role transition to Running.
+
+The existing `DeleteRole`, role recreation, ControllerRevision, Pod hash labels, and workqueue retry paths remain in use.
+
+### Risks and Mitigations
+
+#### Rollout throughput reduction
+
+Ready-based startup gating delays an upstream entry Role until its dependency closure is Ready and can be slower than independent rollout. Internal dependency stages may prestart together. After all Roles are unlocked, `maxSkew` and each Role's `maxUnavailable` determine throughput.
+
+#### Deadlock from discrete replica counts
+
+Strict percentage inequalities can be impossible for small Roles. Per-Role ceiling conversion provides one-replica liveness without inflating every Role's budget. Coordinator tests cover mixed replica counts.
+
+#### Stale informer observations
+
+Candidate admission uses conservative in-flight reservations and simulated increments. Operations are idempotent, and RoleDeleting/target-Creating/missing replacement slots remain reserved across reconciles.
+
+#### Misconfigured dependency direction
+
+API documentation states that `A dependsOn B` makes B a startup prerequisite of A. Webhook DAG validation and examples reduce ambiguity.
+
+#### Feature interaction complexity
+
+The coordinator only filters candidates that already passed existing Role update rules. It does not own deletion, creation, readiness, or recovery.
+
+### Test Plan
+
+#### Unit tests
+
+- Percent parsing and rejection of absolute `maxSkew`.
+- Role selection defaulting and explicit subset behavior.
+- Dependency existence, duplicate, self-edge, and cycle validation.
+- Progress calculation with target hash, `RoleRunning`, Creating, Deleting, and missing replacement slots.
+- Per-Role partition denominator and different partitions across Roles.
+- Unchanged selected Roles and fully partitioned changed dependencies.
+- Per-Role integer limits for equal and unequal replica counts.
+- Quantization of a small Role does not inflate other Roles' limits.
+- Ready-based startup dependency gating at equal and unequal replica counts.
+- Coordination preserves the existing behavior when `maxUnavailable` is omitted.
+- Candidate simulation prevents over-selection in one reconcile.
+- Deterministic selection order and descending ordinal behavior.
+- Existing `maxUnavailable` always remains an upper bound.
+- Controller restart snapshot produces the same decision.
+
+#### Property and fuzz tests
+
+For random DAGs, replica counts, partitions, Ready states, and local budgets:
+
+- selected candidates never violate local availability or partition;
+- projected reservations never exceed that Role's quantized integer limit;
+- dependency gating never admits a dependent before every dependency has a target-revision Ready replica;
+- selection is deterministic for the same snapshot;
+- repeated Ready transitions eventually complete when all creations succeed;
+- invalid graphs are always rejected.
+
+#### Integration tests
+
+- Spec update event enqueues a ModelServing and selects only dependency-allowed work.
+- Delete events preserve reservation through deletion/recreation gaps.
+- each participating RoleRunning transition enqueues reconciliation.
+- rate-limited retries do not duplicate deletions.
+- controller restart during Deleting and Creating reconstructs reservations.
+- a second template update during rollout switches target hashes safely.
+
+#### End-to-end tests
+
+- A/B/C equal replicas, delayed C readiness: B and C may prestart, while A waits until both dependencies have a target-revision Ready replica.
+- Different replica counts with configured skew below one Role's single-replica step.
+- Mixed partitions: A partially remains old while B/C complete.
+- One Role unschedulable: upstream stops and old capacity remains.
+- Explicit Role subset: selected Roles coordinate; unselected Role preserves legacy behavior.
+
+### Rollout Plan
+
+1. Add the opt-in alpha API and webhook validation.
+2. Add per-ServingGroup state construction and pure candidate selection.
+3. Integrate candidate filtering into `RoleRollingUpdate` and enqueue intermediate participating RoleRunning transitions.
+4. Add unit, controller, and end-to-end coverage with injected readiness delays.
+
+When `coordination` is absent, the existing independent Role rolling update behavior remains unchanged.
+
+### Alternatives
+
+#### Rely only on business-layer version routing
+
+Rejected as the controller can still make a new upstream Role reachable before any compatible downstream replica is Ready. Routing cannot select a nonexistent endpoint.
+
+#### Use only dependency order
+
+The invariant `progress_A <= progress_B <= progress_C` prevents upstream from leading, but by itself allows C to reach 100% while A remains at 0%. `maxSkew` is still needed to bound idle downstream progress.
+
+#### Use only maxSkew with simultaneous candidate admission
+
+Rejected because all Roles can be at zero when A, B, and C are admitted simultaneously. Different readiness latency can then expose A before C. The dependency Ready gate must constrain admission.
+
+#### Define skew as a raw replica-count difference
+
+Rejected because Roles commonly have different desired counts. A one-replica difference means 50% for a two-replica Role but 1% for a hundred-replica Role.
+
+#### Mutate Pod readiness until dependencies are Ready
+
+Rejected for the initial design. It couples rollout control to kubelet readiness and Service endpoint semantics, can hide otherwise healthy Pods, and still needs a policy for already Ready Pods when a dependency later fails. Candidate admission prevents the unsafe state earlier.
+
+### References
+
+- [Kthena Role rolling update proposal](https://github.com/volcano-sh/kthena/blob/main/docs/proposal/role-rollingupdate.md)

--- a/docs/proposal/coordinated-role-rolling-update.md
+++ b/docs/proposal/coordinated-role-rolling-update.md
@@ -195,10 +195,12 @@ For every selected Role, the state builder reads three inputs:
 They define the stable population covered by proportional replacement:
 
 ```text
-T = max(min(previousDesired, desired) - userPartition, 0)
+stableEnd = min(previousDesired, desired)
+stableReplacementRange = [userPartition, stableEnd)
+T = max(stableEnd - userPartition, 0)
 ```
 
-`T` is the number of pre-update stable slots covered by proportional replacement. It uses the smaller of the old and new desired counts, so ordinary scale-up capacity and scale-down excess stay outside the proportional denominator.
+`T` is the number of pre-update stable Role ordinal slots covered by proportional replacement. It uses the smaller of the old and new desired counts, so ordinary scale-up slots at ordinals greater than or equal to `stableEnd` and scale-down excess stay outside the proportional denominator. The controller obtains the ordinal from the Role ID, and the existing scale path fills missing ordinals inside its expected range. If Role scale synchronization fills a missing ordinal inside `stableReplacementRange`, that capacity occupies a pre-update stable slot and is therefore replacement capacity, regardless of which execution path created it.
 
 The proportional calculation keeps only three per-Role values. They are reconstructed on every reconcile and are not persisted in the API or status:
 
@@ -206,7 +208,7 @@ The proportional calculation keeps only three per-Role values. They are reconstr
 | --- | --- | --- |
 | `T` | total pre-update stable slots to replace | Step 2 uses it as the progress denominator and replacement target |
 | `S` | slots whose replacement has started | Step 2 subtracts it from the allowed total so in-flight work is not admitted again |
-| `R` | started slots backed by target-version stable `RoleRunning` capacity | Step 2 uses `R/T` as normalized Ready progress |
+| `R` | started slots in `stableReplacementRange` backed by target-version `RoleRunning` capacity at the same ordinal | Step 2 uses `R/T` as normalized Ready progress |
 
 `S` prevents already admitted deletion and recreation work from consuming the allowance again. `R` advances only when stable target-version capacity reaches `RoleRunning`. Their reconstruction from Role and Pod observations is described later in [State Reconstruction and Controller Restart](#state-reconstruction-and-controller-restart).
 
@@ -256,7 +258,7 @@ Dependency coordination uses two additional per-Role states, separate from the p
 | `targetState` | `NotStarted`, `Started`, or `Ready` | gates the first target-version start of a rollout root |
 | `hasOldVersion` | whether old-version capacity still exists | retains the final old replica on a dependency path |
 
-Replacement, ordinary scale-up, and surge capacity may update `targetState`, but only stable replacement capacity contributes to `T`, `S`, and `R`.
+Replacement, ordinary scale-up, and surge capacity may update `targetState`, but only target-version capacity occupying `stableReplacementRange` contributes to `T`, `S`, and `R`.
 
 An edge:
 
@@ -366,9 +368,9 @@ During a template update, target-version Role capacity can come from three paths
 
 `rolesToDeleteForRoleRollingUpdate` remains responsible for outdated detection, descending Role ordering, and the Role's `maxUnavailable`. Coordination only narrows its candidate set through `effectivePartition`.
 
-For a simultaneous template update and ordinary scale-up, `syncRoleReplicas` creates target capacity toward `desired` after `targetStartAllowed` becomes true. The `desired-previousDesired` expansion amount stays outside proportional progress, while a resulting target-hash `RoleRunning` replica can make `targetState=Ready` for dependency startup.
+For a simultaneous template update and ordinary scale-up, `syncRoleReplicas` creates target capacity toward `desired` after `targetStartAllowed` becomes true. Target capacity at ordinals in `[stableEnd, desired)` stays outside proportional progress, while a resulting target-hash `RoleRunning` replica can make `targetState=Ready` for dependency startup. Target capacity that fills an ordinal in `stableReplacementRange` is counted as replacement progress.
 
-For example, `previousDesired=10`, `desired=12`, and `userPartition=0` produce `T=10`, with two ordinary scale-up replicas outside `T`. The ten pre-update stable slots form the proportional denominator, independent of which ordinals the existing scale-up policy chooses.
+For example, `previousDesired=10`, `desired=12`, and `userPartition=0` produce `stableReplacementRange=[0,10)` and `T=10`. Ordinals 10 and 11 are ordinary scale-up slots outside `T`. The ten pre-update stable ordinal slots form the proportional denominator.
 
 For a simultaneous scale-down, `min(previousDesired, desired)` excludes the removed excess from the proportional population. Existing scale-down policy reconciles that excess, while `T` remains the replacement denominator.
 
@@ -387,7 +389,7 @@ else:
     temporaryExpected = desired
 ```
 
-`dependencyRetentionIsBinding` is true only when dependency coordination, rather than `userPartition`, is retaining the final old replica. Normal Role scale synchronization creates capacity up to `temporaryExpected`. The controller does not label an individual Role as surge and does not infer surge identity from its ordinal. Eligible target-hash capacity that becomes `RoleRunning` can make `targetState=Ready` and unlock a dependent root.
+`dependencyRetentionIsBinding` is true only when dependency coordination, rather than `userPartition`, is retaining the final old replica. Normal Role scale synchronization creates capacity up to `temporaryExpected`. The controller does not persist a permanent replacement, scale-up, or surge origin on an individual Role. Each reconcile classifies its current capacity by ordinal range: `stableReplacementRange` contributes to proportional progress, `[stableEnd, desired)` contributes ordinary scale-up capacity, and `[desired, temporaryExpected)` contributes admitted surge capacity. Eligible target-hash capacity in these admitted ranges that becomes `RoleRunning` can make `targetState=Ready` and unlock a dependent root.
 
 Old-replica deletion still follows `effectivePartition` and `maxUnavailable`. `maxSkew` still follows `R/T`; temporary capacity above `desired` is outside the stable target capacity used to derive `R`.
 
@@ -447,37 +449,38 @@ No coordination state is persisted. Every reconcile derives it from the ModelSer
 
 ##### Proportional state
 
-- `T` is calculated from `previousDesired`, `desired`, and `userPartition`.
-- `S` is `T` minus the non-deleting old replicas that still occupy the updateable stable population. A slot remains started while its old replica is deleting, its stable capacity is missing, or its replacement is Creating.
-- `R` is the part of `S` backed by target-hash `RoleRunning` capacity inside the stable desired count. Before deriving it, the controller conservatively removes ordinary scale-up capacity and any current capacity above `desired` from the observed target Ready count. Those replicas can therefore never inflate proportional progress; an ambiguous snapshot may temporarily undercount `R` until scaling converges.
+- `T` is the size of `stableReplacementRange=[userPartition,min(previousDesired,desired))`.
+- `S` is `T` minus the non-deleting old replicas that still occupy this ordinal range. A slot remains started while its old replica is deleting, its stable capacity is missing, or its replacement is Creating.
+- `R` is the number of started ordinals in this range occupied by a target-hash `RoleRunning` replica.
 
-Here, `remainingOldToUpdate` is the number of non-deleting old replicas still occupying the updateable stable population, `targetReady` is the observed target-hash `RoleRunning` count, and `observedNonDeleting` is the current non-deleting Role count. The count-based reconstruction is:
+Here, `remainingOldToUpdate` is the number of non-deleting old replicas still occupying `stableReplacementRange`, and `stableTargetReady` is the number of target-hash `RoleRunning` replicas whose Role ordinal is in that range. The reconstruction is:
 
 ```text
-S = T - min(T, remainingOldToUpdate)
-
-ordinaryScale       = max(desired - previousDesired, 0)
-temporaryExcess     = max(observedNonDeleting - desired, 0)
-replacementReady    = max(targetReady - ordinaryScale - temporaryExcess, 0)
-R                   = min(S, replacementReady)
+stableEnd              = min(previousDesired, desired)
+stableReplacementRange = [userPartition, stableEnd)
+T                      = max(stableEnd - userPartition, 0)
+S                      = T - min(T, remainingOldToUpdate)
+R                      = min(S, stableTargetReady)
 ```
 
-Subtracting the full ordinary-scale and excess counts is conservative when individual origins are ambiguous: it can delay another admission, but cannot let scale-up, scale-down excess, or surge capacity consume `maxSkew` progress.
+This range-based reconstruction is independent of Ready ordering. If a replacement becomes Ready before an ordinary scale-up replica, it advances `R` immediately. If the scale-up replica becomes Ready first, it may satisfy dependency startup but does not advance `R`. Capacity above `stableEnd` cannot inflate proportional progress.
+
+For example, `previousDesired=2`, `desired=3`, and `userPartition=0` produce `stableReplacementRange=[0,2)`. If target ordinal 0 is `RoleRunning` while scale-up ordinal 2 is not Ready, then `R=1`. If ordinal 2 is Ready while the target replacement at ordinal 0 is not Ready, then `R=0`; the scale-up capacity affects only dependency state.
 
 ##### Dependency state
 
-- `targetState` becomes `Started` when target-version replacement, ordinary scale-up, or admitted surge work exists. It becomes `Ready` when target-hash `RoleRunning` capacity remains after conservatively excluding scale-down excess above the currently admitted capacity limit.
+- `targetState` becomes `Started` when target-version replacement, ordinary scale-up, or admitted surge work exists in the currently admitted ordinal range. It becomes `Ready` when target-hash `RoleRunning` capacity exists in that range.
 - `hasOldVersion` remains true while an old-hash Role or terminating old Pod still exists, or while a partition-protected old slot is temporarily missing and awaiting recovery. Terminating Pods are read from the Pod informer cache so the final-old-replica protection survives datastore reconstruction.
 
 ```text
 dependencyExpected = desired + admittedSurge
-scaleDownExcess    = max(observedNonDeleting - dependencyExpected, 0)
-dependencyReady    = max(targetReady - scaleDownExcess, 0)
+dependencyRange    = [0, dependencyExpected)
+dependencyReady    = target-hash RoleRunning capacity in dependencyRange
 ```
 
-`admittedSurge` is the resolved `maxSurge` only while target startup is allowed and `surgeRequired` from Step 5 is true; otherwise it is zero. `dependencyReady > 0` sets `targetState=Ready`. This allows admitted surge capacity to unlock a root without letting replicas that are merely awaiting ordinary scale-down do so.
+`admittedSurge` is the resolved `maxSurge` only while target startup is allowed and `surgeRequired` from Step 5 is true; otherwise it is zero. `dependencyReady > 0` sets `targetState=Ready`. This allows ordinary scale-up and admitted surge capacity to unlock a root, while Role ordinals outside `dependencyRange` that are awaiting scale-down are ignored.
 
-Ordinary scale-up is derived as `max(desired-previousDesired, 0)`. Capacity above `desired` while `surgeRequired` is true is treated as temporary surge capacity. Revision and template-hash labels distinguish old and target versions; no individual Role ordinal is permanently classified as replacement, scale-up, or surge.
+Ordinary scale-up occupies the admitted desired range above `stableEnd`. Capacity in `[desired, dependencyExpected)` is admitted surge capacity while `surgeRequired` is true. Revision and template-hash labels distinguish old and target versions, and the ordinal boundaries classify their current coordination semantics without persisting an origin label.
 
 After a controller restart, the startup path rebuilds the datastore and enqueues existing ModelServings. The first reconcile observes the same revisions, hashes, deletion state, missing capacity, and Ready conditions, reconstructs the values above, and resumes from the resulting limits.
 
@@ -570,7 +573,7 @@ Main code changes:
 - API types, generated clients, deepcopy code, and CRDs for `roleCoordination`;
 - admission parsing of the old and new ModelServing objects for update-time rollout feasibility validation;
 - webhook validation for Role selection, `maxSkew`, dependency DAGs, partition-limited target capacity, and insufficient bootstrap capacity on update;
-- flat Role-state construction for `T`, `S`, `R`, `targetState`, `hasOldVersion`, and `active` from the ControllerRevision, Role spec, datastore Roles, Pods, hashes, readiness, and current counts;
+- flat Role-state construction for `T`, `S`, `R`, `targetState`, `hasOldVersion`, and `active` from the ControllerRevision, Role spec, datastore Roles, Role ordinals, Pods, hashes, readiness, and admitted capacity ranges;
 - `syncModelServing` construction of one per-ServingGroup decision map before Role replica synchronization, passed to both `syncRoleReplicas` and `manageRollingUpdate`;
 - `rolesToDeleteForRoleRollingUpdate` integration for `effectivePartition`;
 - `scaleUpRoles` integration with dependency startup and `targetState` updates during a coordinated Role rollout;
@@ -592,7 +595,7 @@ Small Roles have coarse progress steps. Per-Role ceiling conversion permits one 
 
 #### Ordinary Scale-up and Surge Capacity
 
-Ordinary scale-up and temporary capacity contribute through `targetState`. After reaching `RoleRunning`, both provide dependency Ready capacity. Ordinary scale-up persists inside `desired`, while the expected count contracts to `desired` after eligible old replicas are gone. Replacement progress remains `R/T`.
+Ordinary scale-up and temporary capacity contribute through `targetState`. After reaching `RoleRunning` in an admitted ordinal range, both provide dependency Ready capacity. Only target Ready capacity inside `stableReplacementRange` contributes to `R`; Ready ordering between replacement and expansion capacity therefore cannot change the measured proportional progress. Ordinary scale-up persists inside `desired`, while the expected count contracts to `desired` after eligible old replicas are gone.
 
 #### Informer convergence
 
@@ -610,8 +613,9 @@ The ModelServing condition records the blocking ServingGroup, Role, reason, and 
 - UPDATE capacity validation for changed dependencies, including `partition < replicas` and single-replica bootstrap through ordinary scale-up or positive `maxSurge`.
 - Rollout-root inference for chains, branches, multiple roots, and isolated Roles.
 - `T=max(min(previousDesired,desired)-userPartition,0)` for equal, scale-up, and scale-down updates.
-- `S` and `R` construction from Running, Creating, Deleting, terminating, missing, ordinary scale-up, and temporary-capacity states.
-- Count-based distinction among ordinary scale-up, stable replacement Ready capacity, and temporary expected capacity without ordinal classification.
+- `S` and `R` construction from Running, Creating, Deleting, terminating, and missing states inside `stableReplacementRange`.
+- Ordinal-range distinction among stable replacement, ordinary scale-up, admitted surge, and scale-down excess capacity.
+- A replacement Ready before ordinary scale-up advances `R` immediately, while ordinary scale-up Ready before replacement leaves `R` unchanged and only advances `targetState`.
 - Ordinary scale-up and surge transitions through `targetState=Started` and `targetState=Ready`.
 - Equal and unequal Role replica counts.
 - Zero or one active replacement Role releases the cross-Role ratio limit.
@@ -635,7 +639,7 @@ For generated replica counts, partitions, Role states, and acyclic graphs:
 - `effectivePartition >= userPartition`;
 - new replacement admission is zero when `S >= allowedStarted`, and otherwise projected `S` stays within `allowedStarted`;
 - a rollout root starts after every Role in its closure reaches `targetState=Ready`;
-- target-hash RoleRunning capacity sets `targetState=Ready`, while `R <= S <= T`;
+- target-hash RoleRunning capacity inside `dependencyRange` sets `targetState=Ready`; only capacity inside `stableReplacementRange` contributes to `R`, while `R <= S <= T`;
 - `T` remains derived solely from `previousDesired`, `desired`, and `userPartition` when ordinary scale-up or temporary excess exists;
 - scale-down capacity is reconciled through the desired range;
 - an observed old caller retains its direct old dependency;
@@ -652,7 +656,7 @@ For generated replica counts, partitions, Role states, and acyclic graphs:
 - Controller restart reconstructs the temporary expected count without creating capacity above `desired+maxSurge`.
 - Terminating old Pods retain the old-version dependency boundary.
 - Status updates preserve existing conditions and update `CoordinatedRoleRolloutBlocked`.
-- Concurrent template update and scale-up uses `R/T` for `maxSkew` and `targetState` for scale-up dependency startup.
+- Concurrent template update and scale-up uses stable-range `R/T` for `maxSkew` and the wider admitted dependency range for scale-up startup, including both Ready-order permutations.
 - Surge creation reaches the configured `maxSurge` through dependency startup.
 - A rollout root creates replacement, ordinary scale-up, or surge target capacity after its dependency closure reaches `Ready`.
 
@@ -662,6 +666,7 @@ For generated replica counts, partitions, Role states, and acyclic graphs:
 - A/B/C rollout completion in old-version order A, B, C.
 - Unequal A/B/C replica counts with `maxSkew: 10%`.
 - Different user partitions across Roles.
+- Concurrent update and ordinary scale-up with replacement Ready before expansion, and with expansion Ready before replacement.
 - One-replica B and C establish target Ready capacity through `maxSurge: 1` while old B and C remain available.
 - Admission reports the capacity requirement for a changed fully partitioned dependency.
 - Admission reports the bootstrap requirement for a one-replica dependency.


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

This PR adds a design proposal for coordinated proportional rolling updates across multiple Roles in the same ServingGroup.

The proposal introduces:

- normalized Ready progress for Roles with different replica counts;
- `maxSkew` to bound rollout progress differences between participating Roles;
- an optional Role dependency DAG used as a startup gate;
- coordination on top of each Role's existing `partition` and `maxUnavailable` constraints;
- reconciliation based on observed Role state without introducing persistent rollout batch state.

This PR contains the proposal only. The implementation is submitted separately in #1676.

**Which issue(s) this PR fixes**:

Related to #1675

**Bug evidence (required for bug-related PRs)**:

N/A

**Special notes for your reviewer**:

This is a design-only PR. Please review the API semantics, progress calculation, dependency startup behavior, and candidate selection algorithm.

Implementation PR: #1676

**Does this PR introduce a user-facing change?**:

```release-note
NONE