### PR TITLE
docs: document volcano queue placement and node targeting for ModelServing (#899)

### DIFF
--- a/docs/kthena/docs/user-guide/gang-scheduling.md
+++ b/docs/kthena/docs/user-guide/gang-scheduling.md
@@ -53,6 +53,34 @@ type GangPolicy struct {
 }
 ```
 
+## Queue Placement
+
+Volcano schedules every PodGroup through a [Queue](https://volcano.sh/en/docs/queue/). Kthena reads the queue name from the ModelServing object's own `metadata.annotations` — not from the pod template, as stock Volcano workloads do — and writes it into `PodGroup.spec.queue`.
+
+```yaml
+apiVersion: workload.serving.volcano.sh/v1alpha1
+kind: ModelServing
+metadata:
+  name: sample
+  annotations:
+    scheduling.volcano.sh/queue-name: my-queue   # the Queue must already exist
+spec:
+  schedulerName: volcano   # the CRD default; any other scheduler means no PodGroup
+  template:
+    roles:
+      - name: prefill
+        entryTemplate:
+          spec:
+            nodeSelector:            # workerTemplate.spec takes it too
+              nvidia.com/gpu.product: NVIDIA-H100-80GB-HBM3
+```
+
+- The annotation goes on the **ModelServing**, not on the pod template.
+- **Set it at creation.** On a running ModelServing the controller skips updates whose `spec` is unchanged, so an annotation edit alone takes effect only at the next reconcile (a spec change, a pod event, or a controller restart). Pods already bound to a node do not move.
+- **Remove it and the PodGroup falls back to Volcano's default queue.** Kthena writes an empty queue name and the PodGroup CRD defaults the field to `default`.
+- `nodeSelector`, `affinity` and `tolerations` are ordinary `corev1.PodSpec` fields, set per role on `entryTemplate.spec` or `workerTemplate.spec`.
+- **ModelBooster cannot set the queue annotation** — the ModelBooster controller does not propagate annotations onto the ModelServing it generates. For node targeting it exposes `spec.backend.workers[].affinity.nodeAffinity`, which does reach its pods.
+
 ## Preparation
 
 ### Prerequisites
@@ -66,7 +94,7 @@ type GangPolicy struct {
 1. Deploy model serving with the MinRoleReplicas configuration
 
 ```sh
-kubectl apply -f examples/model-serving/gang-scheduling.yaml
+kubectl apply -f examples/model-serving/gangPolicy.yaml
 
 NAMESPACE            NAME                                               READY   STATUS    RESTARTS   AGE
 default              sample-0-decode-0-0                                1/1     Running   0          15s

--- a/docs/kthena/docs/user-guide/gang-scheduling.md
+++ b/docs/kthena/docs/user-guide/gang-scheduling.md
@@ -55,7 +55,7 @@ type GangPolicy struct {
 
 ## Queue Placement
 
-Volcano schedules every PodGroup through a [Queue](https://volcano.sh/en/docs/queue/). Kthena reads the queue name from the ModelServing object's own `metadata.annotations` — not from the pod template, as stock Volcano workloads do — and writes it into `PodGroup.spec.queue`.
+To place a ModelServing's PodGroups in a Volcano [Queue](https://volcano.sh/en/docs/queue/), set the `scheduling.volcano.sh/queue-name` annotation on the ModelServing itself, not on the pod template. Kthena copies it into `PodGroup.spec.queue`; without it, the PodGroup uses Volcano's `default` queue.
 
 ```yaml
 apiVersion: workload.serving.volcano.sh/v1alpha1
@@ -75,9 +75,7 @@ spec:
               nvidia.com/gpu.product: NVIDIA-H100-80GB-HBM3
 ```
 
-- The annotation goes on the **ModelServing**, not on the pod template.
 - **Set it at creation.** On a running ModelServing the controller skips updates whose `spec` is unchanged, so an annotation edit alone takes effect only at the next reconcile (a spec change, a pod event, or a controller restart). Pods already bound to a node do not move.
-- **Remove it and the PodGroup falls back to Volcano's default queue.** Kthena writes an empty queue name and the PodGroup CRD defaults the field to `default`.
 - `nodeSelector`, `affinity` and `tolerations` are ordinary `corev1.PodSpec` fields, set per role on `entryTemplate.spec` or `workerTemplate.spec`.
 - **ModelBooster cannot set the queue annotation** — the ModelBooster controller does not propagate annotations onto the ModelServing it generates. For node targeting it exposes `spec.backend.workers[].affinity.nodeAffinity`, which does reach its pods.
 

--- a/docs/kthena/versioned_docs/version-v0.4.0/user-guide/gang-scheduling.md
+++ b/docs/kthena/versioned_docs/version-v0.4.0/user-guide/gang-scheduling.md
@@ -66,7 +66,7 @@ type GangPolicy struct {
 1. Deploy model serving with the MinRoleReplicas configuration
 
 ```sh
-kubectl apply -f examples/model-serving/gang-scheduling.yaml
+kubectl apply -f examples/model-serving/gangPolicy.yaml
 
 NAMESPACE            NAME                                               READY   STATUS    RESTARTS   AGE
 default              sample-0-decode-0-0                                1/1     Running   0          15s

--- a/docs/kthena/versioned_docs/version-v1.0.0/user-guide/gang-scheduling.md
+++ b/docs/kthena/versioned_docs/version-v1.0.0/user-guide/gang-scheduling.md
@@ -53,6 +53,34 @@ type GangPolicy struct {
 }
 ```
 
+## Queue Placement
+
+Volcano schedules every PodGroup through a [Queue](https://volcano.sh/en/docs/queue/). Kthena reads the queue name from the ModelServing object's own `metadata.annotations` — not from the pod template, as stock Volcano workloads do — and writes it into `PodGroup.spec.queue`.
+
+```yaml
+apiVersion: workload.serving.volcano.sh/v1alpha1
+kind: ModelServing
+metadata:
+  name: sample
+  annotations:
+    scheduling.volcano.sh/queue-name: my-queue   # the Queue must already exist
+spec:
+  schedulerName: volcano   # the CRD default; any other scheduler means no PodGroup
+  template:
+    roles:
+      - name: prefill
+        entryTemplate:
+          spec:
+            nodeSelector:            # workerTemplate.spec takes it too
+              nvidia.com/gpu.product: NVIDIA-H100-80GB-HBM3
+```
+
+- The annotation goes on the **ModelServing**, not on the pod template.
+- **Set it at creation.** On a running ModelServing the controller skips updates whose `spec` is unchanged, so an annotation edit alone takes effect only at the next reconcile (a spec change, a pod event, or a controller restart). Pods already bound to a node do not move.
+- **Remove it and the PodGroup falls back to Volcano's default queue.** Kthena writes an empty queue name and the PodGroup CRD defaults the field to `default`.
+- `nodeSelector`, `affinity` and `tolerations` are ordinary `corev1.PodSpec` fields, set per role on `entryTemplate.spec` or `workerTemplate.spec`.
+- **ModelBooster cannot set the queue annotation** — the ModelBooster controller does not propagate annotations onto the ModelServing it generates. For node targeting it exposes `spec.backend.workers[].affinity.nodeAffinity`, which does reach its pods.
+
 ## Preparation
 
 ### Prerequisites
@@ -66,7 +94,7 @@ type GangPolicy struct {
 1. Deploy model serving with the MinRoleReplicas configuration
 
 ```sh
-kubectl apply -f examples/model-serving/gang-scheduling.yaml
+kubectl apply -f examples/model-serving/gangPolicy.yaml
 
 NAMESPACE            NAME                                               READY   STATUS    RESTARTS   AGE
 default              sample-0-decode-0-0                                1/1     Running   0          15s

--- a/docs/kthena/versioned_docs/version-v1.0.0/user-guide/gang-scheduling.md
+++ b/docs/kthena/versioned_docs/version-v1.0.0/user-guide/gang-scheduling.md
@@ -55,7 +55,7 @@ type GangPolicy struct {
 
 ## Queue Placement
 
-Volcano schedules every PodGroup through a [Queue](https://volcano.sh/en/docs/queue/). Kthena reads the queue name from the ModelServing object's own `metadata.annotations` — not from the pod template, as stock Volcano workloads do — and writes it into `PodGroup.spec.queue`.
+To place a ModelServing's PodGroups in a Volcano [Queue](https://volcano.sh/en/docs/queue/), set the `scheduling.volcano.sh/queue-name` annotation on the ModelServing itself, not on the pod template. Kthena copies it into `PodGroup.spec.queue`; without it, the PodGroup uses Volcano's `default` queue.
 
 ```yaml
 apiVersion: workload.serving.volcano.sh/v1alpha1
@@ -75,9 +75,7 @@ spec:
               nvidia.com/gpu.product: NVIDIA-H100-80GB-HBM3
 ```
 
-- The annotation goes on the **ModelServing**, not on the pod template.
 - **Set it at creation.** On a running ModelServing the controller skips updates whose `spec` is unchanged, so an annotation edit alone takes effect only at the next reconcile (a spec change, a pod event, or a controller restart). Pods already bound to a node do not move.
-- **Remove it and the PodGroup falls back to Volcano's default queue.** Kthena writes an empty queue name and the PodGroup CRD defaults the field to `default`.
 - `nodeSelector`, `affinity` and `tolerations` are ordinary `corev1.PodSpec` fields, set per role on `entryTemplate.spec` or `workerTemplate.spec`.
 - **ModelBooster cannot set the queue annotation** — the ModelBooster controller does not propagate annotations onto the ModelServing it generates. For node targeting it exposes `spec.backend.workers[].affinity.nodeAffinity`, which does reach its pods.
 

--- a/examples/model-serving/gangPolicy.yaml
+++ b/examples/model-serving/gangPolicy.yaml
@@ -3,6 +3,8 @@ kind: ModelServing
 metadata:
   name: sample
   namespace: default
+  # annotations:
+  #   scheduling.volcano.sh/queue-name: my-queue   # place the PodGroup in a Volcano Queue
 spec:
   schedulerName: volcano
   replicas: 1  # servingGroup replicas
@@ -17,6 +19,8 @@ spec:
         replicas: 2       # role replicas, for example, 1P1D
         entryTemplate:
           spec:
+            # nodeSelector:
+            #   nvidia.com/gpu.product: NVIDIA-H100-80GB-HBM3
             containers:
               - name: leader
                 image: nginx


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

Documents how Kthena places ModelServing pods with a Volcano queue and how to target
specific nodes. Neither was documented: the queue name annotation is read from the
ModelServing object's own `metadata.annotations`, not the pod template as stock Volcano
workloads expect, and the only prior answer on the issue predates the annotation support
landing. Also fixes a broken example path in the same guide
(`gang-scheduling.yaml` → `gangPolicy.yaml`).

This PR was written in part with the assistance of generative AI; I reviewed and tested
every change myself before submitting.

**Which issue(s) this PR fixes**:

Ref #899

**Bug evidence (required for bug-related PRs)**:

N/A

**Special notes for your reviewer**:

Docs-only; no runtime behavior changes. The queue annotation
(`scheduling.volcano.sh/queue-name`) only takes effect at the next reconcile of the
ModelServing — an annotation-only edit does not trigger one, since the update handler
skips unchanged specs. The new "Queue Placement" section is added to `docs/` and
`versioned_docs/version-v1.0.0` only; `version-v0.4.0` predates the annotation support and
gets the broken-link fix alone.

**Does this PR introduce a user-facing change?**:

```release-note
Document Volcano queue placement and per-role node targeting for ModelServing in the gang scheduling guide.
```
