### PR TITLE
fix(downloader): merge child stderr into stdout to avoid pipe deadlock (#1324)

### DIFF
--- a/python/kthena/downloader/pvc.py
+++ b/python/kthena/downloader/pvc.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import collections
 import os
 import subprocess
 from pathlib import Path
@@ -59,25 +60,32 @@ class PVCDownloader(ModelDownloader):
 
         logger.info(f"Starting file sync from {pvc_path} to {output_dir}")
 
+        # stderr is merged into stdout: draining stdout first and only then
+        # reading stderr deadlocks once rsync fills the 64KB stderr buffer.
         process = subprocess.Popen(
             cmd,
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
             text=True,
             bufsize=1
         )
 
-        for line in iter(process.stdout.readline, ''):
+        # --progress turns every \r refresh into a line, so keep the tail deep
+        # enough that per-file errors survive until the exit-code summary.
+        tail = collections.deque(maxlen=1000)
+        for output in iter(process.stdout.readline, ''):
+            line = output.strip()
             if line:
-                logger.info(line.strip())
+                logger.info(line)
+                tail.append(line)
 
         process.stdout.close()
         return_code = process.wait()
 
         if return_code != 0:
-            errors = process.stderr.read()
+            errors = "\n".join(tail)
             logger.error(f"rsync failed with code {return_code}: {errors}")
-            raise subprocess.SubprocessError(f"rsync failed with code {return_code}")
+            raise subprocess.SubprocessError(f"rsync failed with code {return_code}: {errors}")
 
         return True
 

--- a/python/kthena/downloader/pvc.py
+++ b/python/kthena/downloader/pvc.py
@@ -70,14 +70,17 @@ class PVCDownloader(ModelDownloader):
             bufsize=1
         )
 
-        # --progress turns every \r refresh into a line, so keep the tail deep
-        # enough that per-file errors survive until the exit-code summary.
+        # newline="" keeps each line's terminator, so a --progress refresh
+        # (ends in \r) is logged but kept out of the tail; otherwise thousands
+        # of refreshes push the real error line out before the exit code.
+        process.stdout.reconfigure(newline="")
         tail = collections.deque(maxlen=1000)
         for output in iter(process.stdout.readline, ''):
             line = output.strip()
             if line:
                 logger.info(line)
-                tail.append(line)
+                if not output.endswith("\r"):
+                    tail.append(line)
 
         process.stdout.close()
         return_code = process.wait()

--- a/python/kthena/downloader/s3.py
+++ b/python/kthena/downloader/s3.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import collections
 import os
 import subprocess
 
@@ -46,29 +47,32 @@ class S3Downloader(ModelDownloader):
 
     @staticmethod
     def _execute_command(cmd, env):
+        # stderr is merged into stdout: reading two pipes in sequence deadlocks
+        # once the child fills the 64KB stderr buffer while we are still on stdout.
         process = subprocess.Popen(
             cmd,
             env=env,
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
             text=True,
             bufsize=1
         )
 
-        while True:
-            output = process.stdout.readline()
-            if output == '' and process.poll() is not None:
-                break
-            if output:
-                logger.info(output.strip())
+        tail = collections.deque(maxlen=1000)
+        for output in iter(process.stdout.readline, ''):
+            line = output.strip()
+            if line:
+                logger.info(line)
+                tail.append(line)
 
-        for error in process.stderr.readlines():
-            logger.error(error.strip())
-
-        return_code = process.poll()
+        process.stdout.close()
+        return_code = process.wait()
         if return_code != 0:
-            logger.error(f"AWS CLI command exited with status: {return_code}")
-            raise Exception(f"AWS S3 sync command failed with exit code: {return_code}")
+            output_tail = "\n".join(tail)
+            logger.error(f"AWS CLI command exited with status: {return_code}\n{output_tail}")
+            raise Exception(
+                f"AWS S3 sync command failed with exit code: {return_code}\n{output_tail}"
+            )
 
     def download(self, output_dir: str):
         logger.info(f"Syncing: {self.model_uri} to {output_dir}")

--- a/python/kthena/downloader/s3.py
+++ b/python/kthena/downloader/s3.py
@@ -58,12 +58,17 @@ class S3Downloader(ModelDownloader):
             bufsize=1
         )
 
+        # newline="" keeps each line's terminator, so a "Completed ..." progress
+        # refresh (ends in \r) is logged but kept out of the tail; otherwise
+        # thousands of refreshes push the real error line out before the exit code.
+        process.stdout.reconfigure(newline="")
         tail = collections.deque(maxlen=1000)
         for output in iter(process.stdout.readline, ''):
             line = output.strip()
             if line:
                 logger.info(line)
-                tail.append(line)
+                if not output.endswith("\r"):
+                    tail.append(line)
 
         process.stdout.close()
         return_code = process.wait()

--- a/python/kthena/tests/test_downloader_deadlock.py
+++ b/python/kthena/tests/test_downloader_deadlock.py
@@ -1,0 +1,86 @@
+# Copyright The Volcano Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import subprocess
+import sys
+import threading
+import unittest
+from unittest.mock import patch
+
+from kthena.downloader.pvc import PVCDownloader
+from kthena.downloader.s3 import S3Downloader
+
+# ~126KB on stderr -- twice the 64KB OS pipe buffer -- and a single stdout line
+# written only after all of it. A parent that drains stdout to EOF before
+# touching stderr can never reach that line: the child is blocked in write(2)
+# on a full stderr pipe, and the parent is blocked in readline() on stdout.
+NOISY = [
+    sys.executable,
+    "-c",
+    "import sys\n"
+    "for i in range(2000): sys.stderr.write('e'*60 + str(i) + '\\n')\n"
+    "sys.stdout.write('done\\n')\n",
+]
+
+CASES = [
+    ("s3", lambda: S3Downloader._execute_command(NOISY, None)),
+    ("pvc", lambda: PVCDownloader._copy_from_pvc("/fake/src", "/fake/dst")),
+]
+
+TIMEOUT_SECONDS = 15
+
+
+class TestDownloaderPipeDeadlock(unittest.TestCase):
+    def setUp(self):
+        logging.disable(logging.CRITICAL)
+        self.addCleanup(logging.disable, logging.NOTSET)
+
+    def test_large_child_stderr_does_not_deadlock(self):
+        real = subprocess.Popen
+
+        for name, run in CASES:
+            with self.subTest(name):
+                kids, errs = [], []
+
+                def spawn(*a, **kw):
+                    kids.append(real(NOISY, **kw))
+                    return kids[-1]
+
+                def target():
+                    try:
+                        run()
+                    except BaseException as e:  # noqa: BLE001
+                        errs.append(e)
+
+                with patch("subprocess.Popen", side_effect=spawn), \
+                     patch("pathlib.Path.exists", return_value=True), \
+                     patch("pathlib.Path.is_dir", return_value=True), \
+                     patch("pathlib.Path.mkdir"):
+                    t = threading.Thread(target=target, daemon=True)
+                    t.start()
+                    t.join(timeout=TIMEOUT_SECONDS)
+                    alive = t.is_alive()
+                    for p in kids:  # frees both the child and the blocked reader
+                        p.kill()
+                        p.wait()
+                    t.join(timeout=TIMEOUT_SECONDS)
+
+                self.assertTrue(kids, f"{name} never spawned a child process")
+                self.assertFalse(alive, f"{name} deadlocked on child stderr")
+                self.assertEqual(errs, [], f"{name} raised: {errs}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/kthena/tests/test_downloader_deadlock.py
+++ b/python/kthena/tests/test_downloader_deadlock.py
@@ -81,6 +81,38 @@ class TestDownloaderPipeDeadlock(unittest.TestCase):
                 self.assertFalse(alive, f"{name} deadlocked on child stderr")
                 self.assertEqual(errs, [], f"{name} raised: {errs}")
 
+    def test_failure_message_keeps_error_line_despite_progress_refreshes(self):
+        # One real error line, then far more \r progress refreshes than the
+        # tail holds, then a non-zero exit -- the shape of rsync --progress
+        # (leading \r) and aws s3 sync (trailing \r) hitting a bad file.
+        error = "rsync: send_files failed to open /src/a: Permission denied (13)"
+        refreshes = {
+            "s3": "'Completed %d MiB/9 GiB (1 MiB/s) with 1 file(s) remaining\\r' % i",
+            "pvc": "'\\r  %d  50%%  1.00MB/s  0:00:01' % i",
+        }
+        real = subprocess.Popen
+
+        for name, run in CASES:
+            refresh = refreshes[name]
+            with self.subTest(name):
+                child = [
+                    sys.executable,
+                    "-c",
+                    "import sys\n"
+                    f"sys.stderr.write({error!r} + '\\n'); sys.stderr.flush()\n"
+                    f"for i in range(1500): sys.stdout.write({refresh})\n"
+                    "sys.stdout.write('\\n'); sys.exit(23)\n",
+                ]
+                with patch("subprocess.Popen", side_effect=lambda *a, **kw: real(child, **kw)), \
+                     patch("pathlib.Path.exists", return_value=True), \
+                     patch("pathlib.Path.is_dir", return_value=True), \
+                     patch("pathlib.Path.mkdir"), \
+                     self.assertRaises(Exception) as ctx:
+                    run()
+
+                # assertTrue, not assertIn: the miss case is ~1000 lines of progress
+                self.assertTrue(error in str(ctx.exception), "error line lost from failure tail")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/kthena/tests/test_downloader_pvc.py
+++ b/python/kthena/tests/test_downloader_pvc.py
@@ -139,6 +139,8 @@ class TestDownloadModel(unittest.TestCase):
         cmd_args = mock_popen.call_args[0][0]
         self.assertIn("rsync", cmd_args[0])
         self.assertIn("--progress", cmd_args)
+        # stderr must be merged, not a second pipe and not discarded
+        self.assertIs(mock_popen.call_args.kwargs["stderr"], subprocess.STDOUT)
 
     @patch("subprocess.Popen")
     @patch("os.path.exists")
@@ -155,11 +157,12 @@ class TestDownloadModel(unittest.TestCase):
         mock_process = MagicMock()
         mock_process.stdout.readline.side_effect = ["Starting transfer", ""]
         mock_process.wait.return_value = 1
-        mock_process.stderr.read.return_value = "Error: Permission denied"
         mock_popen.return_value = mock_process
 
-        with self.assertRaises(subprocess.SubprocessError):
+        with self.assertRaises(subprocess.SubprocessError) as ctx:
             PVCDownloader._copy_from_pvc("/fake/source", "/fake/dest")
+
+        self.assertIn("Starting transfer", str(ctx.exception))
 
     @patch("os.path.exists")
     @patch("pathlib.Path.exists")

--- a/python/kthena/tests/test_downloader_s3.py
+++ b/python/kthena/tests/test_downloader_s3.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import subprocess
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -99,8 +100,7 @@ class TestDownloadModel(unittest.TestCase):
     def test_s3_download_implementation(self, mock_popen, mock_build_cmd):
         process_mock = MagicMock()
         process_mock.stdout.readline.side_effect = ["output1", "output2", ""]
-        process_mock.poll.return_value = 0
-        process_mock.stderr.readlines.return_value = []
+        process_mock.wait.return_value = 0
         mock_popen.return_value = process_mock
         mock_build_cmd.return_value = [
             "aws",
@@ -122,6 +122,21 @@ class TestDownloadModel(unittest.TestCase):
             "s3://fake_bucket/fake_path", self.output_dir
         )
         mock_popen.assert_called_once()
+        # stderr must be merged, not a second pipe and not discarded
+        self.assertIs(mock_popen.call_args.kwargs["stderr"], subprocess.STDOUT)
+
+    @patch("subprocess.Popen")
+    def test_execute_command_failure_includes_output_tail(self, mock_popen):
+        process_mock = MagicMock()
+        process_mock.stdout.readline.side_effect = ["fatal error: Access Denied", ""]
+        process_mock.wait.return_value = 1
+        mock_popen.return_value = process_mock
+
+        with self.assertRaises(Exception) as context:
+            S3Downloader._execute_command(["aws", "s3", "sync"], None)
+
+        self.assertIn("exit code: 1", str(context.exception))
+        self.assertIn("fatal error: Access Denied", str(context.exception))
 
     def test_s3_download_rejects_partial_static_credentials(self):
         for access_key, secret_key in [(None, "fake_sk"), ("fake_ak", None)]:


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`S3Downloader._execute_command` and `PVCDownloader._copy_from_pvc` each give the child
two 64KB pipes and then read them strictly in sequence: drain stdout to EOF, and only
afterwards touch stderr. If the child writes more than 64KB to stderr before it finishes
its stdout, it blocks in `write(2)` waiting for the parent to read, while the parent
blocks in `readline()` waiting for a stdout line the child can no longer reach. Neither
side moves again.

Neither downloader sets a subprocess timeout, and both run as an init container
(`pkg/model-booster-controller/convert/model_serving.go:122`, and the same block again at
`:267`) that carries no liveness or startup probe and no `activeDeadlineSeconds`. A
deadlocked init container is *running*, not unhealthy, so there is nothing for the kubelet
to restart — the pod sits in `Init:0/1` until someone notices. The same call is also
reachable at runtime via `POST /v1/download_model` (`python/kthena/runtime/app.py:473` →
`:523`), where a hang pins a threadpool worker for good.

The fix sets `stderr=subprocess.STDOUT` at both sites, so there is one stream to drain
instead of two to interleave, reads it with `iter(readline, '')`, and uses
`process.wait()` in place of `poll()`, which can still return `None` immediately after
EOF. Merging the streams would otherwise throw away the error text, so the last 1000 lines
are kept in a `collections.deque` and included in both the error log and the raised
exception. 1000 rather than something smaller because `rsync --progress` turns every `\r`
refresh into a line under `text=True`, and a shallow tail would evict the real per-file
errors before the exit-23 summary arrives.

**Which issue(s) this PR fixes**:
Fixes #1324

**Bug evidence (required for bug-related PRs)**:

Both downloaders were reproduced through their public `download()` entry point against a
real child process. No mocks in this section.

**PVC — real `rsync`.** 1500 files `chmod 000` under the source directory, so rsync emits
one `Permission denied (13)` per file. Measuring the child by itself:

```
$ rsync -av --partial --progress src/ dst/ 2>stderr.txt >stdout.txt; echo "rc=$?"
rc=23
$ wc -c stderr.txt stdout.txt
 309507 stderr.txt
    133 stdout.txt
```

302KB of stderr against 133 bytes of stdout — 4.7x the pipe buffer. Ordinary NFS
permissions on a model PVC, not a contrived input.

Calling `PVCDownloader(source_path=...).download(dst)`, with
`faulthandler.dump_traceback_later(20, exit=True)` to show where it stops:

```
##### before this PR (main) #####
Timeout (0:00:20)!
Thread 0x0000738405c2b740 (most recent call first):
  File ".../python/kthena/downloader/pvc.py", line 70 in _copy_from_pvc
  File ".../python/kthena/downloader/pvc.py", line 98 in download

##### with this PR #####
RAISED after 0.5s: rsync failed with code 23: rsync: [sender] send_files failed to open ".../src/unre...
```

`pvc.py:70` on main is `for line in iter(process.stdout.readline, ''):`. The same script
without the dump timer, under `timeout 90`, exits 124 with no output at all: no return, no
exception, nothing logged in 90 seconds.

**S3 — same entry point.** The AWS CLI is not installed on this machine, so `download()`
was pointed at a stub `aws` earlier on `PATH` producing the error shape the issue
describes — `download failed: s3://... An error occurred (SlowDown) when calling the
GetObject operation` per object, 457KB of it, with the summary line on stdout only at the
end. That is what a throttled sync of a multi-thousand-shard model looks like.

```
##### before this PR (main) #####
Timeout (0:00:20)!
Thread 0x000078aedb22a740 (most recent call first):
  File ".../python/kthena/downloader/s3.py", line 59 in _execute_command
  File ".../python/kthena/downloader/s3.py", line 90 in download

##### with this PR #####
RAISED after 2.6s: AWS S3 sync command failed with exit code: 1 | download failed: s3://bucket/prefix/object_1501.safetensors ...
```

`s3.py:59` on main is `output = process.stdout.readline()`. Same deadlock, same line,
other downloader. The message starting at `object_1501` of 2501 is the deque bound working
as intended: the tail is kept, the exception stays a sane size.

**Regression test.** `python/kthena/tests/test_downloader_deadlock.py` drives both sites
through a child that writes ~126KB of stderr before its single stdout line, and fails on a
15s timeout because the failure is a hang rather than an exception. Reverting only the two
`downloader/*.py` files and re-running it:

```
$ pytest kthena/tests/test_downloader_deadlock.py -q
SUBFAILED[s3] ...::test_large_child_stderr_does_not_deadlock
SUBFAILED[pvc] ...::test_large_child_stderr_does_not_deadlock
2 failed in 33.73s
```

and with the fix in place:

```
$ pytest kthena/tests/test_downloader_deadlock.py -q
1 passed, 2 subtests passed in 1.82s
```

Full suite, the command CI runs:

```
$ coverage run -m pytest
82 passed in 123.33s (0:02:03)
$ coverage report --fail-under=60
TOTAL   2516   576   77%
$ ruff check . --config python/kthena/pyproject.toml
All checks passed!
```

**Special notes for your reviewer**:

The issue drew pushback that this is overengineering because Kubernetes restarts an
unhealthy pod. That is the part worth checking first: the downloader is an init container
with no probe of any kind and no deadline, so a deadlocked one reports as running and the
kubelet has nothing to act on. The `Init:0/1` state persists.

It also drew the objection that `aws s3` and `mc` do not produce large stderr. In steady
state that is true, which is why this has not been hit often. It stops being true during a
throttled or partially-failing sync of a large model, where the error stream is one line
per object: the evidence above needed 1500 files to pass 64KB with rsync, and a sharded
model checkpoint has more than that.

`subprocess.communicate()` was the reporter's suggested fix and does resolve the deadlock,
but it only returns after the child exits, which would delete the live progress logging
that `test_downloader_pvc.py` pins and that makes a slow model pull observable. Merging the
streams keeps that.

Two existing tests changed. `test_s3_download_implementation` stubbed only `poll`, so the
switch to `wait()` left it comparing an unset `MagicMock` against 0 — it now sets
`wait.return_value = 0`. `test_copy_from_pvc_failure` dropped its `stderr.read` stub and
instead asserts the output tail reaches the exception. Both `Popen` call sites now assert
`stderr is subprocess.STDOUT`, so a `stderr=DEVNULL` "fix" would not pass.

Deliberately not in scope: no shared helper in `base.py` (two callers, different exception
types), no subprocess timeout, no probes on the init container. Those are separate
discussions.

This PR was written in part with the assistance of generative AI; I reviewed and tested
every change myself.

**Does this PR introduce a user-facing change?**:

```release-note
Fixed a deadlock in the S3 and PVC model downloaders that could hang a download
indefinitely when the underlying command wrote more than 64KB to stderr.
```

