### PR TITLE
docs: add llm-d Router integration guide

### DIFF
--- a/docs/kthena/docs/user-guide/llm-d-router-integration.md
+++ b/docs/kthena/docs/user-guide/llm-d-router-integration.md
@@ -1,0 +1,315 @@
+# Integrate ModelServing with llm-d Router
+
+This guide shows how to route requests from
+[llm-d Router](https://github.com/llm-d/llm-d-router) to model servers managed by
+Kthena. The integration uses labels that Kthena already adds to ModelServing
+Pods, so no Kthena controller changes are required.
+
+The examples use llm-d Router v0.10.0. Deploy the router in the same namespace
+as the ModelServing workload.
+
+## Prerequisites
+
+- A Kubernetes cluster with Kthena installed.
+- Helm 3 or later.
+- For Gateway mode, Gateway API and Gateway API Inference Extension v1 CRDs,
+  plus a compatible Gateway implementation.
+- For P/D disaggregation, Kubernetes 1.29 or later. The example uses a native
+  sidecar container, which is not enabled by default on Kubernetes 1.28.
+
+## Kthena labels
+
+Kthena adds the following labels to ModelServing Pods:
+
+| Label | Use |
+| --- | --- |
+| `modelserving.volcano.sh/name` | Select a ModelServing workload |
+| `modelserving.volcano.sh/entry` | Exclude worker Pods from routing |
+| `modelserving.volcano.sh/role` | Select prefill or decode Pods |
+| `modelserving.volcano.sh/group-name` | Keep P/D routing within a ServingGroup |
+| `modelserving.volcano.sh/revision` | Identify a ModelServing revision |
+
+The examples assume the ModelServing is named `my-model` and its role names are
+`prefill` and `decode`. Adjust the selectors if different names are used.
+
+Choose either standalone mode or Gateway mode for each router release.
+
+## Standalone mode
+
+Standalone mode deploys EPP and an Envoy proxy without requiring a Kubernetes
+Gateway. Save the following as `llm-d-router-values.yaml`:
+
+```yaml
+router:
+  inferencePool:
+    create: false
+  modelServers:
+    matchLabels:
+      modelserving.volcano.sh/name: my-model
+      modelserving.volcano.sh/entry: "true"
+    type: vllm
+    protocol: http
+    targetPorts:
+      - number: 8000
+```
+
+Install the standalone chart:
+
+```bash
+helm upgrade --install my-model-router \
+  oci://ghcr.io/llm-d/charts/llm-d-router-standalone \
+  --version v0.10.0 \
+  --namespace my-model \
+  --create-namespace \
+  -f llm-d-router-values.yaml
+```
+
+:::note
+The chart defaults reserve production-sized resources. Override
+`router.epp.resources` and `router.proxy.resources` when using a small
+development cluster.
+:::
+
+## Gateway mode
+
+Install the Gateway API Inference Extension v1 CRDs if they are not already
+present:
+
+```bash
+kubectl apply -f \
+  https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/v1.5.0/v1-manifests.yaml
+```
+
+Save the following as `llm-d-router-gateway-values.yaml`:
+
+```yaml
+router:
+  inferencePool:
+    create: true
+    failureMode: FailClose
+  modelServers:
+    matchLabels:
+      modelserving.volcano.sh/name: my-model
+      modelserving.volcano.sh/entry: "true"
+    type: vllm
+    protocol: http
+    targetPorts:
+      - number: 8000
+provider:
+  name: none
+```
+
+Install the Gateway chart:
+
+```bash
+helm upgrade --install my-model-router \
+  oci://ghcr.io/llm-d/charts/llm-d-router-gateway \
+  --version v0.10.0 \
+  --namespace my-model \
+  --create-namespace \
+  -f llm-d-router-gateway-values.yaml
+```
+
+The chart creates an `InferencePool` that selects only Kthena entry Pods. Use
+an `HTTPRoute` to attach the pool to a Gateway implementation supported by
+llm-d Router. See the
+[llm-d Router Gateway mode documentation](https://github.com/llm-d/llm-d-router/blob/v0.10.0/config/charts/README.md#2-gateway-mode-llm-d-router-gateway)
+for provider-specific setup.
+
+The Gateway API Inference Extension v1 failure modes are `FailOpen` and
+`FailClose`.
+
+## Prefill/decode disaggregation
+
+Start with a ModelServing workload containing `prefill` and `decode` roles, as
+described in
+[Prefill-Decode Disaggregation with ModelServing](./prefill-decode-disaggregation/modelserving-vllm-pd-disaggregation.md).
+The prefill entry server continues to listen on port 8000. The decode entry Pod
+exposes the llm-d sidecar on port 8000 and moves the model server to port 8200.
+
+### Configure the decode sidecar
+
+Add the sidecar to the decode `entryTemplate`:
+
+```yaml
+- name: decode
+  replicas: 1
+  entryTemplate:
+    spec:
+      initContainers:
+        - name: routing-sidecar
+          image: ghcr.io/llm-d/llm-d-router-disagg-sidecar:v0.10.0
+          restartPolicy: Always
+          args:
+            - --port=8000
+            - --model-server-port=8200
+            - --kv-connector=nixlv2
+            - --secure-proxy=false
+          ports:
+            - name: sidecar-http
+              containerPort: 8000
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+      containers:
+        - name: model-server
+          image: <model-server-image>
+          # Configure the model server to listen on port 8200.
+          ports:
+            - name: model-server
+              containerPort: 8200
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8200
+```
+
+`restartPolicy: Always` on an init container uses Kubernetes native sidecars.
+Kubernetes 1.28 clusters can only use this syntax when the `SidecarContainers`
+feature gate is enabled on the control plane and every node; this guide requires
+Kubernetes 1.29 or later, where the gate is enabled by default.
+
+The `nixlv2` sidecar connector corresponds to vLLM's `NixlConnector`. Configure
+the prefill and decode model servers with compatible `--kv-transfer-config`
+values.
+
+### Configure EPP for P/D routing
+
+The EPP configuration must define the role filters, P/D scheduling profiles,
+profile handler, and ServingGroup screener in one `EndpointPickerConfig`. Save
+the following as `llm-d-router-pd-values.yaml`:
+
+```yaml
+router:
+  inferencePool:
+    create: false
+  modelServers:
+    matchLabels:
+      modelserving.volcano.sh/name: my-model
+      modelserving.volcano.sh/entry: "true"
+    type: vllm
+    protocol: http
+    targetPorts:
+      - number: 8000
+  epp:
+    flags:
+      allow-experimental-plugins: true
+    pluginsConfigFile: kthena-pd.yaml
+    pluginsCustomConfig:
+      kthena-pd.yaml: |
+        apiVersion: llm-d.ai/v1alpha1
+        kind: EndpointPickerConfig
+        plugins:
+          - type: disaggregatedset-rollout-screener
+            name: kthena-serving-group
+            parameters:
+              scope:
+                labelSelector: "modelserving.volcano.sh/name=my-model,modelserving.volcano.sh/entry=true"
+              revisionGating:
+                mode: max-role
+                requireRoles:
+                  values: [prefill, decode]
+                revisionLabelKey: modelserving.volcano.sh/group-name
+                roleLabelKey: modelserving.volcano.sh/role
+          - type: label-selector-filter
+            name: kthena-prefill
+            parameters:
+              matchExpressions:
+                - key: modelserving.volcano.sh/role
+                  operator: In
+                  values: [prefill]
+          - type: label-selector-filter
+            name: kthena-decode
+            parameters:
+              matchExpressions:
+                - key: modelserving.volcano.sh/role
+                  operator: In
+                  values: [decode]
+          - type: approx-prefix-cache-producer
+            parameters:
+              autoTune: false
+              blockSizeTokens: 5
+              maxPrefixTokensToMatch: 1280
+              lruCapacityPerServer: 31250
+          - type: prefix-cache-scorer
+          - type: max-score-picker
+          - type: prefix-based-pd-decider
+            parameters:
+              nonCachedTokens: 8
+              promptTokens: 0
+          - type: disagg-profile-handler
+            parameters:
+              profiles:
+                prefill: prefill
+                decode: decode
+              deciders:
+                prefill: prefix-based-pd-decider
+        schedulingProfiles:
+          - name: prefill
+            plugins:
+              - pluginRef: kthena-prefill
+              - pluginRef: max-score-picker
+              - pluginRef: prefix-cache-scorer
+          - name: decode
+            plugins:
+              - pluginRef: kthena-decode
+              - pluginRef: max-score-picker
+              - pluginRef: prefix-cache-scorer
+```
+
+The screener has its own Pod watch, independent of the router's endpoint
+selector. Including `modelserving.volcano.sh/entry=true` in its scope prevents
+worker Pods from making an incomplete ServingGroup appear routable. The
+screener is experimental in llm-d Router v0.10.0, which is why the EPP flag is
+required.
+
+Install or update the standalone router with the P/D values:
+
+```bash
+helm upgrade --install my-model-router \
+  oci://ghcr.io/llm-d/charts/llm-d-router-standalone \
+  --version v0.10.0 \
+  --namespace my-model \
+  --create-namespace \
+  -f llm-d-router-pd-values.yaml
+```
+
+The example disaggregates requests with at least eight non-cached prompt
+tokens. Tune `nonCachedTokens` and the scoring configuration for the workload.
+The values above target standalone mode. For Gateway mode, add the same
+`router.epp` block to the Gateway values and keep `router.inferencePool.create`
+set to `true`.
+
+## Verify the integration
+
+Forward the standalone router Service and send an OpenAI-compatible request:
+
+```bash
+kubectl -n my-model port-forward service/my-model-router-epp 8081:8081
+
+curl http://127.0.0.1:8081/v1/chat/completions \
+  -H 'content-type: application/json' \
+  -d '{
+    "model": "my-model",
+    "messages": [{
+      "role": "user",
+      "content": "Explain how separate prefill and decode servers cooperate during inference."
+    }],
+    "max_tokens": 8
+  }'
+```
+
+The request model must match the name served by the model server. For P/D
+inference, check the prefill and decode logs for the same request ID and confirm
+that both Pods have the same `modelserving.volcano.sh/group-name` value.
+
+## Limitations
+
+- ServingGroup screening uses the experimental
+  `disaggregatedset-rollout-screener` in llm-d Router v0.10.0.
+- The decode sidecar is configured manually until Kthena provides a reusable
+  ModelServing plugin.
+- The integration has been verified with the llm-d inference simulator. Validate
+  the selected vLLM KV connector and GPU data path before production use.
+- Updating the EPP plugin ConfigMap may require restarting the EPP Deployment.

--- a/docs/kthena/sidebars.ts
+++ b/docs/kthena/sidebars.ts
@@ -83,6 +83,7 @@ const sidebars: SidebarsConfig = {
             'user-guide/rate-limit',
             "user-guide/gateway-api-support",
             'user-guide/gateway-inference-extension-support',
+            'user-guide/llm-d-router-integration',
           ],
         },
         {


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

Documents how to route Kthena-managed workloads with llm-d Router.

The guide covers ordinary inference, Gateway API Inference Extension, P/D
disaggregation, Kthena label mapping, ServingGroup selection, and manual llm-d
decode sidecar configuration.

**Which issue(s) this PR fixes**:

Part of #1693

**Bug evidence (required for bug-related PRs)**:

N/A

**Special notes for your reviewer**:

AI assistance was used to draft the documentation; the reported results were
reviewed and validated locally by the contributor.

The integration was tested on an ARM64 Kind cluster with Kthena commit
`f5b8fd7bc54b8de4a2b769266c8618182a06f37c`, llm-d Router v0.10.0, llm-d
inference simulator v0.9.0, and Gateway API Inference Extension v1.5.0.

| Scenario | Result | Timing |
| --- | --- | --- |
| Ordinary inference | 10/10 HTTP 200 | mean 7.229 ms, median 5.493 ms |
| Full ServingGroup rollout | 6/6 HTTP 200 | mean 4.716 ms |
| Scale from 2 to 3 entry Pods | 3/3 HTTP 200 | mean 5.686 ms |
| Initial P/D request | 1/1 HTTP 200 | 33.456 ms |
| Two-ServingGroup P/D routing | 8/8 HTTP 200 | mean 21.426 ms, median 20.327 ms |
| P/D group affinity | 8/8 same-group pairs | 0 cross-group pairs |
| `InferencePool` | Server-side validation passed | `failureMode: FailClose` |

Prefill and decode logs contained matching request IDs. Prefill requests used
`do_remote_decode: true`; the corresponding decode requests used
`do_remote_prefill: true` and contained remote KV-transfer metadata.

<details>
<summary>Raw request timings</summary>

```text
Ordinary:
0.016967 0.005197 0.005909 0.004585 0.005286
0.004838 0.005597 0.005880 0.005389 0.012637

After full rollout:
0.005323 0.005076 0.004575 0.004342 0.004574 0.004405

After scale-out:
0.005503 0.007176 0.004379

Initial P/D:
0.033456

Two-group P/D:
0.029833 0.021380 0.019744 0.020674
0.019764 0.020578 0.019356 0.020075
```

</details>

The PoC validates discovery, routing, rollout, scale-out, P/D request
transformation, and ServingGroup affinity with the simulator. Real GPU inference
and KV-cache transfer still require GPU-cluster validation.

Documentation validation:

- Parsed all four embedded YAML fragments.
- Rendered the ordinary, Gateway, and P/D values with the official llm-d Router
  v0.10.0 OCI charts.
- Asserted the rendered endpoint selectors, selected P/D config file, plugin
  registrations, scheduling profiles, experimental flag, InferencePool failure
  mode, and standalone Service name.
- Ran `git diff --check`.
- Docusaurus validation is covered by the repository CI.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
