### PR TITLE
fix(api): require matchLabels in ModelServer CRD

### DIFF
--- a/charts/kthena/charts/networking/crds/networking.serving.volcano.sh_modelservers.yaml
+++ b/charts/kthena/charts/networking/crds/networking.serving.volcano.sh_modelservers.yaml
@@ -143,6 +143,7 @@ spec:
                     description: |-
                       The base labels to match the model serving instances.
                       All serving instances must match these labels.
+                    minProperties: 1
                     type: object
                   pdGroup:
                     description: |-
@@ -171,6 +172,8 @@ spec:
                     - groupKey
                     - prefillLabels
                     type: object
+                required:
+                - matchLabels
                 type: object
             required:
             - inferenceEngine

--- a/docs/kthena/docs/reference/crd/networking.serving.volcano.sh.md
+++ b/docs/kthena/docs/reference/crd/networking.serving.volcano.sh.md
@@ -581,7 +581,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `matchLabels` _object (keys:string, values:string)_ | The base labels to match the model serving instances.<br />All serving instances must match these labels. |  |  |
+| `matchLabels` _object (keys:string, values:string)_ | The base labels to match the model serving instances.<br />All serving instances must match these labels. |  | MinProperties: 1 <br />Required: \{\} <br /> |
 | `pdGroup` _[PDGroup](#pdgroup)_ | PDGroup is used to further match different roles of the model serving instances,<br />mainly used in case like PD disaggregation. |  |  |
 
 

--- a/pkg/apis/networking/v1alpha1/modelserver_types.go
+++ b/pkg/apis/networking/v1alpha1/modelserver_types.go
@@ -67,8 +67,9 @@ const (
 type WorkloadSelector struct {
 	// The base labels to match the model serving instances.
 	// All serving instances must match these labels.
-	// +kube:validation:Required
-	MatchLabels map[string]string `json:"matchLabels,omitempty"`
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MinProperties=1
+	MatchLabels map[string]string `json:"matchLabels"`
 	// PDGroup is used to further match different roles of the model serving instances,
 	// mainly used in case like PD disaggregation.
 	PDGroup *PDGroup `json:"pdGroup,omitempty"`


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`WorkloadSelector.MatchLabels` carried a `+kube:validation:Required` marker rather than `+kubebuilder:validation:Required`. controller-gen silently ignores markers it does not recognise, so the generated CRD left `matchLabels` optional and `workloadSelector: {}` was accepted by the API server.

That matters because an empty `MatchLabels` map does not select nothing, it selects everything:

```go
sel, _ := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{MatchLabels: nil})
// sel.String() == ""   sel.Matches(labels.Set{"app": "unrelated-db"}) == true
```

`modelserver_controller.go` builds the selector that way in two places, in `syncModelServerHandler` and `addOrUpdatePod`, so such a ModelServer would bind every ready pod in its namespace as an inference backend.

A default install was never exposed to this. `validateModelServer` in the router webhook already rejects an empty `matchLabels`, the webhook is enabled by default, and it runs with `failurePolicy: Fail` on CREATE and UPDATE. This change makes the CRD schema enforce the same rule the webhook does, which still holds when `kthenaRouter.webhook.enabled` is false.

`+kube:validation:Required` was the only occurrence of a `+kube:` marker in the repository.

**Which issue(s) this PR fixes**:

None, found while reading the ModelServer selector path.

**Special notes for your reviewer**:

The diff is the marker fix plus what `make generate` produced from it: `required: [matchLabels]` and `minProperties: 1` under `workloadSelector`. I also dropped `omitempty` from the json tag since the field is no longer optional.

No new Go test. The behaviour this enforces is already covered by `TestValidateModelServer` in `pkg/kthena-router/webhook/validator_test.go`, including the empty `matchLabels` case, and this change is confined to the generated schema.

Any ModelServer that passes the webhook today already satisfies the new schema, so this is not a break for valid objects.

**Does this PR introduce a user-facing change?**

```release-note
NONE
```
