### PR TITLE
fix(router): clear stale rate limiter when ModelRoute rateLimit is removed

### DIFF
--- a/pkg/kthena-router/datastore/store.go
+++ b/pkg/kthena-router/datastore/store.go
@@ -227,6 +227,9 @@ type Store interface {
 	AddOrUpdateModelRoute(mr *aiv1alpha1.ModelRoute) error
 	DeleteModelRoute(namespacedName string) error
 	GetModelRoute(namespacedName string) *aiv1alpha1.ModelRoute
+	// GetModelRoutesByModelName returns the ModelRoutes for a base model name,
+	// ordered oldest-first (the order MatchModelTarget evaluates them).
+	GetModelRoutesByModelName(modelName string) []*aiv1alpha1.ModelRoute
 	AddOrUpdateExternalModelProvider(provider *aiv1alpha1.ExternalModelProvider) error
 	DeleteExternalModelProvider(name types.NamespacedName) error
 	GetExternalModelProvider(name types.NamespacedName) *aiv1alpha1.ExternalModelProvider
@@ -2216,6 +2219,21 @@ func (s *store) GetModelRoute(namespacedName string) *aiv1alpha1.ModelRoute {
 	}
 
 	return nil
+}
+
+// GetModelRoutesByModelName returns the ModelRoutes registered for a base model
+// name. The returned slice is a copy kept oldest-first.
+func (s *store) GetModelRoutesByModelName(modelName string) []*aiv1alpha1.ModelRoute {
+	s.routeMutex.RLock()
+	defer s.routeMutex.RUnlock()
+
+	routes := s.routes[modelName]
+	if len(routes) == 0 {
+		return nil
+	}
+	out := make([]*aiv1alpha1.ModelRoute, len(routes))
+	copy(out, routes)
+	return out
 }
 
 // Gateway methods (using standard Gateway API)

--- a/pkg/kthena-router/debug/handlers_test.go
+++ b/pkg/kthena-router/debug/handlers_test.go
@@ -218,6 +218,14 @@ func (m *MockStore) GetModelRoute(namespacedName string) *aiv1alpha1.ModelRoute 
 	}
 	return args.Get(0).(*aiv1alpha1.ModelRoute)
 }
+
+func (m *MockStore) GetModelRoutesByModelName(modelName string) []*aiv1alpha1.ModelRoute {
+	args := m.Called(modelName)
+	if args.Get(0) == nil {
+		return nil
+	}
+	return args.Get(0).([]*aiv1alpha1.ModelRoute)
+}
 func (m *MockStore) AddOrUpdateGateway(gateway *gatewayv1.Gateway) error {
 	args := m.Called(gateway)
 	return args.Error(0)

--- a/pkg/kthena-router/filters/ratelimit/ratelimit.go
+++ b/pkg/kthena-router/filters/ratelimit/ratelimit.go
@@ -169,6 +169,8 @@ func (r *TokenRateLimiter) AddOrUpdateLimiter(model string, ratelimit *networkin
 				*ratelimit.InputTokensPerUnit,
 				ratelimit.Unit,
 			)
+		} else {
+			delete(r.inputLimiter, model)
 		}
 
 		if ratelimit.OutputTokensPerUnit != nil {
@@ -180,6 +182,8 @@ func (r *TokenRateLimiter) AddOrUpdateLimiter(model string, ratelimit *networkin
 				*ratelimit.OutputTokensPerUnit,
 				ratelimit.Unit,
 			)
+		} else {
+			delete(r.outputLimiter, model)
 		}
 	} else {
 		// Create local rate limiters
@@ -190,6 +194,8 @@ func (r *TokenRateLimiter) AddOrUpdateLimiter(model string, ratelimit *networkin
 				rate.Limit(float64(*ratelimit.InputTokensPerUnit)/duration.Seconds()),
 				int(*ratelimit.InputTokensPerUnit),
 			)
+		} else {
+			delete(r.inputLimiter, model)
 		}
 
 		if ratelimit.OutputTokensPerUnit != nil {
@@ -197,6 +203,8 @@ func (r *TokenRateLimiter) AddOrUpdateLimiter(model string, ratelimit *networkin
 				rate.Limit(float64(*ratelimit.OutputTokensPerUnit)/duration.Seconds()),
 				int(*ratelimit.OutputTokensPerUnit),
 			)
+		} else {
+			delete(r.outputLimiter, model)
 		}
 	}
 

--- a/pkg/kthena-router/filters/ratelimit/ratelimit_test.go
+++ b/pkg/kthena-router/filters/ratelimit/ratelimit_test.go
@@ -196,6 +196,79 @@ func TestTokenRateLimiter_DeleteLimiter(t *testing.T) {
 	rl.RecordOutputTokens(model, 100)
 }
 
+func TestTokenRateLimiter_AddOrUpdateClearsRemovedInputLimit(t *testing.T) {
+	rl := NewTokenRateLimiter()
+	model := "test-model"
+	inputTokens := uint32(3)
+	outputTokens := uint32(5)
+	unit := networkingv1alpha1.Second
+
+	rl.AddOrUpdateLimiter(model, &networkingv1alpha1.RateLimit{
+		InputTokensPerUnit:  &inputTokens,
+		OutputTokensPerUnit: &outputTokens,
+		Unit:                unit,
+	})
+
+	// Exhaust the input limiter.
+	_ = rl.RateLimit(model, "hello world")
+	if err := rl.RateLimit(model, "hello world"); err == nil {
+		t.Fatalf("expected input rate limit error before update")
+	}
+
+	// Update dropping the input token limit; the stale input limiter must go.
+	rl.AddOrUpdateLimiter(model, &networkingv1alpha1.RateLimit{
+		OutputTokensPerUnit: &outputTokens,
+		Unit:                unit,
+	})
+
+	for i := 0; i < 10; i++ {
+		if err := rl.RateLimit(model, "hello world"); err != nil {
+			if _, ok := err.(*InputRateLimitExceededError); ok {
+				t.Fatalf("input limiter should have been cleared, got %v", err)
+			}
+		}
+	}
+
+	// The output limiter must still be in effect.
+	rl.RecordOutputTokens(model, 5)
+	if err := rl.RateLimit(model, "hello world"); err == nil {
+		t.Fatalf("expected output rate limit still enforced")
+	} else if _, ok := err.(*OutputRateLimitExceededError); !ok {
+		t.Fatalf("expected OutputRateLimitExceededError, got %T: %v", err, err)
+	}
+}
+
+func TestTokenRateLimiter_AddOrUpdateClearsRemovedOutputLimit(t *testing.T) {
+	rl := NewTokenRateLimiter()
+	model := "test-model"
+	inputTokens := uint32(100)
+	outputTokens := uint32(5)
+	unit := networkingv1alpha1.Second
+
+	rl.AddOrUpdateLimiter(model, &networkingv1alpha1.RateLimit{
+		InputTokensPerUnit:  &inputTokens,
+		OutputTokensPerUnit: &outputTokens,
+		Unit:                unit,
+	})
+
+	// Exhaust the output limiter.
+	rl.RecordOutputTokens(model, 5)
+	if err := rl.RateLimit(model, "short"); err == nil {
+		t.Fatalf("expected output rate limit error before update")
+	}
+
+	// Update dropping the output token limit; the stale output limiter must go.
+	rl.AddOrUpdateLimiter(model, &networkingv1alpha1.RateLimit{
+		InputTokensPerUnit: &inputTokens,
+		Unit:               unit,
+	})
+
+	rl.RecordOutputTokens(model, 1000)
+	if err := rl.RateLimit(model, "short"); err != nil {
+		t.Fatalf("output limiter should have been cleared, got %v", err)
+	}
+}
+
 func TestTokenRateLimiter_OutputRateLimit(t *testing.T) {
 	rl := NewTokenRateLimiter()
 	model := "test-model"

--- a/pkg/kthena-router/router/ratelimit_callback_test.go
+++ b/pkg/kthena-router/router/ratelimit_callback_test.go
@@ -1,0 +1,226 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package router
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	aiv1alpha1 "github.com/volcano-sh/kthena/pkg/apis/networking/v1alpha1"
+	"github.com/volcano-sh/kthena/pkg/kthena-router/datastore"
+	"github.com/volcano-sh/kthena/pkg/kthena-router/filters/ratelimit"
+)
+
+const rateLimitCallbackModel = "rate-limited-model"
+
+func uint32Ptr(v uint32) *uint32 { return &v }
+
+// rlRoute describes a ModelRoute for the shared test model. created controls the
+// oldest-first ordering the callback uses to pick the effective rate limit.
+type rlRoute struct {
+	name    string
+	created int64
+	rl      *aiv1alpha1.RateLimit
+}
+
+func upsertRLRoute(t *testing.T, store datastore.Store, r rlRoute) {
+	t.Helper()
+	assert.NoError(t, store.AddOrUpdateModelRoute(&aiv1alpha1.ModelRoute{
+		ObjectMeta: v1.ObjectMeta{
+			Name:              r.name,
+			Namespace:         "default",
+			CreationTimestamp: v1.Unix(r.created, 0),
+		},
+		Spec: aiv1alpha1.ModelRouteSpec{
+			ModelName: rateLimitCallbackModel,
+			RateLimit: r.rl,
+			Rules: []*aiv1alpha1.Rule{
+				{TargetModels: []*aiv1alpha1.TargetModel{{ModelServerName: "model-server"}}},
+			},
+		},
+	}))
+}
+
+// inputRateLimited reports whether an input-token limiter is currently rejecting
+// requests for the model. It issues several requests so a freshly created
+// limiter is exhausted and a cleared one is seen to consistently allow traffic.
+func inputRateLimited(r *Router) bool {
+	for i := 0; i < 20; i++ {
+		if _, ok := r.loadRateLimiter.RateLimit(rateLimitCallbackModel, "hello world").(*ratelimit.InputRateLimitExceededError); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// outputRateLimited reports whether an output-token limiter is currently in
+// effect for the model.
+func outputRateLimited(r *Router) bool {
+	// Drain the bucket one token at a time; an oversized single AllowN call is
+	// rejected without consuming anything.
+	for i := 0; i < 200; i++ {
+		r.loadRateLimiter.RecordOutputTokens(rateLimitCallbackModel, 1)
+	}
+	_, ok := r.loadRateLimiter.RateLimit(rateLimitCallbackModel, "short").(*ratelimit.OutputRateLimitExceededError)
+	return ok
+}
+
+// TestRouter_RateLimitCallback exercises the real ModelRoute datastore callback
+// registered in NewRouter. It applies an initial set of ModelRoutes for one
+// model name, performs a transition (upsert or delete of one route), and checks
+// the resulting in-process limiter state - including the case where several
+// ModelRoutes share a model name.
+func TestRouter_RateLimitCallback(t *testing.T) {
+	// Callbacks are asynchronous, so poll for the converged state.
+	const (
+		eventuallyWait = 3 * time.Second
+		eventuallyTick = 20 * time.Millisecond
+	)
+
+	inputOnly := &aiv1alpha1.RateLimit{InputTokensPerUnit: uint32Ptr(3), Unit: aiv1alpha1.Second}
+	inputAndOutput := &aiv1alpha1.RateLimit{InputTokensPerUnit: uint32Ptr(3), OutputTokensPerUnit: uint32Ptr(5), Unit: aiv1alpha1.Second}
+	highInputAndOutput := &aiv1alpha1.RateLimit{InputTokensPerUnit: uint32Ptr(100), OutputTokensPerUnit: uint32Ptr(5), Unit: aiv1alpha1.Second}
+	highInputOnly := &aiv1alpha1.RateLimit{InputTokensPerUnit: uint32Ptr(100), Unit: aiv1alpha1.Second}
+	hugeInputOnly := &aiv1alpha1.RateLimit{InputTokensPerUnit: uint32Ptr(1_000_000), Unit: aiv1alpha1.Second}
+	outputOnly := &aiv1alpha1.RateLimit{OutputTokensPerUnit: uint32Ptr(5), Unit: aiv1alpha1.Second}
+	emptyLimit := &aiv1alpha1.RateLimit{Unit: aiv1alpha1.Second}
+
+	tests := []struct {
+		name    string
+		initial []rlRoute
+		// state to wait for after the initial routes are applied.
+		initialInputLimited  bool
+		initialOutputLimited bool
+		// transition under test: upsert this route, or delete deleteRoute.
+		upsert     *rlRoute
+		deleteName string
+		// expected state after the transition.
+		wantInputLimited  bool
+		wantOutputLimited bool
+	}{
+		{
+			name:                "single route: rateLimit -> nil clears the limiter",
+			initial:             []rlRoute{{"a", 1, inputOnly}},
+			initialInputLimited: true,
+			upsert:              &rlRoute{"a", 1, nil},
+		},
+		{
+			name:                "single route: empty RateLimit clears the limiter",
+			initial:             []rlRoute{{"a", 1, inputOnly}},
+			initialInputLimited: true,
+			upsert:              &rlRoute{"a", 1, emptyLimit},
+		},
+		{
+			name:                "single route: input limit removed, output kept",
+			initial:             []rlRoute{{"a", 1, inputAndOutput}},
+			initialInputLimited: true,
+			upsert:              &rlRoute{"a", 1, outputOnly},
+			wantOutputLimited:   true,
+		},
+		{
+			name:                 "single route: output limit removed, input kept",
+			initial:              []rlRoute{{"a", 1, highInputAndOutput}},
+			initialOutputLimited: true,
+			upsert:               &rlRoute{"a", 1, highInputOnly},
+		},
+		{
+			name:                "single route: valid limit A -> B",
+			initial:             []rlRoute{{"a", 1, inputOnly}},
+			initialInputLimited: true,
+			upsert:              &rlRoute{"a", 1, hugeInputOnly},
+		},
+		{
+			name:                "single route: deleting the only route clears the limiter",
+			initial:             []rlRoute{{"a", 1, inputOnly}},
+			initialInputLimited: true,
+			deleteName:          "a",
+		},
+		{
+			name:                "shared model, both limited: removing rateLimit from one keeps the other's limiter",
+			initial:             []rlRoute{{"a", 1, inputOnly}, {"b", 2, inputOnly}},
+			initialInputLimited: true,
+			upsert:              &rlRoute{"a", 1, nil},
+			wantInputLimited:    true,
+		},
+		{
+			name:                "shared model, both limited: deleting one keeps the other's limiter",
+			initial:             []rlRoute{{"a", 1, inputOnly}, {"b", 2, inputOnly}},
+			initialInputLimited: true,
+			deleteName:          "a",
+			wantInputLimited:    true,
+		},
+		{
+			name:                "shared model, one limited: deleting the limited route removes the limiter",
+			initial:             []rlRoute{{"a", 1, inputOnly}, {"b", 2, nil}},
+			initialInputLimited: true,
+			deleteName:          "a",
+		},
+		{
+			name:                "shared model, one limited: clearing the limited route removes the limiter",
+			initial:             []rlRoute{{"a", 1, inputOnly}, {"b", 2, nil}},
+			initialInputLimited: true,
+			upsert:              &rlRoute{"a", 1, nil},
+		},
+		{
+			name:                "shared model, different limits: deleting the first makes the second effective",
+			initial:             []rlRoute{{"a", 1, inputOnly}, {"b", 2, outputOnly}},
+			initialInputLimited: true,
+			deleteName:          "a",
+			wantOutputLimited:   true,
+		},
+		{
+			name:                "shared model, different limits: clearing the first makes the second effective",
+			initial:             []rlRoute{{"a", 1, inputOnly}, {"b", 2, outputOnly}},
+			initialInputLimited: true,
+			upsert:              &rlRoute{"a", 1, nil},
+			wantOutputLimited:   true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			store := datastore.New()
+			router := NewRouter(store, "../scheduler/testdata/configmap.yaml")
+
+			for _, r := range tc.initial {
+				upsertRLRoute(t, store, r)
+			}
+			if tc.initialInputLimited {
+				assert.Eventually(t, func() bool { return inputRateLimited(router) }, eventuallyWait, eventuallyTick,
+					"input limiter should be active after the initial routes are applied")
+			}
+			if tc.initialOutputLimited {
+				assert.Eventually(t, func() bool { return outputRateLimited(router) }, eventuallyWait, eventuallyTick,
+					"output limiter should be active after the initial routes are applied")
+			}
+
+			if tc.deleteName != "" {
+				assert.NoError(t, store.DeleteModelRoute("default/"+tc.deleteName))
+			} else {
+				upsertRLRoute(t, store, *tc.upsert)
+			}
+
+			assert.Eventually(t, func() bool { return inputRateLimited(router) == tc.wantInputLimited }, eventuallyWait, eventuallyTick,
+				"input limiter state after the transition")
+			assert.Eventually(t, func() bool { return outputRateLimited(router) == tc.wantOutputLimited }, eventuallyWait, eventuallyTick,
+				"output limiter state after the transition")
+		})
+	}
+}

--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -30,6 +30,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -123,6 +124,18 @@ func (r *Router) ActiveRequestCount() int64 {
 	return r.metrics.ActiveRequestsCount()
 }
 
+// effectiveModelRateLimit returns the rate limit that applies to a model: the
+// first spec.rateLimit configured among its ModelRoutes (evaluated oldest-first,
+// as MatchModelTarget does), or nil if none configure one.
+func effectiveModelRateLimit(routes []*v1alpha1.ModelRoute) *v1alpha1.RateLimit {
+	for _, route := range routes {
+		if route.Spec.RateLimit != nil {
+			return route.Spec.RateLimit
+		}
+	}
+	return nil
+}
+
 func NewRouter(store datastore.Store, routerConfigPath string) *Router {
 	// User fairness and session boost are mutually exclusive scheduling strategies.
 	// Enabling both is a configuration error.
@@ -139,22 +152,29 @@ func NewRouter(store datastore.Store, routerConfigPath string) *Router {
 	// Initialize tokenizer
 	tokenizerInstance := tokenizer.NewSimpleEstimateTokenizer()
 
+	// A model's limiter is keyed by model name but several ModelRoutes may share
+	// one, so every ModelRoute event recomputes the model's effective rate limit
+	// from the current route set. rateLimitMu serializes callbacks so the
+	// recompute and the apply are atomic; the last callback then always reads the
+	// converged route set and stale async events cannot reapply an old config.
+	var rateLimitMu sync.Mutex
 	store.RegisterCallback("ModelRoute", func(data datastore.EventData) {
-		switch data.EventType {
-		case datastore.EventAdd, datastore.EventUpdate:
-			if data.ModelRoute == nil || data.ModelRoute.Spec.RateLimit == nil {
-				return
-			}
-			klog.Infof("add or update rate limit for model %s", data.ModelName)
+		model := data.ModelName
+		if model == "" {
+			return
+		}
+		rateLimitMu.Lock()
+		defer rateLimitMu.Unlock()
 
-			// Configure the unified rate limiter for this model
-			if err := loadRateLimiter.AddOrUpdateLimiter(data.ModelName, data.ModelRoute.Spec.RateLimit); err != nil {
-				klog.Errorf("failed to configure rate limiter for model %s: %v", data.ModelName, err)
-			}
-
-		case datastore.EventDelete:
-			klog.Infof("delete rate limit for model %s", data.ModelName)
-			loadRateLimiter.DeleteLimiter(data.ModelName)
+		rateLimit := effectiveModelRateLimit(store.GetModelRoutesByModelName(model))
+		if rateLimit == nil {
+			klog.Infof("clear rate limit for model %s", model)
+			loadRateLimiter.DeleteLimiter(model)
+			return
+		}
+		klog.Infof("add or update rate limit for model %s", model)
+		if err := loadRateLimiter.AddOrUpdateLimiter(model, rateLimit); err != nil {
+			klog.Errorf("failed to configure rate limiter for model %s: %v", model, err)
 		}
 	})
 

--- a/test/e2e/router/shared.go
+++ b/test/e2e/router/shared.go
@@ -708,8 +708,11 @@ func TestModelRouteWithRateLimitShared(t *testing.T, testCtx *routercontext.Rout
 		rateLimitWindowSeconds = 60
 		windowResetBuffer      = 10 * time.Second
 		inputTokenLimit        = 30
-		outputTokenLimit       = 100
-		tokensPerRequest       = 10
+		// The echo-mode simulator returns two completion tokens for the standard
+		// "hello world" message, so an output budget of six is drained to exactly
+		// zero after three requests and then enforced on the fourth.
+		outputTokenLimit = 6
+		tokensPerRequest = 10
 	)
 	ctx := context.Background()
 
@@ -972,17 +975,16 @@ func TestModelRouteWithRateLimitShared(t *testing.T, testCtx *routercontext.Rout
 		// Wait for update to propagate
 		time.Sleep(2 * time.Second)
 
-		longerPrompt := []utils.ChatMessage{
-			utils.NewChatMessage("user", "Write a detailed explanation of rate limiting"),
-		}
-
-		// Send requests until we hit the output token limit
+		// Send requests until we hit the output token limit. The stale input
+		// limiter must not interfere: with a predictable two-token echo response
+		// per request, the six-token output budget is exhausted after three
+		// successful requests.
 		var successfulRequests int
 		var totalResponseSize int
 		var rateLimited bool
 
 		for attempt := 0; attempt < 20; attempt++ {
-			resp := utils.SendChatRequest(t, updatedModelRoute.Spec.ModelName, longerPrompt)
+			resp := utils.SendChatRequest(t, updatedModelRoute.Spec.ModelName, standardMessage)
 			responseBody, readErr := io.ReadAll(resp.Body)
 			resp.Body.Close()
 


### PR DESCRIPTION


### What this PR does / why we need it

When a `ModelRoute` has `spec.rateLimit` configured and the field is later removed, the router keeps the previously created in-process rate limiter. This causes requests to remain rate-limited even though the configuration no longer specifies a limit.

This PR fixes both stale-limiter paths:

* When `spec.rateLimit` becomes `nil` on an Add/Update event, explicitly delete the model's limiter.
* When `inputTokensPerUnit` or `outputTokensPerUnit` is removed from an existing `RateLimit`, delete the corresponding stale limiter.

Valid rate-limit updates and full `ModelRoute` deletion continue to work unchanged.

### Which issue(s) this PR fixes

Fixes #1704

### Bug evidence (required for bug-related PRs)

The production path is:

`ModelRoute informer Update` → `ModelRouteController.syncHandler` → `store.AddOrUpdateModelRoute()` → `ModelRoute` callback registered by `NewRouter()` → rate-limiter update/delete.

The bug was reproduced through the actual `datastore.New()` and `NewRouter()` callback wiring.

Previously, when `spec.rateLimit` became `nil`, the callback returned without calling `DeleteLimiter`, leaving the existing limiter active. Similarly, `AddOrUpdateLimiter` did not remove an existing input/output limiter when the corresponding token-limit field was unset.

The fix removes these stale entries so subsequent requests are no longer incorrectly rate-limited.

### Special notes for your reviewer

Added regression coverage for:

* `rateLimit → nil`
* empty `RateLimit{}`
* removal of input limit
* removal of output limit
* valid rate-limit update
* full `ModelRoute` deletion

The callback is asynchronous, so the router-level tests use eventual assertions.

### Does this PR introduce a user-facing change?

```release-note
NONE
```
