### PR TITLE
router: size the TopNPodInfos result slices up front

### DIFF
--- a/pkg/kthena-router/scheduler/scheduler_impl.go
+++ b/pkg/kthena-router/scheduler/scheduler_impl.go
@@ -273,7 +273,8 @@ func (s *SchedulerImpl) RunPostHooks(ctx *framework.Context, index int) {
 }
 
 func TopNPodInfos(m map[*datastore.PodInfo]int, n int) []*datastore.PodInfo {
-	var list []podInfoWithValue
+	// One entry per scored pod, so the length is known before the loop
+	list := make([]podInfoWithValue, 0, len(m))
 	for k, v := range m {
 		list = append(list, podInfoWithValue{pod: k, score: v})
 	}
@@ -282,11 +283,15 @@ func TopNPodInfos(m map[*datastore.PodInfo]int, n int) []*datastore.PodInfo {
 		return list[i].score > list[j].score
 	})
 
-	res := []*datastore.PodInfo{}
-	for i := range list {
-		if i >= n {
-			break
-		}
+	// Clamp first, make() panics on a negative capacity
+	if n > len(list) {
+		n = len(list)
+	}
+	if n < 0 {
+		n = 0
+	}
+	res := make([]*datastore.PodInfo, 0, n)
+	for i := 0; i < n; i++ {
 		res = append(res, list[i].pod)
 	}
 

--- a/pkg/kthena-router/scheduler/scheduler_impl_test.go
+++ b/pkg/kthena-router/scheduler/scheduler_impl_test.go
@@ -88,11 +88,21 @@ func TestTopNPodInfos(t *testing.T) {
 			n:        0,
 			expected: 0,
 		},
+		{
+			name: "negative n returns empty slice",
+			scores: map[*datastore.PodInfo]int{
+				createTestPodInfo("pod1"): 100,
+			},
+			n:        -1,
+			expected: 0,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := TopNPodInfos(tt.scores, tt.n)
+			// Callers branch on BestPods != nil, so an empty result must not be nil
+			assert.NotNil(t, result)
 			assert.Equal(t, tt.expected, len(result))
 		})
 	}
@@ -396,5 +406,33 @@ func BenchmarkRunScorePlugins(b *testing.B) {
 				_ = scheduler.RunScorePlugins(pods, ctx)
 			}
 		})
+	}
+}
+
+// Helper function to build a scored pod map
+func benchScores(n int) map[*datastore.PodInfo]int {
+	m := make(map[*datastore.PodInfo]int, n)
+	for i := 0; i < n; i++ {
+		p := &datastore.PodInfo{Pod: &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("pod-%d", i), Namespace: "default"},
+		}}
+		m[p] = (i * 7) % 101
+	}
+	return m
+}
+
+// BenchmarkTopNPodInfos measures top-N selection at the pod counts and topN values the scheduler uses.
+func BenchmarkTopNPodInfos(b *testing.B) {
+	for _, pods := range []int{8, 32, 128} {
+		for _, n := range []int{1, 5} {
+			b.Run(fmt.Sprintf("pods=%d/topN=%d", pods, n), func(b *testing.B) {
+				m := benchScores(pods)
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					_ = TopNPodInfos(m, n)
+				}
+			})
+		}
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement

**What this PR does / why we need it**:

`TopNPodInfos` built both of its slices by appending to a nil slice, so each call regrew the backing array as it went. Both lengths are known before the loops run: one entry per scored pod, and at most `n` results.

It is on the request path. The plain path calls it once per scheduling decision, and the PD-disaggregated path calls it once for the decode set plus once per selected decode pod, so up to six times per request at the default `topN = 5`.

Ordering is unchanged. The comparator and the map iteration that feeds it are untouched, so pods with equal scores are still picked the same way.

go1.26 linux/amd64, `-count=6`, medians:

```
pods  topN     before                      after
   8     1      834 ns    336 B   8 allocs      678 ns    224 B   5 allocs
   8     5      865 ns    392 B   8 allocs      700 ns    264 B   5 allocs
  32     1     3086 ns   1104 B  10 allocs     2718 ns    608 B   5 allocs
  32     5     3227 ns   1160 B  10 allocs     2696 ns    648 B   5 allocs
 128     1    15778 ns   4560 B  12 allocs    14063 ns   2400 B   5 allocs
 128     5    15928 ns   4616 B  12 allocs    14368 ns   2440 B   5 allocs
```

Allocations flatten to 5 at every pod count where before they grew with it, and bytes roughly halve from 32 pods up. Worth being clear on scale: about 500ns and 5 allocations per call at 32 pods, so this is allocation churn under load rather than anything one request would notice.

Results are unchanged, checked against the previous implementation across 20k randomised inputs including empty maps, repeated scores, and `n` from negative through larger than the pod count.

`BenchmarkTopNPodInfos` is added next to the existing `BenchmarkRunScorePlugins` so the table can be re-run against either side.

**Which issue(s) this PR fixes**:

Fixes #1701

**Special notes for your reviewer**:

`n` is clamped to `[0, len(list)]` before the `make`. That is load bearing rather than tidying: `make()` panics on a negative capacity, while the previous `append` loop returned an empty slice for any `n <= 0`.

`TestTopNPodInfos` covers a negative `n` and asserts the result is non-nil on every case, not only its length. Both matter to callers: `router.go:915` and `prefix_cache.go:210` branch on `ctx.BestPods != nil` rather than on its length, so a nil empty result would silently change routing.

Both assertions are load bearing. Dropping the `n < 0` clamp fails the negative case with `panic: runtime error: makeslice: cap out of range`, and returning `var res []*datastore.PodInfo` instead of the `make` fails all four empty-result cases with `Expected value not to be nil`. The same tests pass unchanged against the implementation on `main`; they pin existing behaviour rather than describe new behaviour.

**Does this PR introduce a user-facing change?**

```release-note
NONE
```