### PR TITLE
downloader: allow AWS default credentials for S3

### DIFF
--- a/python/kthena/downloader/s3.py
+++ b/python/kthena/downloader/s3.py
@@ -73,8 +73,8 @@ class S3Downloader(ModelDownloader):
     def download(self, output_dir: str):
         logger.info(f"Syncing: {self.model_uri} to {output_dir}")
 
-        if not self.access_key or not self.secret_key:
-            raise ValueError("Missing credentials")
+        if bool(self.access_key) != bool(self.secret_key):
+            raise ValueError("access_key and secret_key must be provided together")
 
         os.makedirs(output_dir, exist_ok=True)
         bucket_name, bucket_path = parse_bucket_from_model_url(self.model_uri, "s3")

--- a/python/kthena/tests/test_downloader_s3.py
+++ b/python/kthena/tests/test_downloader_s3.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -122,7 +123,7 @@ class TestDownloadModel(unittest.TestCase):
         )
         mock_popen.assert_called_once()
 
-    def test_s3_download_missing_credentials(self):
+    def test_s3_download_rejects_partial_static_credentials(self):
         for access_key, secret_key in [(None, "fake_sk"), ("fake_ak", None)]:
             downloader = S3Downloader(
                 model_uri=self.source,
@@ -134,7 +135,28 @@ class TestDownloadModel(unittest.TestCase):
             with self.assertRaises(ValueError) as context:
                 downloader.download(self.output_dir)
 
-            self.assertIn("Missing credentials", str(context.exception))
+            self.assertIn("must be provided together", str(context.exception))
+
+    @patch.object(S3Downloader, "_execute_command")
+    def test_s3_download_uses_default_credential_chain(self, mock_execute):
+        downloader = S3Downloader(model_uri=self.source)
+        credential_env = {
+            "AWS_ROLE_ARN": "arn:aws:iam::123456789012:role/kthena-downloader",
+            "AWS_WEB_IDENTITY_TOKEN_FILE": "/var/run/secrets/eks.amazonaws.com/serviceaccount/token",
+        }
+
+        with patch.dict(os.environ, credential_env, clear=True):
+            downloader.download(self.output_dir)
+
+        mock_execute.assert_called_once()
+        _, env = mock_execute.call_args.args
+        self.assertEqual(env["AWS_ROLE_ARN"], credential_env["AWS_ROLE_ARN"])
+        self.assertEqual(
+            env["AWS_WEB_IDENTITY_TOKEN_FILE"],
+            credential_env["AWS_WEB_IDENTITY_TOKEN_FILE"],
+        )
+        self.assertNotIn("AWS_ACCESS_KEY_ID", env)
+        self.assertNotIn("AWS_SECRET_ACCESS_KEY", env)
 
     def test_get_s3_downloader(self):
         downloader = get_downloader(self.source, self.credentials)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Allow S3/OBS downloads to invoke the AWS CLI without application-level static access keys, so the CLI can use its inherited default credential provider chain (for example EKS IRSA/web identity). An incomplete static credential pair is still rejected before starting the download.

The behavior is now:
- both `access_key` and `secret_key` set: inject the static credentials as before;
- only one set: return a configuration error;
- neither set: preserve the inherited environment and let the AWS CLI resolve credentials.

**Which issue(s) this PR fixes**:
Fixes #1690

**Bug evidence (required for bug-related PRs)**:

The downloader configuration reads the optional `ACCESS_KEY` and `SECRET_KEY` environment variables and passes them to `S3Downloader`:
https://github.com/volcano-sh/kthena/blob/f5b8fd7bc54b8de4a2b769266c8618182a06f37c/python/kthena/downloader/app.py#L38-L46

Before this change, `S3Downloader.download` raised `ValueError("Missing credentials")` whenever those two application values were absent, before `_prepare_environment` or `aws s3 sync` could run:
https://github.com/volcano-sh/kthena/blob/f5b8fd7bc54b8de4a2b769266c8618182a06f37c/python/kthena/downloader/s3.py#L73-L88

Reproduction: run the downloader with `AWS_ROLE_ARN` and `AWS_WEB_IDENTITY_TOKEN_FILE` (the environment provided to an IRSA-enabled Pod), omit `ACCESS_KEY` and `SECRET_KEY`, and request an `s3://` model. Before the fix the downloader fails immediately and never executes the AWS CLI. The added test reproduces this path and verifies that the web-identity environment reaches `_execute_command` without synthetic static key variables.

**Special notes for your reviewer**:

AI assistance was used to inspect the downloader credential path, draft the implementation, and add the regression test. The author reviewed the changes and validation results.

Validation:
- `PYTHONPATH=. python3 -m unittest kthena.tests.test_downloader_s3 -v`
- `PYTHONPATH=. python3 -m unittest kthena.tests.test_downloader_s3 kthena.tests.test_downloader_pvc kthena.tests.test_lock_manager -v` (36 tests)
- `make lint-python`
- `python3 -m compileall -q kthena`
- Full Python test discovery was attempted, but unrelated optional test dependencies (`huggingface_hub`, `modelscope`, `pytest`, `fastapi`, and `msgspec`) are not installed in the local WSL environment.

**Does this PR introduce a user-facing change?**:

```release-note
S3 and OBS model downloads can use the AWS CLI default credential provider chain when static access and secret keys are omitted.
```
