### PR TITLE
router: reject invalid provider header values at admission

### DIFF
--- a/pkg/kthena-router/providers/adapter_test.go
+++ b/pkg/kthena-router/providers/adapter_test.go
@@ -785,6 +785,11 @@ func TestBuildRequestRejectsInvalidRuntimeConfiguration(t *testing.T) {
 			baseURL: "https://api.example.com",
 			headers: map[string]string{"X-Tenant": "tenant-a\r\nX-Injected: true"},
 		},
+		{
+			name:    "header value contains DEL",
+			baseURL: "https://api.example.com",
+			headers: map[string]string{"X-Tenant": "tenant-a\x7f"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/kthena-router/webhook/validator.go
+++ b/pkg/kthena-router/webhook/validator.go
@@ -355,8 +355,8 @@ func (v *KthenaRouterValidator) validateExternalModelProvider(provider *networki
 		if common.IsReservedProviderHeader(header) {
 			allErrs = append(allErrs, field.Invalid(headerField, header, "header is reserved and cannot be configured as a static header"))
 		}
-		if strings.ContainsAny(value, "\r\n") {
-			allErrs = append(allErrs, field.Invalid(headerField, value, "header value must not contain CR or LF"))
+		if !httpguts.ValidHeaderFieldValue(value) {
+			allErrs = append(allErrs, field.Invalid(headerField, value, "header value must be a valid HTTP header field value"))
 		}
 	}
 

--- a/pkg/kthena-router/webhook/validator_test.go
+++ b/pkg/kthena-router/webhook/validator_test.go
@@ -991,7 +991,22 @@ func TestValidateExternalModelProvider(t *testing.T) {
 				},
 			},
 			expectValid:    false,
-			expectedReason: "validation failed:\n  - spec.headers[X-Tenant]: Invalid value: \"tenant-a\\r\\nX-Injected: true\": header value must not contain CR or LF",
+			expectedReason: "validation failed:\n  - spec.headers[X-Tenant]: Invalid value: \"tenant-a\\r\\nX-Injected: true\": header value must be a valid HTTP header field value",
+		},
+		{
+			name: "invalid provider - static header value contains DEL",
+			provider: &networkingv1alpha1.ExternalModelProvider{
+				ObjectMeta: metav1.ObjectMeta{Name: "bad-provider", Namespace: "default"},
+				Spec: networkingv1alpha1.ExternalModelProviderSpec{
+					ProviderType: networkingv1alpha1.OpenAI,
+					BaseURL:      "https://api.example.com/v1",
+					Headers: map[string]string{
+						"X-Tenant": "tenant-a\x7f",
+					},
+				},
+			},
+			expectValid:    false,
+			expectedReason: "validation failed:\n  - spec.headers[X-Tenant]: Invalid value: \"tenant-a\\x7f\": header value must be a valid HTTP header field value",
 		},
 		{
 			name: "invalid provider - optional secret ref",


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The ExternalModelProvider admission webhook previously rejected static header values only when they contained CR or LF. The provider reconciliation and request-building paths already use httpguts.ValidHeaderFieldValue, so other invalid values such as DEL (U+007F) passed admission but immediately made the provider ConfigurationInvalid and prevented every request from being forwarded.

This change reuses ValidHeaderFieldValue at admission so invalid resources are rejected at the user-facing boundary. It also adds regression coverage to both the webhook and runtime provider validation for the DEL case.

**Which issue(s) this PR fixes**:

Fixes #1696

**Bug evidence (required for bug-related PRs)**:

Reproduction configuration:

```yaml
apiVersion: networking.serving.volcano.sh/v1alpha1
kind: ExternalModelProvider
metadata:
  name: invalid-header
spec:
  providerType: OpenAI
  baseURL: https://api.example.com/v1
  headers:
    X-Tenant: "tenant-a\u007f"
```

On main at f2398651, the production path is:

1. The webhook checks only CR/LF and admits the resource: https://github.com/volcano-sh/kthena/blob/f2398651/pkg/kthena-router/webhook/validator.go#L349-L359
2. The controller calls providers.ValidateConfiguration and marks Ready=False with ConfigurationInvalid: https://github.com/volcano-sh/kthena/blob/f2398651/pkg/kthena-router/controller/externalmodelprovider_controller.go#L382-L388
3. Runtime header validation rejects U+007F through httpguts.ValidHeaderFieldValue: https://github.com/volcano-sh/kthena/blob/f2398651/pkg/kthena-router/providers/adapter.go#L336-L348
4. The request builder invokes the same validation before forwarding, so no request can reach the provider: https://github.com/volcano-sh/kthena/blob/f2398651/pkg/kthena-router/providers/adapter.go#L198-L211

The issue was found through source review and reproduced through the admission and runtime validation paths; it has not been observed in a live cluster.

Verification:

```
go test ./pkg/kthena-router/webhook ./pkg/kthena-router/providers ./pkg/kthena-router/controller ./pkg/kthena-router/router
go vet ./pkg/kthena-router/webhook ./pkg/kthena-router/providers
```

**Special notes for your reviewer**:

Generative AI assisted with code analysis, test drafting, and PR text. All changes were reviewed, tested, committed, and signed off by the author.

The validator already imports and uses httpguts for header names, so this does not add a dependency. It deliberately matches the existing runtime predicate rather than maintaining a second partial definition of a valid HTTP header field value.

**Does this PR introduce a user-facing change?**:

```release-note
Reject ExternalModelProvider resources whose static headers contain invalid HTTP field values.
```
