### PR TITLE
e2e: pin the llm-d inference sim image

### DIFF
--- a/test/e2e/router/router-plugins/testdata/LLM-Mock-plugins-slow.yaml
+++ b/test/e2e/router/router-plugins/testdata/LLM-Mock-plugins-slow.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: llm-engine
-          image: ghcr.io/llm-d/llm-d-inference-sim:latest
+          image: ghcr.io/llm-d/llm-d-inference-sim:v0.10.2
           imagePullPolicy: IfNotPresent
           args:
             - --model=kthena-plugin-mock

--- a/test/e2e/router/router-plugins/testdata/LLM-Mock-plugins.yaml
+++ b/test/e2e/router/router-plugins/testdata/LLM-Mock-plugins.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: llm-engine
-          image: ghcr.io/llm-d/llm-d-inference-sim:latest
+          image: ghcr.io/llm-d/llm-d-inference-sim:v0.10.2
           imagePullPolicy: IfNotPresent
           env:
             - name: POD_IP

--- a/test/e2e/router/testdata/LLM-Mock-ds1.5b-Canary.yaml
+++ b/test/e2e/router/testdata/LLM-Mock-ds1.5b-Canary.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: llm-engine
-          image: ghcr.io/llm-d/llm-d-inference-sim:latest
+          image: ghcr.io/llm-d/llm-d-inference-sim:v0.10.2
           imagePullPolicy: IfNotPresent
           args:
             - --model=kthena-mock-1.5b-v1
@@ -54,7 +54,7 @@ spec:
     spec:
       containers:
         - name: llm-engine
-          image: ghcr.io/llm-d/llm-d-inference-sim:latest
+          image: ghcr.io/llm-d/llm-d-inference-sim:v0.10.2
           imagePullPolicy: IfNotPresent
           args:
             - --model=kthena-mock-1.5b-v2

--- a/test/e2e/router/testdata/LLM-Mock-ds1.5b.yaml
+++ b/test/e2e/router/testdata/LLM-Mock-ds1.5b.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: llm-engine
-          image: ghcr.io/llm-d/llm-d-inference-sim:latest
+          image: ghcr.io/llm-d/llm-d-inference-sim:v0.10.2
           imagePullPolicy: IfNotPresent
           args:
             - --model=kthena-mock-1.5b

--- a/test/e2e/router/testdata/LLM-Mock-ds7b.yaml
+++ b/test/e2e/router/testdata/LLM-Mock-ds7b.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: llm-engine
-          image: ghcr.io/llm-d/llm-d-inference-sim:latest
+          image: ghcr.io/llm-d/llm-d-inference-sim:v0.10.2
           imagePullPolicy: IfNotPresent
           args:
             - --model=kthena-mock-7b

--- a/test/e2e/router/testdata/ModelServing-ds1.5b-pd-disaggregation.yaml
+++ b/test/e2e/router/testdata/ModelServing-ds1.5b-pd-disaggregation.yaml
@@ -19,7 +19,7 @@ spec:
           spec:
             containers:
               - name: leader
-                image: ghcr.io/llm-d/llm-d-inference-sim:latest
+                image: ghcr.io/llm-d/llm-d-inference-sim:v0.10.2
                 imagePullPolicy: IfNotPresent
                 args:
                   - --model=kthena-mock-1.5b-prefill
@@ -49,7 +49,7 @@ spec:
           spec:
             containers:
               - name: leader
-                image: ghcr.io/llm-d/llm-d-inference-sim:latest
+                image: ghcr.io/llm-d/llm-d-inference-sim:v0.10.2
                 imagePullPolicy: IfNotPresent
                 args:
                   - --model=kthena-mock-1.5b-decode

--- a/test/e2e/router/testdata/ModelServing-ds1.5b-pd-multinode.yaml
+++ b/test/e2e/router/testdata/ModelServing-ds1.5b-pd-multinode.yaml
@@ -19,7 +19,7 @@ spec:
           spec:
             containers:
               - name: leader
-                image: ghcr.io/llm-d/llm-d-inference-sim:latest
+                image: ghcr.io/llm-d/llm-d-inference-sim:v0.10.2
                 imagePullPolicy: IfNotPresent
                 args:
                   - --model=kthena-mock-1.5b-prefill-multinode
@@ -50,7 +50,7 @@ spec:
           spec:
             containers:
               - name: leader
-                image: ghcr.io/llm-d/llm-d-inference-sim:latest
+                image: ghcr.io/llm-d/llm-d-inference-sim:v0.10.2
                 imagePullPolicy: IfNotPresent
                 args:
                   - --model=kthena-mock-1.5b-decode-multinode


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Pins the vLLM mock simulator image in the e2e testdata to `v0.10.2`, replacing the floating `latest` tag in all ten references. llm-d published v0.11.0 and v0.11.1 yesterday, the first releases since July, and every PR's e2e has been red since: the PD backends never become ready and the plugin test backends answer 503. The sglang simulator is already pinned and its tests kept passing in the same runs.

Full evidence, including three same-morning PRs with disjoint diffs failing identically, is in #1720. Verified that the `v0.10.2` tag exists on ghcr. Migrating to v0.11 can then happen deliberately, decoupled from CI health.

**Which issue(s) this PR fixes**:

Fixes #1720

**Bug evidence (required for bug-related PRs)**:

In #1720. This PR's own e2e run is the verification: with the pin, the previously failing jobs should return green on the same tests.

**Special notes for your reviewer**:

Ten image lines changed, nothing else.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
