### PR TITLE
fix(downloader): keep lock inode stable

### DIFF
--- a/python/kthena/downloader/base.py
+++ b/python/kthena/downloader/base.py
@@ -44,7 +44,7 @@ class ModelDownloader(ABC):
     def download_model(self, output_dir: str):
         os.makedirs(output_dir, exist_ok=True)
         lock_path = os.path.join(output_dir, ".lock")
-        self.lock_manager = LockManager(lock_path, timeout=15)
+        self.lock_manager = LockManager(lock_path)
         while True:
             try:
                 if self.lock_manager.try_acquire():

--- a/python/kthena/downloader/lock.py
+++ b/python/kthena/downloader/lock.py
@@ -14,10 +14,7 @@
 
 import fcntl
 import os
-import threading
-import time
 from typing import Optional, IO
-import stat
 
 from kthena.downloader.logger import setup_logger
 
@@ -29,13 +26,9 @@ class LockError(Exception):
 
 
 class LockManager:
-    def __init__(self, lock_path: str, timeout: int = 15):
+    def __init__(self, lock_path: str):
         self.lock_path = lock_path
-        self.timeout = timeout
-        self.renew_interval = 5
-        self.stop_renew_event = threading.Event()
         self._lock_file: Optional[IO] = None
-        self._renew_thread: Optional[threading.Thread] = None
         self._is_locked = False
 
     def __enter__(self) -> 'LockManager':
@@ -56,21 +49,33 @@ class LockManager:
         try:
             lock_dir = os.path.dirname(self.lock_path)
             os.makedirs(lock_dir, exist_ok=True)
-            if os.path.exists(self.lock_path):
-                mtime = os.path.getmtime(self.lock_path)
-                if time.time() - mtime < self.timeout:
-                    logger.info(f"Lock file exists and is not expired: {self.lock_path}")
-                    return False
-            self._lock_file = open(self.lock_path, "w")
-            os.chmod(self.lock_path, stat.S_IRUSR | stat.S_IWUSR)
+            try:
+                fd = os.open(
+                    self.lock_path,
+                    os.O_RDWR | os.O_CREAT | os.O_EXCL,
+                    0o666,
+                )
+                created = True
+            except FileExistsError:
+                fd = os.open(self.lock_path, os.O_RDWR)
+                created = False
+            try:
+                # The lock contains no secrets, and the cache directory is already
+                # shared writable storage. Ignore the process umask so pods running
+                # as different UIDs can contend on the same persistent inode.
+                if created:
+                    os.fchmod(fd, 0o666)
+                self._lock_file = os.fdopen(fd, "r+")
+            except Exception:
+                os.close(fd)
+                raise
             fcntl.flock(self._lock_file, fcntl.LOCK_EX | fcntl.LOCK_NB)
-            self._lock_file.write(f"{os.getpid()}\n")
-            self._lock_file.flush()
-            os.utime(self.lock_path, None)
             self._is_locked = True
-            self._start_renew_thread()
             logger.info(f"Lock acquired: {self.lock_path}")
             return True
+        except BlockingIOError:
+            self._cleanup()
+            return False
         except Exception as e:
             logger.error(f"Error acquiring lock: {e}")
             self._cleanup()
@@ -79,18 +84,8 @@ class LockManager:
     def release(self) -> None:
         if not self._is_locked:
             return
-        self.stop_renew()
-        if self._lock_file:
-            try:
-                fcntl.flock(self._lock_file, fcntl.LOCK_UN)
-                self._lock_file.close()
-                if os.path.exists(self.lock_path):
-                    os.remove(self.lock_path)
-                    logger.info(f"Lock released and file removed: {self.lock_path}")
-            except Exception as e:
-                logger.error(f"Error releasing lock: {e}")
-            finally:
-                self._cleanup()
+        self._cleanup()
+        logger.info(f"Lock released: {self.lock_path}")
 
     def _cleanup(self) -> None:
         if self._lock_file:
@@ -100,31 +95,3 @@ class LockManager:
                 logger.error(f"Error while closing lock file: {e}")
         self._lock_file = None
         self._is_locked = False
-
-    def _start_renew_thread(self) -> None:
-        self.stop_renew_event.clear()
-        self._renew_thread = threading.Thread(
-            target=self.renew,
-            args=(self.renew_interval,),
-            daemon=True
-        )
-        self._renew_thread.start()
-
-    def renew(self, interval: int = 15) -> None:
-        while not self.stop_renew_event.is_set():
-            if not self._is_locked:
-                break
-            if os.path.exists(self.lock_path):
-                try:
-                    os.utime(self.lock_path, None)
-                    logger.info(f"Lock renewed: {self.lock_path}")
-                except IOError as e:
-                    logger.error(f"IOError while renewing lock: {e}")
-            else:
-                logger.warning(f"Lock file does not exist, renew skipped: {self.lock_path}")
-            self.stop_renew_event.wait(interval)
-
-    def stop_renew(self) -> None:
-        self.stop_renew_event.set()
-        if self._renew_thread and self._renew_thread.is_alive():
-            self._renew_thread.join(timeout=1.0)

--- a/python/kthena/tests/test_lock_manager.py
+++ b/python/kthena/tests/test_lock_manager.py
@@ -13,9 +13,8 @@
 # limitations under the License.
 
 import os
-import time
 import unittest
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from kthena.downloader.lock import LockManager, LockError
 from kthena.tests.test_utils import create_temp_dir, cleanup_temp_dir
@@ -41,29 +40,57 @@ class TestLockManager(unittest.TestCase):
     def _assert_lock_file_exists(self):
         self.assertTrue(os.path.exists(self.lock_path), "Lock file should exist")
 
-    def _assert_lock_file_removed(self):
-        self.assertFalse(os.path.exists(self.lock_path), "Lock file should be removed")
+    def _assert_lock_file_persists(self):
+        self.assertTrue(
+            os.path.exists(self.lock_path),
+            "Lock file must keep a stable inode after release",
+        )
 
     def test_lock_manager_acquire_release(self):
         self._acquire_lock()
         self._assert_lock_file_exists()
         self.lock_manager.release()
-        self._assert_lock_file_removed()
+        self._assert_lock_file_persists()
 
     def test_lock_manager_context_manager(self):
         with LockManager(self.lock_path) as lock_manager:
             self._assert_lock_file_exists()
             self.assertTrue(lock_manager.is_locked, "Lock should be marked as locked")
-        self._assert_lock_file_removed()
+        self._assert_lock_file_persists()
 
-    def test_lock_manager_renew(self):
+    def test_new_lock_file_is_made_shared_writable(self):
+        with patch("os.fchmod", wraps=os.fchmod) as chmod:
+            self._acquire_lock()
+        chmod.assert_called_once()
+        self.assertEqual(0o666, chmod.call_args.args[1])
+
+    def test_existing_lock_file_does_not_require_chmod(self):
         self._acquire_lock()
-        time.sleep(0.5)
-        self._assert_lock_file_exists()
         self.lock_manager.release()
-        self._assert_lock_file_removed()
 
-    def test_lock_manager_acquire_failure(self):
+        next_manager = LockManager(self.lock_path)
+        with patch("os.fchmod", side_effect=PermissionError("not owner")) as chmod:
+            self._acquire_lock(next_manager)
+        chmod.assert_not_called()
+        next_manager.release()
+
+    def test_lock_file_inode_is_reused_after_release(self):
+        self._acquire_lock()
+        inode = os.stat(self.lock_path).st_ino
+
+        self.lock_manager.release()
+
+        next_manager = LockManager(self.lock_path)
+        self._acquire_lock(next_manager)
+        self.assertEqual(
+            inode,
+            os.stat(self.lock_path).st_ino,
+            "Recreating the lock file permits independent locks on different inodes",
+        )
+        next_manager.release()
+
+    @patch("kthena.downloader.lock.logger.error")
+    def test_lock_manager_acquire_failure(self, mock_logger_error):
         lock_manager1 = LockManager(self.lock_path)
         lock_manager2 = LockManager(self.lock_path)
 
@@ -72,7 +99,12 @@ class TestLockManager(unittest.TestCase):
             lock_manager2.try_acquire(),
             "Second lock manager should fail to acquire the lock",
         )
+        mock_logger_error.assert_not_called()
         lock_manager1.release()
+
+    def test_lock_file_does_not_store_pid(self):
+        self._acquire_lock()
+        self.assertEqual(0, os.path.getsize(self.lock_path))
 
     def test_context_manager_failure(self):
         self._acquire_lock()
@@ -94,33 +126,6 @@ class TestLockManager(unittest.TestCase):
             self.lock_manager.is_locked, "is_locked should be False after release"
         )
 
-    def test_renew_thread_starts_automatically(self):
-        with patch.object(
-            self.lock_manager, "_start_renew_thread"
-        ) as mock_start_thread:
-            self.lock_manager.try_acquire()
-            mock_start_thread.assert_called_once()
-            self.lock_manager.release()
-
-    def test_renew_thread_stops_on_release(self):
-        self._acquire_lock()
-        self.assertIsNotNone(
-            self.lock_manager._renew_thread, "Renew thread should be created"
-        )
-        self.assertTrue(
-            self.lock_manager._renew_thread.is_alive(), "Renew thread should be running"
-        )
-
-        self.lock_manager.release()
-        self.assertFalse(
-            (
-                self.lock_manager._renew_thread.is_alive()
-                if self.lock_manager._renew_thread
-                else True
-            ),
-            "Renew thread should be stopped",
-        )
-
     @patch("kthena.downloader.lock.logger.error")
     def test_lock_manager_acquire_exception_handling(self, mock_logger_error):
         with patch("os.makedirs", side_effect=OSError("Mocked error")):
@@ -132,36 +137,15 @@ class TestLockManager(unittest.TestCase):
 
     @patch("kthena.downloader.lock.logger.error")
     def test_lock_manager_release_exception_handling(self, mock_logger_error):
-        self._acquire_lock()
-        with patch("os.remove", side_effect=OSError("Mocked error")):
-            self.lock_manager.release()
-            mock_logger_error.assert_called_with("Error releasing lock: Mocked error")
+        lock_file = Mock()
+        lock_file.close.side_effect = OSError("Mocked error")
+        self.lock_manager._lock_file = lock_file
+        self.lock_manager._is_locked = True
 
-    def test_lock_manager_renew_lock_file_missing(self):
-        self._acquire_lock()
-        os.remove(self.lock_path)
-        time.sleep(0.5)
         self.lock_manager.release()
 
-    def test_lock_manager_stop_renew(self):
-        self._acquire_lock()
-        self.assertTrue(
-            self.lock_manager._renew_thread.is_alive(), "Renew thread should be running"
-        )
-        self.lock_manager.stop_renew()
-        max_wait = 0.2
-        start_time = time.time()
-        while time.time() - start_time < max_wait and (
-            self.lock_manager._renew_thread
-            and self.lock_manager._renew_thread.is_alive()
-        ):
-            time.sleep(0.02)
-        self.assertTrue(
-            not self.lock_manager._renew_thread
-            or not self.lock_manager._renew_thread.is_alive(),
-            "Renew thread should be stopped or None",
-        )
-        self.lock_manager.release()
+        mock_logger_error.assert_called_with("Error while closing lock file: Mocked error")
+        self.assertFalse(self.lock_manager.is_locked)
 
     def test_multiple_locks_management(self):
         lock_paths = [os.path.join(self.temp_dir, f"lock_{i}.lock") for i in range(3)]
@@ -177,8 +161,8 @@ class TestLockManager(unittest.TestCase):
             manager.release()
 
         for path in lock_paths:
-            self.assertFalse(
-                os.path.exists(path), "Lock file should be removed after release"
+            self.assertTrue(
+                os.path.exists(path), "Lock file should keep a stable inode after release"
             )
 
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Keeps the downloader lock path bound to one stable inode for all owners.

- Opens `.lock` without truncation before attempting non-blocking `flock`.
- Uses non-blocking `flock` as the only source of ownership instead of treating a fresh mtime as a lock.
- Keeps the persistent marker empty, avoiding stale PID metadata after release.
- Treats `BlockingIOError` as expected lock contention without emitting an error log.
- Leaves the lock file in place on release, preventing another owner from holding an unlinked old inode while a third owner locks a newly created inode.
- Creates the marker as `0666` because it contains no secrets and lives in an already shared-writable cache directory; later owners open it without trying to change another UID's file mode.
- Removes the obsolete mtime timeout and renew thread.
- Adds regression coverage for stable inode reuse and persistent-file permissions.

The kernel releases `flock` automatically when a process exits or closes its descriptor, so a persistent marker file does not leave a stale lock.

**Which issue(s) this PR fixes**:

Fixes #1714

**Bug evidence (required for bug-related PRs)**:

The production `LockManager.release()` on `main` unlocks the descriptor and then removes the lock path ([source](https://github.com/volcano-sh/kthena/blob/dd7e5af6b0ec847bb49d9b2b8fe7bdb337e333b8/python/kthena/downloader/lock.py#L80-L92)). Concurrent downloads targeting the same output directory trigger the race.

I ran the repository's actual `LockManager` from `origin/main` with a controlled interleaving: A releases, B acquires immediately after A's `LOCK_UN`, and C attempts acquisition after A removes the path. I then ran the same reproduction against this branch:

```text
origin/main: B_locked=True C_locked=True B_inode=70382 C_inode=70383
HEAD:        B_locked=True C_locked=False B_inode=70382 C_inode=None
```

On `main`, B and C simultaneously hold exclusive locks on different inodes for the same `.lock` pathname. With this change, C correctly receives `EAGAIN` while B owns the stable inode.

I also created and released the persistent lock as UID 0, then acquired the same inode as UID 65534:

```text
uid=65534 acquired=True
```

**Special notes for your reviewer**:

The `.lock` marker now remains in the model cache directory after release. Its presence does not mean the lock is held; kernel `flock` ownership is authoritative.

Implementation and tests were prepared with Codex and reviewed locally by the author.

Testing:

```text
PYTHONPATH=python python3 -m unittest kthena.tests.test_lock_manager -v
Ran 12 tests — OK

ruff check python/kthena/downloader/lock.py python/kthena/downloader/base.py python/kthena/tests/test_lock_manager.py --config python/kthena/pyproject.toml
All checks passed!

python -m compileall -q python/kthena/downloader/lock.py python/kthena/downloader/base.py python/kthena/tests/test_lock_manager.py
```

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```