### PR TITLE
fix: refresh reason, message and timestamp when a ModelServing condition is superseded

### DIFF
--- a/pkg/model-serving-controller/utils/utils.go
+++ b/pkg/model-serving-controller/utils/utils.go
@@ -475,6 +475,13 @@ func SetConditionWithRolloutAndProgressState(
 			// Available and progressing/updateInprogress are not allowed to be true at the same time.
 			if exclusiveConditionTypes(curCondition, newCond) && curCondition.Status == metav1.ConditionTrue && newCond.Status == metav1.ConditionTrue {
 				ms.Status.Conditions[i].Status = metav1.ConditionFalse
+				// This condition just transitioned, so its timestamp has to move with it and its
+				// reason and message have to describe what superseded it. Assigning only Status
+				// leaves the text that was written when the condition went True, so the object
+				// reports a state it is no longer in.
+				ms.Status.Conditions[i].LastTransitionTime = newCond.LastTransitionTime
+				ms.Status.Conditions[i].Reason = newCond.Reason
+				ms.Status.Conditions[i].Message = newCond.Message
 				shouldUpdate = true
 			}
 		}

--- a/pkg/model-serving-controller/utils/utils.go
+++ b/pkg/model-serving-controller/utils/utils.go
@@ -475,10 +475,6 @@ func SetConditionWithRolloutAndProgressState(
 			// Available and progressing/updateInprogress are not allowed to be true at the same time.
 			if exclusiveConditionTypes(curCondition, newCond) && curCondition.Status == metav1.ConditionTrue && newCond.Status == metav1.ConditionTrue {
 				ms.Status.Conditions[i].Status = metav1.ConditionFalse
-				// This condition just transitioned, so its timestamp has to move with it and its
-				// reason and message have to describe what superseded it. Assigning only Status
-				// leaves the text that was written when the condition went True, so the object
-				// reports a state it is no longer in.
 				ms.Status.Conditions[i].LastTransitionTime = newCond.LastTransitionTime
 				ms.Status.Conditions[i].Reason = newCond.Reason
 				ms.Status.Conditions[i].Message = newCond.Message

--- a/pkg/model-serving-controller/utils/utils_test.go
+++ b/pkg/model-serving-controller/utils/utils_test.go
@@ -18,9 +18,11 @@ package utils
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
@@ -165,6 +167,70 @@ func TestSetCondition(t *testing.T) {
 		assert.Equal(t, string(workloadv1alpha1.ModelServingProgressing), cond.Type)
 		assert.Equal(t, metav1.ConditionTrue, cond.Status)
 		assert.Contains(t, cond.Message, SomeGroupsAreProgressing)
+	})
+
+	t.Run("superseded condition reports the state that replaced it", func(t *testing.T) {
+		wentTrue := metav1.NewTime(time.Now().Add(-time.Hour))
+		ms := &workloadv1alpha1.ModelServing{
+			Spec: workloadv1alpha1.ModelServingSpec{},
+			Status: workloadv1alpha1.ModelServingStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:               string(workloadv1alpha1.ModelServingAvailable),
+						Status:             metav1.ConditionTrue,
+						Reason:             "AllGroupsReady",
+						Message:            AllGroupsIsReady,
+						LastTransitionTime: wentTrue,
+					},
+				},
+			},
+		}
+
+		// A rollout starts, so UpdateInProgress goes True and Available has to go False.
+		shouldUpdate := SetCondition(ms, []int{3}, []int{2, 3}, []int{0, 1})
+		assert.True(t, shouldUpdate)
+		assert.Len(t, ms.Status.Conditions, 2)
+
+		available := meta.FindStatusCondition(ms.Status.Conditions, string(workloadv1alpha1.ModelServingAvailable))
+		if assert.NotNil(t, available) {
+			assert.Equal(t, metav1.ConditionFalse, available.Status)
+			// The reason and message have to explain the False state, not the True one it left.
+			assert.Equal(t, "GroupsUpdating", available.Reason)
+			assert.Contains(t, available.Message, SomeGroupsAreProgressing)
+			assert.NotEqual(t, AllGroupsIsReady, available.Message)
+			// metav1.Condition requires LastTransitionTime to move when Status does.
+			assert.True(t, available.LastTransitionTime.After(wentTrue.Time))
+		}
+	})
+
+	t.Run("superseded UpdateInProgress reports completion", func(t *testing.T) {
+		wentTrue := metav1.NewTime(time.Now().Add(-time.Hour))
+		ms := &workloadv1alpha1.ModelServing{
+			Spec: workloadv1alpha1.ModelServingSpec{},
+			Status: workloadv1alpha1.ModelServingStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:               string(workloadv1alpha1.ModelServingUpdateInProgress),
+						Status:             metav1.ConditionTrue,
+						Reason:             "GroupsUpdating",
+						Message:            SomeGroupsAreProgressing + ": [0 4], " + SomeGroupsAreUpdated + ": [0]",
+						LastTransitionTime: wentTrue,
+					},
+				},
+			},
+		}
+
+		// The rollout finishes: nothing is progressing, so Available goes True.
+		shouldUpdate := SetCondition(ms, []int{}, []int{0, 1, 2, 3}, []int{})
+		assert.True(t, shouldUpdate)
+
+		updating := meta.FindStatusCondition(ms.Status.Conditions, string(workloadv1alpha1.ModelServingUpdateInProgress))
+		if assert.NotNil(t, updating) {
+			assert.Equal(t, metav1.ConditionFalse, updating.Status)
+			assert.Equal(t, "AllGroupsReady", updating.Reason)
+			assert.Equal(t, AllGroupsIsReady, updating.Message)
+			assert.True(t, updating.LastTransitionTime.After(wentTrue.Time))
+		}
 	})
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`ModelServing` keeps `Available`, `Progressing` and `UpdateInProgress` mutually exclusive. When one of them goes True, the conflicting condition is retired by assigning `Status` and nothing else:

https://github.com/volcano-sh/kthena/blob/08fdab1eeb8e867bf82239654a275d199d8b032c/pkg/model-serving-controller/utils/utils.go#L475-L479

`Reason`, `Message` and `LastTransitionTime` keep the values they were given when that condition went True, so the retired condition describes a state the object is no longer in.

`LastTransitionTime` is the part that is not merely cosmetic. `metav1.Condition` defines it as "the last time the condition transitioned from one status to another", and here the status transitions while the field does not move. Anything measuring how long a rollout has been finished, or waiting on a transition timestamp, reads a stale value.

The retired condition is given the reason, message and timestamp of the condition that superseded it. `Available` going False during a rollout then reads `GroupsUpdating` with the progressing-groups message, and `UpdateInProgress` going False at the end of a rollout reads `AllGroupsReady`.

**Which issue(s) this PR fixes**:

N/A

**Bug evidence (required for bug-related PRs)**:

Reproduced on a live kind cluster (Kubernetes v1.36.1) running `kthena-controller-manager` built from `08fdab1ee` with `--controllers=modelserving -v=4`.

Workload:

```yaml
apiVersion: workload.serving.volcano.sh/v1alpha1
kind: ModelServing
metadata:
  name: rollout
  namespace: default
spec:
  replicas: 4
  schedulerName: default-scheduler
  rolloutStrategy:
    type: ServingGroupRollingUpdate
    rollingUpdateConfiguration:
      maxSurge: 1
      maxUnavailable: 1
      partition: 0
  template:
    restartGracePeriodSeconds: 5
    roles:
      - name: prefill
        replicas: 1
        workerReplicas: 0
        maxUnavailable: 1
        entryTemplate:
          spec:
            terminationGracePeriodSeconds: 1
            containers:
              - name: leader
                image: busybox:1.36
                imagePullPolicy: IfNotPresent
                command: ["/bin/sh", "-c", "sleep 3600"]
                env:
                  - name: REV
                    value: "v2"
```

Triggering user action: edit the entry template so the ServingGroups roll (`REV` `v2` to `v3`), which is an ordinary `kubectl patch`/`kubectl apply` on the `ModelServing`.

Polling `.status.conditions` across that rollout, on `08fdab1ee`:

```
[20:22:27] Available=True |AllGroupsReady |All Serving groups are ready                                     |LTT=2026-09-05T11:26:53Z
           UpdateInProgress=False|GroupsUpdating|Some groups is progressing: [1 2], Updated Groups are: [2 3 4]|LTT=2026-09-05T11:26:49Z
           UPD=4 AVL=4 CUR=57464dd88c NEW=57464dd88c

[20:22:27] Available=False|AllGroupsReady |All Serving groups are ready                                     |LTT=2026-09-05T11:26:53Z
           UpdateInProgress=True |GroupsUpdating|Some groups is progressing: [0 4], Updated Groups are: [0]  |LTT=2026-09-05T14:52:27Z
           UPD=1 AVL=3 CUR=57464dd88c NEW=746975dc66

[20:22:33] Available=True |AllGroupsReady |All Serving groups are ready                                     |LTT=2026-09-05T14:52:33Z
           UpdateInProgress=False|GroupsUpdating|Some groups is progressing: [0 4], Updated Groups are: [0]  |LTT=2026-09-05T14:52:27Z
           UPD=4 AVL=4 CUR=746975dc66 NEW=746975dc66
```

Two things to note in that trace.

At `20:22:27` the rollout starts and `Available` flips True to False, but it still carries `AllGroupsReady` / `All Serving groups are ready` and `LTT=11:26:53Z`, which is when it went True three and a half hours earlier.

At `20:22:33` the rollout is complete (`updatedReplicas=4`, `availableReplicas=4`, `currentRevision == updateRevision`) and `UpdateInProgress` flips True to False, but it still reads `GroupsUpdating` with a mid-rollout message, and its `LastTransitionTime` is `14:52:27Z`, six seconds before it actually transitioned. `Available` in the same update does move its `LastTransitionTime` to `14:52:33Z`, because that condition goes through the same-type branch which replaces the whole struct.

The first line of the trace also shows this is not transient. Those values had been sitting on the object since `11:26`, survived a controller restart, and survived a forced resync, because nothing in the retire path ever rewrites them.

Same workload and same rollout with this patch applied:

```
[20:30:51] Available=False|GroupsUpdating|Some groups is progressing: [1 4], Updated Groups are: [1]|LTT=2026-09-05T15:00:51Z
           UpdateInProgress=True |GroupsUpdating|Some groups is progressing: [1 4], Updated Groups are: [1]|LTT=2026-09-05T15:00:51Z
           UPD=1 AVL=3 CUR=746975dc66 NEW=6dcfb86497

[20:30:57] Progressing=False      |AllGroupsReady|All Serving groups are ready|LTT=2026-09-05T15:00:57Z
           Available=True         |AllGroupsReady|All Serving groups are ready|LTT=2026-09-05T15:00:57Z
           UpdateInProgress=False |AllGroupsReady|All Serving groups are ready|LTT=2026-09-05T15:00:57Z
           UPD=4 AVL=4 CUR=6dcfb86497 NEW=6dcfb86497
```

`Available` now explains that it is False because groups are updating, `UpdateInProgress` explains that it is False because all groups are ready, and every `LastTransitionTime` matches the update in which the status actually changed.

The two added subtests fail on `08fdab1ee` and pass with the patch:

```
--- FAIL: TestSetCondition/superseded_UpdateInProgress_reports_completion
    utils_test.go:230:
        Error:      Not equal:
                    expected: "AllGroupsReady"
                    actual  : "GroupsUpdating"
    utils_test.go:231:
        Error:      Not equal:
                    expected: "All Serving groups are ready"
                    actual  : "Some groups is progressing: [0 4], Updated Groups are: [0]"
    utils_test.go:232:
        Error:      Should be true
FAIL
```

The `actual` values there are the same strings the cluster produced.

**Special notes for your reviewer**:

Scoped deliberately to the retire path. The other half of this function has a related problem, where a condition whose status stays True never picks up a new `Reason`/`Message` because `newCondition` always builds with `ConditionTrue`, so the message freezes for the whole rollout. That one is already fixed in #1504, which I did not want to duplicate or conflict with, so this PR leaves the same-type branch alone. The two changes touch adjacent lines but different branches.

`pkg/model-serving-controller/...`, `cli/kthena/...` and `pkg/model-booster-controller/...` pass, and `go vet ./pkg/model-serving-controller/...` is clean.

**Does this PR introduce a user-facing change?**:

```release-note
Fixed ModelServing status conditions keeping a stale reason, message and lastTransitionTime after being superseded by a conflicting condition.
```
