### PR TITLE
api: deprecate the ModelBooster API

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -88,6 +88,10 @@ issues:
         - maligned
     - path: _test\.go$
       text: "dot-imports: should not use dot imports"
+    # ModelBooster remains supported by the controller and CLI throughout its deprecation period.
+    - linters:
+        - staticcheck
+      text: "SA1019: .* is deprecated: ModelBooster is deprecated as of Kthena v1.1"
     # We need to use the deprecated module since the jsonpb replacement is not backwards compatible.
     - linters:
         - staticcheck

--- a/charts/kthena/charts/workload/crds/workload.serving.volcano.sh_modelboosters.yaml
+++ b/charts/kthena/charts/workload/crds/workload.serving.volcano.sh_modelboosters.yaml
@@ -25,7 +25,12 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ModelBooster is the Schema for the models API.
+        description: |-
+          ModelBooster is the Schema for the models API.
+
+          Deprecated: ModelBooster is deprecated as of Kthena v1.1.
+          Use ModelServing, ModelServer, and ModelRoute instead.
+          ModelBooster will be removed no earlier than Kthena v1.5.
         properties:
           apiVersion:
             description: |-
@@ -45,7 +50,12 @@ spec:
           metadata:
             type: object
           spec:
-            description: ModelBoosterSpec defines the desired state of ModelBooster.
+            description: |-
+              ModelBoosterSpec defines the desired state of ModelBooster.
+
+              Deprecated: ModelBooster is deprecated as of Kthena v1.1.
+              Use ModelServing, ModelServer, and ModelRoute instead.
+              ModelBooster will be removed no earlier than Kthena v1.5.
             properties:
               backend:
                 description: |-
@@ -339,7 +349,12 @@ spec:
                     description: Workers is the list of workers associated with this
                       backend.
                     items:
-                      description: ModelWorker defines the model worker configuration.
+                      description: |-
+                        ModelWorker defines the model worker configuration.
+
+                        Deprecated: ModelBooster is deprecated as of Kthena v1.1.
+                        Use ModelServing, ModelServer, and ModelRoute instead.
+                        ModelBooster will be removed no earlier than Kthena v1.5.
                       properties:
                         affinity:
                           description: Affinity specifies the affinity rules for scheduling
@@ -1469,7 +1484,12 @@ spec:
             - backend
             type: object
           status:
-            description: ModelStatus defines the observed state of ModelBooster.
+            description: |-
+              ModelStatus defines the observed state of ModelBooster.
+
+              Deprecated: ModelBooster is deprecated as of Kthena v1.1.
+              Use ModelServing, ModelServer, and ModelRoute instead.
+              ModelBooster will be removed no earlier than Kthena v1.5.
             properties:
               conditions:
                 description: Conditions represents the latest available observations

--- a/docs/kthena/docs/reference/crd/workload.serving.volcano.sh.md
+++ b/docs/kthena/docs/reference/crd/workload.serving.volcano.sh.md
@@ -405,6 +405,10 @@ _Appears in:_
 
 ModelBackend defines the configuration for a model backend.
 
+Deprecated: ModelBooster is deprecated as of Kthena v1.1.
+Use ModelServing, ModelServer, and ModelRoute instead.
+ModelBooster will be removed no earlier than Kthena v1.5.
+
 
 
 _Appears in:_
@@ -430,6 +434,10 @@ _Underlying type:_ _string_
 
 ModelBackendType defines the type of model backend.
 
+Deprecated: ModelBooster is deprecated as of Kthena v1.1.
+Use ModelServing, ModelServer, and ModelRoute instead.
+ModelBooster will be removed no earlier than Kthena v1.5.
+
 _Validation:_
 - Enum: [vLLM vLLMDisaggregated]
 
@@ -451,6 +459,10 @@ _Appears in:_
 
 ModelBooster is the Schema for the models API.
 
+Deprecated: ModelBooster is deprecated as of Kthena v1.1.
+Use ModelServing, ModelServer, and ModelRoute instead.
+ModelBooster will be removed no earlier than Kthena v1.5.
+
 
 
 _Appears in:_
@@ -470,6 +482,10 @@ _Appears in:_
 
 ModelBoosterList contains a list of ModelBooster.
 
+Deprecated: ModelBooster is deprecated as of Kthena v1.1.
+Use ModelServing, ModelServer, and ModelRoute instead.
+ModelBooster will be removed no earlier than Kthena v1.5.
+
 
 
 
@@ -486,6 +502,10 @@ ModelBoosterList contains a list of ModelBooster.
 
 
 ModelBoosterSpec defines the desired state of ModelBooster.
+
+Deprecated: ModelBooster is deprecated as of Kthena v1.1.
+Use ModelServing, ModelServer, and ModelRoute instead.
+ModelBooster will be removed no earlier than Kthena v1.5.
 
 
 
@@ -590,6 +610,10 @@ _Appears in:_
 
 ModelStatus defines the observed state of ModelBooster.
 
+Deprecated: ModelBooster is deprecated as of Kthena v1.1.
+Use ModelServing, ModelServer, and ModelRoute instead.
+ModelBooster will be removed no earlier than Kthena v1.5.
+
 
 
 _Appears in:_
@@ -607,6 +631,10 @@ _Appears in:_
 
 
 ModelWorker defines the model worker configuration.
+
+Deprecated: ModelBooster is deprecated as of Kthena v1.1.
+Use ModelServing, ModelServer, and ModelRoute instead.
+ModelBooster will be removed no earlier than Kthena v1.5.
 
 
 
@@ -630,6 +658,10 @@ _Appears in:_
 _Underlying type:_ _string_
 
 ModelWorkerType defines the type of model worker.
+
+Deprecated: ModelBooster is deprecated as of Kthena v1.1.
+Use ModelServing, ModelServer, and ModelRoute instead.
+ModelBooster will be removed no earlier than Kthena v1.5.
 
 _Validation:_
 - Enum: [server prefill decode controller coordinator]

--- a/pkg/apis/workload/v1alpha1/model_booster_types.go
+++ b/pkg/apis/workload/v1alpha1/model_booster_types.go
@@ -24,6 +24,10 @@ import (
 )
 
 // ModelBoosterSpec defines the desired state of ModelBooster.
+//
+// Deprecated: ModelBooster is deprecated as of Kthena v1.1.
+// Use ModelServing, ModelServer, and ModelRoute instead.
+// ModelBooster will be removed no earlier than Kthena v1.5.
 type ModelBoosterSpec struct {
 	// Name is the name of the model. ModelBooster CR name is restricted by kubernetes, for example, can't contain uppercase letters.
 	// So we use this field to specify the ModelBooster name.
@@ -45,6 +49,10 @@ type ModelBoosterSpec struct {
 }
 
 // ModelBackend defines the configuration for a model backend.
+//
+// Deprecated: ModelBooster is deprecated as of Kthena v1.1.
+// Use ModelServing, ModelServer, and ModelRoute instead.
+// ModelBooster will be removed no earlier than Kthena v1.5.
 type ModelBackend struct {
 	// Name is the name of the backend. Can't duplicate with other ModelBackend name in the same ModelBooster CR.
 	// Note: update name will cause the old ModelServing deletion and a new ModelServing creation.
@@ -122,6 +130,10 @@ type ModelBackend struct {
 }
 
 // ModelBackendType defines the type of model backend.
+//
+// Deprecated: ModelBooster is deprecated as of Kthena v1.1.
+// Use ModelServing, ModelServer, and ModelRoute instead.
+// ModelBooster will be removed no earlier than Kthena v1.5.
 // +kubebuilder:validation:Enum=vLLM;vLLMDisaggregated
 type ModelBackendType string
 
@@ -139,6 +151,10 @@ const (
 )
 
 // ModelWorker defines the model worker configuration.
+//
+// Deprecated: ModelBooster is deprecated as of Kthena v1.1.
+// Use ModelServing, ModelServer, and ModelRoute instead.
+// ModelBooster will be removed no earlier than Kthena v1.5.
 type ModelWorker struct {
 	// Type is the type of the model worker.
 	// +kubebuilder:default=server
@@ -170,6 +186,10 @@ type ModelWorker struct {
 }
 
 // ModelWorkerType defines the type of model worker.
+//
+// Deprecated: ModelBooster is deprecated as of Kthena v1.1.
+// Use ModelServing, ModelServer, and ModelRoute instead.
+// ModelBooster will be removed no earlier than Kthena v1.5.
 // +kubebuilder:validation:Enum=server;prefill;decode;controller;coordinator
 type ModelWorkerType string
 
@@ -187,6 +207,10 @@ const (
 )
 
 // ModelStatus defines the observed state of ModelBooster.
+//
+// Deprecated: ModelBooster is deprecated as of Kthena v1.1.
+// Use ModelServing, ModelServer, and ModelRoute instead.
+// ModelBooster will be removed no earlier than Kthena v1.5.
 type ModelStatus struct {
 	// Conditions represents the latest available observations of the model's state.
 	// +listType=map
@@ -197,6 +221,11 @@ type ModelStatus struct {
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
+// ModelStatusConditionType defines a condition type reported by ModelBooster.
+//
+// Deprecated: ModelBooster is deprecated as of Kthena v1.1.
+// Use ModelServing, ModelServer, and ModelRoute instead.
+// ModelBooster will be removed no earlier than Kthena v1.5.
 type ModelStatusConditionType string
 
 const (
@@ -213,6 +242,10 @@ const (
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // ModelBooster is the Schema for the models API.
+//
+// Deprecated: ModelBooster is deprecated as of Kthena v1.1.
+// Use ModelServing, ModelServer, and ModelRoute instead.
+// ModelBooster will be removed no earlier than Kthena v1.5.
 type ModelBooster struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -224,6 +257,10 @@ type ModelBooster struct {
 // +kubebuilder:object:root=true
 
 // ModelBoosterList contains a list of ModelBooster.
+//
+// Deprecated: ModelBooster is deprecated as of Kthena v1.1.
+// Use ModelServing, ModelServer, and ModelRoute instead.
+// ModelBooster will be removed no earlier than Kthena v1.5.
 type ModelBoosterList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:
Marks the ModelBooster API and its supporting exported types as deprecated as of Kthena v1.1.
The deprecation notice recommends ModelServing, ModelServer, and ModelRoute as replacements and states that ModelBooster will not be removed before Kthena v1.5.

**Which issue(s) this PR fixes**:
Fixes #1706

**Bug evidence (required for bug-related PRs)**:
<!--
For a bug-related PR, provide evidence from the production path:
- Include the relevant workload configuration and logs or events.
- For a panic, include the complete panic trace.
- Describe the user action or cluster event that triggers the problem and how the
  change fixes it.
- Use source permalinks that point to the exact commit when citing code.

AI-generated analysis, a static scan, or a unit test that only calls an internal
function does not prove a bug on its own. If the reported bug relies solely on AI
analysis without reproduction instructions or production-path evidence, maintainers
may close the issue and the related PR.

Write "N/A" for PRs that are not bug-related.
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
 ModelBooster is deprecated as of Kthena v1.1 and will be removed no earlier than v1.5. Use ModelServing, ModelServer, and ModelRoute instead.

```
