### PR TITLE
autoscaler: fix heterogeneous autoscaler get stuck scaling down

### DIFF
--- a/pkg/autoscaler/autoscaler/optimizer.go
+++ b/pkg/autoscaler/autoscaler/optimizer.go
@@ -229,13 +229,13 @@ func (optimizer *Optimizer) Optimize(ctx context.Context, podLister listerv1.Pod
 		MaxInstances:         optimizer.Meta.MaxReplicas,
 		CurrentInstances:     instancesCountSum,
 		RecommendedInstances: recommendedInstances}
-	recommendedInstances = CorrectedInstancesAlgorithm.GetCorrectedInstances()
+	correctedInstances := CorrectedInstancesAlgorithm.GetCorrectedInstances()
 
-	klog.InfoS("autoscale controller", "recommendedInstances", recommendedInstances, "correctedInstances", recommendedInstances)
+	klog.InfoS("autoscale controller", "recommendedInstances", recommendedInstances, "correctedInstances", correctedInstances)
 	optimizer.Status.AppendRecommendation(recommendedInstances)
-	optimizer.Status.AppendCorrected(recommendedInstances)
+	optimizer.Status.AppendCorrected(correctedInstances)
 
-	replicasMap := optimizer.Meta.RestoreReplicasOfEachBackend(recommendedInstances)
+	replicasMap := optimizer.Meta.RestoreReplicasOfEachBackend(correctedInstances)
 	return replicasMap, nil
 }
 

--- a/pkg/autoscaler/autoscaler/optimizer_test.go
+++ b/pkg/autoscaler/autoscaler/optimizer_test.go
@@ -17,13 +17,23 @@ limitations under the License.
 package autoscaler
 
 import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	corelister "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
 
 	workload "github.com/volcano-sh/kthena/pkg/apis/workload/v1alpha1"
 )
@@ -413,4 +423,104 @@ func TestRestoreReplicasOfEachBackend(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+// Optimize must record the raw recommendation, not the corrected value, into
+// the recommendation windows; otherwise the scale-down stabilization window
+// refills itself every cycle and never drains (#1644).
+func TestOptimizeRecordsRawRecommendationInStabilizationWindows(t *testing.T) {
+	var metricValue atomic.Value
+	metricValue.Store("100")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/api/v1/query") {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"status":"success","data":{"resultType":"scalar","result":[1700000000,"%s"]}}`, metricValue.Load())
+	}))
+	t.Cleanup(srv.Close)
+
+	targetRef := corev1.ObjectReference{Kind: "ModelServing", Name: "backend-a"}
+	policy := &workload.AutoscalingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "hetero-policy", Namespace: "default"},
+		Spec: workload.AutoscalingPolicySpec{
+			TolerancePercent: 10,
+			Metrics: []workload.AutoscalingPolicyMetric{
+				{Name: "http_rps", TargetValue: resource.MustParse("10")},
+			},
+			Behavior: workload.AutoscalingPolicyBehavior{
+				ScaleUp: workload.AutoscalingPolicyScaleUpPolicy{
+					StablePolicy: workload.AutoscalingPolicyStablePolicy{
+						Instances:           ptr(int32(1000)),
+						Percent:             ptr(int32(1000)),
+						Period:              &metav1.Duration{Duration: 15 * time.Second},
+						SelectPolicy:        workload.SelectPolicyOr,
+						StabilizationWindow: &metav1.Duration{Duration: time.Hour},
+					},
+					PanicPolicy: workload.AutoscalingPolicyPanicPolicy{
+						Percent:               ptr(int32(1000)),
+						Period:                metav1.Duration{Duration: 15 * time.Second},
+						PanicThresholdPercent: ptr(int32(1000)),
+					},
+				},
+				ScaleDown: workload.AutoscalingPolicyStablePolicy{
+					Instances:           ptr(int32(1000)),
+					Percent:             ptr(int32(100)),
+					Period:              &metav1.Duration{Duration: 15 * time.Second},
+					SelectPolicy:        workload.SelectPolicyOr,
+					StabilizationWindow: &metav1.Duration{Duration: time.Hour},
+				},
+			},
+			HeterogeneousTarget: &workload.HeterogeneousTarget{
+				CostExpansionRatePercent: 100,
+				Params: []workload.HeterogeneousTargetParam{
+					{
+						Target: workload.Target{
+							TargetRef: targetRef,
+							MetricSources: map[string]workload.MetricSource{
+								"http_rps": {Prometheus: &workload.PrometheusMetricSource{
+									ServerURL: srv.URL,
+									Query:     "sum(rate(http_requests_total[2m]))",
+								}},
+							},
+						},
+						Cost:        100,
+						MinReplicas: 0,
+						MaxReplicas: 100,
+					},
+				},
+			},
+		},
+	}
+
+	optimizer := NewOptimizer(policy)
+	podLister := corelister.NewPodLister(cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{}))
+	targetKey := HeterogeneousTargetKey(targetRef, policy.Namespace)
+	current := map[string]int32{targetKey: 10}
+
+	// High-demand cycle: recommendation matches the current 10 replicas.
+	replicas, err := optimizer.Optimize(context.Background(), podLister, policy, current)
+	require.NoError(t, err)
+	require.NotNil(t, replicas)
+	assert.Equal(t, int32(10), replicas[targetKey])
+
+	// Low-demand cycle: the stabilization window holds replicas at 10 while
+	// the recommendation windows must record the raw value 2.
+	metricValue.Store("20")
+	replicas, err = optimizer.Optimize(context.Background(), podLister, policy, current)
+	require.NoError(t, err)
+	require.NotNil(t, replicas)
+	assert.Equal(t, int32(10), replicas[targetKey],
+		"scale down should be held up by the stabilization window")
+
+	rawMin, ok := optimizer.Status.History.MinRecommendation.GetBest()
+	require.True(t, ok)
+	assert.Equal(t, int32(2), rawMin,
+		"recommendation windows must record the raw recommendation, not the corrected value")
+
+	heldMax, ok := optimizer.Status.History.MaxCorrected.GetBest(current[targetKey])
+	require.True(t, ok)
+	assert.Equal(t, int32(10), heldMax,
+		"corrected windows must record the corrected value")
 }


### PR DESCRIPTION
Fixes #1644

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
`Optimizer.Optimize` (the heterogeneous path) overwrites the raw metric recommendation with the behavior-corrected value and records that corrected value into **both** the recommendation and the corrected history windows. During a scale-down hold the corrected value equals the current (high) replica count, so every reconcile cycle re-inserts the held-high value into `MaxRecommendation` with a fresh timestamp — the scale-down stabilization window can never drain, and the target stays pinned at its peak for as long as the optimizer history lives.

This change mirrors the homogeneous path's bookkeeping (`recordScaleOneTargetResult`): keep `GetCorrectedInstances()` in a separate variable, record the raw recommendation into the recommendation windows and the corrected value into the corrected windows. The log line now reports both values instead of printing the same variable twice.

**Which issue(s) this PR fixes**:
Fixes #1644

**Bug evidence (required for bug-related PRs)**:
The complete production path with source permalinks is documented in #1644. Executed evidence:

- The added regression test `TestOptimizeRecordsRawRecommendationInStabilizationWindows` drives `Optimize` — the controller's actual per-cycle entry point — end to end with a real `AutoscalingPolicy` and an httptest Prometheus stub. On `main`, the recommendation window receives the held-up corrected value `10` instead of the raw recommendation `2` (the test fails); with this change it receives the raw recommendation while the returned replicas remain correctly held by the stabilization window.
- A wall-clock run of the full loop (`scaleDown.stabilizationWindow: 400ms`, one high-demand cycle, then low-demand reconciles every 150ms for 1.8s): on `main` every cycle returns 10 — still pinned 4.5x past the window; with this change, replicas hold at 10 while the window is live and drain to 2 at t≈450ms, exactly at the window boundary. The demo is sleep-based so it is not part of the test suite; output:

<details>
<summary>wall-clock demo output (main vs. this change)</summary>

`main`:

```
t=0ms    high-demand cycle: replicas=10
t=150ms  low-demand cycle:  replicas=10
t=300ms  low-demand cycle:  replicas=10
t=450ms  low-demand cycle:  replicas=10
...
t=1.81s  low-demand cycle:  replicas=10   (still pinned, 4.5x past the window)
```

with this change:

```
t=0ms    high-demand cycle: replicas=10
t=150ms  low-demand cycle:  replicas=10
t=300ms  low-demand cycle:  replicas=10
t=450ms  low-demand cycle:  replicas=2
t=600ms  low-demand cycle:  replicas=2
```

</details>

Verification run locally: `go test -race ./pkg/autoscaler/...` all green; `golangci-lint run` (v1.64.8) clean on the changed packages; branch rebased on current `main`.


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Fixed the heterogeneous autoscaler getting stuck during scale-down: corrected replica counts were recorded into the stabilization windows, preventing them from ever draining.
```
