### PR TITLE
docs: organize ecosystem integrations

### DIFF
--- a/docs/kthena/docs/ecosystem/dynamo-on-kthena.md
+++ b/docs/kthena/docs/ecosystem/dynamo-on-kthena.md
@@ -1,4 +1,4 @@
-# Integrate Dynamo with Kthena
+# NVIDIA Dynamo on Kthena
 
 This guide describes how to run [NVIDIA Dynamo](https://github.com/ai-dynamo/dynamo) multinode workloads with Kthena. Dynamo creates standard `LeaderWorkerSet` (LWS) resources, and Kthena reconciles them into `ModelServing` workloads.
 
@@ -27,8 +27,8 @@ Kthena preserves the LWS behavior observed by Dynamo's distributed runtimes:
 
 - A Kubernetes cluster supported by Dynamo and Kthena.
 - [Volcano](https://volcano.sh/en/docs/installation/) installed and available for gang scheduling.
+- The [LeaderWorkerSet CRD](https://github.com/kubernetes-sigs/lws) installed before starting the Kthena Controller Manager (validated with LWS CRD `v0.10.0`).
 - Kthena installed with the workload controller and webhook enabled. See the [Kthena installation guide](../getting-started/installation.md).
-- The [LeaderWorkerSet CRD](https://github.com/kubernetes-sigs/lws), without the native LWS controller or webhook.
 - Dynamo installed according to its [installation documentation](https://github.com/ai-dynamo/dynamo/blob/main/docs/fern/pages/kubernetes/installation/install-dynamo.md).
 
 :::warning
@@ -111,4 +111,4 @@ This identity supports Dynamo TRT-LLM's worker-host derivation from the leader a
 - The Kthena workload webhook must remain enabled for Dynamo-generated LWS resources.
 - This integration covers the current Dynamo LWS workload contract; it does not change Dynamo or provide a general replacement for every LWS feature.
 
-For an overview of Kthena's LeaderWorkerSet integration, see [LeaderWorkerSet integration](./lws-integration.md).
+For an overview of Kthena's LeaderWorkerSet integration, see [LeaderWorkerSet integration](../user-guide/lws-integration.md).

--- a/docs/kthena/docs/ecosystem/llm-d-router-with-kthena.md
+++ b/docs/kthena/docs/ecosystem/llm-d-router-with-kthena.md
@@ -1,4 +1,4 @@
-# Integrate ModelServing with llm-d Router
+# llm-d Router with Kthena
 
 This guide shows how to route requests from
 [llm-d Router](https://github.com/llm-d/llm-d-router) to model servers managed by
@@ -123,7 +123,7 @@ The Gateway API Inference Extension v1 failure modes are `FailOpen` and
 
 Start with a ModelServing workload containing `prefill` and `decode` roles, as
 described in
-[Prefill-Decode Disaggregation with ModelServing](./prefill-decode-disaggregation/modelserving-vllm-pd-disaggregation.md).
+[Prefill-Decode Disaggregation with ModelServing](../user-guide/prefill-decode-disaggregation/modelserving-vllm-pd-disaggregation.md).
 The prefill entry server continues to listen on port 8000. The decode entry Pod
 exposes the llm-d sidecar on port 8000 and moves the model server to port 8200.
 

--- a/docs/kthena/sidebars.ts
+++ b/docs/kthena/sidebars.ts
@@ -56,11 +56,6 @@ const sidebars: SidebarsConfig = {
             'user-guide/modelserving-plugin-framework',
           ],
         },
-        {
-          type: 'category',
-          label: 'Integrations',
-          items: ['user-guide/dynamo-integration', 'user-guide/llm-d-router-integration'],
-        },
         'user-guide/multi-node-inference',
         {
           type: 'doc',
@@ -114,6 +109,11 @@ const sidebars: SidebarsConfig = {
           ],
         },
       ],
+    },
+    {
+      type: 'category',
+      label: 'Ecosystem',
+      items: ['ecosystem/dynamo-on-kthena', 'ecosystem/llm-d-router-with-kthena'],
     },
     {
       type: 'category',


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

<img width="351" height="441" alt="image" src="https://github.com/user-attachments/assets/95f19120-4094-44ad-aa8d-af42c75aadd7" />


Move external integration guides into a top-level Ecosystem section following Volcano documentation structure. Rename the pages to `NVIDIA Dynamo on Kthena` and `llm-d Router with Kthena`, and clarify the LWS CRD prerequisite.

**Which issue(s) this PR fixes**:
Ref #1723

**Bug evidence (required for bug-related PRs)**:
N/A

**Special notes for your reviewer**:
Documentation-only; no runtime behavior changes.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```