### PR TITLE
ci: recognize MIT-0 and check license policy changes

### DIFF
--- a/.github/workflows/python-licenses-lint.yml
+++ b/.github/workflows/python-licenses-lint.yml
@@ -7,6 +7,8 @@ on:
       - release-*
     paths:
       - "python/**"
+      - "config/python-licenses-lint.ini"
+      - ".github/workflows/python-licenses-lint.yml"
 
 jobs:
   python-licenses-lint:

--- a/config/python-licenses-lint.ini
+++ b/config/python-licenses-lint.ini
@@ -23,6 +23,7 @@ authorized_licenses:
         bsd-2-clause
         bsd 2-clause
         mit
+        mit-0
         mit license
         python software foundation
         python software foundation license


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The Python license check rejects cffi 2.1.1 (a dependency of modelscope via modelscope-hub and cryptography) because its MIT-0 identifier is absent from the allowlist. Add that exact identifier, and run the check when its configuration or workflow changes.

[SPDX defines MIT-0](https://spdx.org/licenses/MIT-0.html) as MIT with the attribution paragraph removed.

**Which issue(s) this PR fixes**:

Unblocks #1746; split out to keep that PVC lock fix focused.

**Bug evidence (required for bug-related PRs)**:

[Failed CI run](https://github.com/volcano-sh/kthena/actions/runs/34006985162/job/101415922792):

```text
check unknown packages...
1 package.
    cffi (2.1.1): ['MIT-0']
      dependency:
          cffi << cryptography << modelscope-hub << modelscope
Process completed with exit code 255.
```

**Special notes for your reviewer**:

Prepared with Codex. The identical configuration change passed [Python Licenses Lint](https://github.com/volcano-sh/kthena/actions/runs/34194118740/job/101958035960) on #1746 before being split into this PR. No packages are exempted from checking.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
