### PR TITLE
test(e2e): don't assert inside the role-based rollout Eventually

### DIFF
--- a/test/e2e/controller-manager/model_serving_rollout_test.go
+++ b/test/e2e/controller-manager/model_serving_rollout_test.go
@@ -972,13 +972,27 @@ func TestModelServingRoleBasedRollingUpdate(t *testing.T) {
 	// This has improved the robustness of the end-to-end tests.
 	require.Eventually(t, func() bool {
 		// Wait for the rolling update to complete
-		utils.WaitForModelServingReady(t, ctx, kthenaClient, testNamespace, updatedMS.Name)
-
-		// Get final state
 		finalMS, err := kthenaClient.WorkloadV1alpha1().ModelServings(testNamespace).Get(ctx, updatedMS.Name, metav1.GetOptions{})
-		require.NoError(t, err, "Failed to get final ModelServing")
-		assert.Equal(t, int32(2), *finalMS.Spec.Replicas, "Final ModelServing should have 2 replicas in spec")
-		assert.Equal(t, int32(2), finalMS.Status.AvailableReplicas, "Final ModelServing should have 2 available replicas after update")
+		if err != nil {
+			t.Logf("Failed to get final ModelServing: %v", err)
+			return false
+		}
+		if finalMS.Status.ObservedGeneration != finalMS.Generation {
+			t.Logf("ModelServing status is at generation %d, expecting %d", finalMS.Status.ObservedGeneration, finalMS.Generation)
+			return false
+		}
+		if *finalMS.Spec.Replicas != 2 {
+			t.Logf("Final ModelServing has %d replicas in spec, expecting 2", *finalMS.Spec.Replicas)
+			return false
+		}
+		if finalMS.Status.Replicas != 2 {
+			t.Logf("Final ModelServing has %d replicas in status, expecting 2", finalMS.Status.Replicas)
+			return false
+		}
+		if finalMS.Status.AvailableReplicas != 2 {
+			t.Logf("Final ModelServing has %d available replicas, expecting 2", finalMS.Status.AvailableReplicas)
+			return false
+		}
 
 		// Verify that the prefill role image has been updated
 		prefillRoleUpdated := false
@@ -988,7 +1002,10 @@ func TestModelServingRoleBasedRollingUpdate(t *testing.T) {
 				break
 			}
 		}
-		assert.True(t, prefillRoleUpdated, "Prefill role should have been updated to nginx:alpine")
+		if !prefillRoleUpdated {
+			t.Logf("Prefill role has not been updated to nginx:alpine yet")
+			return false
+		}
 
 		prefillPodLabelSelector := fmt.Sprintf("modelserving.volcano.sh/name=%s,modelserving.volcano.sh/role=prefill", modelServing.Name)
 		prefillPodList, err := kubeClient.CoreV1().Pods(testNamespace).List(ctx, metav1.ListOptions{


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

TestModelServingRoleBasedRollingUpdate can fail even when the rollout finishes fine. It uses assert.Equal and assert.True inside the require.Eventually closure. If an assert fails on the first tick, the test is marked failed right away, even if the retry passes after.

I changed those checks to log and return false. That's how the pod checks further down the same closure already work.

I also took out the WaitForModelServingReady call and put its three checks inline. That helper polls for up to 5 minutes inside a 2 minute Eventually and ends in a require.NoError. I'm not sure that part ever actually bites in CI, but it's the same problem so I took it out too.

**Which issue(s) this PR fixes**:
N/A

**Bug evidence (required for bug-related PRs)**:

From the E2E (controller-manager) job on #1753: https://github.com/volcano-sh/kthena/actions/runs/34474956138/job/102863399847

```
model_serving_rollout_test.go:975: Waiting for ModelServing to be ready...
model_serving_rollout_test.go:981:
    Error:      Not equal:
                expected: 2
                actual  : 1
model_serving_rollout_test.go:975: Waiting for ModelServing to be ready...
model_serving_rollout_test.go:1037: ModelServing role-based rolling update test passed successfully
--- FAIL: TestModelServingRoleBasedRollingUpdate (12.14s)
```

The first tick sees 1 available replica, so the assert fails. The retry then sees 2 and the closure returns true, but the test has already failed by then.

The asserts: https://github.com/volcano-sh/kthena/blob/6905ebb5dd33e466b46d05c080139f80146ee2b4/test/e2e/controller-manager/model_serving_rollout_test.go#L973-L991
The helper's require: https://github.com/volcano-sh/kthena/blob/6905ebb5dd33e466b46d05c080139f80146ee2b4/test/e2e/utils/utils.go#L60
testify runs the condition on its own goroutine: https://github.com/stretchr/testify/blob/v1.11.1/assert/assertions.go#L2005

**Special notes for your reviewer**:

I checked the other Eventually closures in the repo and this is the only one with assert or require inside. The rest of test/e2e already returns a bool.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
