### PR TITLE
router: fix trafficPolicy timeout for PD routing

### DIFF
--- a/charts/kthena/charts/networking/crds/networking.serving.volcano.sh_modelservers.yaml
+++ b/charts/kthena/charts/networking/crds/networking.serving.volcano.sh_modelservers.yaml
@@ -105,8 +105,9 @@ spec:
                     description: |-
                       Timeout bounds how long the router waits for the backend to start responding,
                       covering connection setup, sending the request and waiting for the response
-                      headers. It does not bound the response body, so a streamed response may run
-                      longer. By default, there is no timeout.
+                      headers. It does not bound inference response bodies, so a streamed response
+                      may run longer. Connector setup exchanges may use the timeout for their
+                      complete response. By default, there is no timeout.
                     type: string
                 type: object
               workloadPort:

--- a/pkg/apis/networking/v1alpha1/modelserver_types.go
+++ b/pkg/apis/networking/v1alpha1/modelserver_types.go
@@ -123,8 +123,9 @@ type KVConnectorSpec struct {
 type TrafficPolicy struct {
 	// Timeout bounds how long the router waits for the backend to start responding,
 	// covering connection setup, sending the request and waiting for the response
-	// headers. It does not bound the response body, so a streamed response may run
-	// longer. By default, there is no timeout.
+	// headers. It does not bound inference response bodies, so a streamed response
+	// may run longer. Connector setup exchanges may use the timeout for their
+	// complete response. By default, there is no timeout.
 	// +optional
 	Timeout *metav1.Duration `json:"timeout,omitempty"`
 	// The retry policy for the inference request.

--- a/pkg/kthena-router/connectors/connectors_test.go
+++ b/pkg/kthena-router/connectors/connectors_test.go
@@ -127,7 +127,7 @@ func TestHTTPConnectorProxy(t *testing.T) {
 
 		// The HTTP connector does support the Proxy method, but it will fail
 		// because the test addresses don't exist and the prefill/decode calls will fail
-		_, err := connector.Proxy(c, reqBody, "localhost:8000", "localhost:8001", nil)
+		_, err := connector.Proxy(c, reqBody, "localhost:8000", "localhost:8001", 0, nil)
 		if err == nil {
 			t.Error("Expected HTTP connector Proxy to return error due to network/connection issues")
 		}
@@ -213,7 +213,7 @@ func TestHTTPConnectorProxy(t *testing.T) {
 		}
 
 		// The HTTP connector will fail due to network issues
-		_, err := connector.Proxy(c, reqBody, "localhost:8000", "localhost:8001", nil)
+		_, err := connector.Proxy(c, reqBody, "localhost:8000", "localhost:8001", 0, nil)
 		if err == nil {
 			t.Error("Expected HTTP connector Proxy to return error due to network/connection issues")
 		}
@@ -307,7 +307,7 @@ func TestHTTPConnectorProxy(t *testing.T) {
 		}
 
 		// The HTTP connector will fail due to network issues
-		_, err := connector.Proxy(c, reqBody, "localhost:8000", "localhost:8001", nil)
+		_, err := connector.Proxy(c, reqBody, "localhost:8000", "localhost:8001", 0, nil)
 		if err == nil {
 			t.Error("Expected HTTP connector Proxy to return error due to network/connection issues")
 		}
@@ -365,7 +365,7 @@ func TestHTTPConnectorProxy(t *testing.T) {
 		}
 
 		// The HTTP connector will fail due to network issues
-		_, err := connector.Proxy(c, reqBody, "localhost:8000", "localhost:8001", nil)
+		_, err := connector.Proxy(c, reqBody, "localhost:8000", "localhost:8001", 0, nil)
 		if err == nil {
 			t.Error("Expected HTTP connector Proxy to return error due to network/connection issues")
 		}
@@ -458,7 +458,7 @@ func TestHTTPConnectorProxy(t *testing.T) {
 		}
 
 		// The HTTP connector will fail due to network issues
-		_, err := connector.Proxy(c, reqBodyCopy, "localhost:8000", "localhost:8001", nil)
+		_, err := connector.Proxy(c, reqBodyCopy, "localhost:8000", "localhost:8001", 0, nil)
 		if err == nil {
 			t.Error("Expected HTTP connector Proxy to return error due to network/connection issues")
 		}

--- a/pkg/kthena-router/connectors/http.go
+++ b/pkg/kthena-router/connectors/http.go
@@ -18,6 +18,7 @@ package connectors
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"k8s.io/klog/v2"
@@ -43,25 +44,25 @@ func (h *HTTPConnector) Name() string {
 }
 
 // prefill executes prefill request
-func (h *HTTPConnector) prefill(req *http.Request, prefillAddr string) error {
+func (h *HTTPConnector) prefill(req *http.Request, prefillAddr string, timeout time.Duration) error {
 	req.URL.Host = prefillAddr
 	req.URL.Scheme = "http"
 
 	klog.V(4).Infof("Sending prefill request to %s", prefillAddr)
-	return prefillerProxy(nil, req)
+	return prefillerProxy(nil, req, timeout)
 }
 
 // decode executes decode request and streams response
-func (h *HTTPConnector) decode(c *gin.Context, req *http.Request, decodeAddr string) (int, error) {
+func (h *HTTPConnector) decode(c *gin.Context, req *http.Request, decodeAddr string, timeout time.Duration) (int, error) {
 	req.URL.Host = decodeAddr
 	req.URL.Scheme = "http"
 
 	klog.V(4).Infof("Sending decode request to %s", decodeAddr)
-	return decoderProxy(c, req)
+	return decoderProxy(c, req, timeout)
 }
 
 // Proxy executes the complete prefill-decode flow for HTTP connector
-func (h *HTTPConnector) Proxy(c *gin.Context, reqBody map[string]interface{}, prefillAddr, decodeAddr string, hooks *OnFlightHooks) (int, error) {
+func (h *HTTPConnector) Proxy(c *gin.Context, reqBody map[string]interface{}, prefillAddr, decodeAddr string, timeout time.Duration, hooks *OnFlightHooks) (int, error) {
 	// Get metrics recorder from context
 	var metricsRecorder *metrics.RequestMetricsRecorder
 	if recorder, exists := c.Get("metricsRecorder"); exists {
@@ -85,7 +86,7 @@ func (h *HTTPConnector) Proxy(c *gin.Context, reqBody map[string]interface{}, pr
 		hooks.IncrPrefill()
 	}
 
-	err := h.prefill(h.prefillRequest, prefillAddr)
+	err := h.prefill(h.prefillRequest, prefillAddr, timeout)
 
 	if hooks != nil && hooks.DecrPrefill != nil {
 		hooks.DecrPrefill()
@@ -112,7 +113,7 @@ func (h *HTTPConnector) Proxy(c *gin.Context, reqBody map[string]interface{}, pr
 		hooks.IncrDecode()
 	}
 
-	result, decodeErr := h.decode(c, h.decodeRequest, decodeAddr)
+	result, decodeErr := h.decode(c, h.decodeRequest, decodeAddr, timeout)
 
 	if hooks != nil && hooks.DecrDecode != nil {
 		hooks.DecrDecode()

--- a/pkg/kthena-router/connectors/interface.go
+++ b/pkg/kthena-router/connectors/interface.go
@@ -17,6 +17,8 @@ limitations under the License.
 package connectors
 
 import (
+	"time"
+
 	"github.com/gin-gonic/gin"
 )
 
@@ -26,8 +28,9 @@ type KVConnector interface {
 	Name() string
 
 	// Proxy executes the complete prefill-decode flow with KV cache coordination.
+	// timeout bounds upstream requests without truncating streaming decode responses.
 	// hooks carries optional on-flight counter callbacks for the prefill and decode
 	// pods; pass nil when not needed.
 	// Returns the number of output tokens consumed, or error if the operation fails.
-	Proxy(c *gin.Context, reqBody map[string]interface{}, prefillAddr, decodeAddr string, hooks *OnFlightHooks) (int, error)
+	Proxy(c *gin.Context, reqBody map[string]interface{}, prefillAddr, decodeAddr string, timeout time.Duration, hooks *OnFlightHooks) (int, error)
 }

--- a/pkg/kthena-router/connectors/nixl.go
+++ b/pkg/kthena-router/connectors/nixl.go
@@ -18,12 +18,14 @@ package connectors
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"maps"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"k8s.io/klog/v2"
@@ -51,7 +53,7 @@ func (n *NIXLConnector) Name() string {
 }
 
 // Proxy executes the complete prefill-decode flow using NIXL for high-performance KV transfer
-func (n *NIXLConnector) Proxy(c *gin.Context, reqBody map[string]interface{}, prefillAddr, decodeAddr string, hooks *OnFlightHooks) (int, error) {
+func (n *NIXLConnector) Proxy(c *gin.Context, reqBody map[string]interface{}, prefillAddr, decodeAddr string, timeout time.Duration, hooks *OnFlightHooks) (int, error) {
 	// Get metrics recorder from context
 	var metricsRecorder *metrics.RequestMetricsRecorder
 	if recorder, exists := c.Get("metricsRecorder"); exists {
@@ -76,7 +78,7 @@ func (n *NIXLConnector) Proxy(c *gin.Context, reqBody map[string]interface{}, pr
 	}
 
 	// 1. send prefill request
-	kvTransferParams, err := n.prefill(n.prefillRequest, prefillAddr)
+	kvTransferParams, err := n.prefill(n.prefillRequest, prefillAddr, timeout)
 
 	if hooks != nil && hooks.DecrPrefill != nil {
 		hooks.DecrPrefill()
@@ -105,7 +107,7 @@ func (n *NIXLConnector) Proxy(c *gin.Context, reqBody map[string]interface{}, pr
 
 	// 2. send decode request
 	decodeReq := n.buildDecodeRequest(c, n.decodeRequestBody, kvTransferParams)
-	result, decodeErr := n.decode(c, decodeReq, decodeAddr)
+	result, decodeErr := n.decode(c, decodeReq, decodeAddr, timeout)
 
 	if hooks != nil && hooks.DecrDecode != nil {
 		hooks.DecrDecode()
@@ -123,12 +125,18 @@ func (n *NIXLConnector) Proxy(c *gin.Context, reqBody map[string]interface{}, pr
 }
 
 // prefill send prefill request, returns kv_transfer_params
-func (n *NIXLConnector) prefill(req *http.Request, prefillAddr string) (interface{}, error) {
+func (n *NIXLConnector) prefill(req *http.Request, prefillAddr string, timeout time.Duration) (interface{}, error) {
 	req.URL.Host = prefillAddr
 	req.URL.Scheme = "http"
 	klog.V(4).Infof("%s prefill: sending to %s", n.name, req.URL.String())
 
-	// Send prefill request
+	// NIXL returns connector setup metadata in the response body, so the timeout
+	// covers the body read. Decode response bodies remain unbounded.
+	if timeout > 0 {
+		ctx, cancel := context.WithTimeout(req.Context(), timeout)
+		defer cancel()
+		req = req.WithContext(ctx)
+	}
 	resp, err := http.DefaultTransport.RoundTrip(req)
 	if err != nil {
 		return nil, err
@@ -172,7 +180,7 @@ func (n *NIXLConnector) buildDecodeRequest(c *gin.Context, reqBody map[string]in
 }
 
 // decode send decode request with streaming response
-func (n *NIXLConnector) decode(c *gin.Context, req *http.Request, decodeAddr string) (int, error) {
+func (n *NIXLConnector) decode(c *gin.Context, req *http.Request, decodeAddr string, timeout time.Duration) (int, error) {
 	// Set kv_transfer_params from prefill response
 	req.URL.Host = decodeAddr
 	req.URL.Scheme = "http"
@@ -180,7 +188,7 @@ func (n *NIXLConnector) decode(c *gin.Context, req *http.Request, decodeAddr str
 	klog.V(4).Infof("%s decode: sending to %s", n.name, req.URL.String())
 
 	// Use decoderProxy to handle the decode response with proper streaming
-	return decoderProxy(c, req)
+	return decoderProxy(c, req, timeout)
 }
 
 func cloneReqBody(reqBody map[string]interface{}) map[string]interface{} {

--- a/pkg/kthena-router/connectors/nixl_test.go
+++ b/pkg/kthena-router/connectors/nixl_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package connectors
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -24,6 +25,7 @@ import (
 	"net/http/httptest"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/common"
@@ -51,7 +53,7 @@ func TestNIXLConnectorProxy(t *testing.T) {
 		}
 
 		// The NIXL connector will fail due to network issues (prefill request)
-		_, err := connector.Proxy(c, reqBody, "localhost:8000", "localhost:8001", nil)
+		_, err := connector.Proxy(c, reqBody, "localhost:8000", "localhost:8001", 0, nil)
 		if err == nil {
 			t.Error("Expected NIXL connector Proxy to return error due to network/connection issues")
 		}
@@ -147,7 +149,7 @@ func TestNIXLConnectorProxy(t *testing.T) {
 		}
 
 		// The NIXL connector will fail due to network issues
-		_, err := connector.Proxy(c, reqBody, "localhost:8000", "localhost:8001", nil)
+		_, err := connector.Proxy(c, reqBody, "localhost:8000", "localhost:8001", 0, nil)
 		if err == nil {
 			t.Error("Expected NIXL connector Proxy to return error due to network/connection issues")
 		}
@@ -241,7 +243,7 @@ func TestNIXLConnectorProxy(t *testing.T) {
 		}
 
 		// The NIXL connector will fail due to network issues
-		_, err := connector.Proxy(c, reqBody, "localhost:8000", "localhost:8001", nil)
+		_, err := connector.Proxy(c, reqBody, "localhost:8000", "localhost:8001", 0, nil)
 		if err == nil {
 			t.Error("Expected NIXL connector Proxy to return error due to network/connection issues")
 		}
@@ -285,7 +287,7 @@ func TestNIXLConnectorProxy(t *testing.T) {
 		}
 
 		// The NIXL connector will fail due to network issues
-		_, err := connector.Proxy(c, reqBody, "localhost:8000", "localhost:8001", nil)
+		_, err := connector.Proxy(c, reqBody, "localhost:8000", "localhost:8001", 0, nil)
 		if err == nil {
 			t.Error("Expected NIXL connector Proxy to return error due to network/connection issues")
 		}
@@ -342,7 +344,7 @@ func TestNIXLConnectorProxy(t *testing.T) {
 		}
 
 		// The NIXL connector will fail due to network issues
-		_, err := connector.Proxy(c, reqBody, "localhost:8000", "localhost:8001", nil)
+		_, err := connector.Proxy(c, reqBody, "localhost:8000", "localhost:8001", 0, nil)
 		if err == nil {
 			t.Error("Expected NIXL connector Proxy to return error due to network/connection issues")
 		}
@@ -376,6 +378,37 @@ func TestNIXLConnectorProxy(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestNIXLPrefillTimeoutIncludesResponseBody(t *testing.T) {
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"kv_transfer_params":`))
+		w.(http.Flusher).Flush()
+		<-release
+	}))
+	defer func() {
+		close(release)
+		server.Close()
+	}()
+
+	requestCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(requestCtx, http.MethodPost, server.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	connector := NewNIXLConnector().(*NIXLConnector)
+	start := time.Now()
+	_, err = connector.prefill(req, server.Listener.Addr().String(), 100*time.Millisecond)
+	if err == nil {
+		t.Fatal("prefill succeeded after response body stalled")
+	}
+	if elapsed := time.Since(start); elapsed >= time.Second {
+		t.Fatalf("prefill took %v after response body stalled", elapsed)
+	}
 }
 
 // TestNIXLConnectorRetryBodyNotDrained checks that calling Proxy() twice on the
@@ -418,9 +451,9 @@ func TestNIXLConnectorRetryBodyNotDrained(t *testing.T) {
 	decodeAddr := "127.0.0.1:1" // nothing listening here; decode will fail
 
 	// First call — simulates retry iteration 0
-	connector.Proxy(makeCtx(), reqBody, prefillAddr, decodeAddr, nil)
+	connector.Proxy(makeCtx(), reqBody, prefillAddr, decodeAddr, 0, nil)
 	// Second call — simulates retry iteration 1 on the same connector instance
-	connector.Proxy(makeCtx(), reqBody, prefillAddr, decodeAddr, nil)
+	connector.Proxy(makeCtx(), reqBody, prefillAddr, decodeAddr, 0, nil)
 
 	if bodyLengths[0] == 0 {
 		t.Error("first Proxy call sent empty body to prefill backend")
@@ -454,7 +487,7 @@ func TestNIXLConnectorReqBodyNotMutated(t *testing.T) {
 		keysBefore[k] = struct{}{}
 	}
 
-	connector.Proxy(c, reqBody, "127.0.0.1:1", "127.0.0.1:2", nil)
+	connector.Proxy(c, reqBody, "127.0.0.1:1", "127.0.0.1:2", 0, nil)
 
 	for k := range reqBody {
 		if _, existed := keysBefore[k]; !existed {

--- a/pkg/kthena-router/connectors/sglang.go
+++ b/pkg/kthena-router/connectors/sglang.go
@@ -25,6 +25,7 @@ import (
 	"math/rand"
 	"net"
 	"net/http"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"k8s.io/klog/v2"
@@ -79,7 +80,7 @@ func (s *SGLangConnector) Name() string {
 // prefill to time out and abort with "KVTransferError: Aborted by AbortReq".
 // The decode request carries bootstrap_host = prefillHost so the decode receiver can
 // locate the prefill's bootstrap server; both requests carry the same bootstrap_room.
-func (s *SGLangConnector) Proxy(c *gin.Context, reqBody map[string]interface{}, prefillAddr, decodeAddr string, hooks *OnFlightHooks) (int, error) {
+func (s *SGLangConnector) Proxy(c *gin.Context, reqBody map[string]interface{}, prefillAddr, decodeAddr string, timeout time.Duration, hooks *OnFlightHooks) (int, error) {
 	// A bootstrap room identifies one prefill/decode attempt. Generate it here
 	// so retries cannot observe state left behind by an earlier worker pair.
 	bootstrapRoom := s.newBootstrapRoom()
@@ -150,17 +151,21 @@ func (s *SGLangConnector) Proxy(c *gin.Context, reqBody map[string]interface{}, 
 		hooks.IncrDecode()
 	}
 
-	// prefillCtx is cancelled if decode fails, which aborts the prefill HTTP
-	// request immediately instead of letting it hang waiting for a bootstrap
-	// connection from a decode receiver that is already gone.
+	// Cancel either phase if the other fails so neither request is left waiting
+	// for a peer that is already gone.
 	prefillCtx, cancelPrefill := context.WithCancel(c.Request.Context())
 	defer cancelPrefill()
+	decodeCtx, cancelDecode := context.WithCancel(c.Request.Context())
+	defer cancelDecode()
 
 	type prefillOutcome struct{ err error }
 	prefillCh := make(chan prefillOutcome, 1)
 
 	go func() {
-		err := s.prefill(prefillRequest.WithContext(prefillCtx), prefillAddr, bootstrapRoom)
+		err := s.prefill(prefillRequest.WithContext(prefillCtx), prefillAddr, bootstrapRoom, timeout)
+		if err != nil {
+			cancelDecode()
+		}
 		// Decrement the prefill pod's on-flight counter as soon as prefill finishes,
 		// so the scheduler gets an accurate view even while decode is still running.
 		if hooks != nil && hooks.DecrPrefill != nil {
@@ -171,7 +176,7 @@ func (s *SGLangConnector) Proxy(c *gin.Context, reqBody map[string]interface{}, 
 
 	// Run decode in the current goroutine so that streaming writes reach the
 	// gin.Context from the request-handling goroutine.
-	result, decodeErr := s.decode(c, decodeRequest, decodeAddr, bootstrapRoom)
+	result, decodeErr := s.decode(c, decodeRequest.WithContext(decodeCtx), decodeAddr, bootstrapRoom, timeout)
 
 	if hooks != nil && hooks.DecrDecode != nil {
 		hooks.DecrDecode()
@@ -210,18 +215,18 @@ func (s *SGLangConnector) Proxy(c *gin.Context, reqBody map[string]interface{}, 
 	return result, decodeErr
 }
 
-func (s *SGLangConnector) prefill(req *http.Request, prefillAddr string, bootstrapRoom int64) error {
+func (s *SGLangConnector) prefill(req *http.Request, prefillAddr string, bootstrapRoom int64, timeout time.Duration) error {
 	req.URL.Host = prefillAddr
 	req.URL.Scheme = "http"
 	klog.V(4).Infof("sglang prefill: sending to %s (bootstrap_room=%d)", req.URL.String(), bootstrapRoom)
-	return prefillerProxy(nil, req)
+	return prefillerProxy(nil, req, timeout)
 }
 
-func (s *SGLangConnector) decode(c *gin.Context, req *http.Request, decodeAddr string, bootstrapRoom int64) (int, error) {
+func (s *SGLangConnector) decode(c *gin.Context, req *http.Request, decodeAddr string, bootstrapRoom int64, timeout time.Duration) (int, error) {
 	req.URL.Host = decodeAddr
 	req.URL.Scheme = "http"
 	klog.V(4).Infof("sglang decode: sending to %s (bootstrap_room=%d)", req.URL.String(), bootstrapRoom)
-	return decoderProxy(c, req)
+	return decoderProxy(c, req, timeout)
 }
 
 func buildRequest(req *http.Request, reqBody map[string]interface{}) (*http.Request, error) {

--- a/pkg/kthena-router/connectors/sglang_test.go
+++ b/pkg/kthena-router/connectors/sglang_test.go
@@ -17,12 +17,14 @@ limitations under the License.
 package connectors
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 )
@@ -98,11 +100,11 @@ func TestSGLangConnectorRetryIsolation(t *testing.T) {
 	decodeAddr := decodeServer.Listener.Addr().String()
 
 	// First call simulates the initial PD attempt.
-	if _, err := connector.Proxy(makeCtx(), reqBody, prefillAddr, decodeAddr, nil); err != nil {
+	if _, err := connector.Proxy(makeCtx(), reqBody, prefillAddr, decodeAddr, 0, nil); err != nil {
 		t.Fatalf("first Proxy call failed: %v", err)
 	}
 	// The second call simulates another attempt on the same connector.
-	if _, err := connector.Proxy(makeCtx(), reqBody, prefillAddr, decodeAddr, nil); err != nil {
+	if _, err := connector.Proxy(makeCtx(), reqBody, prefillAddr, decodeAddr, 0, nil); err != nil {
 		t.Fatalf("second Proxy call failed: %v", err)
 	}
 
@@ -125,6 +127,61 @@ func TestSGLangConnectorRetryIsolation(t *testing.T) {
 	}
 	if prefillRooms[0] == prefillRooms[1] {
 		t.Errorf("retry reused bootstrap room %d", prefillRooms[0])
+	}
+}
+
+func TestSGLangConnectorPrefillTimeoutCancelsDecode(t *testing.T) {
+	releasePrefill := make(chan struct{})
+	prefillServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-r.Context().Done():
+		case <-releasePrefill:
+		}
+	}))
+	defer func() {
+		close(releasePrefill)
+		prefillServer.Close()
+	}()
+
+	decodeCancelled := make(chan struct{})
+	decodeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		w.(http.Flusher).Flush()
+		<-r.Context().Done()
+		close(decodeCancelled)
+	}))
+	defer decodeServer.Close()
+
+	requestCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	req, _ := http.NewRequestWithContext(requestCtx, http.MethodPost, "/v1/chat/completions", nil)
+	c, _ := gin.CreateTestContext(CreateTestResponseRecorder())
+	c.Request = req
+
+	reqBody := map[string]interface{}{
+		"model":      "test-model",
+		"stream":     true,
+		"max_tokens": 100,
+		"messages": []interface{}{
+			map[string]interface{}{"role": "user", "content": "hello"},
+		},
+	}
+
+	connector := NewSGLangConnector()
+	start := time.Now()
+	_, err := connector.Proxy(c, reqBody, prefillServer.Listener.Addr().String(), decodeServer.Listener.Addr().String(), 100*time.Millisecond, nil)
+	if err == nil {
+		t.Fatal("Proxy() succeeded after prefill timed out")
+	}
+	if elapsed := time.Since(start); elapsed >= time.Second {
+		t.Fatalf("Proxy() took %v after prefill timed out", elapsed)
+	}
+
+	select {
+	case <-decodeCancelled:
+	case <-time.After(time.Second):
+		t.Fatal("decode request was not cancelled after prefill timed out")
 	}
 }
 
@@ -151,7 +208,7 @@ func TestSGLangConnectorReqBodyNotMutated(t *testing.T) {
 		keysBefore[k] = struct{}{}
 	}
 
-	_, _ = connector.Proxy(c, reqBody, "127.0.0.1:1", "127.0.0.1:2", nil)
+	_, _ = connector.Proxy(c, reqBody, "127.0.0.1:1", "127.0.0.1:2", 0, nil)
 
 	for k := range reqBody {
 		if _, existed := keysBefore[k]; !existed {

--- a/pkg/kthena-router/connectors/transport.go
+++ b/pkg/kthena-router/connectors/transport.go
@@ -19,11 +19,13 @@ package connectors
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"mime"
 	"net/http"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/volcano-sh/kthena/pkg/kthena-router/common"
@@ -31,8 +33,41 @@ import (
 	"k8s.io/klog/v2"
 )
 
-func prefillerProxy(_ *gin.Context, req *http.Request) error {
+type cancelOnClose struct {
+	io.ReadCloser
+	cancel context.CancelFunc
+}
+
+func (b *cancelOnClose) Close() error {
+	err := b.ReadCloser.Close()
+	b.cancel()
+	return err
+}
+
+func roundTrip(req *http.Request, timeout time.Duration) (*http.Response, error) {
+	// Stop the timeout after response headers so long-running streams can finish.
+	cancel := context.CancelFunc(func() {})
+	if timeout > 0 {
+		var ctx context.Context
+		ctx, cancel = context.WithCancel(req.Context())
+		timer := time.AfterFunc(timeout, cancel)
+		defer timer.Stop()
+		req = req.WithContext(ctx)
+	}
+
 	resp, err := http.DefaultTransport.RoundTrip(req)
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+	if timeout > 0 {
+		resp.Body = &cancelOnClose{ReadCloser: resp.Body, cancel: cancel}
+	}
+	return resp, nil
+}
+
+func prefillerProxy(_ *gin.Context, req *http.Request, timeout time.Duration) error {
+	resp, err := roundTrip(req, timeout)
 	if err != nil {
 		return fmt.Errorf("prefill request failed: %w", err)
 	}
@@ -46,8 +81,8 @@ func prefillerProxy(_ *gin.Context, req *http.Request) error {
 	return nil
 }
 
-func decoderProxy(c *gin.Context, req *http.Request) (int, error) {
-	resp, err := http.DefaultTransport.RoundTrip(req)
+func decoderProxy(c *gin.Context, req *http.Request, timeout time.Duration) (int, error) {
+	resp, err := roundTrip(req, timeout)
 	if err != nil {
 		return 0, fmt.Errorf("decode request failed: %w", err)
 	}

--- a/pkg/kthena-router/connectors/transport_test.go
+++ b/pkg/kthena-router/connectors/transport_test.go
@@ -18,11 +18,13 @@ package connectors
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
@@ -557,7 +559,7 @@ func TestPrefillerProxy(t *testing.T) {
 			require.NoError(t, err)
 			testReq.Header.Set("Content-Type", "application/json")
 
-			err = prefillerProxy(c, testReq)
+			err = prefillerProxy(c, testReq, 0)
 
 			if tt.expectError {
 				assert.Error(t, err)
@@ -569,6 +571,28 @@ func TestPrefillerProxy(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPrefillerProxyHonorsTimeout(t *testing.T) {
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-release
+	}))
+	defer func() {
+		close(release)
+		server.Close()
+	}()
+
+	requestCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(requestCtx, http.MethodPost, server.URL, nil)
+	require.NoError(t, err)
+
+	start := time.Now()
+	err = prefillerProxy(nil, req, 100*time.Millisecond)
+
+	assert.Error(t, err)
+	assert.Less(t, time.Since(start), time.Second)
 }
 
 func TestDecoderProxy(t *testing.T) {
@@ -643,7 +667,7 @@ func TestDecoderProxy(t *testing.T) {
 			require.NoError(t, err)
 			testReq.Header.Set("Content-Type", "application/json")
 
-			_, err = decoderProxy(c, testReq)
+			_, err = decoderProxy(c, testReq, 0)
 
 			if tt.expectError {
 				assert.Error(t, err)
@@ -655,4 +679,25 @@ func TestDecoderProxy(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDecoderProxyTimeoutDoesNotTruncateStream(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		w.(http.Flusher).Flush()
+		time.Sleep(200 * time.Millisecond)
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer server.Close()
+
+	w := CreateTestResponseRecorder()
+	c, _ := gin.CreateTestContext(w)
+	req, err := http.NewRequest(http.MethodPost, server.URL, nil)
+	require.NoError(t, err)
+
+	_, err = decoderProxy(c, req, 50*time.Millisecond)
+
+	assert.NoError(t, err)
+	assert.Contains(t, w.Body.String(), "data: [DONE]")
 }

--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -955,7 +955,7 @@ func (r *Router) proxyModelEndpoint(
 	}
 
 	// PD disaggregated mode - use KV connector
-	return r.proxyToPDDisaggregated(c, req, ctx, kvConnector, modelRequest, port)
+	return r.proxyToPDDisaggregated(c, req, ctx, kvConnector, modelRequest, port, timeout)
 }
 
 func (r *Router) proxyExternalProvider(
@@ -1398,6 +1398,7 @@ func (r *Router) proxyToPDDisaggregated(
 	kvConnector connectors.KVConnector,
 	modelRequest ModelRequest,
 	port int32,
+	timeout time.Duration,
 ) error {
 	// Get metrics recorder from context
 	var metricsRecorder *metrics.RequestMetricsRecorder
@@ -1439,7 +1440,7 @@ func (r *Router) proxyToPDDisaggregated(
 		}
 
 		// Execute the PD disaggregated proxy operation
-		outputTokens, err := kvConnector.Proxy(c, modelRequest, prefillAddr, decodeAddr, hooks)
+		outputTokens, err := kvConnector.Proxy(c, modelRequest, prefillAddr, decodeAddr, timeout, hooks)
 		if c.Writer.Written() {
 			accesslog.SetUpstreamInfo(c, c.Writer.Status(), 0)
 		}

--- a/pkg/kthena-router/router/router_test.go
+++ b/pkg/kthena-router/router/router_test.go
@@ -3077,6 +3077,7 @@ func TestRouter_HandlerFunc_UnknownModel_RejectsBeforeQueueing(t *testing.T) {
 
 type mockKVConnector struct {
 	calls        atomic.Int32
+	timeout      time.Duration
 	proxyHandler func(c *gin.Context, reqBody map[string]interface{}, prefillAddr, decodeAddr string, hooks *connectors.OnFlightHooks) (int, error)
 }
 
@@ -3084,8 +3085,9 @@ func (m *mockKVConnector) Name() string {
 	return "mock"
 }
 
-func (m *mockKVConnector) Proxy(c *gin.Context, reqBody map[string]interface{}, prefillAddr, decodeAddr string, hooks *connectors.OnFlightHooks) (int, error) {
+func (m *mockKVConnector) Proxy(c *gin.Context, reqBody map[string]interface{}, prefillAddr, decodeAddr string, timeout time.Duration, hooks *connectors.OnFlightHooks) (int, error) {
 	m.calls.Add(1)
+	m.timeout = timeout
 	if m.proxyHandler != nil {
 		return m.proxyHandler(c, reqBody, prefillAddr, decodeAddr, hooks)
 	}
@@ -3182,7 +3184,7 @@ func TestRouter_ProxyToPDDisaggregated_RetryBehavior(t *testing.T) {
 			c, _ := gin.CreateTestContext(w)
 			c.Request, _ = http.NewRequest("POST", "/v1/chat/completions", bytes.NewBufferString(`{"model":"test-model"}`))
 
-			err := router.proxyToPDDisaggregated(c, c.Request, ctx, mockConnector, ModelRequest{"model": "test-model"}, 8000)
+			err := router.proxyToPDDisaggregated(c, c.Request, ctx, mockConnector, ModelRequest{"model": "test-model"}, 8000, 2*time.Second)
 
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -3191,6 +3193,7 @@ func TestRouter_ProxyToPDDisaggregated_RetryBehavior(t *testing.T) {
 				assert.NoError(t, err)
 			}
 			assert.Equal(t, tt.wantCalls, mockConnector.calls.Load(), tt.callsMsg)
+			assert.Equal(t, 2*time.Second, mockConnector.timeout)
 			assert.Equal(t, tt.wantStatus, w.Code)
 		})
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/area router

**What this PR does / why we need it**:

PD-disaggregated requests were dropping `ModelServer.spec.trafficPolicy.timeout` before calling the KV connector.

This passes the timeout through the HTTP, NIXL, and SGLang connectors and applies it while connecting, uploading the request, and waiting for response headers. The timeout stops after headers arrive, so long-running streams are not truncated.

**Which issue(s) this PR fixes**:

Fixes #1710  
Refs #1498  
Follow-up to #1603

**Bug evidence (required for bug-related PRs)**:

Found through source review. Not reproduced in a cluster.

The timeout reaches `proxyModelEndpoint`, but the PD branch previously called `proxyToPDDisaggregated` without passing it:

https://github.com/volcano-sh/kthena/blob/dd7e5af6ab0517094c6bf8c05bfeb64747290147/pkg/kthena-router/router/router.go#L895-L958

The connector path then used `http.DefaultTransport` without the configured deadline:

https://github.com/volcano-sh/kthena/blob/dd7e5af6ab0517094c6bf8c05bfeb64747290147/pkg/kthena-router/connectors/transport.go#L34-L54

Reproduction:

1. Deploy the existing PD-disaggregated ModelServer example with `trafficPolicy.timeout: 1s`.
2. Point the prefill or decode role at a backend that accepts the request but does not send response headers.
3. Send an inference request through the matching ModelRoute.
4. Before this change, the request stays open past 1s until the backend responds or the client disconnects.

The fix passes the timeout into every connector attempt and uses the same stream-safe cancellation pattern as the aggregated path.

**Special notes for your reviewer**:

The timeout applies separately to each prefill and decode upstream request. It only bounds the request until response headers arrive; response bodies and streaming output are not given a whole-request deadline.

Retry behavior and the aggregated path are unchanged.

This PR was written in part with the assistance of generative AI. I reviewed and tested the changes myself.

**Does this PR introduce a user-facing change?**:

```release-note
kthena-router: PD-disaggregated requests now honor ModelServer trafficPolicy.timeout while waiting for upstream response headers.
```