### PR TITLE
test(model-serving-controller): cover getMetaObject tombstone and non-object paths

### DIFF
--- a/pkg/model-serving-controller/controller/model_serving_controller_test.go
+++ b/pkg/model-serving-controller/controller/model_serving_controller_test.go
@@ -492,6 +492,52 @@ func TestIsServingGroupOutdatedOnIndexerError(t *testing.T) {
 	assert.False(t, result, "should return false on indexer error to avoid spurious deletion")
 }
 
+// TestGetMetaObject tests the getMetaObject helper for raw objects, tombstones, and invalid inputs.
+func TestGetMetaObject(t *testing.T) {
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "pod-0"}}
+
+	tests := []struct {
+		name     string
+		obj      interface{}
+		wantName string
+	}{
+		{
+			name:     "raw object",
+			obj:      pod,
+			wantName: "pod-0",
+		},
+		{
+			name:     "tombstone with object",
+			obj:      cache.DeletedFinalStateUnknown{Key: "default/pod-0", Obj: pod},
+			wantName: "pod-0",
+		},
+		{
+			name: "tombstone with non-object",
+			obj:  cache.DeletedFinalStateUnknown{Key: "default/pod-0", Obj: "not-an-object"},
+		},
+		{
+			name: "unexpected type",
+			obj:  "not-an-object",
+		},
+		{
+			name: "nil",
+			obj:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getMetaObject(tt.obj)
+			if tt.wantName == "" {
+				assert.Nil(t, got)
+				return
+			}
+			require.NotNil(t, got)
+			assert.Equal(t, tt.wantName, got.GetName())
+		})
+	}
+}
+
 func TestCheckServingGroupReady(t *testing.T) {
 	tests := []struct {
 		name          string


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Adds unit test coverage for the `getMetaObject` helper in the ModelServing controller.

`getMetaObject` is used by the Pod, Service, and PodGroup informer `FilterFunc`s to safely extract a `metav1.Object` from informer events. The existing tests only covered the direct `metav1.Object` case, leaving the `cache.DeletedFinalStateUnknown` tombstone and invalid-input paths uncovered.

This PR adds a table-driven `TestGetMetaObject` covering:

- Direct `metav1.Object`
- `cache.DeletedFinalStateUnknown` containing a `metav1.Object`
- Tombstone containing a non-object
- Unexpected/foreign object type
- `nil`

The tombstone case is particularly important because a regression in this path could cause delete events to be ignored during informer relists, preventing the associated cleanup/reconciliation from being triggered.

No production code or API/CRD behavior is changed.

**Which issue(s) this PR fixes**:

Fixes #1722 

**Bug evidence (required for bug-related PRs)**:

N/A — this is a test-only cleanup/coverage improvement.

**Special notes for your reviewer**:

- Test-only change; no production code modified.
- `getMetaObject` coverage increases from 33.3% to 100%.
- The test was verified against a naive type-assertion-only implementation and correctly fails for the tombstone case.
- All existing ModelServing controller tests pass.
- Full ModelServing controller package tests pass.
- `go build ./...`, `go vet`, `gofmt`, `goimports`, and golangci-lint pass.

**Does this PR introduce a user-facing change?**:

No.

```release-note
NONE