### PR TITLE
runtime: key counter rename rules by the parsed family name

### DIFF
--- a/python/kthena/runtime/standard.py
+++ b/python/kthena/runtime/standard.py
@@ -26,7 +26,13 @@ class EngineType(Enum):
 
 
 class StandardMetricNames:
-    GENERATION_TOKENS_TOTAL = "kthena:generation_tokens_total"
+    # The runtime's parser munges counter families into their OpenMetrics
+    # form: the FAMILY name loses the _total suffix while samples keep it.
+    # Rules are matched by family name, so the counter rule is keyed by the
+    # munged family and RenameMetric's suffix arithmetic restores _total on
+    # the exposed samples, yielding the documented
+    # kthena:generation_tokens_total series.
+    GENERATION_TOKENS = "kthena:generation_tokens"
     NUM_REQUESTS_WAITING = "kthena:num_requests_waiting"
     TIME_TO_FIRST_TOKEN_SECONDS = "kthena:time_to_first_token_seconds"
     TIME_PER_OUTPUT_TOKEN_SECONDS = "kthena:time_per_output_token_seconds"
@@ -36,8 +42,8 @@ class StandardMetricNames:
 STANDARD_RULES: Dict[str, List[MetricOperator]] = {
     EngineType.VLLM.value: [
         RenameMetric(
-            "vllm:generation_tokens_total",
-            StandardMetricNames.GENERATION_TOKENS_TOTAL,
+            "vllm:generation_tokens",
+            StandardMetricNames.GENERATION_TOKENS,
         ),
         RenameMetric(
             "vllm:num_requests_waiting", StandardMetricNames.NUM_REQUESTS_WAITING
@@ -57,8 +63,8 @@ STANDARD_RULES: Dict[str, List[MetricOperator]] = {
     ],
     EngineType.SGLANG.value: [
         RenameMetric(
-            "sglang:generation_tokens_total",
-            StandardMetricNames.GENERATION_TOKENS_TOTAL,
+            "sglang:generation_tokens",
+            StandardMetricNames.GENERATION_TOKENS,
         ),
         RenameMetric("sglang:num_queue_reqs", StandardMetricNames.NUM_REQUESTS_WAITING),
         RenameMetric(

--- a/python/kthena/runtime/standard.py
+++ b/python/kthena/runtime/standard.py
@@ -26,12 +26,6 @@ class EngineType(Enum):
 
 
 class StandardMetricNames:
-    # The runtime's parser munges counter families into their OpenMetrics
-    # form: the FAMILY name loses the _total suffix while samples keep it.
-    # Rules are matched by family name, so the counter rule is keyed by the
-    # munged family and RenameMetric's suffix arithmetic restores _total on
-    # the exposed samples, yielding the documented
-    # kthena:generation_tokens_total series.
     GENERATION_TOKENS = "kthena:generation_tokens"
     NUM_REQUESTS_WAITING = "kthena:num_requests_waiting"
     TIME_TO_FIRST_TOKEN_SECONDS = "kthena:time_to_first_token_seconds"

--- a/python/kthena/tests/test_metrics.py
+++ b/python/kthena/tests/test_metrics.py
@@ -95,3 +95,55 @@ def test_metric_adapter_handles_empty_metrics():
 
     adapter = MetricAdapter(empty_metric_text, standard)
     assert len(adapter.metrics) == 0
+VLLM_COUNTER_METRICS = """
+# HELP vllm:generation_tokens_total Number of generation tokens processed.
+# TYPE vllm:generation_tokens_total counter
+vllm:generation_tokens_total{model_name="m"} 42.0
+""".strip()
+
+SGLANG_COUNTER_METRICS = """
+# HELP sglang:generation_tokens_total Number of generation tokens processed.
+# TYPE sglang:generation_tokens_total counter
+sglang:generation_tokens_total{model_name="m"} 7.0
+""".strip()
+
+
+def _standardized(adapter, name):
+    return [m for m in adapter.metrics if m.name == name]
+
+
+def test_vllm_counter_rename_survives_parser_family_munging():
+    # The parser strips _total from a counter FAMILY name, so the rule must
+    # match the munged family and the samples must come back out with _total.
+    standard = MetricStandard("vllm")
+    adapter = MetricAdapter(VLLM_COUNTER_METRICS, standard)
+
+    twins = _standardized(adapter, "kthena:generation_tokens")
+    assert len(twins) == 1, [m.name for m in adapter.metrics]
+    twin = twins[0]
+    assert twin.type == "counter"
+    sample_names = [s.name for s in twin.samples]
+    assert "kthena:generation_tokens_total" in sample_names
+    total = next(s for s in twin.samples if s.name == "kthena:generation_tokens_total")
+    assert total.value == 42.0
+    assert total.labels == {"model_name": "m"}
+
+
+def test_sglang_counter_rename_survives_parser_family_munging():
+    standard = MetricStandard("sglang")
+    adapter = MetricAdapter(SGLANG_COUNTER_METRICS, standard)
+
+    twins = _standardized(adapter, "kthena:generation_tokens")
+    assert len(twins) == 1, [m.name for m in adapter.metrics]
+    sample_names = [s.name for s in twins[0].samples]
+    assert "kthena:generation_tokens_total" in sample_names
+
+
+def test_process_metrics_exposes_documented_counter_series():
+    import asyncio
+
+    from kthena.runtime.collect import process_metrics
+
+    standard = MetricStandard("vllm")
+    output = asyncio.run(process_metrics(VLLM_COUNTER_METRICS, standard))
+    assert b'kthena:generation_tokens_total{model_name="m"} 42.0' in output


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The runtime documents a standardized `kthena:generation_tokens_total` series, but it is never emitted for either engine. The rename rules are keyed by the raw counter name (`vllm:generation_tokens_total`, `sglang:generation_tokens_total`) while the lookup uses the PARSED family name, and the pinned parser (prometheus-client 0.19.0) munges counter families into their OpenMetrics form, stripping `_total` from the family name. The counter family therefore arrives named `vllm:generation_tokens` and the rule never matches. Gauge and histogram family names are untouched, which is why every other rename works and exactly this counter is missing.

The fix keys the two counter rules by the munged family name and renames to a `kthena:generation_tokens` family. `RenameMetric` already does per sample suffix arithmetic, so the exposed samples come out as `kthena:generation_tokens_total` exactly as documented (a `_created` sample would map the same way).

**Which issue(s) this PR fixes**:

Fixes #1652

**Bug evidence (required for bug-related PRs)**:

The parser level and end to end reproduction are in #1652. The new tests are a flip proof on this branch:

with the tests added but the fix reverted:

```
FAILED tests/test_metrics.py::test_vllm_counter_rename_survives_parser_family_munging
FAILED tests/test_metrics.py::test_sglang_counter_rename_survives_parser_family_munging
FAILED tests/test_metrics.py::test_process_metrics_exposes_documented_counter_series
3 failed, 6 passed
```

The last failure shows the sidecar output containing only the original `vllm:generation_tokens_total` and no `kthena:` twin. With the fix, `9 passed`, and the end to end test asserts the documented series in the actual `process_metrics` output:

```
kthena:generation_tokens_total{model_name="m"} 42.0
```

Production path: the rules are registered by family name at [standard.py#L37-L64](https://github.com/volcano-sh/kthena/blob/dd7e5af6ab0517094c6bf8c05bfeb64747290147/python/kthena/runtime/standard.py#L37-L64), the lookup is `metric_operators_dict.get(origin_metric.name)` at [standard.py#L121](https://github.com/volcano-sh/kthena/blob/dd7e5af6ab0517094c6bf8c05bfeb64747290147/python/kthena/runtime/standard.py#L121), the parser is pinned at [requirements.txt#L5](https://github.com/volcano-sh/kthena/blob/dd7e5af6ab0517094c6bf8c05bfeb64747290147/python/kthena/runtime/requirements.txt#L5), and the suffix arithmetic that restores `_total` on samples is [metric.py#L77](https://github.com/volcano-sh/kthena/blob/dd7e5af6ab0517094c6bf8c05bfeb64747290147/python/kthena/runtime/metric.py#L77).

`ruff check` passes on both touched files. The full python suite passes apart from the six modules that import `fcntl` and cannot run on a Windows dev box; they are untouched by this change.

**Special notes for your reviewer**:

The exposed TYPE line becomes `# TYPE kthena:generation_tokens counter` with the `kthena:generation_tokens_total` sample, which is standard counter exposition and what any Prometheus client scrapes as `kthena:generation_tokens_total`. The docs page ([runtime.md#L126](https://github.com/volcano-sh/kthena/blob/dd7e5af6ab0517094c6bf8c05bfeb64747290147/docs/kthena/docs/user-guide/runtime.md#L126)) therefore stays accurate as written.

**Does this PR introduce a user-facing change?**:

```release-note
Fixed the runtime sidecar so the documented kthena:generation_tokens_total standardized counter is actually emitted for vLLM and SGLang backends.
```
