### PR TITLE
webhook: add ModelBooster deprecation warnings

### DIFF
--- a/pkg/model-booster-controller/webhook/model_deprecation_test.go
+++ b/pkg/model-booster-controller/webhook/model_deprecation_test.go
@@ -1,0 +1,177 @@
+/*
+Copyright The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	registryv1alpha1 "github.com/volcano-sh/kthena/pkg/apis/workload/v1alpha1"
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestModelBoosterDeprecationWarnings(t *testing.T) {
+	tests := []struct {
+		name            string
+		operation       admissionv1.Operation
+		subresource     string
+		includeOldModel bool
+		mutate          func(*registryv1alpha1.ModelBooster)
+		wantWarning     bool
+	}{
+		{
+			name:        "create",
+			operation:   admissionv1.Create,
+			wantWarning: true,
+		},
+		{
+			name:            "spec update",
+			operation:       admissionv1.Update,
+			includeOldModel: true,
+			mutate: func(model *registryv1alpha1.ModelBooster) {
+				model.Spec.Backend.SchedulerName = "volcano"
+			},
+			wantWarning: true,
+		},
+		{
+			name:            "status-only update",
+			operation:       admissionv1.Update,
+			includeOldModel: true,
+			mutate: func(model *registryv1alpha1.ModelBooster) {
+				model.Status.ObservedGeneration++
+			},
+		},
+		{
+			name:            "metadata-only update",
+			operation:       admissionv1.Update,
+			includeOldModel: true,
+			mutate: func(model *registryv1alpha1.ModelBooster) {
+				model.Labels = map[string]string{"example": "value"}
+			},
+		},
+		{
+			name:            "status subresource update",
+			operation:       admissionv1.Update,
+			subresource:     "status",
+			includeOldModel: true,
+			mutate: func(model *registryv1alpha1.ModelBooster) {
+				model.Status.ObservedGeneration++
+			},
+		},
+		{
+			name:        "update without old object",
+			operation:   admissionv1.Update,
+			wantWarning: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oldModel := validModelBoosterForDeprecationTest()
+			newModel := oldModel.DeepCopy()
+			if tt.mutate != nil {
+				tt.mutate(newModel)
+			}
+
+			var admissionOldModel *registryv1alpha1.ModelBooster
+			if tt.includeOldModel {
+				admissionOldModel = oldModel
+			}
+			response := handleModelBoosterAdmission(t, tt.operation, tt.subresource, newModel, admissionOldModel)
+			require.True(t, response.Allowed)
+			if tt.wantWarning {
+				assert.Equal(t, []string{modelBoosterDeprecationWarning}, response.Warnings)
+			} else {
+				assert.Empty(t, response.Warnings)
+			}
+		})
+	}
+}
+
+func validModelBoosterForDeprecationTest() *registryv1alpha1.ModelBooster {
+	return &registryv1alpha1.ModelBooster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-model",
+			Namespace: "default",
+		},
+		Spec: registryv1alpha1.ModelBoosterSpec{
+			Backend: registryv1alpha1.ModelBackend{
+				Name:     "backend",
+				Type:     registryv1alpha1.ModelBackendTypeVLLM,
+				ModelURI: "hf://test/model",
+				Replicas: 1,
+				Workers: []registryv1alpha1.ModelWorker{
+					{
+						Type:  registryv1alpha1.ModelWorkerTypeServer,
+						Pods:  1,
+						Image: "test-image:latest",
+					},
+				},
+			},
+		},
+	}
+}
+
+func handleModelBoosterAdmission(
+	t *testing.T,
+	operation admissionv1.Operation,
+	subresource string,
+	model *registryv1alpha1.ModelBooster,
+	oldModel *registryv1alpha1.ModelBooster,
+) *admissionv1.AdmissionResponse {
+	t.Helper()
+
+	request := &admissionv1.AdmissionRequest{
+		UID:         types.UID("test-request"),
+		Operation:   operation,
+		SubResource: subresource,
+		Object: runtime.RawExtension{
+			Raw: mustMarshalAdmissionObject(t, model),
+		},
+	}
+	if oldModel != nil {
+		request.OldObject.Raw = mustMarshalAdmissionObject(t, oldModel)
+	}
+
+	requestBody := mustMarshalAdmissionObject(t, admissionv1.AdmissionReview{Request: request})
+	httpRequest := httptest.NewRequest(http.MethodPost, "/validate/modelbooster", bytes.NewReader(requestBody))
+	httpRequest.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+
+	NewModelValidator().Handle(recorder, httpRequest)
+	require.Equal(t, http.StatusOK, recorder.Code)
+
+	var responseReview admissionv1.AdmissionReview
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &responseReview))
+	require.NotNil(t, responseReview.Response)
+	return responseReview.Response
+}
+
+func mustMarshalAdmissionObject(t *testing.T, object any) []byte {
+	t.Helper()
+	data, err := json.Marshal(object)
+	require.NoError(t, err)
+	return data
+}

--- a/pkg/model-booster-controller/webhook/model_validator.go
+++ b/pkg/model-booster-controller/webhook/model_validator.go
@@ -17,6 +17,7 @@ limitations under the License.
 package webhook
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -28,10 +29,14 @@ import (
 	"github.com/volcano-sh/kthena/pkg/model-booster-controller/convert"
 	"github.com/volcano-sh/kthena/pkg/model-booster-controller/utils"
 	admissionv1 "k8s.io/api/admission/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/klog/v2"
 )
+
+const modelBoosterDeprecationWarning = "ModelBooster is deprecated in v1.1; Use ModelServing, ModelServer, and ModelRoute. " +
+	"Removal is no earlier than v1.5."
 
 // ModelValidator handles validation of ModelBooster resources
 type ModelValidator struct {
@@ -57,8 +62,9 @@ func (v *ModelValidator) Handle(w http.ResponseWriter, r *http.Request) {
 
 	// Create the admission response
 	admissionResponse := admissionv1.AdmissionResponse{
-		Allowed: allowed,
-		UID:     admissionReview.Request.UID,
+		Allowed:  allowed,
+		UID:      admissionReview.Request.UID,
+		Warnings: modelBoosterDeprecationWarnings(admissionReview.Request, model),
 	}
 
 	if !allowed {
@@ -76,6 +82,32 @@ func (v *ModelValidator) Handle(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("could not send response: %v", err), http.StatusInternalServerError)
 		return
 	}
+}
+
+func modelBoosterDeprecationWarnings(request *admissionv1.AdmissionRequest, model *registryv1alpha1.ModelBooster) []string {
+	switch request.Operation {
+	case admissionv1.Create:
+		return []string{modelBoosterDeprecationWarning}
+	case admissionv1.Update:
+		if request.SubResource != "" || request.RequestSubResource != "" {
+			return nil
+		}
+
+		var oldModel registryv1alpha1.ModelBooster
+		if len(request.OldObject.Raw) == 0 {
+			klog.Warning("ModelBooster update admission request has no old object; emitting deprecation warning")
+			return []string{modelBoosterDeprecationWarning}
+		}
+		if err := json.Unmarshal(request.OldObject.Raw, &oldModel); err != nil {
+			klog.Warningf("Failed to decode old ModelBooster in update admission request; emitting deprecation warning: %v", err)
+			return []string{modelBoosterDeprecationWarning}
+		}
+		if !apiequality.Semantic.DeepEqual(oldModel.Spec, model.Spec) {
+			return []string{modelBoosterDeprecationWarning}
+		}
+	}
+
+	return nil
 }
 
 // validateModel validates the ModelBooster resource

--- a/test/e2e/controller-manager/webhook_test.go
+++ b/test/e2e/controller-manager/webhook_test.go
@@ -17,18 +17,58 @@ limitations under the License.
 package controller_manager
 
 import (
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	clientset "github.com/volcano-sh/kthena/client-go/clientset/versioned"
 	workload "github.com/volcano-sh/kthena/pkg/apis/workload/v1alpha1"
+	"github.com/volcano-sh/kthena/test/e2e/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const expectedModelBoosterDeprecationWarning = "ModelBooster is deprecated in v1.1; Use ModelServing, ModelServer, and ModelRoute. " +
+	"Removal is no earlier than v1.5."
+
+type recordingWarningHandler struct {
+	mu       sync.Mutex
+	warnings []string
+}
+
+func (h *recordingWarningHandler) HandleWarningHeader(_ int, _ string, message string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.warnings = append(h.warnings, message)
+}
+
+func (h *recordingWarningHandler) reset() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.warnings = nil
+}
+
+func (h *recordingWarningHandler) contains(message string) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for _, warning := range h.warnings {
+		if warning == message {
+			return true
+		}
+	}
+	return false
+}
+
 // TestWebhook tests that the webhooks (validation and mutation) work as expected.
 func TestWebhook(t *testing.T) {
-	ctx, kthenaClient, _ := setupControllerManagerE2ETest(t)
+	ctx, _, _ := setupControllerManagerE2ETest(t)
+	warningHandler := &recordingWarningHandler{}
+	config, err := utils.GetKubeConfig()
+	require.NoError(t, err, "Failed to get kubeconfig")
+	config.WarningHandler = warningHandler
+	kthenaClient, err := clientset.NewForConfig(config)
+	require.NoError(t, err, "Failed to create Kthena client")
 
 	// waiting for webhook to be ready before running tests
 	waitForWebhookReady(t, ctx, kthenaClient, testNamespace)
@@ -39,6 +79,7 @@ func TestWebhook(t *testing.T) {
 		expectError   bool
 		errorMsg      string
 		checkMutation func(t *testing.T, obj interface{})
+		expectWarning bool
 	}{
 		{
 			name:        "Invalid ModelBooster (replicas too large)",
@@ -47,9 +88,10 @@ func TestWebhook(t *testing.T) {
 			errorMsg:    "replicas",
 		},
 		{
-			name:        "Valid ModelBooster (DryRun)",
-			resource:    createValidModelBoosterForWebhookTest(),
-			expectError: false,
+			name:          "Valid ModelBooster (DryRun)",
+			resource:      createValidModelBoosterForWebhookTest(),
+			expectError:   false,
+			expectWarning: true,
 		},
 		{
 			name:        "Invalid AutoscalingPolicy (duplicate metric names)",
@@ -86,6 +128,7 @@ func TestWebhook(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			warningHandler.reset()
 			var err error
 			var created interface{}
 
@@ -108,6 +151,10 @@ func TestWebhook(t *testing.T) {
 				if tc.checkMutation != nil {
 					tc.checkMutation(t, created)
 				}
+			}
+			if tc.expectWarning {
+				assert.True(t, warningHandler.contains(expectedModelBoosterDeprecationWarning),
+					"Expected ModelBooster deprecation warning")
 			}
 		})
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind enhancement

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:
Adds user-visible admission warnings for the deprecated ModelBooster API.

The validating webhook now emits a warning when:
  - A ModelBooster is created.
  - An existing ModelBooster spec is changed.

Metadata-only, status-only, and subresource updates do not produce warnings. 
The warning is emitted from the validating webhook to avoid duplicates from mutating webhook reinvocation.

**Which issue(s) this PR fixes**:
Fixes #1706 

**Bug evidence (required for bug-related PRs)**:
<!--
For a bug-related PR, provide evidence from the production path:
- Include the relevant workload configuration and logs or events.
- For a panic, include the complete panic trace.
- Describe the user action or cluster event that triggers the problem and how the
  change fixes it.
- Use source permalinks that point to the exact commit when citing code.

AI-generated analysis, a static scan, or a unit test that only calls an internal
function does not prove a bug on its own. If the reported bug relies solely on AI
analysis without reproduction instructions or production-path evidence, maintainers
may close the issue and the related PR.

Write "N/A" for PRs that are not bug-related.
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
