### PR TITLE
webhook: allow a role with zero replicas under RoleRollingUpdate

### DIFF
--- a/pkg/model-serving-controller/webhook/validator.go
+++ b/pkg/model-serving-controller/webhook/validator.go
@@ -254,7 +254,7 @@ func validateMaxUnavailableForRoles(ms *workloadv1alpha1.ModelServing) field.Err
 			if err != nil {
 				budgetsValid = false
 				allErrs = append(allErrs, field.Invalid(maxUnavailablePath, role.MaxUnavailable, fmt.Sprintf("invalid maxUnavailable: %v", err)))
-			} else if maxUnavailable > replicas {
+			} else if replicas > 0 && maxUnavailable > replicas {
 				allErrs = append(allErrs, field.Invalid(maxUnavailablePath, role.MaxUnavailable, fmt.Sprintf("maxUnavailable cannot be greater than replicas (%d)", replicas)))
 			} else {
 				maxUnavailableValue = maxUnavailable

--- a/pkg/model-serving-controller/webhook/validator_test.go
+++ b/pkg/model-serving-controller/webhook/validator_test.go
@@ -597,6 +597,19 @@ func TestValidateMaxUnavailableForRoles(t *testing.T) {
 			}},
 		},
 		{
+			name: "allows CRD default maxUnavailable when the role has zero replicas",
+			ms: &workloadv1alpha1.ModelServing{Spec: workloadv1alpha1.ModelServingSpec{
+				RolloutStrategy: &workloadv1alpha1.RolloutStrategy{Type: workloadv1alpha1.RoleRollingUpdate},
+				Template: workloadv1alpha1.ServingGroup{Roles: []workloadv1alpha1.Role{{
+					Name:     "prefill",
+					Replicas: ptr.To[int32](0),
+					RollingUpdateConfiguration: workloadv1alpha1.RollingUpdateConfiguration{
+						MaxUnavailable: ptr.To(intstr.FromInt(1)),
+					},
+				}}},
+			}},
+		},
+		{
 			name: "requires role rolling update for partition",
 			ms: &workloadv1alpha1.ModelServing{Spec: workloadv1alpha1.ModelServingSpec{
 				RolloutStrategy: &workloadv1alpha1.RolloutStrategy{Type: workloadv1alpha1.ServingGroupRollingUpdate},


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

A role with `replicas: 0` is rejected by admission under `RoleRollingUpdate`, and the error names `maxUnavailable`, a field the user never set. The CRD defaults that field to 1, so the API server fills it in before admission runs and the budget check reports `1 > 0`. #1749 has the diagnosis and the reproduction.

The comparison now applies only when the role has replicas. A role with none has nothing to make unavailable, and the other budget checks in the same function already skip at zero because they are guarded by `replicas > partition`.

@LiZhenCheng9527 pointed out that the deeper root cause is the `+kubebuilder:default=1` on `maxUnavailable` itself, which dates from when `maxSurge` did not exist. Dropping that default and letting the "both resolve to 0" rule stand alone would fix this at the source, but it is an API change that needs the CRDs regenerated, so it is worth doing on its own rather than here. This PR keeps the fix small so the reported bug is unblocked.

**Which issue(s) this PR fixes**:
Fixes #1749

**Bug evidence (required for bug-related PRs)**:

Reproduction and permalinks are in #1749. I drove the exported handler `ModelServingValidator.Handle` over HTTP with the `AdmissionReview` the API server sends on `kubectl apply`:

```
replicas=0, maxUnavailable=1 (what the API server sends)   allowed=false
    message="validation failed:
      - spec.template.roles[0].maxUnavailable: Invalid value: 1:
        maxUnavailable cannot be greater than replicas (0)"

replicas=0, maxUnavailable absent (what a Go test builds)  allowed=true
replicas=2, maxUnavailable=1 (control)                     allowed=true
```

After the change all three are allowed.

The middle case is why the existing unit tests miss this. A `Role` built in Go leaves `MaxUnavailable` nil, and the loop skips a role whose partition, maxUnavailable and maxSurge are all nil. The test added here sets it explicitly, as CRD defaulting does, and fails on `main`.

```
go build ./...                              ok
go vet ./pkg/model-serving-controller/...   ok
go test ./pkg/model-serving-controller/...  ok
```

**Special notes for your reviewer**:

@kube-gopher the test comment is removed, thanks for catching it.

This PR was written in part with the assistance of generative AI. I verified the reproduction and ran the tests myself.

**Does this PR introduce a user-facing change?**:

```release-note
Fixed ModelServing admission rejecting a role with zero replicas under RoleRollingUpdate, caused by the role's defaulted maxUnavailable being compared against a replica count of 0.
```
