### PR TITLE
router: in-memory KV cache index for kvcache-aware plugin

### DIFF
--- a/charts/kthena/charts/networking/templates/kthena-router/component/deployment.yaml
+++ b/charts/kthena/charts/networking/templates/kthena-router/component/deployment.yaml
@@ -69,6 +69,14 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
             - name: REDIS_HOST
               valueFrom:
                 configMapKeyRef:

--- a/config/python-licenses-lint.ini
+++ b/config/python-licenses-lint.ini
@@ -24,6 +24,7 @@ authorized_licenses:
         bsd 2-clause
         mit
         mit license
+        mit-0
         python software foundation
         python software foundation license
         zpl 2.1

--- a/docs/kthena/docs/user-guide/config-router.md
+++ b/docs/kthena/docs/user-guide/config-router.md
@@ -14,12 +14,12 @@ The scheduler configuration includes plugin configurations and lists of enabled/
 
 Plugin Configuration (PluginConfig):
 
-| Plugin Name   | Parameters                                                  | Description                                                                                               |
-| ------------- | ----------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| least-request | maxWaitingRequests                                          | Sets the maximum number of waiting requests                                                               |
-| least-latency | TTFTTPOTWeightFactor                                        | Sets the TTFT weight factor. Must be between `0.0` and `1.0`.                                             |
-| prefix-cache  | blockSizeToHash<br />maxBlocksToMatch<br />maxHashCacheSize | Configures prefix cache parameters                                                                        |
-| kvcache-aware | blockSizeToHash<br />maxBlocksToMatch                       | Configures KV cache aware token-block matching parameters. Requires Redis and the Kthena Runtime sidecar. |
+| Plugin Name   | Parameters                                                                              | Description                                                                                                                                                                                               |
+| ------------- | --------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| least-request | maxWaitingRequests                                                                      | Sets the maximum number of waiting requests                                                                                                                                                               |
+| least-latency | TTFTTPOTWeightFactor                                                                    | Sets the TTFT weight factor. Must be between `0.0` and `1.0`.                                                                                                                                             |
+| prefix-cache  | blockSizeToHash<br />maxBlocksToMatch<br />maxHashCacheSize                             | Configures prefix cache parameters                                                                                                                                                                        |
+| kvcache-aware | blockSizeToHash<br />maxBlocksToMatch<br />indexMode<br />kvEventsPort<br />runtimePort | Configures KV cache aware token-block matching parameters. Requires the Kthena Runtime sidecar; uses Redis (`indexMode: redis`, default) or an in-memory index fed by runtime push (`indexMode: memory`). |
 
 `TTFTTPOTWeightFactor` controls how the least-latency plugin balances Time To First Token (TTFT) and Time Per Output Token (TPOT):
 

--- a/docs/kthena/docs/user-guide/kvcache-aware.md
+++ b/docs/kthena/docs/user-guide/kvcache-aware.md
@@ -509,23 +509,41 @@ Send the same prompt to the router multiple times. On the first request, the `kv
 
 ## How It Differs from Other Plugins
 
-| Feature                | `prefix-cache`            | `kvcache-aware`                   |
-| ---------------------- | ------------------------- | --------------------------------- |
-| Matching unit          | Byte-based prefix         | Token-block based                 |
-| Cache data source      | Router in-memory tracking | Redis (distributed)               |
-| Cross-pod coordination | No (local to router)      | Yes (via Redis)                   |
-| Cache truth source     | Router heuristic          | Actual engine KV events from vLLM |
-| Dependencies           | None                      | Redis + Runtime sidecar           |
+| Feature                | `prefix-cache`            | `kvcache-aware` (redis)           | `kvcache-aware` (memory)              |
+| ---------------------- | ------------------------- | --------------------------------- | ------------------------------------- |
+| Matching unit          | Byte-based prefix         | Token-block based                 | Token-block based                     |
+| Cache data source      | Router in-memory tracking | Redis (distributed)               | Router in-memory index (pushed)       |
+| Cross-pod coordination | No (local to router)      | Yes (via Redis)                   | Yes (sidecars push to every router)   |
+| Cache truth source     | Router heuristic          | Actual engine KV events from vLLM | Actual engine KV events from vLLM     |
+| Dependencies           | None                      | Redis + Runtime sidecar           | Runtime sidecar (no Redis)            |
 
 - Use **`prefix-cache`** when you want lightweight, dependency-free prefix matching for simple workloads.
 - Use **`kvcache-aware`** when you need accurate, distributed KV cache coordination backed by real engine cache events — particularly effective with long shared system prompts.
 
 ## Troubleshooting
 
+Common to both backends:
+
 | Symptom                                                  | Possible Cause                          | Resolution                                                                                        |
 | -------------------------------------------------------- | --------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| Plugin scores are always 0                               | Redis not reachable from router         | Verify Redis connectivity and env vars (`REDIS_HOST`, `REDIS_PORT`)                               |
-| No Redis keys (`matrix:kv:block:*`)                      | Runtime sidecar not receiving KV events | Check that `VLLM_USE_V1=1` is set, runtime `--engine vllm` / `--pod` / `--model` args are correct |
-| Runtime log: `Failed to initialize Redis client`         | Redis not deployed or unreachable       | Deploy Redis and verify the `redis-config` ConfigMap exists in the same namespace                 |
+| No KV events in the runtime sidecar                      | Runtime sidecar not receiving KV events | Check that `VLLM_USE_V1=1` is set, runtime `--engine vllm` / `--pod` / `--model` args are correct |
 | Runtime log: `Pod identifier or model name not provided` | Missing `--pod` or `--model` args       | Ensure the runtime sidecar has `--pod $(POD_NAME).$(NAMESPACE)` and `--model <name>`              |
-| Router log: `redis client not initialized`               | Router cannot connect to Redis          | Check that Redis env vars are available to the router pod                                         |
+
+Redis backend (`indexMode: redis`):
+
+| Symptom                                          | Possible Cause                    | Resolution                                                                        |
+| ------------------------------------------------ | --------------------------------- | --------------------------------------------------------------------------------- |
+| Plugin scores are always 0                       | Redis not reachable from router   | Verify Redis connectivity and env vars (`REDIS_HOST`, `REDIS_PORT`)               |
+| No Redis keys (`matrix:kv:block:*`)              | Sidecar cannot write to Redis     | Verify sidecar Redis env vars and network access to the Redis service             |
+| Runtime log: `Failed to initialize Redis client` | Redis not deployed or unreachable | Deploy Redis and verify the `redis-config` ConfigMap exists in the same namespace |
+| Router log: `redis client not initialized`       | Router cannot connect to Redis    | Check that Redis env vars are available to the router pod                         |
+
+Memory backend (`indexMode: memory`):
+
+| Symptom                                                     | Possible Cause                                             | Resolution                                                                                             |
+| ----------------------------------------------------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| Plugin scores are always 0                                  | Sidecars cannot push to the router's KV events port        | Verify `POD_IP` is injected on the router deployment and the events port is reachable from model pods  |
+| Router log: `POD_IP environment variable is not set`        | Downward API env var missing on the router deployment      | Add `POD_IP` via the downward API (`status.podIP`) to the router container                             |
+| Runtime log: `Runtime is not in memory KV event sync mode`  | Sidecar not started in memory mode                         | Set `KV_EVENT_SYNC_MODE=memory` on the runtime sidecar                                                 |
+| Runtime log: `Failed to push KV events to router ...`       | Router events endpoint unreachable or router restarting    | Check network reachability; the sidecar resends a full snapshot on the router's next heartbeat         |
+| Scores stale after pod deletion                             | Missed removal events                                      | Entries are garbage-collected automatically; verify router logs for registration/heartbeat activity    |

--- a/docs/kthena/docs/user-guide/kvcache-aware.md
+++ b/docs/kthena/docs/user-guide/kvcache-aware.md
@@ -354,6 +354,10 @@ data:
               weight: 1
 ```
 
+:::note
+Always enable `kvcache-aware` together with at least one other score plugin (e.g. `least-request`). The plugin returns no scores when there are no cached blocks yet (cold start) or when tokenization fails; if it were the only score plugin, the scheduler would have no candidate pods and requests would fail.
+:::
+
 **Plugin arguments:**
 
 | Parameter                     | Default | Description                                                                                        |

--- a/docs/kthena/docs/user-guide/kvcache-aware.md
+++ b/docs/kthena/docs/user-guide/kvcache-aware.md
@@ -1,6 +1,6 @@
 # KV Cache Aware Plugin
 
-The `kvcache-aware` plugin is a score plugin for the Kthena Router scheduler that routes inference requests to pods most likely to have matching KV cache entries. It uses **token-block based matching** with **Redis-based distributed coordination** to maximize cache hits and reduce redundant prefill computation.
+The `kvcache-aware` plugin is a score plugin for the Kthena Router scheduler that routes inference requests to pods most likely to have matching KV cache entries. It uses **token-block based matching** with a choice of two coordination backends: **Redis-based distributed coordination** (default) or a **direct in-memory push mode** where runtime sidecars push KV events straight into the router's memory, removing the per-request Redis round-trip.
 
 ## Overview
 
@@ -9,19 +9,46 @@ When multiple vLLM pods serve the same model, each pod maintains its own KV cach
 The `kvcache-aware` plugin solves this by:
 1. Tokenizing the incoming prompt using the model's tokenizer.
 2. Dividing the token sequence into fixed-size blocks and hashing each block.
-3. Querying Redis to find which pods have cached each token block.
+3. Looking up which pods have cached each token block — either in Redis, or in the router's local in-memory index.
 4. Scoring pods based on consecutive block matches from the beginning of the prompt.
 
 Pods with more consecutive matching blocks score higher and are preferred for routing.
 
+## Coordination backends
+
+| Backend           | How block ownership reaches the router                                                 | Per-request lookup                      | Extra infrastructure |
+| ----------------- | -------------------------------------------------------------------------------------- | --------------------------------------- | -------------------- |
+| `redis` (default) | Runtime sidecars write standardized block hashes into Redis                            | Batched Redis pipeline query            | Redis instance       |
+| `memory`          | Runtime sidecars push KV events directly to every registered router instance over HTTP | Local in-memory map lookup (no network) | None                 |
+
+### How memory mode works
+
+Because the router may run with multiple replicas, each router instance **actively registers itself** with every runtime sidecar:
+
+1. Each router replica periodically (default every 30s) calls `POST /kvcache/routers/register` on every known model-serving pod's runtime sidecar, sending its own push endpoint (`http://<router-pod-ip>:<kvEventsPort>`) and a TTL (default 90s). Registration doubles as a heartbeat — sidecars drop routers that stop renewing.
+2. When a sidecar sees a **new** registration (or a renewal after expiry), it pushes a full **snapshot** of its current KV block index to that router, so a freshly started or restarted router immediately has complete state.
+3. From then on, every KV cache event (`stored` / `removed` / `cleared`) is converted to standardized block hashes and pushed to **all registered router instances** via `POST <router-endpoint>/kvcache/events`.
+4. At request time the plugin answers block-ownership lookups from its local in-memory index — no Redis query, no network latency on the scoring path.
+
+Stale entries are garbage-collected in the router after 24 hours, and ownership written before the owning pod's containers last restarted is ignored, same as in Redis mode.
+
+**Trade-offs of memory mode:**
+
+- Scoring lookups are local memory reads, removing the Redis round-trip latency from the request path.
+- No Redis deployment is required for KV cache coordination.
+- Each router replica keeps its own copy of the index (memory usage scales with cached blocks × replicas).
+- If a runtime sidecar restarts, its in-memory engine-hash mapping is lost; entries it previously pushed age out via the router's 24h GC and pod-restart freshness checks.
+
 ## Prerequisites
 
-- **Redis**: A Redis instance accessible by both the router and the runtime sidecars. Deploy Redis using the provided [redis-standalone.yaml](../assets/examples/redis/redis-standalone.yaml) example.
-- **Kthena Runtime sidecar**: Must be deployed alongside each vLLM pod. The sidecar listens to vLLM's ZMQ `kv-events` stream and writes token block hashes into Redis.
+- **Redis** (Redis backend only): A Redis instance accessible by both the router and the runtime sidecars. Deploy Redis using the provided [redis-standalone.yaml](../assets/examples/redis/redis-standalone.yaml) example. Memory mode does not need Redis.
+- **Kthena Runtime sidecar**: Must be deployed alongside each vLLM pod. The sidecar listens to vLLM's ZMQ `kv-events` stream and either writes token block hashes into Redis or pushes them to registered routers.
 - **vLLM v1 with KV event support**: The vLLM engine must be running with `VLLM_USE_V1=1` and expose the ZMQ kv-events topic.
 - **Multi-pod inference deployment**: The plugin is meaningful only when multiple pods serve the same model.
 
 ## Architecture
+
+**Redis backend (default):**
 
 ```
                         ┌────────────────┐
@@ -61,9 +88,43 @@ Pods with more consecutive matching blocks score higher and are preferred for ro
 - The **Runtime sidecar** subscribes to vLLM ZMQ kv-events (`VLLM_BLOCK_STORED`, `VLLM_BLOCK_REMOVED`, `VLLM_ALL_BLOCKS_CLEARED`) and writes standardized token block hashes into Redis.
 - The **Router's `kvcache-aware` plugin** queries Redis at request time to find pods with matching blocks and scores them.
 
+**Memory backend:**
+
+```
+                        ┌────────────────┐
+                        │ Client Request │
+                        └───────┐────────┘
+                                │
+                                ▼
+        ┌─────────────────────┐  ┌─────────────────────┐
+        │  Kthena Router #1     │  │  Kthena Router #2     │
+        │  ┌───────────────┐  │  │  ┌───────────────┐  │
+        │  │ in-memory index │  │  │  │ in-memory index │  │
+        │  └───────────────┘  │  │  └───────────────┘  │
+        └───▲────────┐───────┘  └───▲────────┐───────┘
+            │        │              │        │
+   push KV  │        │ register     │        │ register
+   events   │        │ (heartbeat)  │        │ (heartbeat)
+            │        ▼              │        ▼
+           ┌┘────────────────────┴─────────────┐
+           │          vLLM Pods                   │
+           │  ┌───────────────┐                   │
+           │  │Runtime sidecar│ ◀── ZMQ kv-events │
+           │  └───────────────┘                   │
+           │  ┌───────────────┐                   │
+           │  │  vLLM Engine  │                   │
+           │  └───────────────┘                   │
+           └─────────────────────────────────────┘
+```
+
+- Each **router replica** registers with every runtime sidecar and receives pushed KV events on its `kvEventsPort` (default 9080).
+- The **Runtime sidecar** (started with `KV_EVENT_SYNC_MODE=memory`) keeps a registry of live routers and pushes standardized block hashes to all of them; newly registered routers get a full snapshot first.
+
 ## Setup
 
-### Step 1: Deploy Redis
+### Step 1: Deploy Redis (Redis backend only)
+
+> Skip this step when using the in-memory backend (`indexMode: memory`).
 
 Deploy Redis in the `kthena-system` namespace (where the Kthena Router runs):
 
@@ -295,16 +356,85 @@ data:
 
 **Plugin arguments:**
 
-| Parameter             | Default | Description                                                                      |
-| --------------------- | ------- | -------------------------------------------------------------------------------- |
-| `blockSizeToHash`     | 16      | Number of tokens per block. Must match the vLLM block size for optimal matching. |
-| `maxBlocksToMatch`    | 128     | Maximum number of blocks to process per request. Limits Redis queries.           |
-| `vllmTokenizerPort`   | 8000    | Port used to fetch the tokenizer from vLLM pods.                                 |
-| `sglangTokenizerPort` | 30000   | Port used to fetch the tokenizer from SGLang pods.                               |
+| Parameter                     | Default | Description                                                                                        |
+| ----------------------------- | ------- | -------------------------------------------------------------------------------------------------- |
+| `blockSizeToHash`             | 16      | Number of tokens per block. Must match the vLLM block size for optimal matching.                   |
+| `maxBlocksToMatch`            | 128     | Maximum number of blocks to process per request. Limits lookups.                                   |
+| `vllmTokenizerPort`           | 8000    | Port used to fetch the tokenizer from vLLM pods.                                                   |
+| `sglangTokenizerPort`         | 30000   | Port used to fetch the tokenizer from SGLang pods.                                                 |
+| `indexMode`                   | `redis` | Coordination backend: `redis` or `memory`.                                                         |
+| `kvEventsPort`                | 9080    | Memory mode only: port the router listens on for KV events pushed by runtime sidecars.             |
+| `runtimePort`                 | 9000    | Memory mode only: runtime sidecar port the router registers with (match the sidecar `--port`).     |
+| `registrationIntervalSeconds` | 30      | Memory mode only: how often the router re-registers (heartbeats) with each sidecar.                |
+| `registrationTTLSeconds`      | 90      | Memory mode only: registration TTL requested from sidecars; must exceed the registration interval. |
 
 **Helm values:**
 
 The `kvcache-aware` plugin is **not** enabled in the Helm chart by default. To enable it, override the router ConfigMap in your `values.yaml` to include `kvcache-aware` in both `pluginConfig` and `Score.enabled` sections as shown above.
+
+### Using the in-memory backend (optional)
+
+To remove the per-request Redis round-trip, switch both sides to memory mode:
+
+**1. Runtime sidecar**: set `KV_EVENT_SYNC_MODE=memory` in the runtime sidecar container's environment (instead of the `REDIS_HOST`/`REDIS_PORT` variables):
+
+```yaml
+- name: runtime
+  image: ghcr.io/volcano-sh/runtime:latest
+  args: [ ... ]
+  env:
+    - name: KV_EVENT_SYNC_MODE
+      value: "memory"
+    # POD_NAME / NAMESPACE etc. unchanged
+```
+
+**2. Router ConfigMap**: set `indexMode: memory` on the plugin:
+
+```yaml
+scheduler:
+  pluginConfig:
+  - name: kvcache-aware
+    args:
+      indexMode: memory
+      blockSizeToHash: 16
+      maxBlocksToMatch: 128
+      kvEventsPort: 9080
+      runtimePort: 8900   # must match the runtime sidecar --port
+  plugins:
+    Score:
+      enabled:
+        - name: kvcache-aware
+          weight: 1
+```
+
+**3. Router pod requirements**: the router derives its push endpoint from the `POD_IP` environment variable (injected via the downward API by the Helm chart). Runtime sidecars must be able to reach the router pod IP on `kvEventsPort`. If you manage the router Deployment yourself, add:
+
+```yaml
+env:
+  - name: POD_NAME
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.name
+  - name: POD_IP
+    valueFrom:
+      fieldRef:
+        fieldPath: status.podIP
+```
+
+With multiple router replicas, every replica registers itself independently and each receives the full KV event stream, so scheduling decisions stay consistent across instances.
+
+To verify memory mode is active:
+
+```bash
+# Router side
+kubectl logs deployment/kthena-router -n <namespace> | grep -i "memory mode active"
+# Sidecar side
+kubectl logs <vllm-pod> -c runtime -n <namespace> | grep -iE "memory|router registered"
+```
+
+Expected messages:
+- Router: `KVCacheAware: memory mode active, eventsPort=9080, ...`
+- Sidecar: `KV event sync mode: memory (push to registered routers)` and `Router registered: id=<router-pod>, endpoint=http://<router-ip>:9080`
 
 ### Step 4: Restart the Router
 

--- a/docs/kthena/docs/user-guide/runtime.md
+++ b/docs/kthena/docs/user-guide/runtime.md
@@ -1,13 +1,15 @@
 # Runtime
 
-Kthena Runtime is a lightweight sidecar service designed to standardize Prometheus metrics from inference engines, provide LoRA adapter download/load/unload capabilities, support model downloading, and publish KV cache events to Redis for the `kvcache-aware` router plugin.
+Kthena Runtime is a lightweight sidecar service designed to standardize Prometheus metrics from inference engines, provide LoRA adapter download/load/unload capabilities, support model downloading, and publish KV cache events for the `kvcache-aware` router plugin — either to Redis or directly to router instances in memory push mode.
 
 ## Overview
 
 - Metrics standardization: fetch native metrics from the engine's /metrics endpoint, rename them to unified Kthena metrics according to rules.
 - LoRA lifecycle management: simple HTTP APIs to download+load and unload LoRA adapters for dynamic enable/disable.
 - Model downloading: supports downloading models from S3/OBS/PVC/HuggingFace to a local path.
-- KV cache event ingestion: for vLLM engines, subscribes to the ZMQ `kv-events` stream and writes standardized token block hashes into Redis, enabling the router's [`kvcache-aware`](kvcache-aware.md) score plugin.
+- KV cache event ingestion: for vLLM engines, subscribes to the ZMQ `kv-events` stream and publishes standardized token block hashes, enabling the router's [`kvcache-aware`](kvcache-aware.md) score plugin. Two sync modes are supported (env `KV_EVENT_SYNC_MODE`):
+  - `redis` (default): block hashes are written into Redis and queried by the router per request.
+  - `memory`: router instances register with the runtime via `POST /kvcache/routers/register` (renewed periodically as a heartbeat with a TTL); the runtime then pushes KV events (with a full snapshot on first registration) to every registered router's `/kvcache/events` endpoint, so the router can score from its local in-memory index without Redis.
 
 Notes:
 
@@ -73,6 +75,11 @@ Startup arguments:
 - `-M, --engine-metrics-path` (default `/metrics`): engine metrics path
 - `-I, --pod` (required): current instance/Pod identifier, used for events and Redis keys
 - `-N, --model` (required): model name
+
+Environment variables:
+
+- `KV_EVENT_SYNC_MODE` (default `redis`): KV cache event sync backend, `redis` or `memory`. In `memory` mode the runtime does not connect to Redis; instead it pushes KV events to router instances that registered themselves via `POST /kvcache/routers/register`. See the [`kvcache-aware`](kvcache-aware.md) guide for the full setup.
+- `REDIS_HOST`, `REDIS_PORT`, `REDIS_PASSWORD`: Redis connection used in `redis` mode.
 
 In the ModelBooster YAML, you can control Runtime startup values via `spec.backend.env`:
 

--- a/pkg/kthena-router/scheduler/factory.go
+++ b/pkg/kthena-router/scheduler/factory.go
@@ -82,8 +82,8 @@ func registerDefaultPlugins(registry *PluginRegistry) {
 		return plugins.NewPrefixCache(store, args)
 	})
 
-	registry.registerScorePlugin(plugins.KVCacheAwarePluginName, func(_ datastore.Store, args runtime.RawExtension) framework.ScorePlugin {
-		return plugins.NewKVCacheAware(args)
+	registry.registerScorePlugin(plugins.KVCacheAwarePluginName, func(store datastore.Store, args runtime.RawExtension) framework.ScorePlugin {
+		return plugins.NewKVCacheAware(store, args)
 	})
 	// filterPlugin
 	registry.registerFilterPlugin(plugins.LeastRequestPluginName, func(args runtime.RawExtension) framework.FilterPlugin {

--- a/pkg/kthena-router/scheduler/plugins/kvcache_aware.go
+++ b/pkg/kthena-router/scheduler/plugins/kvcache_aware.go
@@ -217,21 +217,29 @@ func normalizeIndexMode(mode string) string {
 	case kvCacheIndexModeMemory:
 		return kvCacheIndexModeMemory
 	default:
-		klog.Warningf("KVCacheAware: invalid indexMode %q, using %q", mode, kvCacheIndexModeRedis)
-		return kvCacheIndexModeRedis
+		klog.Fatalf("KVCacheAware: invalid indexMode %q, must be %q or %q",
+			mode, kvCacheIndexModeRedis, kvCacheIndexModeMemory)
+		return ""
 	}
 }
 
 // startMemoryMode starts the KV events listener, the sidecar registration
 // heartbeat, and the in-memory index GC.
 func (t *KVCacheAware) startMemoryMode(store datastore.Store, args KVCacheAwareArgs) {
+	if store == nil {
+		klog.Fatalf("KVCacheAware: memory mode requires a datastore for sidecar registration")
+	}
 	eventsPort := args.KVEventsPort
-	if eventsPort <= 0 || eventsPort > maxTokenizerPort {
+	if eventsPort == 0 {
 		eventsPort = defaultKVEventsPort
+	} else if eventsPort < 1 || eventsPort > maxTokenizerPort {
+		klog.Fatalf("KVCacheAware: invalid kvEventsPort %d, must be within [1, %d]", eventsPort, maxTokenizerPort)
 	}
 	runtimePort := args.RuntimePort
-	if runtimePort <= 0 || runtimePort > maxTokenizerPort {
+	if runtimePort == 0 {
 		runtimePort = defaultRuntimePort
+	} else if runtimePort < 1 || runtimePort > maxTokenizerPort {
+		klog.Fatalf("KVCacheAware: invalid runtimePort %d, must be within [1, %d]", runtimePort, maxTokenizerPort)
 	}
 	intervalSec := args.RegistrationIntervalSeconds
 	if intervalSec <= 0 {
@@ -252,10 +260,6 @@ func (t *KVCacheAware) startMemoryMode(store datastore.Store, args KVCacheAwareA
 	if err != nil {
 		klog.Errorf("KVCacheAware: memory mode enabled but router endpoint cannot be derived (%v); "+
 			"sidecar registration disabled, kvcache-aware scoring will not work", err)
-		return
-	}
-	if store == nil {
-		klog.Errorf("KVCacheAware: memory mode requires a datastore; sidecar registration disabled")
 		return
 	}
 

--- a/pkg/kthena-router/scheduler/plugins/kvcache_aware.go
+++ b/pkg/kthena-router/scheduler/plugins/kvcache_aware.go
@@ -76,6 +76,16 @@ const (
 
 	kvCacheGCInterval = time.Hour
 	kvCacheGCScanSize = int64(100)
+
+	// kvCacheIndexModeRedis queries the Redis block matrix written by runtime
+	// sidecars (default). kvCacheIndexModeMemory serves scores from an in-memory
+	// index fed by KV events that runtime sidecars push directly to this router.
+	kvCacheIndexModeRedis  = "redis"
+	kvCacheIndexModeMemory = "memory"
+
+	// defaultKVEventsPort is the port this router listens on for KV events
+	// pushed by runtime sidecars in memory index mode.
+	defaultKVEventsPort = 9080
 )
 
 type KVCacheAwareArgs struct {
@@ -85,13 +95,29 @@ type KVCacheAwareArgs struct {
 	VLLMTokenizerPort int `yaml:"vllmTokenizerPort,omitempty"`
 	// SGLangTokenizerPort overrides the default SGLang tokenizer port (30000).
 	SGLangTokenizerPort int `yaml:"sglangTokenizerPort,omitempty"`
+	// IndexMode selects the coordination backend: "redis" (default) or "memory".
+	IndexMode string `yaml:"indexMode,omitempty"`
+	// KVEventsPort is the port this router listens on for KV events pushed by
+	// runtime sidecars (memory mode only, default 9080).
+	KVEventsPort int `yaml:"kvEventsPort,omitempty"`
+	// RuntimePort is the port of the runtime sidecar the router registers with
+	// (memory mode only, default 9000).
+	RuntimePort int `yaml:"runtimePort,omitempty"`
+	// RegistrationIntervalSeconds is the re-registration (heartbeat) interval
+	// (memory mode only, default 30).
+	RegistrationIntervalSeconds int `yaml:"registrationIntervalSeconds,omitempty"`
+	// RegistrationTTLSeconds is the registration TTL requested from sidecars;
+	// must exceed the registration interval (memory mode only, default 90).
+	RegistrationTTLSeconds int `yaml:"registrationTTLSeconds,omitempty"`
 }
 
 type KVCacheAware struct {
 	name             string
 	maxBlocksToMatch int
 	keyPrefix        string
+	indexMode        string
 	redisClient      *redis.Client
+	memoryIndex      *KVBlockMemoryIndex
 	processor        *TokenBlockProcessor
 	tokenizerManager *tokenization.TokenizerManager
 	gcCursor         uint64
@@ -124,7 +150,7 @@ func (b KVCacheAwareBlock) String(prefix string) string {
 	return fmt.Sprintf("%s%s@%d", prefix, b.ModelName, b.ChunkHash)
 }
 
-func NewKVCacheAware(pluginArg runtime.RawExtension) *KVCacheAware {
+func NewKVCacheAware(store datastore.Store, pluginArg runtime.RawExtension) *KVCacheAware {
 	klog.Infof("KVCacheAware: initializing plugin, raw args length=%d", len(pluginArg.Raw))
 
 	var args KVCacheAwareArgs
@@ -142,12 +168,13 @@ func NewKVCacheAware(pluginArg runtime.RawExtension) *KVCacheAware {
 	if maxBlocksToMatch <= 0 {
 		maxBlocksToMatch = defaultMaxBlocksToMatch
 	}
+	indexMode := normalizeIndexMode(args.IndexMode)
 
 	vllmPort := normalizeTokenizerPort(tokenization.EngineVLLM, args.VLLMTokenizerPort, defaultVLLMTokenizerPort)
 	sglangPort := normalizeTokenizerPort(tokenization.EngineSGLang, args.SGLangTokenizerPort, defaultSGLangTokenizerPort)
 
-	klog.Infof("KVCacheAware: config blockSizeToHash=%d, maxBlocksToMatch=%d, vllmTokenizerPort=%d, sglangTokenizerPort=%d",
-		blockSizeToHash, maxBlocksToMatch, vllmPort, sglangPort)
+	klog.Infof("KVCacheAware: config indexMode=%s, blockSizeToHash=%d, maxBlocksToMatch=%d, vllmTokenizerPort=%d, sglangTokenizerPort=%d",
+		indexMode, blockSizeToHash, maxBlocksToMatch, vllmPort, sglangPort)
 
 	managerConfig := tokenization.TokenizerManagerConfig{
 		EndpointPorts: map[string]int{
@@ -157,23 +184,85 @@ func NewKVCacheAware(pluginArg runtime.RawExtension) *KVCacheAware {
 	}
 	manager := tokenization.NewTokenizerManager(managerConfig)
 
+	plugin := &KVCacheAware{
+		name:             KVCacheAwarePluginName,
+		maxBlocksToMatch: maxBlocksToMatch,
+		keyPrefix:        kvCacheKeyPrefix,
+		indexMode:        indexMode,
+		processor:        &TokenBlockProcessor{blockSize: blockSizeToHash},
+		tokenizerManager: manager,
+	}
+
+	if indexMode == kvCacheIndexModeMemory {
+		plugin.memoryIndex = NewKVBlockMemoryIndex()
+		plugin.startMemoryMode(store, args)
+		return plugin
+	}
+
 	redisClient := utils.TryGetRedisClient()
 	if redisClient == nil {
 		klog.Warningf("KVCacheAware: Redis client is nil — kvcache-aware scoring will not work")
 	} else {
 		klog.Infof("KVCacheAware: Redis client initialized successfully")
 	}
-
-	plugin := &KVCacheAware{
-		name:             KVCacheAwarePluginName,
-		maxBlocksToMatch: maxBlocksToMatch,
-		keyPrefix:        kvCacheKeyPrefix,
-		redisClient:      redisClient,
-		processor:        &TokenBlockProcessor{blockSize: blockSizeToHash},
-		tokenizerManager: manager,
-	}
+	plugin.redisClient = redisClient
 	plugin.startGC()
 	return plugin
+}
+
+func normalizeIndexMode(mode string) string {
+	switch mode {
+	case "", kvCacheIndexModeRedis:
+		return kvCacheIndexModeRedis
+	case kvCacheIndexModeMemory:
+		return kvCacheIndexModeMemory
+	default:
+		klog.Warningf("KVCacheAware: invalid indexMode %q, using %q", mode, kvCacheIndexModeRedis)
+		return kvCacheIndexModeRedis
+	}
+}
+
+// startMemoryMode starts the KV events listener, the sidecar registration
+// heartbeat, and the in-memory index GC.
+func (t *KVCacheAware) startMemoryMode(store datastore.Store, args KVCacheAwareArgs) {
+	eventsPort := args.KVEventsPort
+	if eventsPort <= 0 || eventsPort > maxTokenizerPort {
+		eventsPort = defaultKVEventsPort
+	}
+	runtimePort := args.RuntimePort
+	if runtimePort <= 0 || runtimePort > maxTokenizerPort {
+		runtimePort = defaultRuntimePort
+	}
+	intervalSec := args.RegistrationIntervalSeconds
+	if intervalSec <= 0 {
+		intervalSec = defaultRegistrationIntervalSec
+	}
+	ttlSec := args.RegistrationTTLSeconds
+	if ttlSec <= intervalSec {
+		ttlSec = defaultRegistrationTTLSec
+		if ttlSec <= intervalSec {
+			ttlSec = intervalSec * 3
+		}
+	}
+
+	startKVEventsServer(eventsPort, t.memoryIndex)
+	go t.memoryIndex.runGC(context.Background(), kvCacheGCInterval, kvCacheFieldFreshDuration)
+
+	endpoint, err := routerSelfEndpoint(eventsPort)
+	if err != nil {
+		klog.Errorf("KVCacheAware: memory mode enabled but router endpoint cannot be derived (%v); "+
+			"sidecar registration disabled, kvcache-aware scoring will not work", err)
+		return
+	}
+	if store == nil {
+		klog.Errorf("KVCacheAware: memory mode requires a datastore; sidecar registration disabled")
+		return
+	}
+
+	registrar := newKVRouterRegistrar(store, routerInstanceID(), endpoint, runtimePort, intervalSec, ttlSec)
+	go registrar.run(context.Background())
+	klog.Infof("KVCacheAware: memory mode active, eventsPort=%d, runtimePort=%d, interval=%ds, ttl=%ds, endpoint=%s",
+		eventsPort, runtimePort, intervalSec, ttlSec, endpoint)
 }
 
 func normalizeTokenizerPort(engine string, configuredPort, defaultPort int) int {
@@ -248,16 +337,16 @@ func (t *KVCacheAware) Score(ctx *framework.Context, pods []*datastore.PodInfo) 
 	}
 
 	redisStart := time.Now()
-	blockToPods, err := t.queryRedisForBlocks(blockHashes, ctx.Model, ownerStartTimes(pods))
+	blockToPods, err := t.queryBlocks(blockHashes, ctx.Model, ownerStartTimes(pods))
 	redisDuration := time.Since(redisStart)
 	if err != nil {
 		if ctx.MetricsRecorder != nil {
 			ctx.MetricsRecorder.RecordKVCacheError(metrics.StageRedis)
 		}
-		klog.Warningf("KVCacheAware.Score: Redis query failed after %v: %v", redisDuration, err)
+		klog.Warningf("KVCacheAware.Score: block index query failed after %v: %v", redisDuration, err)
 		return nil
 	}
-	klog.V(4).Infof("KVCacheAware.Score: Redis query took %v, blocksWithHits=%d/%d",
+	klog.V(4).Infof("KVCacheAware.Score: block index query took %v, blocksWithHits=%d/%d",
 		redisDuration, len(blockToPods), len(blockHashes))
 
 	if ctx.MetricsRecorder != nil {
@@ -296,6 +385,33 @@ func (t *KVCacheAware) Score(ctx *framework.Context, pods []*datastore.PodInfo) 
 
 	klog.V(4).Infof("KVCacheAware.Score: completed in %v, finalScores=%v", time.Since(scoreStart), podScores)
 	return scoreResults
+}
+
+// queryBlocks resolves block ownership through the configured backend.
+func (t *KVCacheAware) queryBlocks(blockHashes []uint64, modelName string, ownerStartedAt map[string]int64) (map[uint64][]string, error) {
+	if t.indexMode == kvCacheIndexModeMemory {
+		return t.queryMemoryForBlocks(blockHashes, modelName, ownerStartedAt)
+	}
+	return t.queryRedisForBlocks(blockHashes, modelName, ownerStartedAt)
+}
+
+// queryMemoryForBlocks resolves block ownership from the in-memory index fed
+// by KV events pushed by runtime sidecars.
+func (t *KVCacheAware) queryMemoryForBlocks(blockHashes []uint64, modelName string, ownerStartedAt map[string]int64) (map[uint64][]string, error) {
+	if t.memoryIndex == nil {
+		return nil, fmt.Errorf("memory index not initialized")
+	}
+
+	blockToPods := make(map[uint64][]string)
+	for hash, entries := range t.memoryIndex.GetBlockOwners(modelName, blockHashes) {
+		pods := freshOwners(entries, ownerStartedAt)
+		if len(pods) == 0 {
+			continue
+		}
+		blockToPods[hash] = pods
+	}
+	klog.V(4).Infof("KVCacheAware.queryMemory: total blocks with hits: %d/%d", len(blockToPods), len(blockHashes))
+	return blockToPods, nil
 }
 
 // queryRedisForBlocks queries Redis to find which pods have cached the given token block hashes

--- a/pkg/kthena-router/scheduler/plugins/kvcache_memory_index.go
+++ b/pkg/kthena-router/scheduler/plugins/kvcache_memory_index.go
@@ -1,0 +1,273 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugins
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"k8s.io/klog/v2"
+)
+
+// KV event types pushed by the runtime sidecar in memory sync mode.
+// Kept in sync by hand with python/kthena/runtime/memory_kv_manager.py.
+const (
+	kvEventStored   = "stored"
+	kvEventRemoved  = "removed"
+	kvEventCleared  = "cleared"
+	kvEventSnapshot = "snapshot"
+)
+
+// KVEvent is a single KV cache event carried in a push payload. All block
+// hashes are standardized hashes computed by the runtime sidecar.
+type KVEvent struct {
+	Type        string   `json:"type"`
+	BlockHashes []uint64 `json:"block_hashes,omitempty"`
+	Timestamp   int64    `json:"timestamp,omitempty"`
+}
+
+// KVEventPayload is the body of POST /kvcache/events pushed by a runtime sidecar.
+type KVEventPayload struct {
+	PodIdentifier string    `json:"pod_identifier"`
+	ModelName     string    `json:"model_name"`
+	Events        []KVEvent `json:"events"`
+}
+
+// ownerModelKey indexes per-owner-per-model block sets for removal and snapshots.
+type ownerModelKey struct {
+	owner string
+	model string
+}
+
+// KVBlockMemoryIndex is an in-memory replacement for the Redis block matrix.
+// It stores which pod (owner) currently caches which standardized token block
+// hash, per model, together with the time the block was last stored.
+type KVBlockMemoryIndex struct {
+	mu sync.RWMutex
+	// model -> block hash -> owner(pod.namespace) -> unix seconds of last store
+	blocks map[string]map[uint64]map[string]int64
+	// reverse index for cleared/snapshot events
+	ownerBlocks map[ownerModelKey]map[uint64]struct{}
+}
+
+func NewKVBlockMemoryIndex() *KVBlockMemoryIndex {
+	return &KVBlockMemoryIndex{
+		blocks:      make(map[string]map[uint64]map[string]int64),
+		ownerBlocks: make(map[ownerModelKey]map[uint64]struct{}),
+	}
+}
+
+// Apply updates the index with a pushed event payload.
+func (idx *KVBlockMemoryIndex) Apply(payload *KVEventPayload) error {
+	if payload.PodIdentifier == "" || payload.ModelName == "" {
+		return fmt.Errorf("pod_identifier and model_name are required")
+	}
+
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
+
+	for _, event := range payload.Events {
+		switch event.Type {
+		case kvEventStored:
+			idx.storeLocked(payload.ModelName, payload.PodIdentifier, event.BlockHashes, event.Timestamp)
+		case kvEventRemoved:
+			idx.removeLocked(payload.ModelName, payload.PodIdentifier, event.BlockHashes)
+		case kvEventCleared:
+			idx.clearLocked(payload.ModelName, payload.PodIdentifier)
+		case kvEventSnapshot:
+			// A snapshot replaces everything known about this owner+model.
+			idx.clearLocked(payload.ModelName, payload.PodIdentifier)
+			idx.storeLocked(payload.ModelName, payload.PodIdentifier, event.BlockHashes, event.Timestamp)
+		default:
+			return fmt.Errorf("unknown event type %q", event.Type)
+		}
+	}
+	return nil
+}
+
+func (idx *KVBlockMemoryIndex) storeLocked(model, owner string, hashes []uint64, timestamp int64) {
+	if timestamp <= 0 {
+		timestamp = time.Now().Unix()
+	}
+	modelBlocks, ok := idx.blocks[model]
+	if !ok {
+		modelBlocks = make(map[uint64]map[string]int64)
+		idx.blocks[model] = modelBlocks
+	}
+	key := ownerModelKey{owner: owner, model: model}
+	owned, ok := idx.ownerBlocks[key]
+	if !ok {
+		owned = make(map[uint64]struct{})
+		idx.ownerBlocks[key] = owned
+	}
+	for _, hash := range hashes {
+		owners, ok := modelBlocks[hash]
+		if !ok {
+			owners = make(map[string]int64)
+			modelBlocks[hash] = owners
+		}
+		owners[owner] = timestamp
+		owned[hash] = struct{}{}
+	}
+}
+
+func (idx *KVBlockMemoryIndex) removeLocked(model, owner string, hashes []uint64) {
+	modelBlocks := idx.blocks[model]
+	owned := idx.ownerBlocks[ownerModelKey{owner: owner, model: model}]
+	for _, hash := range hashes {
+		if owners, ok := modelBlocks[hash]; ok {
+			delete(owners, owner)
+			if len(owners) == 0 {
+				delete(modelBlocks, hash)
+			}
+		}
+		delete(owned, hash)
+	}
+}
+
+func (idx *KVBlockMemoryIndex) clearLocked(model, owner string) {
+	key := ownerModelKey{owner: owner, model: model}
+	modelBlocks := idx.blocks[model]
+	for hash := range idx.ownerBlocks[key] {
+		if owners, ok := modelBlocks[hash]; ok {
+			delete(owners, owner)
+			if len(owners) == 0 {
+				delete(modelBlocks, hash)
+			}
+		}
+	}
+	delete(idx.ownerBlocks, key)
+}
+
+// GetBlockOwners returns, for each requested block hash that is present, the
+// owners and the unix-second timestamps of their last store. The timestamps
+// are returned as strings so the result can flow through the same freshness
+// filtering (freshOwners) as the Redis backend.
+func (idx *KVBlockMemoryIndex) GetBlockOwners(model string, hashes []uint64) map[uint64]map[string]string {
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
+
+	result := make(map[uint64]map[string]string)
+	modelBlocks, ok := idx.blocks[model]
+	if !ok {
+		return result
+	}
+	for _, hash := range hashes {
+		owners, ok := modelBlocks[hash]
+		if !ok || len(owners) == 0 {
+			continue
+		}
+		entries := make(map[string]string, len(owners))
+		for owner, ts := range owners {
+			entries[owner] = strconv.FormatInt(ts, 10)
+		}
+		result[hash] = entries
+	}
+	return result
+}
+
+// RemoveOwner drops every block owned by the given pod identifier across all
+// models, e.g. when the pod is deleted.
+func (idx *KVBlockMemoryIndex) RemoveOwner(owner string) {
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
+	for key := range idx.ownerBlocks {
+		if key.owner == owner {
+			idx.clearLocked(key.model, key.owner)
+		}
+	}
+}
+
+// gcStaleEntries drops ownership entries older than freshDuration, mirroring
+// the Redis backend GC so restarts or missed removal events cannot leave dead
+// entries behind forever.
+func (idx *KVBlockMemoryIndex) gcStaleEntries(freshDuration time.Duration) {
+	cutoff := time.Now().Add(-freshDuration).Unix()
+
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
+
+	for model, modelBlocks := range idx.blocks {
+		for hash, owners := range modelBlocks {
+			for owner, ts := range owners {
+				if ts < cutoff {
+					delete(owners, owner)
+					delete(idx.ownerBlocks[ownerModelKey{owner: owner, model: model}], hash)
+				}
+			}
+			if len(owners) == 0 {
+				delete(modelBlocks, hash)
+			}
+		}
+	}
+}
+
+// runGC periodically removes stale entries until ctx is done.
+func (idx *KVBlockMemoryIndex) runGC(ctx context.Context, interval, freshDuration time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			idx.gcStaleEntries(freshDuration)
+		}
+	}
+}
+
+// kvEventsHandler handles POST /kvcache/events pushed by runtime sidecars.
+func kvEventsHandler(index *KVBlockMemoryIndex) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var payload KVEventPayload
+		if err := c.ShouldBindJSON(&payload); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid payload: " + err.Error()})
+			return
+		}
+		if err := index.Apply(&payload); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		klog.V(4).Infof("KVCacheAware: applied %d pushed events from pod=%s model=%s",
+			len(payload.Events), payload.PodIdentifier, payload.ModelName)
+		c.JSON(http.StatusOK, gin.H{"status": "ok"})
+	}
+}
+
+// startKVEventsServer starts the HTTP listener that receives pushed KV events
+// from runtime sidecars when the plugin runs in memory index mode.
+func startKVEventsServer(port int, index *KVBlockMemoryIndex) {
+	engine := gin.New()
+	engine.Use(gin.Recovery())
+	engine.POST("/kvcache/events", kvEventsHandler(index))
+
+	server := &http.Server{
+		Addr:    fmt.Sprintf(":%d", port),
+		Handler: engine.Handler(),
+	}
+	go func() {
+		klog.Infof("KVCacheAware: starting KV events server on %s", server.Addr)
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			klog.Errorf("KVCacheAware: KV events server failed: %v", err)
+		}
+	}()
+}

--- a/pkg/kthena-router/scheduler/plugins/kvcache_memory_index.go
+++ b/pkg/kthena-router/scheduler/plugins/kvcache_memory_index.go
@@ -28,6 +28,25 @@ import (
 	"k8s.io/klog/v2"
 )
 
+// The in-memory KV index ("memory" index mode) replaces the shared Redis
+// block matrix with a per-router-process index kept in sync by push:
+//
+//  1. The runtime sidecar next to each inference engine subscribes to the
+//     engine's KV cache events, converts engine block hashes into
+//     standardized token-block hashes, and keeps the authoritative
+//     per-model block set for its pod
+//     (python/kthena/runtime/memory_kv_manager.py).
+//  2. Every router periodically registers with each runtime sidecar
+//     (kvcache_registration.go), announcing its push endpoint, a TTL, and a
+//     per-process generation.
+//  3. Sidecars push incremental stored/removed/cleared deltas to all
+//     registered routers, and push a full replace-style snapshot to a router
+//     whose process is new (generation change or expired registration) or
+//     whose previous push failed, so a router can always rebuild its index.
+//  4. Each router applies these events to its KVBlockMemoryIndex and scores
+//     pods by longest prefix match exactly like the Redis backend; a
+//     periodic GC drops entries not refreshed within the freshness window.
+//
 // KV event types pushed by the runtime sidecar in memory sync mode.
 // Kept in sync by hand with python/kthena/runtime/memory_kv_manager.py.
 const (
@@ -57,6 +76,11 @@ type KVEventPayload struct {
 	Events        []KVEvent `json:"events"`
 }
 
+// An owner is the pod identifier of the inference engine pod that holds a
+// block in its KV cache, in the "<podName>.<namespace>" form — the same
+// identifier the Redis backend stores as hash field names, so lookup results
+// flow through the shared scoring path unchanged.
+//
 // ownerModelKey indexes per-owner-per-model block sets for removal and snapshots.
 type ownerModelKey struct {
 	owner string
@@ -68,7 +92,7 @@ type ownerModelKey struct {
 // hash, per model, together with the time the block was last stored.
 type KVBlockMemoryIndex struct {
 	mu sync.RWMutex
-	// model -> block hash -> owner(pod.namespace) -> unix seconds of last store
+	// model -> block hash -> owner(podName.namespace) -> unix seconds of last store
 	blocks map[string]map[uint64]map[string]int64
 	// reverse index for cleared/snapshot events
 	ownerBlocks map[ownerModelKey]map[uint64]struct{}
@@ -216,6 +240,15 @@ func (idx *KVBlockMemoryIndex) RemoveOwner(owner string) {
 // gcStaleEntries drops ownership entries older than freshDuration, mirroring
 // the Redis backend GC so restarts or missed removal events cannot leave dead
 // entries behind forever.
+//
+// The full map is traversed while holding the write lock, blocking concurrent
+// lookups for the duration of the sweep. This is a deliberate simplicity
+// trade-off: the index size is bounded by the aggregate engine KV cache
+// capacity (one entry per cached block per pod), so a sweep is pure in-memory
+// work finishing in milliseconds even at millions of entries, and it runs
+// only once per kvCacheGCInterval (hourly). If the pause ever becomes a
+// problem, the sweep can be made incremental, like the cursor-based SCAN GC
+// of the Redis backend.
 func (idx *KVBlockMemoryIndex) gcStaleEntries(freshDuration time.Duration) {
 	cutoff := time.Now().Add(-freshDuration).Unix()
 

--- a/pkg/kthena-router/scheduler/plugins/kvcache_memory_index.go
+++ b/pkg/kthena-router/scheduler/plugins/kvcache_memory_index.go
@@ -43,6 +43,11 @@ type KVEvent struct {
 	Type        string   `json:"type"`
 	BlockHashes []uint64 `json:"block_hashes,omitempty"`
 	Timestamp   int64    `json:"timestamp,omitempty"`
+	// Timestamps optionally carries one unix-second store time per entry of
+	// BlockHashes. Snapshots use it to preserve original store times instead
+	// of re-stamping every block at snapshot time, which would defeat the
+	// engine-restart freshness filter.
+	Timestamps []int64 `json:"timestamps,omitempty"`
 }
 
 // KVEventPayload is the body of POST /kvcache/events pushed by a runtime sidecar.
@@ -86,9 +91,13 @@ func (idx *KVBlockMemoryIndex) Apply(payload *KVEventPayload) error {
 	defer idx.mu.Unlock()
 
 	for _, event := range payload.Events {
+		if len(event.Timestamps) > 0 && len(event.Timestamps) != len(event.BlockHashes) {
+			return fmt.Errorf("timestamps length %d does not match block_hashes length %d",
+				len(event.Timestamps), len(event.BlockHashes))
+		}
 		switch event.Type {
 		case kvEventStored:
-			idx.storeLocked(payload.ModelName, payload.PodIdentifier, event.BlockHashes, event.Timestamp)
+			idx.storeLocked(payload.ModelName, payload.PodIdentifier, event.BlockHashes, event.Timestamp, event.Timestamps)
 		case kvEventRemoved:
 			idx.removeLocked(payload.ModelName, payload.PodIdentifier, event.BlockHashes)
 		case kvEventCleared:
@@ -96,7 +105,7 @@ func (idx *KVBlockMemoryIndex) Apply(payload *KVEventPayload) error {
 		case kvEventSnapshot:
 			// A snapshot replaces everything known about this owner+model.
 			idx.clearLocked(payload.ModelName, payload.PodIdentifier)
-			idx.storeLocked(payload.ModelName, payload.PodIdentifier, event.BlockHashes, event.Timestamp)
+			idx.storeLocked(payload.ModelName, payload.PodIdentifier, event.BlockHashes, event.Timestamp, event.Timestamps)
 		default:
 			return fmt.Errorf("unknown event type %q", event.Type)
 		}
@@ -104,7 +113,10 @@ func (idx *KVBlockMemoryIndex) Apply(payload *KVEventPayload) error {
 	return nil
 }
 
-func (idx *KVBlockMemoryIndex) storeLocked(model, owner string, hashes []uint64, timestamp int64) {
+func (idx *KVBlockMemoryIndex) storeLocked(model, owner string, hashes []uint64, timestamp int64, timestamps []int64) {
+	if len(hashes) == 0 {
+		return
+	}
 	if timestamp <= 0 {
 		timestamp = time.Now().Unix()
 	}
@@ -119,13 +131,17 @@ func (idx *KVBlockMemoryIndex) storeLocked(model, owner string, hashes []uint64,
 		owned = make(map[uint64]struct{})
 		idx.ownerBlocks[key] = owned
 	}
-	for _, hash := range hashes {
+	for i, hash := range hashes {
 		owners, ok := modelBlocks[hash]
 		if !ok {
 			owners = make(map[string]int64)
 			modelBlocks[hash] = owners
 		}
-		owners[owner] = timestamp
+		ts := timestamp
+		if len(timestamps) > 0 && timestamps[i] > 0 {
+			ts = timestamps[i]
+		}
+		owners[owner] = ts
 		owned[hash] = struct{}{}
 	}
 }

--- a/pkg/kthena-router/scheduler/plugins/kvcache_memory_index_test.go
+++ b/pkg/kthena-router/scheduler/plugins/kvcache_memory_index_test.go
@@ -1,0 +1,366 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugins
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestKVBlockMemoryIndex_Apply(t *testing.T) {
+	now := time.Now().Unix()
+
+	tests := []struct {
+		name        string
+		payloads    []KVEventPayload
+		wantErr     bool
+		queryModel  string
+		queryHashes []uint64
+		wantOwners  map[uint64][]string
+	}{
+		{
+			name: "stored blocks are queryable",
+			payloads: []KVEventPayload{{
+				PodIdentifier: "pod-1.default",
+				ModelName:     "qwen",
+				Events: []KVEvent{
+					{Type: kvEventStored, BlockHashes: []uint64{1, 2}, Timestamp: now},
+				},
+			}},
+			queryModel:  "qwen",
+			queryHashes: []uint64{1, 2, 3},
+			wantOwners: map[uint64][]string{
+				1: {"pod-1.default"},
+				2: {"pod-1.default"},
+			},
+		},
+		{
+			name: "removed blocks disappear",
+			payloads: []KVEventPayload{
+				{
+					PodIdentifier: "pod-1.default",
+					ModelName:     "qwen",
+					Events: []KVEvent{
+						{Type: kvEventStored, BlockHashes: []uint64{1, 2}, Timestamp: now},
+						{Type: kvEventRemoved, BlockHashes: []uint64{1}},
+					},
+				},
+			},
+			queryModel:  "qwen",
+			queryHashes: []uint64{1, 2},
+			wantOwners: map[uint64][]string{
+				2: {"pod-1.default"},
+			},
+		},
+		{
+			name: "cleared drops only the clearing owner",
+			payloads: []KVEventPayload{
+				{
+					PodIdentifier: "pod-1.default",
+					ModelName:     "qwen",
+					Events:        []KVEvent{{Type: kvEventStored, BlockHashes: []uint64{1}, Timestamp: now}},
+				},
+				{
+					PodIdentifier: "pod-2.default",
+					ModelName:     "qwen",
+					Events:        []KVEvent{{Type: kvEventStored, BlockHashes: []uint64{1}, Timestamp: now}},
+				},
+				{
+					PodIdentifier: "pod-1.default",
+					ModelName:     "qwen",
+					Events:        []KVEvent{{Type: kvEventCleared}},
+				},
+			},
+			queryModel:  "qwen",
+			queryHashes: []uint64{1},
+			wantOwners: map[uint64][]string{
+				1: {"pod-2.default"},
+			},
+		},
+		{
+			name: "snapshot replaces previous owner state",
+			payloads: []KVEventPayload{
+				{
+					PodIdentifier: "pod-1.default",
+					ModelName:     "qwen",
+					Events:        []KVEvent{{Type: kvEventStored, BlockHashes: []uint64{1, 2}, Timestamp: now}},
+				},
+				{
+					PodIdentifier: "pod-1.default",
+					ModelName:     "qwen",
+					Events:        []KVEvent{{Type: kvEventSnapshot, BlockHashes: []uint64{3}, Timestamp: now}},
+				},
+			},
+			queryModel:  "qwen",
+			queryHashes: []uint64{1, 2, 3},
+			wantOwners: map[uint64][]string{
+				3: {"pod-1.default"},
+			},
+		},
+		{
+			name: "models are isolated",
+			payloads: []KVEventPayload{{
+				PodIdentifier: "pod-1.default",
+				ModelName:     "qwen",
+				Events:        []KVEvent{{Type: kvEventStored, BlockHashes: []uint64{1}, Timestamp: now}},
+			}},
+			queryModel:  "other-model",
+			queryHashes: []uint64{1},
+			wantOwners:  map[uint64][]string{},
+		},
+		{
+			name: "missing pod identifier is rejected",
+			payloads: []KVEventPayload{{
+				ModelName: "qwen",
+				Events:    []KVEvent{{Type: kvEventStored, BlockHashes: []uint64{1}}},
+			}},
+			wantErr:     true,
+			queryModel:  "qwen",
+			queryHashes: []uint64{1},
+			wantOwners:  map[uint64][]string{},
+		},
+		{
+			name: "unknown event type is rejected",
+			payloads: []KVEventPayload{{
+				PodIdentifier: "pod-1.default",
+				ModelName:     "qwen",
+				Events:        []KVEvent{{Type: "bogus", BlockHashes: []uint64{1}}},
+			}},
+			wantErr:     true,
+			queryModel:  "qwen",
+			queryHashes: []uint64{1},
+			wantOwners:  map[uint64][]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			idx := NewKVBlockMemoryIndex()
+			var gotErr error
+			for i := range tt.payloads {
+				if err := idx.Apply(&tt.payloads[i]); err != nil {
+					gotErr = err
+				}
+			}
+			if (gotErr != nil) != tt.wantErr {
+				t.Fatalf("Apply() error = %v, wantErr = %v", gotErr, tt.wantErr)
+			}
+
+			got := idx.GetBlockOwners(tt.queryModel, tt.queryHashes)
+			if len(got) != len(tt.wantOwners) {
+				t.Fatalf("GetBlockOwners() = %v, want owners for %v", got, tt.wantOwners)
+			}
+			for hash, wantPods := range tt.wantOwners {
+				entries, ok := got[hash]
+				if !ok {
+					t.Fatalf("expected hash %d in result, got %v", hash, got)
+				}
+				if len(entries) != len(wantPods) {
+					t.Fatalf("hash %d: got owners %v, want %v", hash, entries, wantPods)
+				}
+				for _, pod := range wantPods {
+					if _, ok := entries[pod]; !ok {
+						t.Errorf("hash %d: expected owner %s, got %v", hash, pod, entries)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestKVBlockMemoryIndex_RemoveOwner(t *testing.T) {
+	idx := NewKVBlockMemoryIndex()
+	now := time.Now().Unix()
+	for _, payload := range []KVEventPayload{
+		{
+			PodIdentifier: "pod-1.default",
+			ModelName:     "qwen",
+			Events:        []KVEvent{{Type: kvEventStored, BlockHashes: []uint64{1, 2}, Timestamp: now}},
+		},
+		{
+			PodIdentifier: "pod-1.default",
+			ModelName:     "llama",
+			Events:        []KVEvent{{Type: kvEventStored, BlockHashes: []uint64{9}, Timestamp: now}},
+		},
+		{
+			PodIdentifier: "pod-2.default",
+			ModelName:     "qwen",
+			Events:        []KVEvent{{Type: kvEventStored, BlockHashes: []uint64{1}, Timestamp: now}},
+		},
+	} {
+		p := payload
+		if err := idx.Apply(&p); err != nil {
+			t.Fatalf("Apply() failed: %v", err)
+		}
+	}
+
+	idx.RemoveOwner("pod-1.default")
+
+	qwen := idx.GetBlockOwners("qwen", []uint64{1, 2})
+	if len(qwen) != 1 {
+		t.Fatalf("expected only hash 1 to remain for qwen, got %v", qwen)
+	}
+	if _, ok := qwen[1]["pod-2.default"]; !ok {
+		t.Errorf("expected pod-2.default to remain owner of hash 1, got %v", qwen)
+	}
+	if llama := idx.GetBlockOwners("llama", []uint64{9}); len(llama) != 0 {
+		t.Errorf("expected llama blocks of pod-1 to be gone, got %v", llama)
+	}
+}
+
+func TestKVBlockMemoryIndex_GCStaleEntries(t *testing.T) {
+	idx := NewKVBlockMemoryIndex()
+	fresh := time.Now().Unix()
+	stale := time.Now().Add(-25 * time.Hour).Unix()
+
+	for _, payload := range []KVEventPayload{
+		{
+			PodIdentifier: "pod-fresh.default",
+			ModelName:     "qwen",
+			Events:        []KVEvent{{Type: kvEventStored, BlockHashes: []uint64{1}, Timestamp: fresh}},
+		},
+		{
+			PodIdentifier: "pod-stale.default",
+			ModelName:     "qwen",
+			Events:        []KVEvent{{Type: kvEventStored, BlockHashes: []uint64{1, 2}, Timestamp: stale}},
+		},
+	} {
+		p := payload
+		if err := idx.Apply(&p); err != nil {
+			t.Fatalf("Apply() failed: %v", err)
+		}
+	}
+
+	idx.gcStaleEntries(kvCacheFieldFreshDuration)
+
+	got := idx.GetBlockOwners("qwen", []uint64{1, 2})
+	if len(got) != 1 {
+		t.Fatalf("expected only hash 1 to survive GC, got %v", got)
+	}
+	if _, ok := got[1]["pod-fresh.default"]; !ok {
+		t.Errorf("expected fresh owner to survive GC, got %v", got)
+	}
+	if _, ok := got[1]["pod-stale.default"]; ok {
+		t.Errorf("expected stale owner to be removed, got %v", got)
+	}
+}
+
+func TestKVCacheAware_QueryMemoryForBlocks(t *testing.T) {
+	idx := NewKVBlockMemoryIndex()
+	now := time.Now().Unix()
+	payload := KVEventPayload{
+		PodIdentifier: "pod-1.default",
+		ModelName:     "qwen",
+		Events:        []KVEvent{{Type: kvEventStored, BlockHashes: []uint64{111}, Timestamp: now}},
+	}
+	if err := idx.Apply(&payload); err != nil {
+		t.Fatalf("Apply() failed: %v", err)
+	}
+
+	plugin := &KVCacheAware{
+		indexMode:   kvCacheIndexModeMemory,
+		memoryIndex: idx,
+	}
+
+	result, err := plugin.queryBlocks([]uint64{111, 222}, "qwen", nil)
+	if err != nil {
+		t.Fatalf("queryBlocks returned error: %v", err)
+	}
+	if len(result) != 1 || len(result[111]) != 1 || result[111][0] != "pod-1.default" {
+		t.Fatalf("unexpected result: %v", result)
+	}
+
+	// Ownership written before the owning pod's containers started is dropped.
+	result, err = plugin.queryBlocks([]uint64{111}, "qwen",
+		map[string]int64{"pod-1.default": now + 10})
+	if err != nil {
+		t.Fatalf("queryBlocks returned error: %v", err)
+	}
+	if len(result) != 0 {
+		t.Fatalf("expected stale ownership to be dropped, got %v", result)
+	}
+}
+
+func TestKVEventsHandler(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	idx := NewKVBlockMemoryIndex()
+	engine := gin.New()
+	engine.POST("/kvcache/events", kvEventsHandler(idx))
+
+	tests := []struct {
+		name       string
+		body       any
+		rawBody    string
+		wantStatus int
+	}{
+		{
+			name: "valid payload",
+			body: KVEventPayload{
+				PodIdentifier: "pod-1.default",
+				ModelName:     "qwen",
+				Events:        []KVEvent{{Type: kvEventStored, BlockHashes: []uint64{42}, Timestamp: time.Now().Unix()}},
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "invalid json",
+			rawBody:    "{not-json",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name: "missing model name",
+			body: KVEventPayload{
+				PodIdentifier: "pod-1.default",
+				Events:        []KVEvent{{Type: kvEventStored, BlockHashes: []uint64{42}}},
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var body []byte
+			if tt.rawBody != "" {
+				body = []byte(tt.rawBody)
+			} else {
+				var err error
+				body, err = json.Marshal(tt.body)
+				if err != nil {
+					t.Fatalf("failed to marshal body: %v", err)
+				}
+			}
+			req := httptest.NewRequest(http.MethodPost, "/kvcache/events", bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			engine.ServeHTTP(rec, req)
+			if rec.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d, body=%s", rec.Code, tt.wantStatus, rec.Body.String())
+			}
+		})
+	}
+
+	got := idx.GetBlockOwners("qwen", []uint64{42})
+	if len(got) != 1 {
+		t.Fatalf("expected stored block from valid payload, got %v", got)
+	}
+}

--- a/pkg/kthena-router/scheduler/plugins/kvcache_memory_index_test.go
+++ b/pkg/kthena-router/scheduler/plugins/kvcache_memory_index_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 	"time"
 
@@ -118,6 +119,40 @@ func TestKVBlockMemoryIndex_Apply(t *testing.T) {
 			},
 		},
 		{
+			name: "empty snapshot clears previous owner state",
+			payloads: []KVEventPayload{
+				{
+					PodIdentifier: "pod-1.default",
+					ModelName:     "qwen",
+					Events:        []KVEvent{{Type: kvEventStored, BlockHashes: []uint64{1, 2}, Timestamp: now}},
+				},
+				{
+					PodIdentifier: "pod-1.default",
+					ModelName:     "qwen",
+					Events:        []KVEvent{{Type: kvEventSnapshot, Timestamp: now}},
+				},
+			},
+			queryModel:  "qwen",
+			queryHashes: []uint64{1, 2},
+			wantOwners:  map[uint64][]string{},
+		},
+		{
+			name: "mismatched timestamps length is rejected",
+			payloads: []KVEventPayload{{
+				PodIdentifier: "pod-1.default",
+				ModelName:     "qwen",
+				Events: []KVEvent{{
+					Type:        kvEventSnapshot,
+					BlockHashes: []uint64{1, 2},
+					Timestamps:  []int64{now},
+				}},
+			}},
+			wantErr:     true,
+			queryModel:  "qwen",
+			queryHashes: []uint64{1, 2},
+			wantOwners:  map[uint64][]string{},
+		},
+		{
 			name: "models are isolated",
 			payloads: []KVEventPayload{{
 				PodIdentifier: "pod-1.default",
@@ -185,6 +220,33 @@ func TestKVBlockMemoryIndex_Apply(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestKVBlockMemoryIndex_SnapshotPreservesPerBlockTimestamps(t *testing.T) {
+	idx := NewKVBlockMemoryIndex()
+	tsOld := time.Now().Add(-2 * time.Hour).Unix()
+	tsNew := time.Now().Unix()
+
+	payload := KVEventPayload{
+		PodIdentifier: "pod-1.default",
+		ModelName:     "qwen",
+		Events: []KVEvent{{
+			Type:        kvEventSnapshot,
+			BlockHashes: []uint64{1, 2},
+			Timestamps:  []int64{tsOld, tsNew},
+		}},
+	}
+	if err := idx.Apply(&payload); err != nil {
+		t.Fatalf("Apply() failed: %v", err)
+	}
+
+	got := idx.GetBlockOwners("qwen", []uint64{1, 2})
+	if want := strconv.FormatInt(tsOld, 10); got[1]["pod-1.default"] != want {
+		t.Errorf("hash 1 timestamp = %s, want %s", got[1]["pod-1.default"], want)
+	}
+	if want := strconv.FormatInt(tsNew, 10); got[2]["pod-1.default"] != want {
+		t.Errorf("hash 2 timestamp = %s, want %s", got[2]["pod-1.default"], want)
 	}
 }
 

--- a/pkg/kthena-router/scheduler/plugins/kvcache_registration.go
+++ b/pkg/kthena-router/scheduler/plugins/kvcache_registration.go
@@ -1,0 +1,163 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugins
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+
+	"github.com/volcano-sh/kthena/pkg/kthena-router/datastore"
+)
+
+const (
+	runtimeRegisterPath = "/kvcache/routers/register"
+
+	defaultRuntimePort             = 9000
+	defaultRegistrationIntervalSec = 30
+	defaultRegistrationTTLSec      = 90
+)
+
+// routerRegistrationRequest is the body posted to the runtime sidecar's
+// /kvcache/routers/register endpoint. Kept in sync by hand with
+// python/kthena/runtime/app.py.
+type routerRegistrationRequest struct {
+	RouterID   string `json:"router_id"`
+	Endpoint   string `json:"endpoint"`
+	TTLSeconds int    `json:"ttl_seconds"`
+}
+
+// kvRouterRegistrar periodically registers this router instance with the
+// runtime sidecar of every known model-serving pod, so the sidecars can push
+// KV cache events back. Registration doubles as a heartbeat: sidecars expire
+// routers that stop re-registering within the TTL.
+type kvRouterRegistrar struct {
+	store       datastore.Store
+	routerID    string
+	endpoint    string // base URL the sidecar pushes events to, e.g. http://10.0.0.5:9080
+	runtimePort int
+	interval    time.Duration
+	ttlSeconds  int
+	client      *http.Client
+}
+
+func newKVRouterRegistrar(store datastore.Store, routerID, endpoint string,
+	runtimePort, intervalSeconds, ttlSeconds int) *kvRouterRegistrar {
+	return &kvRouterRegistrar{
+		store:       store,
+		routerID:    routerID,
+		endpoint:    endpoint,
+		runtimePort: runtimePort,
+		interval:    time.Duration(intervalSeconds) * time.Second,
+		ttlSeconds:  ttlSeconds,
+		client:      &http.Client{Timeout: 3 * time.Second},
+	}
+}
+
+// routerSelfEndpoint derives the base URL runtime sidecars should push KV
+// events to. POD_IP must be injected via the downward API on the router
+// deployment; without it memory mode cannot receive pushes.
+func routerSelfEndpoint(eventsPort int) (string, error) {
+	podIP := os.Getenv("POD_IP")
+	if podIP == "" {
+		return "", fmt.Errorf("POD_IP environment variable is not set")
+	}
+	return fmt.Sprintf("http://%s:%d", podIP, eventsPort), nil
+}
+
+// routerInstanceID identifies this router replica in sidecar registries.
+func routerInstanceID() string {
+	if name := os.Getenv("POD_NAME"); name != "" {
+		return name
+	}
+	hostname, err := os.Hostname()
+	if err != nil {
+		return "kthena-router"
+	}
+	return hostname
+}
+
+// run registers with all known pods immediately and then on every tick until
+// ctx is done.
+func (r *kvRouterRegistrar) run(ctx context.Context) {
+	r.registerAll(ctx)
+	ticker := time.NewTicker(r.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			r.registerAll(ctx)
+		}
+	}
+}
+
+func (r *kvRouterRegistrar) registerAll(ctx context.Context) {
+	pods := r.store.GetAllPods()
+	registered := 0
+	for _, podInfo := range pods {
+		pod := podInfo.GetPod()
+		if pod == nil || pod.Status.PodIP == "" || pod.Status.Phase != corev1.PodRunning {
+			continue
+		}
+		if err := r.registerWithPod(ctx, pod.Status.PodIP); err != nil {
+			// Pods without a runtime sidecar (or not in memory mode) are expected
+			// to fail; keep this quiet.
+			klog.V(4).Infof("KVCacheAware: registration with pod %s/%s (%s) failed: %v",
+				pod.Namespace, pod.Name, pod.Status.PodIP, err)
+			continue
+		}
+		registered++
+	}
+	klog.V(4).Infof("KVCacheAware: registered with %d/%d runtime sidecars", registered, len(pods))
+}
+
+func (r *kvRouterRegistrar) registerWithPod(ctx context.Context, podIP string) error {
+	body, err := json.Marshal(routerRegistrationRequest{
+		RouterID:   r.routerID,
+		Endpoint:   r.endpoint,
+		TTLSeconds: r.ttlSeconds,
+	})
+	if err != nil {
+		return err
+	}
+
+	url := fmt.Sprintf("http://%s:%d%s", podIP, r.runtimePort, runtimeRegisterPath)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+	return nil
+}

--- a/pkg/kthena-router/scheduler/plugins/kvcache_registration.go
+++ b/pkg/kthena-router/scheduler/plugins/kvcache_registration.go
@@ -19,10 +19,15 @@ package plugins
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
+	"strconv"
+	"sync"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -37,14 +42,22 @@ const (
 	defaultRuntimePort             = 9000
 	defaultRegistrationIntervalSec = 30
 	defaultRegistrationTTLSec      = 90
+
+	// maxConcurrentRegistrations bounds the fan-out of one registration sweep
+	// so that many unreachable pods cannot stretch a sweep past the TTL.
+	maxConcurrentRegistrations = 16
 )
 
 // routerRegistrationRequest is the body posted to the runtime sidecar's
 // /kvcache/routers/register endpoint. Kept in sync by hand with
 // python/kthena/runtime/app.py.
 type routerRegistrationRequest struct {
-	RouterID   string `json:"router_id"`
-	Endpoint   string `json:"endpoint"`
+	RouterID string `json:"router_id"`
+	Endpoint string `json:"endpoint"`
+	// Generation identifies one router process. It changes when the router
+	// container restarts (even with an unchanged pod name), so sidecars can
+	// detect that the in-memory index was lost and push a fresh snapshot.
+	Generation string `json:"generation"`
 	TTLSeconds int    `json:"ttl_seconds"`
 }
 
@@ -55,6 +68,7 @@ type routerRegistrationRequest struct {
 type kvRouterRegistrar struct {
 	store       datastore.Store
 	routerID    string
+	generation  string // unique per router process, see routerRegistrationRequest
 	endpoint    string // base URL the sidecar pushes events to, e.g. http://10.0.0.5:9080
 	runtimePort int
 	interval    time.Duration
@@ -67,12 +81,24 @@ func newKVRouterRegistrar(store datastore.Store, routerID, endpoint string,
 	return &kvRouterRegistrar{
 		store:       store,
 		routerID:    routerID,
+		generation:  newProcessGeneration(),
 		endpoint:    endpoint,
 		runtimePort: runtimePort,
 		interval:    time.Duration(intervalSeconds) * time.Second,
 		ttlSeconds:  ttlSeconds,
 		client:      &http.Client{Timeout: 3 * time.Second},
 	}
+}
+
+// newProcessGeneration returns an identifier that is unique per router
+// process, so a restarted container with the same pod name still triggers a
+// snapshot from every sidecar.
+func newProcessGeneration() string {
+	buf := make([]byte, 8)
+	if _, err := rand.Read(buf); err != nil {
+		return strconv.FormatInt(time.Now().UnixNano(), 36)
+	}
+	return hex.EncodeToString(buf)
 }
 
 // routerSelfEndpoint derives the base URL runtime sidecars should push KV
@@ -83,7 +109,7 @@ func routerSelfEndpoint(eventsPort int) (string, error) {
 	if podIP == "" {
 		return "", fmt.Errorf("POD_IP environment variable is not set")
 	}
-	return fmt.Sprintf("http://%s:%d", podIP, eventsPort), nil
+	return "http://" + net.JoinHostPort(podIP, strconv.Itoa(eventsPort)), nil
 }
 
 // routerInstanceID identifies this router replica in sidecar registries.
@@ -116,21 +142,37 @@ func (r *kvRouterRegistrar) run(ctx context.Context) {
 
 func (r *kvRouterRegistrar) registerAll(ctx context.Context) {
 	pods := r.store.GetAllPods()
-	registered := 0
+	var (
+		wg         sync.WaitGroup
+		mu         sync.Mutex
+		registered int
+	)
+	// Bounded fan-out: registrations run concurrently so a sweep over many
+	// pods without a reachable sidecar stays well below the TTL.
+	sem := make(chan struct{}, maxConcurrentRegistrations)
 	for _, podInfo := range pods {
 		pod := podInfo.GetPod()
 		if pod == nil || pod.Status.PodIP == "" || pod.Status.Phase != corev1.PodRunning {
 			continue
 		}
-		if err := r.registerWithPod(ctx, pod.Status.PodIP); err != nil {
-			// Pods without a runtime sidecar (or not in memory mode) are expected
-			// to fail; keep this quiet.
-			klog.V(4).Infof("KVCacheAware: registration with pod %s/%s (%s) failed: %v",
-				pod.Namespace, pod.Name, pod.Status.PodIP, err)
-			continue
-		}
-		registered++
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(namespace, name, podIP string) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			if err := r.registerWithPod(ctx, podIP); err != nil {
+				// Pods without a runtime sidecar (or not in memory mode) are expected
+				// to fail; keep this quiet.
+				klog.V(4).Infof("KVCacheAware: registration with pod %s/%s (%s) failed: %v",
+					namespace, name, podIP, err)
+				return
+			}
+			mu.Lock()
+			registered++
+			mu.Unlock()
+		}(pod.Namespace, pod.Name, pod.Status.PodIP)
 	}
+	wg.Wait()
 	klog.V(4).Infof("KVCacheAware: registered with %d/%d runtime sidecars", registered, len(pods))
 }
 
@@ -138,13 +180,14 @@ func (r *kvRouterRegistrar) registerWithPod(ctx context.Context, podIP string) e
 	body, err := json.Marshal(routerRegistrationRequest{
 		RouterID:   r.routerID,
 		Endpoint:   r.endpoint,
+		Generation: r.generation,
 		TTLSeconds: r.ttlSeconds,
 	})
 	if err != nil {
 		return err
 	}
 
-	url := fmt.Sprintf("http://%s:%d%s", podIP, r.runtimePort, runtimeRegisterPath)
+	url := "http://" + net.JoinHostPort(podIP, strconv.Itoa(r.runtimePort)) + runtimeRegisterPath
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
 	if err != nil {
 		return err

--- a/pkg/kthena-router/scheduler/plugins/kvcache_registration_test.go
+++ b/pkg/kthena-router/scheduler/plugins/kvcache_registration_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugins
+
+import (
+	"testing"
+)
+
+func TestRouterSelfEndpoint(t *testing.T) {
+	tests := []struct {
+		name    string
+		podIP   string
+		port    int
+		want    string
+		wantErr bool
+	}{
+		{
+			name:  "IPv4 address",
+			podIP: "10.0.0.5",
+			port:  9080,
+			want:  "http://10.0.0.5:9080",
+		},
+		{
+			name:  "IPv6 address is bracketed",
+			podIP: "fd00::1",
+			port:  9080,
+			want:  "http://[fd00::1]:9080",
+		},
+		{
+			name:    "missing POD_IP",
+			podIP:   "",
+			port:    9080,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("POD_IP", tt.podIP)
+			got, err := routerSelfEndpoint(tt.port)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("routerSelfEndpoint() error = %v, wantErr = %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("routerSelfEndpoint() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewProcessGeneration(t *testing.T) {
+	g1 := newProcessGeneration()
+	g2 := newProcessGeneration()
+	if g1 == "" || g2 == "" {
+		t.Fatal("generation must not be empty")
+	}
+	if g1 == g2 {
+		t.Errorf("expected unique generations, got %q twice", g1)
+	}
+}

--- a/python/kthena/runtime/app.py
+++ b/python/kthena/runtime/app.py
@@ -252,11 +252,14 @@ async def register_router(request: Request, background_tasks: BackgroundTasks) -
     - router_id: str - Unique identifier of the router instance (e.g. pod name)
     - endpoint: str - Base URL the runtime pushes KV events to,
       e.g. "http://10.0.0.5:9080"
+    - generation: str (optional) - Identifier of the router process; changes
+      when the router container restarts so a fresh snapshot is pushed
     - ttl_seconds: int (optional) - Registration TTL; routers must re-register
       before it expires (default: 90)
 
-    When the registration is new (or renewed after expiry), the current KV
-    block snapshot is pushed to the router in the background.
+    When the registration is new (renewed after expiry, or from a new process
+    generation), or when a previous event push to this router failed, the
+    current KV block snapshot is pushed to the router in the background.
     """
     state = get_app_state(request.app)
     if state.kv_sync_mode != KV_SYNC_MODE_MEMORY:
@@ -272,19 +275,26 @@ async def register_router(request: Request, background_tasks: BackgroundTasks) -
 
     router_id = body.get("router_id")
     endpoint = body.get("endpoint")
+    generation = body.get("generation", "")
     ttl_seconds = body.get("ttl_seconds", DEFAULT_ROUTER_TTL_SECONDS)
 
     try:
-        needs_snapshot = get_router_registry().register(router_id, endpoint, ttl_seconds)
+        needs_snapshot = get_router_registry().register(
+            router_id, endpoint, ttl_seconds, generation)
     except (ValueError, TypeError) as e:
         raise HTTPException(status_code=400, detail=str(e))
 
-    if needs_snapshot and state.memory_kv_manager and state.pod_identifier:
-        background_tasks.add_task(
-            state.memory_kv_manager.push_snapshot,
-            endpoint.rstrip("/"),
-            state.pod_identifier,
-        )
+    if state.memory_kv_manager and state.pod_identifier:
+        endpoint_base = endpoint.rstrip("/")
+        # Also resend a snapshot when a previous push to this router failed,
+        # so a transient delivery failure cannot leave it divergent forever.
+        if needs_snapshot or state.memory_kv_manager.is_dirty(endpoint_base):
+            needs_snapshot = True
+            background_tasks.add_task(
+                state.memory_kv_manager.push_snapshot,
+                endpoint_base,
+                state.pod_identifier,
+            )
 
     return JSONResponse(
         content={"registered": True, "snapshot_scheduled": needs_snapshot},

--- a/python/kthena/runtime/app.py
+++ b/python/kthena/runtime/app.py
@@ -36,10 +36,29 @@ from kthena.runtime.kv_cache_manager import (
     get_vllm_kv_cache_handler,
     get_sglang_kv_cache_handler,
 )
+from kthena.runtime.memory_kv_manager import get_memory_kv_manager
 from kthena.runtime.redis_client import get_redis_client
+from kthena.runtime.router_registry import (
+    DEFAULT_ROUTER_TTL_SECONDS,
+    get_router_registry,
+)
 from kthena.runtime.standard import MetricStandard, EngineType
 from kthena.runtime.zmq_subscriber import get_vllm_zmq_subscriber
 from kthena.runtime.sglang_zmq_subscriber import get_sglang_zmq_subscriber
+
+# KV event sync backend: "redis" writes standardized block hashes to Redis;
+# "memory" pushes them directly to registered router instances.
+KV_SYNC_MODE_REDIS = "redis"
+KV_SYNC_MODE_MEMORY = "memory"
+
+
+def get_kv_event_sync_mode() -> str:
+    mode = os.getenv("KV_EVENT_SYNC_MODE", KV_SYNC_MODE_REDIS).lower()
+    if mode not in (KV_SYNC_MODE_REDIS, KV_SYNC_MODE_MEMORY):
+        logging.getLogger(__name__).warning(
+            "Invalid KV_EVENT_SYNC_MODE %r, falling back to %r", mode, KV_SYNC_MODE_REDIS)
+        return KV_SYNC_MODE_REDIS
+    return mode
 
 
 class AppState:
@@ -53,6 +72,8 @@ class AppState:
         self.engine_metrics_url: Optional[str] = None
         self.pod_identifier: Optional[str] = None
         self.model_name: Optional[str] = None
+        self.kv_sync_mode: str = KV_SYNC_MODE_REDIS
+        self.memory_kv_manager = None
 
 
 TIMEOUT = float(os.getenv("REQUEST_TIMEOUT", "30.0"))
@@ -96,14 +117,20 @@ async def lifespan(app: FastAPI):
         follow_redirects=True,
     )
 
-    try:
-        redis_client = get_redis_client()
-        await redis_client.connect()
-        state.redis_client = redis_client
-        logger.info("Redis client initialized successfully")
-    except Exception as e:
-        logger.warning("Failed to initialize Redis client:%s",e)
+    state.kv_sync_mode = get_kv_event_sync_mode()
+    if state.kv_sync_mode == KV_SYNC_MODE_MEMORY:
+        state.memory_kv_manager = get_memory_kv_manager()
         state.redis_client = None
+        logger.info("KV event sync mode: memory (push to registered routers)")
+    else:
+        try:
+            redis_client = get_redis_client()
+            await redis_client.connect()
+            state.redis_client = redis_client
+            logger.info("Redis client initialized successfully")
+        except Exception as e:
+            logger.warning("Failed to initialize Redis client:%s",e)
+            state.redis_client = None
 
     try:
         event_publisher = get_event_publisher()
@@ -115,7 +142,7 @@ async def lifespan(app: FastAPI):
         engine = state.metric_standard.engine if state.metric_standard else None
 
         if pod_identifier and model_name and engine == EngineType.VLLM:
-            vllm_kv_cache_handler = get_vllm_kv_cache_handler()
+            vllm_kv_cache_handler = get_vllm_kv_cache_handler(state.memory_kv_manager)
             for event_type in (
                 EventType.VLLM_BLOCK_STORED,
                 EventType.VLLM_BLOCK_REMOVED,
@@ -124,7 +151,7 @@ async def lifespan(app: FastAPI):
                 event_publisher.subscribe(event_type, vllm_kv_cache_handler)
             logger.info("vLLM KV-cache event handler registered")
         elif pod_identifier and model_name and engine == EngineType.SGLANG:
-            sglang_kv_cache_handler = get_sglang_kv_cache_handler()
+            sglang_kv_cache_handler = get_sglang_kv_cache_handler(state.memory_kv_manager)
             for event_type in (
                 EventType.SGLANG_BLOCK_STORED,
                 EventType.SGLANG_BLOCK_REMOVED,
@@ -190,6 +217,9 @@ async def lifespan(app: FastAPI):
     if state.event_publisher:
         cleanup_tasks.append(('Event system', state.event_publisher.stop()))
 
+    if state.memory_kv_manager:
+        cleanup_tasks.append(('Memory KV manager', state.memory_kv_manager.close()))
+
     if state.redis_client:
         cleanup_tasks.append(('Redis client', state.redis_client.disconnect()))
 
@@ -211,6 +241,54 @@ async def health_check() -> JSONResponse:
     return JSONResponse(
         content={"status": "healthy", "service": "runtime"},
         status_code=200
+    )
+
+
+@router.post("/kvcache/routers/register", tags=["KVCache"])
+async def register_router(request: Request, background_tasks: BackgroundTasks) -> JSONResponse:
+    """Register (or renew) a router instance for in-memory KV event push.
+
+    Request body:
+    - router_id: str - Unique identifier of the router instance (e.g. pod name)
+    - endpoint: str - Base URL the runtime pushes KV events to,
+      e.g. "http://10.0.0.5:9080"
+    - ttl_seconds: int (optional) - Registration TTL; routers must re-register
+      before it expires (default: 90)
+
+    When the registration is new (or renewed after expiry), the current KV
+    block snapshot is pushed to the router in the background.
+    """
+    state = get_app_state(request.app)
+    if state.kv_sync_mode != KV_SYNC_MODE_MEMORY:
+        raise HTTPException(
+            status_code=409,
+            detail="Runtime is not in memory KV event sync mode "
+                   "(set KV_EVENT_SYNC_MODE=memory)")
+
+    try:
+        body = await request.json()
+    except Exception:
+        raise HTTPException(status_code=400, detail="Invalid JSON body")
+
+    router_id = body.get("router_id")
+    endpoint = body.get("endpoint")
+    ttl_seconds = body.get("ttl_seconds", DEFAULT_ROUTER_TTL_SECONDS)
+
+    try:
+        needs_snapshot = get_router_registry().register(router_id, endpoint, ttl_seconds)
+    except (ValueError, TypeError) as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    if needs_snapshot and state.memory_kv_manager and state.pod_identifier:
+        background_tasks.add_task(
+            state.memory_kv_manager.push_snapshot,
+            endpoint.rstrip("/"),
+            state.pod_identifier,
+        )
+
+    return JSONResponse(
+        content={"registered": True, "snapshot_scheduled": needs_snapshot},
+        status_code=200,
     )
 
 

--- a/python/kthena/runtime/kv_cache_manager.py
+++ b/python/kthena/runtime/kv_cache_manager.py
@@ -15,7 +15,7 @@
 import hashlib
 import logging
 import time
-from typing import List, Optional, Dict
+from typing import List, Optional, Dict, Tuple
 
 from kthena.runtime.events import (
     EventHandler, EventType, EventData, VLLMEventData,
@@ -54,6 +54,32 @@ def compute_standardized_hash(token_ids: List[int]) -> int:
     # Token ids are detokenizable prompt content, so they must never reach the logs.
     logger.debug(f"KVCacheManager: compute standardized hash={result}, tokens={len(token_ids)}")
     return result
+
+
+def standardize_block_hashes(engine_hashes: List[int],
+                             token_ids: List[int]) -> Optional[List[Tuple[int, int]]]:
+    """Split token_ids evenly across engine_hashes and pair each engine hash
+    with the standardized hash of its token block.
+
+    Returns None when the token count does not divide evenly across the hashes.
+    """
+    if not engine_hashes or not token_ids:
+        return None
+
+    block_size = len(token_ids) // len(engine_hashes)
+    if block_size == 0 or len(token_ids) % len(engine_hashes) != 0:
+        logger.error(
+            f"Token count ({len(token_ids)}) cannot match block size with "
+            f"{len(engine_hashes)} hashes")
+        return None
+
+    pairs: List[Tuple[int, int]] = []
+    for i, engine_hash in enumerate(engine_hashes):
+        block_tokens = token_ids[i * block_size:(i + 1) * block_size]
+        if not block_tokens:
+            continue
+        pairs.append((engine_hash, compute_standardized_hash(block_tokens)))
+    return pairs
 
 
 class VLLMKVCacheRedisManager:
@@ -105,22 +131,11 @@ class VLLMKVCacheRedisManager:
     async def _process_token_blocks_with_mapping(self, model_name: str, engine_hashes: List[int],
                                                  token_ids: List[int], pod_identifier: str,
                                                  timestamp: str, pipe) -> bool:
-        if not engine_hashes:
+        pairs = standardize_block_hashes(engine_hashes, token_ids)
+        if pairs is None:
             return False
 
-        # Calculate block size: len(token_ids) / len(block_hashes)
-        block_size = len(token_ids) // len(engine_hashes)
-        if len(token_ids) % len(engine_hashes) != 0:
-            logger.error(f"Token count ({len(token_ids)}) cannot match block size with {len(engine_hashes)} hashes")
-            return False
-
-        for i, engine_hash in enumerate(engine_hashes):
-            start_idx = i * block_size
-            end_idx = min(start_idx + block_size, len(token_ids))
-            block_tokens = token_ids[start_idx:end_idx]
-            if len(block_tokens) == 0:
-                continue
-            std_hash = compute_standardized_hash(block_tokens)
+        for engine_hash, std_hash in pairs:
             matrix_block_key = self._get_matrix_block_key(model_name, std_hash)
             self.hash_mapping[engine_hash] = std_hash
             mapping_key = self._get_hash_mapping_key(engine_hash, pod_identifier)
@@ -260,8 +275,10 @@ class VLLMKVCacheRedisManager:
 
 class VLLMKVCacheEventHandler(EventHandler):
 
-    def __init__(self, redis_manager: Optional[VLLMKVCacheRedisManager] = None):
-        self.redis_manager = redis_manager or VLLMKVCacheRedisManager()
+    # kv_manager may be any object implementing add_blocks / remove_blocks /
+    # clear_all_blocks, e.g. VLLMKVCacheRedisManager or MemoryKVCacheManager.
+    def __init__(self, kv_manager=None):
+        self.kv_manager = kv_manager or VLLMKVCacheRedisManager()
 
     async def handle(self, event_data: EventData) -> None:
         if not event_data:
@@ -293,7 +310,7 @@ class VLLMKVCacheEventHandler(EventHandler):
             return
 
         block_event = event_data.vllm_event
-        await self.redis_manager.add_blocks(
+        await self.kv_manager.add_blocks(
             model_name=event_data.model_name,
             block_hashes=block_event.block_hashes,
             pod_identifier=event_data.pod_identifier,
@@ -305,21 +322,21 @@ class VLLMKVCacheEventHandler(EventHandler):
             return
 
         block_event = event_data.vllm_event
-        await self.redis_manager.remove_blocks(
+        await self.kv_manager.remove_blocks(
             model_name=event_data.model_name,
             block_hashes=block_event.block_hashes,
             pod_identifier=event_data.pod_identifier
         )
 
     async def _handle_all_blocks_cleared(self, event_data: VLLMEventData) -> None:
-        await self.redis_manager.clear_all_blocks(
+        await self.kv_manager.clear_all_blocks(
             model_name=event_data.model_name,
             pod_identifier=event_data.pod_identifier
         )
 
 
-def get_vllm_kv_cache_handler() -> VLLMKVCacheEventHandler:
-    return VLLMKVCacheEventHandler()
+def get_vllm_kv_cache_handler(kv_manager=None) -> VLLMKVCacheEventHandler:
+    return VLLMKVCacheEventHandler(kv_manager)
 
 
 class SGLangKVCacheRedisManager(VLLMKVCacheRedisManager):
@@ -330,8 +347,10 @@ class SGLangKVCacheRedisManager(VLLMKVCacheRedisManager):
 
 class SGLangKVCacheEventHandler(EventHandler):
 
-    def __init__(self, redis_manager: Optional[SGLangKVCacheRedisManager] = None):
-        self.redis_manager = redis_manager or SGLangKVCacheRedisManager()
+    # kv_manager may be any object implementing add_blocks / remove_blocks /
+    # clear_all_blocks, e.g. SGLangKVCacheRedisManager or MemoryKVCacheManager.
+    def __init__(self, kv_manager=None):
+        self.kv_manager = kv_manager or SGLangKVCacheRedisManager()
 
     async def handle(self, event_data: EventData) -> None:
         if not event_data:
@@ -363,7 +382,7 @@ class SGLangKVCacheEventHandler(EventHandler):
             return
 
         block_event = event_data.sglang_event
-        await self.redis_manager.add_blocks(
+        await self.kv_manager.add_blocks(
             model_name=event_data.model_name,
             block_hashes=block_event.block_hashes,
             pod_identifier=event_data.pod_identifier,
@@ -375,18 +394,18 @@ class SGLangKVCacheEventHandler(EventHandler):
             return
 
         block_event = event_data.sglang_event
-        await self.redis_manager.remove_blocks(
+        await self.kv_manager.remove_blocks(
             model_name=event_data.model_name,
             block_hashes=block_event.block_hashes,
             pod_identifier=event_data.pod_identifier,
         )
 
     async def _handle_all_blocks_cleared(self, event_data: SGLangEventData) -> None:
-        await self.redis_manager.clear_all_blocks(
+        await self.kv_manager.clear_all_blocks(
             model_name=event_data.model_name,
             pod_identifier=event_data.pod_identifier,
         )
 
 
-def get_sglang_kv_cache_handler() -> SGLangKVCacheEventHandler:
-    return SGLangKVCacheEventHandler()
+def get_sglang_kv_cache_handler(kv_manager=None) -> SGLangKVCacheEventHandler:
+    return SGLangKVCacheEventHandler(kv_manager)

--- a/python/kthena/runtime/memory_kv_manager.py
+++ b/python/kthena/runtime/memory_kv_manager.py
@@ -1,0 +1,186 @@
+# Copyright The Volcano Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import logging
+import time
+from typing import Dict, List, Optional
+
+import httpx
+
+from kthena.runtime.kv_cache_manager import standardize_block_hashes
+from kthena.runtime.router_registry import RouterRegistry, get_router_registry
+
+logger = logging.getLogger(__name__)
+
+KV_EVENTS_PATH = "/kvcache/events"
+
+KV_EVENT_STORED = "stored"
+KV_EVENT_REMOVED = "removed"
+KV_EVENT_CLEARED = "cleared"
+KV_EVENT_SNAPSHOT = "snapshot"
+
+PUSH_TIMEOUT_SECONDS = 2.0
+
+
+class MemoryKVCacheManager:
+    """KV cache manager that pushes standardized block hashes directly to
+    registered router instances instead of writing them to Redis.
+
+    Implements the same interface as VLLMKVCacheRedisManager
+    (add_blocks / remove_blocks / clear_all_blocks) so it can back
+    VLLMKVCacheEventHandler and SGLangKVCacheEventHandler.
+    """
+
+    def __init__(self, registry: Optional[RouterRegistry] = None,
+                 client: Optional[httpx.AsyncClient] = None):
+        self.registry = registry or get_router_registry()
+        self._client = client
+        # engine hash -> standardized hash, needed because removal events only
+        # carry engine hashes.
+        self.hash_mapping: Dict[int, int] = {}
+        # model name -> {std_hash: unix seconds when stored}, mirrors what has
+        # been pushed so a newly registered router can receive a snapshot.
+        self._blocks: Dict[str, Dict[int, int]] = {}
+
+    def _get_client(self) -> httpx.AsyncClient:
+        if self._client is None:
+            self._client = httpx.AsyncClient(
+                timeout=httpx.Timeout(PUSH_TIMEOUT_SECONDS))
+        return self._client
+
+    async def close(self) -> None:
+        if self._client is not None:
+            await self._client.aclose()
+            self._client = None
+
+    async def add_blocks(self, model_name: str, block_hashes: List[int],
+                         pod_identifier: str, token_ids: Optional[List[int]] = None) -> bool:
+        if not block_hashes or not model_name or not pod_identifier:
+            return not block_hashes
+        if not token_ids:
+            return True
+
+        pairs = standardize_block_hashes(block_hashes, token_ids)
+        if pairs is None:
+            return False
+
+        timestamp = int(time.time())
+        model_blocks = self._blocks.setdefault(model_name, {})
+        std_hashes = []
+        for engine_hash, std_hash in pairs:
+            self.hash_mapping[engine_hash] = std_hash
+            model_blocks[std_hash] = timestamp
+            std_hashes.append(std_hash)
+
+        await self._push_to_all(pod_identifier, model_name, [{
+            "type": KV_EVENT_STORED,
+            "block_hashes": std_hashes,
+            "timestamp": timestamp,
+        }])
+        logger.info(
+            f"Runtime memory push - Model: {model_name}, Pod: {pod_identifier}, "
+            f"Count: {len(std_hashes)}")
+        return True
+
+    async def remove_blocks(self, model_name: str, block_hashes: List[int],
+                            pod_identifier: str) -> int:
+        if not block_hashes or not model_name or not pod_identifier:
+            return 0
+
+        model_blocks = self._blocks.get(model_name, {})
+        std_hashes = []
+        for engine_hash in block_hashes:
+            std_hash = self.hash_mapping.pop(engine_hash, None)
+            if std_hash is None:
+                continue
+            model_blocks.pop(std_hash, None)
+            std_hashes.append(std_hash)
+
+        if not std_hashes:
+            return 0
+
+        await self._push_to_all(pod_identifier, model_name, [{
+            "type": KV_EVENT_REMOVED,
+            "block_hashes": std_hashes,
+        }])
+        logger.info(
+            f"Removed {len(std_hashes)} blocks for model {model_name}, pod {pod_identifier}")
+        return len(std_hashes)
+
+    async def clear_all_blocks(self, model_name: str, pod_identifier: str) -> int:
+        if not model_name or not pod_identifier:
+            return 0
+
+        cleared = len(self._blocks.pop(model_name, {}))
+        self.hash_mapping.clear()
+
+        await self._push_to_all(pod_identifier, model_name, [{
+            "type": KV_EVENT_CLEARED,
+        }])
+        logger.info(
+            f"Cleared {cleared} blocks for model {model_name}, pod {pod_identifier}")
+        return cleared
+
+    async def push_snapshot(self, endpoint: str, pod_identifier: str) -> None:
+        """Send the full current block index to a single router endpoint.
+
+        Called when a router registers for the first time (or re-registers
+        after its previous registration expired) so it can rebuild its
+        in-memory index.
+        """
+        timestamp = int(time.time())
+        for model_name, model_blocks in self._blocks.items():
+            await self._push(endpoint, pod_identifier, model_name, [{
+                "type": KV_EVENT_SNAPSHOT,
+                "block_hashes": list(model_blocks.keys()),
+                "timestamp": timestamp,
+            }])
+        logger.info(f"Pushed KV snapshot to router endpoint {endpoint}")
+
+    async def _push_to_all(self, pod_identifier: str, model_name: str,
+                           events: List[dict]) -> None:
+        endpoints = self.registry.active_endpoints()
+        if not endpoints:
+            logger.debug("No routers registered, skipping KV event push")
+            return
+        await asyncio.gather(
+            *(self._push(endpoint, pod_identifier, model_name, events)
+              for endpoint in endpoints),
+            return_exceptions=True,
+        )
+
+    async def _push(self, endpoint: str, pod_identifier: str, model_name: str,
+                    events: List[dict]) -> None:
+        payload = {
+            "pod_identifier": pod_identifier,
+            "model_name": model_name,
+            "events": events,
+        }
+        try:
+            response = await self._get_client().post(
+                f"{endpoint}{KV_EVENTS_PATH}", json=payload)
+            response.raise_for_status()
+        except httpx.HTTPError as e:
+            logger.warning(f"Failed to push KV events to router {endpoint}: {e}")
+
+
+_memory_kv_manager: Optional[MemoryKVCacheManager] = None
+
+
+def get_memory_kv_manager() -> MemoryKVCacheManager:
+    global _memory_kv_manager
+    if _memory_kv_manager is None:
+        _memory_kv_manager = MemoryKVCacheManager()
+    return _memory_kv_manager

--- a/python/kthena/runtime/memory_kv_manager.py
+++ b/python/kthena/runtime/memory_kv_manager.py
@@ -41,6 +41,15 @@ class MemoryKVCacheManager:
     Implements the same interface as VLLMKVCacheRedisManager
     (add_blocks / remove_blocks / clear_all_blocks) so it can back
     VLLMKVCacheEventHandler and SGLangKVCacheEventHandler.
+
+    Unlike Redis mode, there is no shared, durable store here: every router
+    process keeps its own private in-memory copy of the index. In Redis mode
+    the sidecar writes each event once into Redis and can forget it, because
+    Redis itself is the authoritative state that any router — including one
+    that just (re)started or briefly lost connectivity — reads on demand. In
+    memory mode this class has to retain that authoritative state (_blocks)
+    itself, so it can replay it as a full snapshot to any router that starts
+    fresh, restarts, or missed a delta push.
     """
 
     def __init__(self, registry: Optional[RouterRegistry] = None,

--- a/python/kthena/runtime/memory_kv_manager.py
+++ b/python/kthena/runtime/memory_kv_manager.py
@@ -52,7 +52,27 @@ class MemoryKVCacheManager:
         self.hash_mapping: Dict[int, int] = {}
         # model name -> {std_hash: unix seconds when stored}, mirrors what has
         # been pushed so a newly registered router can receive a snapshot.
+        # Models stay present (with an empty dict) after being cleared so a
+        # snapshot can authoritatively represent an empty cache.
         self._blocks: Dict[str, Dict[int, int]] = {}
+        # Per-endpoint locks serializing snapshot and delta delivery so an
+        # older replace-style snapshot cannot erase a newer delta.
+        self._endpoint_locks: Dict[str, asyncio.Lock] = {}
+        # Endpoints whose last push failed; they receive a fresh snapshot on
+        # their next registration heartbeat instead of staying divergent.
+        self._dirty_endpoints: set = set()
+
+    def _endpoint_lock(self, endpoint: str) -> asyncio.Lock:
+        lock = self._endpoint_locks.get(endpoint)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._endpoint_locks[endpoint] = lock
+        return lock
+
+    def is_dirty(self, endpoint: str) -> bool:
+        """Whether the last push to this endpoint failed and its index may
+        have diverged, requiring a fresh snapshot."""
+        return endpoint in self._dirty_endpoints
 
     def _get_client(self) -> httpx.AsyncClient:
         if self._client is None:
@@ -123,7 +143,10 @@ class MemoryKVCacheManager:
         if not model_name or not pod_identifier:
             return 0
 
-        cleared = len(self._blocks.pop(model_name, {}))
+        cleared = len(self._blocks.get(model_name, {}))
+        # Keep the model key so later snapshots can still represent the empty
+        # cache for this model and remove stale router entries.
+        self._blocks[model_name] = {}
         self.hash_mapping.clear()
 
         await self._push_to_all(pod_identifier, model_name, [{
@@ -136,18 +159,34 @@ class MemoryKVCacheManager:
     async def push_snapshot(self, endpoint: str, pod_identifier: str) -> None:
         """Send the full current block index to a single router endpoint.
 
-        Called when a router registers for the first time (or re-registers
-        after its previous registration expired) so it can rebuild its
-        in-memory index.
+        Called when a router registers for the first time, re-registers after
+        its previous registration expired, or heartbeats while marked dirty
+        after a failed push, so it can rebuild its in-memory index.
+
+        The endpoint lock serializes the snapshot with concurrent delta
+        pushes: the snapshot payload is built while holding the lock, so it
+        reflects every mutation whose delta was already delivered and cannot
+        be overtaken by a newer delta it does not contain.
         """
-        timestamp = int(time.time())
-        for model_name, model_blocks in self._blocks.items():
-            await self._push(endpoint, pod_identifier, model_name, [{
-                "type": KV_EVENT_SNAPSHOT,
-                "block_hashes": list(model_blocks.keys()),
-                "timestamp": timestamp,
-            }])
-        logger.info(f"Pushed KV snapshot to router endpoint {endpoint}")
+        ok = True
+        async with self._endpoint_lock(endpoint):
+            for model_name, model_blocks in self._blocks.items():
+                # Preserve original per-block store times; re-stamping them at
+                # snapshot time would defeat the engine-restart freshness filter.
+                hashes = list(model_blocks.keys())
+                if not await self._push_locked(endpoint, pod_identifier, model_name, [{
+                    "type": KV_EVENT_SNAPSHOT,
+                    "block_hashes": hashes,
+                    "timestamps": [model_blocks[h] for h in hashes],
+                }]):
+                    ok = False
+        if ok:
+            self._dirty_endpoints.discard(endpoint)
+            logger.info(f"Pushed KV snapshot to router endpoint {endpoint}")
+        else:
+            logger.warning(
+                f"KV snapshot to router endpoint {endpoint} failed; will retry "
+                f"on its next registration heartbeat")
 
     async def _push_to_all(self, pod_identifier: str, model_name: str,
                            events: List[dict]) -> None:
@@ -158,11 +197,16 @@ class MemoryKVCacheManager:
         await asyncio.gather(
             *(self._push(endpoint, pod_identifier, model_name, events)
               for endpoint in endpoints),
-            return_exceptions=True,
         )
 
     async def _push(self, endpoint: str, pod_identifier: str, model_name: str,
-                    events: List[dict]) -> None:
+                    events: List[dict]) -> bool:
+        async with self._endpoint_lock(endpoint):
+            return await self._push_locked(
+                endpoint, pod_identifier, model_name, events)
+
+    async def _push_locked(self, endpoint: str, pod_identifier: str,
+                           model_name: str, events: List[dict]) -> bool:
         payload = {
             "pod_identifier": pod_identifier,
             "model_name": model_name,
@@ -172,8 +216,13 @@ class MemoryKVCacheManager:
             response = await self._get_client().post(
                 f"{endpoint}{KV_EVENTS_PATH}", json=payload)
             response.raise_for_status()
-        except httpx.HTTPError as e:
+            return True
+        except Exception as e:
+            # Mark the endpoint dirty so its next registration heartbeat
+            # triggers a full snapshot instead of leaving it divergent.
+            self._dirty_endpoints.add(endpoint)
             logger.warning(f"Failed to push KV events to router {endpoint}: {e}")
+            return False
 
 
 _memory_kv_manager: Optional[MemoryKVCacheManager] = None

--- a/python/kthena/runtime/router_registry.py
+++ b/python/kthena/runtime/router_registry.py
@@ -1,0 +1,104 @@
+# Copyright The Volcano Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import time
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_ROUTER_TTL_SECONDS = 90
+MAX_ROUTER_TTL_SECONDS = 3600
+
+
+def validate_router_endpoint(endpoint: str) -> bool:
+    """Only plain http/https URLs with a host are accepted as push targets."""
+    if not endpoint:
+        return False
+    try:
+        parsed = urlparse(endpoint)
+    except ValueError:
+        return False
+    return parsed.scheme in ("http", "https") and bool(parsed.hostname)
+
+
+@dataclass
+class RouterRegistration:
+    router_id: str
+    endpoint: str
+    expires_at: float
+
+
+class RouterRegistry:
+    """Tracks router instances registered for in-memory KV event push.
+
+    Routers re-register periodically (heartbeat); registrations that are not
+    renewed within their TTL are pruned and no longer receive events.
+    """
+
+    def __init__(self):
+        self._routers: Dict[str, RouterRegistration] = {}
+
+    def register(self, router_id: str, endpoint: str,
+                 ttl_seconds: int = DEFAULT_ROUTER_TTL_SECONDS) -> bool:
+        """Register or renew a router.
+
+        Returns True when the router needs a full snapshot: it is new, its
+        previous registration expired, or it re-registered with a new endpoint.
+        """
+        if not router_id:
+            raise ValueError("router_id must not be empty")
+        if not validate_router_endpoint(endpoint):
+            raise ValueError(f"invalid router endpoint: {endpoint!r}")
+
+        ttl = min(max(int(ttl_seconds), 1), MAX_ROUTER_TTL_SECONDS)
+        now = time.monotonic()
+        existing = self._routers.get(router_id)
+        needs_snapshot = (
+            existing is None
+            or existing.endpoint != endpoint
+            or existing.expires_at <= now
+        )
+        self._routers[router_id] = RouterRegistration(
+            router_id=router_id,
+            endpoint=endpoint.rstrip("/"),
+            expires_at=now + ttl,
+        )
+        if needs_snapshot:
+            logger.info(
+                f"Router registered: id={router_id}, endpoint={endpoint}, ttl={ttl}s")
+        return needs_snapshot
+
+    def active_endpoints(self) -> List[str]:
+        self._prune()
+        return [r.endpoint for r in self._routers.values()]
+
+    def _prune(self) -> None:
+        now = time.monotonic()
+        expired = [rid for rid, reg in self._routers.items() if reg.expires_at <= now]
+        for rid in expired:
+            logger.info(f"Router registration expired: id={rid}")
+            del self._routers[rid]
+
+
+_router_registry: Optional[RouterRegistry] = None
+
+
+def get_router_registry() -> RouterRegistry:
+    global _router_registry
+    if _router_registry is None:
+        _router_registry = RouterRegistry()
+    return _router_registry

--- a/python/kthena/runtime/router_registry.py
+++ b/python/kthena/runtime/router_registry.py
@@ -40,6 +40,9 @@ class RouterRegistration:
     router_id: str
     endpoint: str
     expires_at: float
+    # Identifies one router process; a restarted router container re-registers
+    # with a new generation even when its pod name (router_id) is unchanged.
+    generation: str = ""
 
 
 class RouterRegistry:
@@ -53,11 +56,14 @@ class RouterRegistry:
         self._routers: Dict[str, RouterRegistration] = {}
 
     def register(self, router_id: str, endpoint: str,
-                 ttl_seconds: int = DEFAULT_ROUTER_TTL_SECONDS) -> bool:
+                 ttl_seconds: int = DEFAULT_ROUTER_TTL_SECONDS,
+                 generation: str = "") -> bool:
         """Register or renew a router.
 
         Returns True when the router needs a full snapshot: it is new, its
-        previous registration expired, or it re-registered with a new endpoint.
+        previous registration expired, it re-registered with a new endpoint,
+        or it re-registered with a new process generation (e.g. after a
+        router container restart that lost the in-memory index).
         """
         if not router_id:
             raise ValueError("router_id must not be empty")
@@ -70,12 +76,14 @@ class RouterRegistry:
         needs_snapshot = (
             existing is None
             or existing.endpoint != endpoint
+            or existing.generation != generation
             or existing.expires_at <= now
         )
         self._routers[router_id] = RouterRegistration(
             router_id=router_id,
             endpoint=endpoint.rstrip("/"),
             expires_at=now + ttl,
+            generation=generation,
         )
         if needs_snapshot:
             logger.info(

--- a/python/kthena/runtime/zmq_subscriber.py
+++ b/python/kthena/runtime/zmq_subscriber.py
@@ -63,6 +63,39 @@ class KVEventBatch(EventBatch):
     events: list[Union[BlockStored, BlockRemoved, AllBlocksCleared]]
 
 
+# Newer vLLM releases encode events as tagged maps instead of arrays and may
+# use bytes (sha256) block hashes. Field sets are trimmed to what the runtime
+# consumes; msgspec ignores unknown map fields.
+class MapBlockStored(msgspec.Struct, omit_defaults=True, gc=False, tag="BlockStored"):
+    block_hashes: list[Union[int, bytes]]
+    parent_block_hash: Optional[Union[int, bytes]] = None
+    token_ids: list[int] = []
+    block_size: int = 0
+    lora_id: Optional[int] = None
+    medium: Optional[str] = None
+
+
+class MapBlockRemoved(msgspec.Struct, omit_defaults=True, gc=False, tag="BlockRemoved"):
+    block_hashes: list[Union[int, bytes]]
+    medium: Optional[str] = None
+
+
+class MapAllBlocksCleared(msgspec.Struct, omit_defaults=True, gc=False, tag="AllBlocksCleared"):
+    pass
+
+
+class MapKVEventBatch(EventBatch):
+    events: list[Union[MapBlockStored, MapBlockRemoved, MapAllBlocksCleared]]
+
+
+def normalize_engine_hash(block_hash: Union[int, bytes]) -> int:
+    """Map an engine block hash to an int key. Newer vLLM emits sha256 bytes;
+    the full digest is kept so distinct hashes stay distinct."""
+    if isinstance(block_hash, bytes):
+        return int.from_bytes(block_hash, byteorder='big')
+    return block_hash
+
+
 class VLLMZMQSubscriber:
 
     def __init__(self, pod_identifier: str, model_name: str):
@@ -72,6 +105,7 @@ class VLLMZMQSubscriber:
         self.running = False
         self.event_publisher = get_event_publisher()
         self.decoder = Decoder(type=KVEventBatch)
+        self.map_decoder = Decoder(type=MapKVEventBatch)
         self._connection_lock = asyncio.Lock()
         self._shutdown_event = asyncio.Event()
 
@@ -196,7 +230,11 @@ class VLLMZMQSubscriber:
             return
 
         try:
-            event_batch = self.decoder.decode(payload)
+            try:
+                event_batch = self.decoder.decode(payload)
+            except msgspec.ValidationError:
+                # Newer vLLM encodes events as tagged maps.
+                event_batch = self.map_decoder.decode(payload)
 
             if not event_batch or not hasattr(event_batch, 'events'):
                 logger.warning("Invalid event batch structure")
@@ -232,24 +270,26 @@ class VLLMZMQSubscriber:
             return
 
         try:
-            if isinstance(event, BlockStored):
+            if isinstance(event, (BlockStored, MapBlockStored)):
 
                 vllm_event = VLLMBlockStoredEvent(
-                    block_hashes=event.block_hashes,
-                    parent_block_hash=event.parent_block_hash,
+                    block_hashes=[normalize_engine_hash(h) for h in event.block_hashes],
+                    parent_block_hash=(
+                        normalize_engine_hash(event.parent_block_hash)
+                        if event.parent_block_hash is not None else None),
                     token_ids=event.token_ids,
                     block_size=event.block_size,
                     lora_id=event.lora_id
                 )
                 event_type = EventType.VLLM_BLOCK_STORED
 
-            elif isinstance(event, BlockRemoved):
+            elif isinstance(event, (BlockRemoved, MapBlockRemoved)):
                 vllm_event = VLLMBlockRemovedEvent(
-                    block_hashes=event.block_hashes
+                    block_hashes=[normalize_engine_hash(h) for h in event.block_hashes]
                 )
                 event_type = EventType.VLLM_BLOCK_REMOVED
 
-            elif isinstance(event, AllBlocksCleared):
+            elif isinstance(event, (AllBlocksCleared, MapAllBlocksCleared)):
                 vllm_event = VLLMAllBlocksClearedEvent()
                 event_type = EventType.VLLM_ALL_BLOCKS_CLEARED
 

--- a/python/kthena/tests/test_memory_kv_manager.py
+++ b/python/kthena/tests/test_memory_kv_manager.py
@@ -1,0 +1,189 @@
+# Copyright The Volcano Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from kthena.runtime.kv_cache_manager import compute_standardized_hash
+from kthena.runtime.memory_kv_manager import (
+    KV_EVENT_CLEARED,
+    KV_EVENT_REMOVED,
+    KV_EVENT_SNAPSHOT,
+    KV_EVENT_STORED,
+    KV_EVENTS_PATH,
+    MemoryKVCacheManager,
+)
+from kthena.runtime.router_registry import RouterRegistry
+
+
+def _make_manager(endpoints):
+    registry = RouterRegistry()
+    for i, endpoint in enumerate(endpoints):
+        registry.register(f"router-{i}", endpoint, ttl_seconds=60)
+
+    client = MagicMock()
+    response = MagicMock()
+    response.raise_for_status = MagicMock()
+    client.post = AsyncMock(return_value=response)
+    return MemoryKVCacheManager(registry=registry, client=client), client
+
+
+def _pushed_payloads(client):
+    return [(call.args[0], call.kwargs["json"]) for call in client.post.await_args_list]
+
+
+@pytest.mark.asyncio
+async def test_add_blocks_pushes_standardized_hashes_to_all_routers():
+    manager, client = _make_manager(
+        ["http://router-a:9080", "http://router-b:9080"])
+
+    token_ids = list(range(32))  # 2 blocks of 16
+    engine_hashes = [111, 222]
+    expected_std = [
+        compute_standardized_hash(token_ids[0:16]),
+        compute_standardized_hash(token_ids[16:32]),
+    ]
+
+    ok = await manager.add_blocks("qwen", engine_hashes, "pod-1.default", token_ids)
+    assert ok
+
+    payloads = _pushed_payloads(client)
+    assert len(payloads) == 2
+    urls = {url for url, _ in payloads}
+    assert urls == {
+        f"http://router-a:9080{KV_EVENTS_PATH}",
+        f"http://router-b:9080{KV_EVENTS_PATH}",
+    }
+    for _, payload in payloads:
+        assert payload["pod_identifier"] == "pod-1.default"
+        assert payload["model_name"] == "qwen"
+        assert len(payload["events"]) == 1
+        event = payload["events"][0]
+        assert event["type"] == KV_EVENT_STORED
+        assert event["block_hashes"] == expected_std
+        assert event["timestamp"] > 0
+
+    # engine -> std mapping is retained for later removals
+    assert manager.hash_mapping == {111: expected_std[0], 222: expected_std[1]}
+
+
+@pytest.mark.asyncio
+async def test_remove_blocks_uses_engine_hash_mapping():
+    manager, client = _make_manager(["http://router-a:9080"])
+    token_ids = list(range(16))
+    await manager.add_blocks("qwen", [111], "pod-1.default", token_ids)
+    client.post.reset_mock()
+
+    removed = await manager.remove_blocks("qwen", [111, 999], "pod-1.default")
+    assert removed == 1
+
+    payloads = _pushed_payloads(client)
+    assert len(payloads) == 1
+    event = payloads[0][1]["events"][0]
+    assert event["type"] == KV_EVENT_REMOVED
+    assert event["block_hashes"] == [compute_standardized_hash(token_ids)]
+    assert 111 not in manager.hash_mapping
+
+
+@pytest.mark.asyncio
+async def test_remove_blocks_without_mapping_pushes_nothing():
+    manager, client = _make_manager(["http://router-a:9080"])
+    removed = await manager.remove_blocks("qwen", [12345], "pod-1.default")
+    assert removed == 0
+    client.post.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_clear_all_blocks_pushes_cleared_event():
+    manager, client = _make_manager(["http://router-a:9080"])
+    await manager.add_blocks("qwen", [111], "pod-1.default", list(range(16)))
+    client.post.reset_mock()
+
+    cleared = await manager.clear_all_blocks("qwen", "pod-1.default")
+    assert cleared == 1
+
+    payloads = _pushed_payloads(client)
+    assert payloads[0][1]["events"][0]["type"] == KV_EVENT_CLEARED
+    assert manager.hash_mapping == {}
+
+
+@pytest.mark.asyncio
+async def test_push_snapshot_sends_full_index_to_single_router():
+    manager, client = _make_manager(["http://router-a:9080"])
+    token_ids = list(range(32))
+    await manager.add_blocks("qwen", [111, 222], "pod-1.default", token_ids)
+    client.post.reset_mock()
+
+    await manager.push_snapshot("http://router-new:9080", "pod-1.default")
+
+    payloads = _pushed_payloads(client)
+    assert len(payloads) == 1
+    url, payload = payloads[0]
+    assert url == f"http://router-new:9080{KV_EVENTS_PATH}"
+    event = payload["events"][0]
+    assert event["type"] == KV_EVENT_SNAPSHOT
+    assert sorted(event["block_hashes"]) == sorted([
+        compute_standardized_hash(token_ids[0:16]),
+        compute_standardized_hash(token_ids[16:32]),
+    ])
+
+
+@pytest.mark.asyncio
+async def test_no_registered_routers_skips_push():
+    manager, client = _make_manager([])
+    ok = await manager.add_blocks("qwen", [111], "pod-1.default", list(range(16)))
+    assert ok
+    client.post.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_add_blocks_with_mismatched_tokens_fails():
+    manager, client = _make_manager(["http://router-a:9080"])
+    # 10 tokens cannot be split evenly across 3 hashes
+    ok = await manager.add_blocks("qwen", [1, 2, 3], "pod-1.default", list(range(10)))
+    assert not ok
+    client.post.assert_not_awaited()
+
+
+def test_router_registry_register_and_expire(monkeypatch):
+    registry = RouterRegistry()
+    clock = {"now": 1000.0}
+    monkeypatch.setattr(
+        "kthena.runtime.router_registry.time.monotonic", lambda: clock["now"])
+
+    # New registration needs a snapshot.
+    assert registry.register("router-a", "http://10.0.0.5:9080", ttl_seconds=60)
+    # Renewal before expiry does not.
+    clock["now"] += 30
+    assert not registry.register("router-a", "http://10.0.0.5:9080", ttl_seconds=60)
+    assert registry.active_endpoints() == ["http://10.0.0.5:9080"]
+
+    # Changing the endpoint triggers a snapshot again.
+    assert registry.register("router-a", "http://10.0.0.6:9080", ttl_seconds=60)
+
+    # Expired registrations are pruned and re-registration needs a snapshot.
+    clock["now"] += 120
+    assert registry.active_endpoints() == []
+    assert registry.register("router-a", "http://10.0.0.6:9080", ttl_seconds=60)
+
+
+def test_router_registry_rejects_invalid_input():
+    registry = RouterRegistry()
+    with pytest.raises(ValueError):
+        registry.register("", "http://10.0.0.5:9080")
+    with pytest.raises(ValueError):
+        registry.register("router-a", "ftp://10.0.0.5:9080")
+    with pytest.raises(ValueError):
+        registry.register("router-a", "not-a-url")

--- a/python/kthena/tests/test_memory_kv_manager.py
+++ b/python/kthena/tests/test_memory_kv_manager.py
@@ -138,6 +138,50 @@ async def test_push_snapshot_sends_full_index_to_single_router():
         compute_standardized_hash(token_ids[0:16]),
         compute_standardized_hash(token_ids[16:32]),
     ])
+    # Snapshots must preserve the original per-block store times so the
+    # router's engine-restart freshness filter keeps working.
+    stored = manager._blocks["qwen"]
+    assert event["timestamps"] == [stored[h] for h in event["block_hashes"]]
+
+
+@pytest.mark.asyncio
+async def test_push_snapshot_represents_cleared_model_as_empty():
+    manager, client = _make_manager(["http://router-a:9080"])
+    await manager.add_blocks("qwen", [111], "pod-1.default", list(range(16)))
+    await manager.clear_all_blocks("qwen", "pod-1.default")
+    client.post.reset_mock()
+
+    await manager.push_snapshot("http://router-new:9080", "pod-1.default")
+
+    payloads = _pushed_payloads(client)
+    assert len(payloads) == 1
+    event = payloads[0][1]["events"][0]
+    assert event["type"] == KV_EVENT_SNAPSHOT
+    assert event["block_hashes"] == []
+
+
+@pytest.mark.asyncio
+async def test_failed_push_marks_endpoint_dirty_until_snapshot_succeeds():
+    manager, client = _make_manager(["http://router-a:9080"])
+    client.post.side_effect = RuntimeError("connection refused")
+
+    await manager.add_blocks("qwen", [111], "pod-1.default", list(range(16)))
+    assert manager.is_dirty("http://router-a:9080")
+
+    # A successful snapshot reconciles the endpoint and clears dirty state.
+    client.post.side_effect = None
+    await manager.push_snapshot("http://router-a:9080", "pod-1.default")
+    assert not manager.is_dirty("http://router-a:9080")
+
+
+@pytest.mark.asyncio
+async def test_failed_snapshot_keeps_endpoint_dirty():
+    manager, client = _make_manager(["http://router-a:9080"])
+    await manager.add_blocks("qwen", [111], "pod-1.default", list(range(16)))
+    client.post.side_effect = RuntimeError("connection refused")
+
+    await manager.push_snapshot("http://router-a:9080", "pod-1.default")
+    assert manager.is_dirty("http://router-a:9080")
 
 
 @pytest.mark.asyncio
@@ -177,6 +221,15 @@ def test_router_registry_register_and_expire(monkeypatch):
     clock["now"] += 120
     assert registry.active_endpoints() == []
     assert registry.register("router-a", "http://10.0.0.6:9080", ttl_seconds=60)
+
+    # A new process generation (router container restart with the same pod
+    # name and endpoint) triggers a snapshot again.
+    assert not registry.register(
+        "router-a", "http://10.0.0.6:9080", ttl_seconds=60)
+    assert registry.register(
+        "router-a", "http://10.0.0.6:9080", ttl_seconds=60, generation="gen-2")
+    assert not registry.register(
+        "router-a", "http://10.0.0.6:9080", ttl_seconds=60, generation="gen-2")
 
 
 def test_router_registry_rejects_invalid_input():

--- a/python/kthena/tests/test_sglang_kv_cache_handler.py
+++ b/python/kthena/tests/test_sglang_kv_cache_handler.py
@@ -86,7 +86,7 @@ async def test_block_stored_writes_matrix_and_mapping_keys():
     pipeline = _FakePipeline()
     redis_client = _make_redis_client(pipeline)
     manager = SGLangKVCacheRedisManager(redis_client=redis_client)
-    handler = SGLangKVCacheEventHandler(redis_manager=manager)
+    handler = SGLangKVCacheEventHandler(kv_manager=manager)
 
     token_ids = list(range(32))  # 2 blocks of 16
     sglang_block_hashes = [111, 222]
@@ -140,7 +140,7 @@ async def test_block_removed_uses_in_memory_mapping():
     manager.hash_mapping[111] = 999
     manager.hash_mapping[222] = 888
 
-    handler = SGLangKVCacheEventHandler(redis_manager=manager)
+    handler = SGLangKVCacheEventHandler(kv_manager=manager)
     event_data = SGLangEventData(
         event_type=EventType.SGLANG_BLOCK_REMOVED,
         timestamp=datetime.now(timezone.utc),
@@ -181,7 +181,7 @@ async def test_all_blocks_cleared_clears_pod_from_matrix():
     redis_client.scan_keys = AsyncMock(side_effect=[matrix_keys, mapping_keys])
 
     manager = SGLangKVCacheRedisManager(redis_client=redis_client)
-    handler = SGLangKVCacheEventHandler(redis_manager=manager)
+    handler = SGLangKVCacheEventHandler(kv_manager=manager)
     event_data = SGLangEventData(
         event_type=EventType.SGLANG_ALL_BLOCKS_CLEARED,
         timestamp=datetime.now(timezone.utc),

--- a/python/kthena/tests/test_zmq_subscriber.py
+++ b/python/kthena/tests/test_zmq_subscriber.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from dataclasses import replace
 
+import msgspec
 import pytest
 
 from kthena.runtime import zmq_subscriber
@@ -66,3 +67,77 @@ async def test_vllm_subscriber_honors_configured_topic_filter(monkeypatch):
     await sub._run_subscriber()
 
     assert processed_payloads == [b"right"]
+
+
+class _CapturePublisher:
+    def __init__(self):
+        self.events = []
+
+    async def publish(self, event_data):
+        self.events.append(event_data)
+
+
+@pytest.mark.asyncio
+async def test_process_message_decodes_legacy_array_format():
+    sub = VLLMZMQSubscriber(pod_identifier="pod-a", model_name="m")
+    publisher = _CapturePublisher()
+    sub.event_publisher = publisher
+
+    payload = msgspec.msgpack.encode(
+        zmq_subscriber.KVEventBatch(
+            ts=1.0,
+            events=[
+                zmq_subscriber.BlockStored(
+                    block_hashes=[123, 456],
+                    parent_block_hash=None,
+                    token_ids=[1, 2, 3, 4],
+                    block_size=2,
+                    lora_id=None,
+                )
+            ],
+        )
+    )
+
+    await sub._process_message(payload, "pod-a", "m")
+
+    assert len(publisher.events) == 1
+    assert publisher.events[0].vllm_event.block_hashes == [123, 456]
+
+
+@pytest.mark.asyncio
+async def test_process_message_decodes_new_map_format_with_bytes_hashes():
+    sub = VLLMZMQSubscriber(pod_identifier="pod-a", model_name="m")
+    publisher = _CapturePublisher()
+    sub.event_publisher = publisher
+
+    digest = bytes(range(32))
+    # Newer vLLM: EventBatch is still an array, but each event is a tagged map
+    # with sha256 bytes block hashes and extra fields the runtime must ignore.
+    raw_batch = [
+        2.0,
+        [
+            {
+                "type": "BlockStored",
+                "block_hashes": [digest],
+                "parent_block_hash": None,
+                "token_ids": [1, 2],
+                "block_size": 2,
+                "lora_id": None,
+                "medium": "GPU",
+                "lora_name": None,
+                "kv_cache_spec_kind": "full_attention",
+            },
+            {"type": "BlockRemoved", "block_hashes": [digest], "medium": "GPU"},
+            {"type": "AllBlocksCleared"},
+        ],
+        None,
+    ]
+    payload = msgspec.msgpack.encode(raw_batch)
+
+    await sub._process_message(payload, "pod-a", "m")
+
+    assert len(publisher.events) == 3
+    expected_hash = int.from_bytes(digest, byteorder="big")
+    assert publisher.events[0].vllm_event.block_hashes == [expected_hash]
+    assert publisher.events[0].vllm_event.token_ids == [1, 2]
+    assert publisher.events[1].vllm_event.block_hashes == [expected_hash]


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Adds an **in-memory KV cache index** to the `kvcache-aware` score plugin as an alternative to the existing Redis-based index, selectable via a new `indexMode` plugin parameter (`redis`, default, unchanged behavior | `memory`).

Motivation: the Redis-based index adds an external dependency and a network hop on the scoring path. For deployments that don't want to operate Redis, the router can now hold the block-hash index in memory and have runtime sidecars push KV events to it directly.

Design overview:

- **Router side (Go)**:
  - `kvcache_memory_index.go`: in-memory block-hash index keyed by (model, block hash) → pod set, updated by KV events (`stored` / `removed` / `cleared` / `snapshot`) received on a new `POST /kvcache/events` endpoint (`kvEventsPort`).
  - `kvcache_registration.go`: the router periodically registers itself with each runtime sidecar (`POST /kvcache/routers/register` on `runtimePort`, default 9000) with a TTL, so sidecars know which routers to push events to; registrations expire if the router goes away.
  - `kvcache_aware.go`: scoring path now consults either the Redis index or the memory index depending on `indexMode`.
- **Runtime side (Python)**:
  - `memory_kv_manager.py`: `MemoryKVCacheManager` implements the same interface as the Redis manager (`add_blocks` / `remove_blocks` / `clear_all_blocks`) but pushes standardized block hashes to all registered routers; on new router registration a full `snapshot` is pushed.
  - `router_registry.py`: TTL-based registry of routers with endpoint validation.
- Also included:
  - runtime: support the new vLLM KV event wire format (tagged-map events, bytes block hashes) in the ZMQ subscriber.
  - docs: `kvcache-aware` must be paired with another score plugin; user-guide updates for the new parameters.

**Which issue(s) this PR fixes**:

N/A

**Bug evidence (required for bug-related PRs)**:

N/A

**Special notes for your reviewer**:

Marked as WIP / draft. Remaining items before it's ready for review:

- [ ] E2E validation of the memory mode in a real cluster (vLLM + runtime sidecar)
- [ ] Behavior on router restart (index rebuild via snapshot push) needs more testing
- [ ] Metrics for the memory index and push path

Feedback on the overall approach (push-based index + router registration with TTL) is welcome at this stage.

**Does this PR introduce a user-facing change?**:

```release-note
kvcache-aware plugin supports a new `indexMode: memory` that keeps the KV block index in router memory, removing the Redis dependency; `indexMode: redis` remains the default.
```
