### PR TITLE
fix(router): honor ModelServer trafficPolicy retry

### DIFF
--- a/pkg/kthena-router/router/router.go
+++ b/pkg/kthena-router/router/router.go
@@ -679,7 +679,8 @@ func (r *Router) doLoadbalance(c *gin.Context, modelRequest ModelRequest) error 
 
 	req := c.Request
 	upstreamTimeout := upstreamTimeoutFor(modelServer)
-	if err := r.proxyModelEndpoint(c, req, ctx, modelRequest, port, upstreamTimeout); err != nil {
+	retry := retryPolicyFor(modelServer)
+	if err := r.proxyModelEndpoint(c, req, ctx, modelRequest, port, upstreamTimeout, retry); err != nil {
 		klog.Errorf("request failed reqID: %s: %v", c.Request.Header.Get("x-request-id"), err)
 		accesslog.SetError(c, "proxy", "request processing failed")
 		if !c.Writer.Written() {
@@ -696,6 +697,25 @@ func upstreamTimeoutFor(ms *v1alpha1.ModelServer) time.Duration {
 		return 0
 	}
 	return ms.Spec.TrafficPolicy.Timeout.Duration
+}
+
+// retryPolicy holds the ModelServer trafficPolicy.retry settings for one request.
+type retryPolicy struct {
+	attempts int
+	interval time.Duration
+}
+
+// retryPolicyFor returns the retry policy configured on the ModelServer. A
+// non-positive attempts leaves the candidate list as the only bound.
+func retryPolicyFor(ms *v1alpha1.ModelServer) retryPolicy {
+	if ms == nil || ms.Spec.TrafficPolicy == nil || ms.Spec.TrafficPolicy.Retry == nil {
+		return retryPolicy{}
+	}
+	policy := retryPolicy{attempts: int(ms.Spec.TrafficPolicy.Retry.Attempts)}
+	if interval := ms.Spec.TrafficPolicy.Retry.RetryInterval; interval != nil {
+		policy.interval = interval.Duration
+	}
+	return policy
 }
 
 func ParseModelRequest(c *gin.Context) (ModelRequest, error) {
@@ -837,6 +857,7 @@ func (r *Router) proxy(
 	stream bool,
 	port int32,
 	timeout time.Duration,
+	retry retryPolicy,
 	onUsage func(u providers.TokenUsage),
 ) error {
 	// Capture body bytes once so each retry attempt gets a fresh reader.
@@ -853,6 +874,18 @@ func (r *Router) proxy(
 	}
 
 	for i := 0; i < len(ctx.BestPods); i++ {
+		if retry.attempts > 0 && i >= retry.attempts {
+			break
+		}
+		// Every iteration past the first follows a failed attempt, so this is
+		// the gap between retries rather than a delay on the first request.
+		if i > 0 && retry.interval > 0 {
+			select {
+			case <-time.After(retry.interval):
+			case <-c.Request.Context().Done():
+				return c.Request.Context().Err()
+			}
+		}
 		req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
 		accesslog.SetUpstreamInfo(c, 0, i+1)
 		pod := ctx.BestPods[i]
@@ -899,6 +932,7 @@ func (r *Router) proxyModelEndpoint(
 	modelRequest ModelRequest,
 	port int32,
 	timeout time.Duration,
+	retry retryPolicy,
 ) error {
 	// Mark start of upstream processing
 	accesslog.MarkUpstreamStart(c)
@@ -918,7 +952,7 @@ func (r *Router) proxyModelEndpoint(
 		stream := isStreaming(modelRequest)
 		modelName := ctx.Model
 		userID := c.GetString(common.UserIdKey)
-		err := r.proxy(c, decodeRequest, ctx, stream, port, timeout, func(usage providers.TokenUsage) {
+		err := r.proxy(c, decodeRequest, ctx, stream, port, timeout, retry, func(usage providers.TokenUsage) {
 			if usage.TotalTokens <= 0 {
 				return
 			}
@@ -955,7 +989,7 @@ func (r *Router) proxyModelEndpoint(
 	}
 
 	// PD disaggregated mode - use KV connector
-	return r.proxyToPDDisaggregated(c, req, ctx, kvConnector, modelRequest, port, timeout)
+	return r.proxyToPDDisaggregated(c, req, ctx, kvConnector, modelRequest, port, timeout, retry)
 }
 
 func (r *Router) proxyExternalProvider(
@@ -1399,6 +1433,7 @@ func (r *Router) proxyToPDDisaggregated(
 	modelRequest ModelRequest,
 	port int32,
 	timeout time.Duration,
+	retry retryPolicy,
 ) error {
 	// Get metrics recorder from context
 	var metricsRecorder *metrics.RequestMetricsRecorder
@@ -1414,10 +1449,24 @@ func (r *Router) proxyToPDDisaggregated(
 		maxRetry = len(ctx.PrefillPods)
 	}
 
+	attempted := 0
 	for i := 0; i < maxRetry; i++ {
 		if ctx.PrefillPods[i] == nil || ctx.DecodePods[i] == nil {
 			continue
 		}
+		if retry.attempts > 0 && attempted >= retry.attempts {
+			break
+		}
+		// Every attempt past the first follows a failed pair, so this is the gap
+		// between retries rather than a delay on the first request.
+		if attempted > 0 && retry.interval > 0 {
+			select {
+			case <-time.After(retry.interval):
+			case <-c.Request.Context().Done():
+				return c.Request.Context().Err()
+			}
+		}
+		attempted++
 		prefillPod := ctx.PrefillPods[i].GetPod()
 		decodePod := ctx.DecodePods[i].GetPod()
 		accesslog.SetUpstreamInfo(c, 0, i+1)

--- a/pkg/kthena-router/router/router_test.go
+++ b/pkg/kthena-router/router/router_test.go
@@ -30,6 +30,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -1926,6 +1927,240 @@ func TestRouter_HandlerFunc_BackendUnavailable(t *testing.T) {
 	}
 }
 
+func TestRouter_HandlerFunc_TrafficPolicyRetry(t *testing.T) {
+	tests := []struct {
+		name         string
+		pods         int
+		retry        *aiv1alpha1.Retry
+		expectedHits int
+		expectGap    time.Duration
+	}{
+		{
+			name:         "no retry policy walks every candidate pod",
+			pods:         3,
+			expectedHits: 3,
+		},
+		{
+			name:         "attempts caps the number of pods tried",
+			pods:         5,
+			retry:        &aiv1alpha1.Retry{Attempts: 2},
+			expectedHits: 2,
+		},
+		{
+			name:         "attempts above the candidate count does not add attempts",
+			pods:         2,
+			retry:        &aiv1alpha1.Retry{Attempts: 10},
+			expectedHits: 2,
+		},
+		{
+			name:         "retryInterval separates attempts",
+			pods:         3,
+			retry:        &aiv1alpha1.Retry{Attempts: 3, RetryInterval: &v1.Duration{Duration: 60 * time.Millisecond}},
+			expectedHits: 3,
+			expectGap:    60 * time.Millisecond,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var mu sync.Mutex
+			var stamps []time.Time
+			backendHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				mu.Lock()
+				stamps = append(stamps, time.Now())
+				mu.Unlock()
+				w.WriteHeader(http.StatusServiceUnavailable)
+			})
+			router, store, backend := setupTestRouter(t, backendHandler)
+			defer backend.Close()
+
+			backendURL, err := url.Parse(backend.URL)
+			assert.NoError(t, err)
+			backendPort, err := strconv.Atoi(backendURL.Port())
+			assert.NoError(t, err)
+
+			modelServer := &aiv1alpha1.ModelServer{
+				ObjectMeta: v1.ObjectMeta{Name: "ms-retry", Namespace: "default"},
+				Spec: aiv1alpha1.ModelServerSpec{
+					Model:        func(s string) *string { return &s }("base-model"),
+					WorkloadPort: aiv1alpha1.WorkloadPort{Port: int32(backendPort)},
+				},
+			}
+			if tt.retry != nil {
+				modelServer.Spec.TrafficPolicy = &aiv1alpha1.TrafficPolicy{Retry: tt.retry}
+			}
+			modelRoute := &aiv1alpha1.ModelRoute{
+				ObjectMeta: v1.ObjectMeta{Name: "mr-retry", Namespace: "default"},
+				Spec: aiv1alpha1.ModelRouteSpec{
+					ModelName: "retry-model",
+					Rules: []*aiv1alpha1.Rule{
+						{TargetModels: []*aiv1alpha1.TargetModel{{ModelServerName: modelServer.Name}}},
+					},
+				},
+			}
+
+			podNames := sets.New[types.NamespacedName]()
+			var pods []*corev1.Pod
+			for i := 0; i < tt.pods; i++ {
+				podName := types.NamespacedName{Name: fmt.Sprintf("pod-retry-%d", i), Namespace: "default"}
+				podNames.Insert(podName)
+				pods = append(pods, &corev1.Pod{
+					ObjectMeta: v1.ObjectMeta{Name: podName.Name, Namespace: podName.Namespace},
+					Status:     corev1.PodStatus{PodIP: backendURL.Hostname(), Phase: corev1.PodRunning},
+				})
+			}
+			store.AddOrUpdateModelServer(modelServer, podNames)
+			for _, pod := range pods {
+				store.AddOrUpdatePod(pod, []*aiv1alpha1.ModelServer{modelServer})
+			}
+			store.AddOrUpdateModelRoute(modelRoute)
+
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request, err = http.NewRequest(http.MethodPost, "/v1/chat/completions",
+				bytes.NewBufferString(`{"model":"retry-model","prompt":"hello"}`))
+			assert.NoError(t, err)
+			c.Request.Header.Set("Content-Type", "application/json")
+
+			router.HandlerFunc()(c)
+
+			assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+			mu.Lock()
+			defer mu.Unlock()
+			assert.Equal(t, tt.expectedHits, len(stamps))
+			for i := 1; i < len(stamps); i++ {
+				gap := stamps[i].Sub(stamps[i-1])
+				if tt.expectGap == 0 {
+					continue
+				}
+				assert.GreaterOrEqual(t, gap, tt.expectGap, "attempt %d followed the previous one too quickly", i)
+			}
+		})
+	}
+}
+
+func TestRouter_HandlerFunc_TrafficPolicyRetryPDDisaggregated(t *testing.T) {
+	tests := []struct {
+		name             string
+		pairs            int
+		retry            *aiv1alpha1.Retry
+		expectedPrefills int
+		expectGap        time.Duration
+	}{
+		{
+			name:             "no retry policy tries every prefill decode pair",
+			pairs:            3,
+			expectedPrefills: 3,
+		},
+		{
+			name:             "attempts caps the number of pairs tried",
+			pairs:            3,
+			retry:            &aiv1alpha1.Retry{Attempts: 1},
+			expectedPrefills: 1,
+		},
+		{
+			name:             "retryInterval separates attempts",
+			pairs:            3,
+			retry:            &aiv1alpha1.Retry{Attempts: 3, RetryInterval: &v1.Duration{Duration: 60 * time.Millisecond}},
+			expectedPrefills: 3,
+			expectGap:        60 * time.Millisecond,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var mu sync.Mutex
+			var stamps []time.Time
+			backendHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, _ := io.ReadAll(r.Body)
+				var reqBody ModelRequest
+				json.Unmarshal(body, &reqBody)
+				if _, hasStream := reqBody["stream"]; !hasStream {
+					mu.Lock()
+					stamps = append(stamps, time.Now())
+					mu.Unlock()
+				}
+				w.WriteHeader(http.StatusServiceUnavailable)
+			})
+			router, store, backend := setupTestRouter(t, backendHandler)
+			defer backend.Close()
+
+			backendURL, _ := url.Parse(backend.URL)
+			backendIP := backendURL.Hostname()
+			backendPort, _ := strconv.Atoi(backendURL.Port())
+
+			modelServer := &aiv1alpha1.ModelServer{
+				ObjectMeta: v1.ObjectMeta{Name: "ms-pd-retry", Namespace: "default"},
+				Spec: aiv1alpha1.ModelServerSpec{
+					Model:           func(s string) *string { return &s }("test-model-base"),
+					WorkloadPort:    aiv1alpha1.WorkloadPort{Port: int32(backendPort)},
+					InferenceEngine: "vLLM",
+					WorkloadSelector: &aiv1alpha1.WorkloadSelector{
+						PDGroup: &aiv1alpha1.PDGroup{
+							GroupKey:      "group",
+							DecodeLabels:  map[string]string{"app": "decode"},
+							PrefillLabels: map[string]string{"app": "prefill"},
+						},
+					},
+				},
+			}
+			if tt.retry != nil {
+				modelServer.Spec.TrafficPolicy = &aiv1alpha1.TrafficPolicy{Retry: tt.retry}
+			}
+			modelRoute := &aiv1alpha1.ModelRoute{
+				ObjectMeta: v1.ObjectMeta{Name: "mr-pd-retry", Namespace: "default"},
+				Spec: aiv1alpha1.ModelRouteSpec{
+					ModelName: "test-model",
+					Rules: []*aiv1alpha1.Rule{
+						{TargetModels: []*aiv1alpha1.TargetModel{{ModelServerName: modelServer.Name}}},
+					},
+				},
+			}
+
+			podNames := sets.New[types.NamespacedName]()
+			var pods []*corev1.Pod
+			for i := 0; i < tt.pairs; i++ {
+				for _, role := range []string{"decode", "prefill"} {
+					name := fmt.Sprintf("%s-pod-%d", role, i)
+					podNames.Insert(types.NamespacedName{Name: name, Namespace: "default"})
+					pods = append(pods, &corev1.Pod{
+						ObjectMeta: v1.ObjectMeta{
+							Name:      name,
+							Namespace: "default",
+							Labels:    map[string]string{"app": role, "group": "test-group"},
+						},
+						Status: corev1.PodStatus{PodIP: backendIP, Phase: corev1.PodRunning},
+					})
+				}
+			}
+			store.AddOrUpdateModelServer(modelServer, podNames)
+			for _, pod := range pods {
+				store.AddOrUpdatePod(pod, []*aiv1alpha1.ModelServer{modelServer})
+			}
+			store.AddOrUpdateModelRoute(modelRoute)
+
+			w := connectors.CreateTestResponseRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request, _ = http.NewRequest("POST", "/v1/chat/completions",
+				bytes.NewBufferString(`{"model": "test-model", "prompt": "hello", "stream": true}`))
+			c.Request.Header.Set("Content-Type", "application/json")
+
+			router.HandlerFunc()(c)
+
+			mu.Lock()
+			defer mu.Unlock()
+			assert.Equal(t, tt.expectedPrefills, len(stamps))
+			for i := 1; i < len(stamps); i++ {
+				if tt.expectGap == 0 {
+					continue
+				}
+				gap := stamps[i].Sub(stamps[i-1])
+				assert.GreaterOrEqual(t, gap, tt.expectGap, "attempt %d followed the previous one too quickly", i)
+			}
+		})
+	}
+}
+
 func TestRouter_HandlerFunc_InferencePoolPodDiscovery(t *testing.T) {
 	tests := []struct {
 		name             string
@@ -3184,7 +3419,7 @@ func TestRouter_ProxyToPDDisaggregated_RetryBehavior(t *testing.T) {
 			c, _ := gin.CreateTestContext(w)
 			c.Request, _ = http.NewRequest("POST", "/v1/chat/completions", bytes.NewBufferString(`{"model":"test-model"}`))
 
-			err := router.proxyToPDDisaggregated(c, c.Request, ctx, mockConnector, ModelRequest{"model": "test-model"}, 8000, 2*time.Second)
+			err := router.proxyToPDDisaggregated(c, c.Request, ctx, mockConnector, ModelRequest{"model": "test-model"}, 8000, 2*time.Second, retryPolicy{})
 
 			if tt.wantErr {
 				assert.Error(t, err)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`trafficPolicy.retry` is declared on the ModelServer CRD but nothing reads it. The fallback loop walks the candidate pods the scheduler returned, so the attempt count is `min(len(BestPods), topN)` and `continue` fires with no gap, whatever `attempts` and `retryInterval` are set to.

`retryPolicyFor` resolves the policy next to `upstreamTimeoutFor`, and it is threaded to `proxy` the same way the timeout is. `attempts` caps the number of pods tried, and `retryInterval` separates attempts. The wait selects on the request context, so a client disconnect does not sit out the gap.

A non-positive `attempts` leaves the candidate list as the only bound, so existing ModelServers keep their current behaviour. ModelBooster writes `Attempts: 5`, which equals the default `topN`, so ModelBooster-generated servers are unchanged too.

**Which issue(s) this PR fixes**:

Fixes #1729

**Bug evidence (required for bug-related PRs)**:

Driving `router.HandlerFunc()` against 503 backends with `retryInterval: 500ms`, before this change:

```
pods  attempts   backend hits   largest gap
   3         1              3            0s
   5         1              5            0s
   8        10              5            0s
   2        10              2            0s
```

Hits are `min(pods, topN)` in every case and no gap ever appears.

`TestRouter_HandlerFunc_TrafficPolicyRetry` covers it. Against `main` the `attempts` case fails on 5 hits where 2 are expected, and the interval case fails with `257.513µs is not greater than or equal to 60ms`. The no-policy and attempts-above-pod-count cases pass on `main`, which is the point: they pin the behaviour that must not change.

**Special notes for your reviewer**:

`attempts` here caps the total number of pods tried. The CRD comment says "the maximum number of times an individual inference request should be retried", which also reads as retries after the first attempt, meaning `attempts + 1` tries. I went with the cap because it keeps every existing ModelServer on its current behaviour and needs no off-by-one at the boundary. Happy to switch to `attempts + 1` if you prefer the literal reading.

The other open question is whether `attempts` should cap this pod walk or drive a per-pod retry. They differ once a pod is tried more than once. This PR keeps one attempt per pod, which is the smaller change; per-pod retry would want its own issue since it also needs a backoff and a cap on total upstream load.

`make lint` cannot run on this Windows checkout. Verified in `golang:1.26` on the exported committed tree: gofmt clean, `go build ./...`, `go vet ./pkg/...`, and `go test -race ./pkg/kthena-router/router/` ok. `TestModelServerController_PodLifecycle`, `TestModelServerController_PodSelectionLogic` and `TestNewTestController_HasSyncedQueueAndStores` fail identically on a pristine `main` export and are unrelated.

**Does this PR introduce a user-facing change?**

```release-note
Fixed ModelServer trafficPolicy.retry being ignored by the router, so attempts and retryInterval now control upstream retries.
```