### PR TITLE
examples,docs: advertise pod IP as NIXL side-channel host

### DIFF
--- a/docs/kthena/docs/assets/examples/model-booster/nixl-pd-disaggregation.yaml
+++ b/docs/kthena/docs/assets/examples/model-booster/nixl-pd-disaggregation.yaml
@@ -36,7 +36,9 @@ spec:
       - name: PYTHONHASHSEED
         value: "1047"
       - name: VLLM_NIXL_SIDE_CHANNEL_HOST
-        value: "0.0.0.0"
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
       - name: VLLM_NIXL_SIDE_CHANNEL_PORT
         value: "5558"
       - name: VLLM_WORKER_MULTIPROC_METHOD

--- a/docs/kthena/docs/assets/examples/model-serving/vllm-pd-multinode.yaml
+++ b/docs/kthena/docs/assets/examples/model-serving/vllm-pd-multinode.yaml
@@ -52,7 +52,9 @@ spec:
                   - name: PYTHONHASHSEED
                     value: "1047"
                   - name: VLLM_NIXL_SIDE_CHANNEL_HOST
-                    value: "0.0.0.0"
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: status.podIP
                   - name: VLLM_NIXL_SIDE_CHANNEL_PORT
                     value: "5558"
                   - name: VLLM_WORKER_MULTIPROC_METHOD
@@ -194,7 +196,9 @@ spec:
                   - name: PYTHONHASHSEED
                     value: "1047"
                   - name: VLLM_NIXL_SIDE_CHANNEL_HOST
-                    value: "0.0.0.0"
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: status.podIP
                   - name: VLLM_NIXL_SIDE_CHANNEL_PORT
                     value: "5558"
                   - name: VLLM_WORKER_MULTIPROC_METHOD

--- a/docs/kthena/docs/user-guide/model-deployment.md
+++ b/docs/kthena/docs/user-guide/model-deployment.md
@@ -294,7 +294,9 @@ spec:
                   - name: VLLM_SERVER_DEV_MODE
                     value: "1"
                   - name: VLLM_NIXL_SIDE_CHANNEL_HOST
-                    value: "0.0.0.0"
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: status.podIP
                   - name: VLLM_NIXL_SIDE_CHANNEL_PORT
                     value: "5558"
                   - name: VLLM_WORKER_MULTIPROC_METHOD
@@ -383,7 +385,9 @@ spec:
                   - name: VLLM_SERVER_DEV_MODE
                     value: "1"
                   - name: VLLM_NIXL_SIDE_CHANNEL_HOST
-                    value: "0.0.0.0"
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: status.podIP
                   - name: VLLM_NIXL_SIDE_CHANNEL_PORT
                     value: "5558"
                   - name: VLLM_WORKER_MULTIPROC_METHOD

--- a/docs/kthena/docs/user-guide/prefill-decode-disaggregation/modelserving-vllm-pd-disaggregation.md
+++ b/docs/kthena/docs/user-guide/prefill-decode-disaggregation/modelserving-vllm-pd-disaggregation.md
@@ -130,7 +130,9 @@ spec:
                   - name: PYTHONHASHSEED
                     value: "1047"
                   - name: VLLM_NIXL_SIDE_CHANNEL_HOST
-                    value: "0.0.0.0"
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: status.podIP
                   - name: VLLM_NIXL_SIDE_CHANNEL_PORT
                     value: "5558"
                   - name: VLLM_WORKER_MULTIPROC_METHOD
@@ -215,7 +217,9 @@ spec:
                   - name: PYTHONHASHSEED
                     value: "1047"
                   - name: VLLM_NIXL_SIDE_CHANNEL_HOST
-                    value: "0.0.0.0"
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: status.podIP
                   - name: VLLM_NIXL_SIDE_CHANNEL_PORT
                     value: "5558"
                   - name: VLLM_WORKER_MULTIPROC_METHOD

--- a/docs/kthena/versioned_docs/version-v0.2.0/user-guide/model-deployment.md
+++ b/docs/kthena/versioned_docs/version-v0.2.0/user-guide/model-deployment.md
@@ -294,7 +294,9 @@ spec:
                   - name: VLLM_SERVER_DEV_MODE
                     value: "1"
                   - name: VLLM_NIXL_SIDE_CHANNEL_HOST
-                    value: "0.0.0.0"
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: status.podIP
                   - name: VLLM_NIXL_SIDE_CHANNEL_PORT
                     value: "5558"
                   - name: VLLM_WORKER_MULTIPROC_METHOD
@@ -383,7 +385,9 @@ spec:
                   - name: VLLM_SERVER_DEV_MODE
                     value: "1"
                   - name: VLLM_NIXL_SIDE_CHANNEL_HOST
-                    value: "0.0.0.0"
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: status.podIP
                   - name: VLLM_NIXL_SIDE_CHANNEL_PORT
                     value: "5558"
                   - name: VLLM_WORKER_MULTIPROC_METHOD

--- a/docs/kthena/versioned_docs/version-v0.3.0/user-guide/model-deployment.md
+++ b/docs/kthena/versioned_docs/version-v0.3.0/user-guide/model-deployment.md
@@ -294,7 +294,9 @@ spec:
                   - name: VLLM_SERVER_DEV_MODE
                     value: "1"
                   - name: VLLM_NIXL_SIDE_CHANNEL_HOST
-                    value: "0.0.0.0"
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: status.podIP
                   - name: VLLM_NIXL_SIDE_CHANNEL_PORT
                     value: "5558"
                   - name: VLLM_WORKER_MULTIPROC_METHOD
@@ -383,7 +385,9 @@ spec:
                   - name: VLLM_SERVER_DEV_MODE
                     value: "1"
                   - name: VLLM_NIXL_SIDE_CHANNEL_HOST
-                    value: "0.0.0.0"
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: status.podIP
                   - name: VLLM_NIXL_SIDE_CHANNEL_PORT
                     value: "5558"
                   - name: VLLM_WORKER_MULTIPROC_METHOD

--- a/docs/kthena/versioned_docs/version-v0.4.0/user-guide/model-deployment.md
+++ b/docs/kthena/versioned_docs/version-v0.4.0/user-guide/model-deployment.md
@@ -294,7 +294,9 @@ spec:
                   - name: VLLM_SERVER_DEV_MODE
                     value: "1"
                   - name: VLLM_NIXL_SIDE_CHANNEL_HOST
-                    value: "0.0.0.0"
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: status.podIP
                   - name: VLLM_NIXL_SIDE_CHANNEL_PORT
                     value: "5558"
                   - name: VLLM_WORKER_MULTIPROC_METHOD
@@ -383,7 +385,9 @@ spec:
                   - name: VLLM_SERVER_DEV_MODE
                     value: "1"
                   - name: VLLM_NIXL_SIDE_CHANNEL_HOST
-                    value: "0.0.0.0"
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: status.podIP
                   - name: VLLM_NIXL_SIDE_CHANNEL_PORT
                     value: "5558"
                   - name: VLLM_WORKER_MULTIPROC_METHOD

--- a/docs/kthena/versioned_docs/version-v0.4.0/user-guide/prefill-decode-disaggregation/vllm-pd-disaggregation.md
+++ b/docs/kthena/versioned_docs/version-v0.4.0/user-guide/prefill-decode-disaggregation/vllm-pd-disaggregation.md
@@ -68,7 +68,9 @@ spec:
                   - name: PYTHONHASHSEED
                     value: "1047"
                   - name: VLLM_NIXL_SIDE_CHANNEL_HOST
-                    value: "0.0.0.0"
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: status.podIP
                   - name: VLLM_NIXL_SIDE_CHANNEL_PORT
                     value: "5558"
                   - name: VLLM_WORKER_MULTIPROC_METHOD
@@ -153,7 +155,9 @@ spec:
                   - name: PYTHONHASHSEED
                     value: "1047"
                   - name: VLLM_NIXL_SIDE_CHANNEL_HOST
-                    value: "0.0.0.0"
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: status.podIP
                   - name: VLLM_NIXL_SIDE_CHANNEL_PORT
                     value: "5558"
                   - name: VLLM_WORKER_MULTIPROC_METHOD

--- a/docs/kthena/versioned_docs/version-v1.0.0/assets/examples/model-serving/vllm-pd-multinode.yaml
+++ b/docs/kthena/versioned_docs/version-v1.0.0/assets/examples/model-serving/vllm-pd-multinode.yaml
@@ -52,7 +52,9 @@ spec:
                   - name: PYTHONHASHSEED
                     value: "1047"
                   - name: VLLM_NIXL_SIDE_CHANNEL_HOST
-                    value: "0.0.0.0"
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: status.podIP
                   - name: VLLM_NIXL_SIDE_CHANNEL_PORT
                     value: "5558"
                   - name: VLLM_WORKER_MULTIPROC_METHOD
@@ -194,7 +196,9 @@ spec:
                   - name: PYTHONHASHSEED
                     value: "1047"
                   - name: VLLM_NIXL_SIDE_CHANNEL_HOST
-                    value: "0.0.0.0"
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: status.podIP
                   - name: VLLM_NIXL_SIDE_CHANNEL_PORT
                     value: "5558"
                   - name: VLLM_WORKER_MULTIPROC_METHOD

--- a/docs/kthena/versioned_docs/version-v1.0.0/user-guide/model-deployment.md
+++ b/docs/kthena/versioned_docs/version-v1.0.0/user-guide/model-deployment.md
@@ -294,7 +294,9 @@ spec:
                   - name: VLLM_SERVER_DEV_MODE
                     value: "1"
                   - name: VLLM_NIXL_SIDE_CHANNEL_HOST
-                    value: "0.0.0.0"
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: status.podIP
                   - name: VLLM_NIXL_SIDE_CHANNEL_PORT
                     value: "5558"
                   - name: VLLM_WORKER_MULTIPROC_METHOD
@@ -383,7 +385,9 @@ spec:
                   - name: VLLM_SERVER_DEV_MODE
                     value: "1"
                   - name: VLLM_NIXL_SIDE_CHANNEL_HOST
-                    value: "0.0.0.0"
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: status.podIP
                   - name: VLLM_NIXL_SIDE_CHANNEL_PORT
                     value: "5558"
                   - name: VLLM_WORKER_MULTIPROC_METHOD

--- a/docs/kthena/versioned_docs/version-v1.0.0/user-guide/prefill-decode-disaggregation/vllm-pd-disaggregation.md
+++ b/docs/kthena/versioned_docs/version-v1.0.0/user-guide/prefill-decode-disaggregation/vllm-pd-disaggregation.md
@@ -68,7 +68,9 @@ spec:
                   - name: PYTHONHASHSEED
                     value: "1047"
                   - name: VLLM_NIXL_SIDE_CHANNEL_HOST
-                    value: "0.0.0.0"
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: status.podIP
                   - name: VLLM_NIXL_SIDE_CHANNEL_PORT
                     value: "5558"
                   - name: VLLM_WORKER_MULTIPROC_METHOD
@@ -153,7 +155,9 @@ spec:
                   - name: PYTHONHASHSEED
                     value: "1047"
                   - name: VLLM_NIXL_SIDE_CHANNEL_HOST
-                    value: "0.0.0.0"
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: status.podIP
                   - name: VLLM_NIXL_SIDE_CHANNEL_PORT
                     value: "5558"
                   - name: VLLM_WORKER_MULTIPROC_METHOD

--- a/examples/model-booster/nixl-pd-disaggregation.yaml
+++ b/examples/model-booster/nixl-pd-disaggregation.yaml
@@ -36,7 +36,9 @@ spec:
       - name: PYTHONHASHSEED
         value: "1047"
       - name: VLLM_NIXL_SIDE_CHANNEL_HOST
-        value: "0.0.0.0"
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
       - name: VLLM_NIXL_SIDE_CHANNEL_PORT
         value: "5558"
       - name: VLLM_WORKER_MULTIPROC_METHOD

--- a/examples/model-serving/gpu-pd-disaggregation.yaml
+++ b/examples/model-serving/gpu-pd-disaggregation.yaml
@@ -43,7 +43,9 @@ spec:
                   - name: PYTHONHASHSEED
                     value: "1047"
                   - name: VLLM_NIXL_SIDE_CHANNEL_HOST
-                    value: "0.0.0.0"
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: status.podIP
                   - name: VLLM_NIXL_SIDE_CHANNEL_PORT
                     value: "5558"
                   - name: VLLM_WORKER_MULTIPROC_METHOD
@@ -128,7 +130,9 @@ spec:
                   - name: PYTHONHASHSEED
                     value: "1047"
                   - name: VLLM_NIXL_SIDE_CHANNEL_HOST
-                    value: "0.0.0.0"
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: status.podIP
                   - name: VLLM_NIXL_SIDE_CHANNEL_PORT
                     value: "5558"
                   - name: VLLM_WORKER_MULTIPROC_METHOD

--- a/examples/model-serving/vllm-pd-multinode.yaml
+++ b/examples/model-serving/vllm-pd-multinode.yaml
@@ -52,7 +52,9 @@ spec:
                   - name: PYTHONHASHSEED
                     value: "1047"
                   - name: VLLM_NIXL_SIDE_CHANNEL_HOST
-                    value: "0.0.0.0"
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: status.podIP
                   - name: VLLM_NIXL_SIDE_CHANNEL_PORT
                     value: "5558"
                   - name: VLLM_WORKER_MULTIPROC_METHOD
@@ -194,7 +196,9 @@ spec:
                   - name: PYTHONHASHSEED
                     value: "1047"
                   - name: VLLM_NIXL_SIDE_CHANNEL_HOST
-                    value: "0.0.0.0"
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: status.podIP
                   - name: VLLM_NIXL_SIDE_CHANNEL_PORT
                     value: "5558"
                   - name: VLLM_WORKER_MULTIPROC_METHOD

--- a/pkg/model-booster-controller/convert/model_serving_test.go
+++ b/pkg/model-booster-controller/convert/model_serving_test.go
@@ -701,3 +701,68 @@ func TestBuildCacheVolume(t *testing.T) {
 		})
 	}
 }
+
+// TestBuildModelServingNixlSideChannelHostUsesPodIP converts the shipped NIXL
+// prefill-decode examples and requires every container that ends up with
+// VLLM_NIXL_SIDE_CHANNEL_HOST to read it from the pod's own address. vLLM uses that one
+// value twice: it binds the NIXL side-channel listener on it and advertises it to the
+// peer engine as remote_host, so a literal wildcard makes the decode engine dial itself
+// and abort the handshake with an engine ID mismatch. The examples are read from the tree
+// instead of being copied into testdata/input precisely so that an example regressing to
+// a literal address fails here.
+func TestBuildModelServingNixlSideChannelHostUsesPodIP(t *testing.T) {
+	const sideChannelHost = "VLLM_NIXL_SIDE_CHANNEL_HOST"
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{
+			name: "example",
+			path: "../../../examples/model-booster/nixl-pd-disaggregation.yaml",
+		},
+		{
+			name: "docs copy of the example",
+			path: "../../../docs/kthena/docs/assets/examples/model-booster/nixl-pd-disaggregation.yaml",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			serving, err := BuildModelServing(loadYaml[workload.ModelBooster](t, tt.path))
+			require.NoError(t, err)
+			require.NotEmpty(t, serving.Spec.Template.Roles)
+
+			var carriers []string
+			for roleIndex := range serving.Spec.Template.Roles {
+				role := &serving.Spec.Template.Roles[roleIndex]
+				templates := []*workload.PodTemplateSpec{&role.EntryTemplate}
+				if role.WorkerTemplate != nil {
+					templates = append(templates, role.WorkerTemplate)
+				}
+				for _, template := range templates {
+					for containerIndex := range template.Spec.Containers {
+						container := &template.Spec.Containers[containerIndex]
+						for _, envVar := range container.Env {
+							if envVar.Name != sideChannelHost {
+								continue
+							}
+							carriers = append(carriers, role.Name+"/"+container.Name)
+							where := fmt.Sprintf("%s on %s/%s", sideChannelHost, role.Name, container.Name)
+							assert.Empty(t, envVar.Value, "%s must not be a literal address", where)
+							if assert.NotNil(t, envVar.ValueFrom, "%s must come from the downward API", where) &&
+								assert.NotNil(t, envVar.ValueFrom.FieldRef, "%s must use a field reference", where) {
+								assert.Equal(t, "status.podIP", envVar.ValueFrom.FieldRef.FieldPath, where)
+							}
+						}
+					}
+				}
+			}
+
+			// Both roles run the engine next to the runtime sidecar, and the sidecar
+			// receives the backend environment too, so the variable lands four times.
+			assert.ElementsMatch(t,
+				[]string{"prefill/runtime", "prefill/vllm", "decode/runtime", "decode/vllm"},
+				carriers)
+		})
+	}
+}

--- a/pkg/model-booster-controller/convert/model_serving_test.go
+++ b/pkg/model-booster-controller/convert/model_serving_test.go
@@ -708,8 +708,7 @@ func TestBuildCacheVolume(t *testing.T) {
 }
 
 // TestBuildModelServingNixlSideChannelHostUsesPodIP covers the conversion path: every container
-// BuildModelServing hands VLLM_NIXL_SIDE_CHANNEL_HOST must read it from status.podIP, so the pod
-// advertises its own address to the peer engine instead of a literal one.
+// BuildModelServing hands VLLM_NIXL_SIDE_CHANNEL_HOST must read it from status.podIP.
 func TestBuildModelServingNixlSideChannelHostUsesPodIP(t *testing.T) {
 	const sideChannelHost = "VLLM_NIXL_SIDE_CHANNEL_HOST"
 
@@ -776,11 +775,8 @@ var (
 
 // TestNixlSideChannelHostShippedManifestsUsePodIP covers every shipped NIXL prefill-decode
 // manifest, including the ModelServing examples and the copies embedded in the guides, which the
-// conversion path never reads. vLLM binds the side-channel listener on
-// VLLM_NIXL_SIDE_CHANNEL_HOST and advertises that same value to the peer engine, so a literal
-// address makes the decode engine dial itself and abort the handshake with an engine ID mismatch.
-// The manifests are read from the tree rather than from testdata, which is what makes any of them
-// regressing to a literal address fail here.
+// conversion path never reads. Reading them from the tree rather than from testdata is what makes
+// one that regresses to a literal address fail here.
 func TestNixlSideChannelHostShippedManifestsUsePodIP(t *testing.T) {
 	const fromPodIP = `{"name":"VLLM_NIXL_SIDE_CHANNEL_HOST","valueFrom":{"fieldRef":{"fieldPath":"status.podIP"}}}`
 

--- a/pkg/model-booster-controller/convert/model_serving_test.go
+++ b/pkg/model-booster-controller/convert/model_serving_test.go
@@ -767,8 +767,8 @@ func TestBuildModelServingNixlSideChannelHostUsesPodIP(t *testing.T) {
 }
 
 var (
-	// one "- name: VLLM_NIXL_SIDE_CHANNEL_HOST" line, the textual shape of a single stanza
-	nixlHostStanza = regexp.MustCompile(`(?m)^[ \t]*-[ \t]+name:[ \t]+VLLM_NIXL_SIDE_CHANNEL_HOST[ \t]*$`)
+	// one "- name: VLLM_NIXL_SIDE_CHANNEL_HOST" line, quoted or not, the textual shape of a stanza
+	nixlHostStanza = regexp.MustCompile(`(?m)^[ \t]*-[ \t]+name:[ \t]+["']?VLLM_NIXL_SIDE_CHANNEL_HOST["']?[ \t]*$`)
 	// the guides embed their manifests in a yaml fence or a "kubectl apply -f -" heredoc
 	nixlEmbeddedYAML = regexp.MustCompile("(?ms)^```yaml\n(.*?)^```$|^kubectl apply -f - <<'EOF'\n(.*?)^EOF$")
 )

--- a/pkg/model-booster-controller/convert/model_serving_test.go
+++ b/pkg/model-booster-controller/convert/model_serving_test.go
@@ -19,6 +19,10 @@ package convert
 import (
 	"encoding/json"
 	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -29,6 +33,7 @@ import (
 	"github.com/volcano-sh/kthena/pkg/model-booster-controller/env"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/yaml"
 )
 
 func TestGetMountPath(t *testing.T) {
@@ -702,14 +707,9 @@ func TestBuildCacheVolume(t *testing.T) {
 	}
 }
 
-// TestBuildModelServingNixlSideChannelHostUsesPodIP converts the shipped NIXL
-// prefill-decode examples and requires every container that ends up with
-// VLLM_NIXL_SIDE_CHANNEL_HOST to read it from the pod's own address. vLLM uses that one
-// value twice: it binds the NIXL side-channel listener on it and advertises it to the
-// peer engine as remote_host, so a literal wildcard makes the decode engine dial itself
-// and abort the handshake with an engine ID mismatch. The examples are read from the tree
-// instead of being copied into testdata/input precisely so that an example regressing to
-// a literal address fails here.
+// TestBuildModelServingNixlSideChannelHostUsesPodIP covers the conversion path: every container
+// BuildModelServing hands VLLM_NIXL_SIDE_CHANNEL_HOST must read it from status.podIP, so the pod
+// advertises its own address to the peer engine instead of a literal one.
 func TestBuildModelServingNixlSideChannelHostUsesPodIP(t *testing.T) {
 	const sideChannelHost = "VLLM_NIXL_SIDE_CHANNEL_HOST"
 
@@ -765,4 +765,114 @@ func TestBuildModelServingNixlSideChannelHostUsesPodIP(t *testing.T) {
 				carriers)
 		})
 	}
+}
+
+var (
+	// one "- name: VLLM_NIXL_SIDE_CHANNEL_HOST" line, the textual shape of a single stanza
+	nixlHostStanza = regexp.MustCompile(`(?m)^[ \t]*-[ \t]+name:[ \t]+VLLM_NIXL_SIDE_CHANNEL_HOST[ \t]*$`)
+	// the guides embed their manifests in a yaml fence or a "kubectl apply -f -" heredoc
+	nixlEmbeddedYAML = regexp.MustCompile("(?ms)^```yaml\n(.*?)^```$|^kubectl apply -f - <<'EOF'\n(.*?)^EOF$")
+)
+
+// TestNixlSideChannelHostShippedManifestsUsePodIP covers every shipped NIXL prefill-decode
+// manifest, including the ModelServing examples and the copies embedded in the guides, which the
+// conversion path never reads. vLLM binds the side-channel listener on
+// VLLM_NIXL_SIDE_CHANNEL_HOST and advertises that same value to the peer engine, so a literal
+// address makes the decode engine dial itself and abort the handshake with an engine ID mismatch.
+// The manifests are read from the tree rather than from testdata, which is what makes any of them
+// regressing to a literal address fail here.
+func TestNixlSideChannelHostShippedManifestsUsePodIP(t *testing.T) {
+	const fromPodIP = `{"name":"VLLM_NIXL_SIDE_CHANNEL_HOST","valueFrom":{"fieldRef":{"fieldPath":"status.podIP"}}}`
+
+	var manifests []string
+	for _, root := range []string{"../../../examples", "../../../docs/kthena"} {
+		require.NoError(t, filepath.WalkDir(root, func(path string, entry fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if entry.IsDir() {
+				// Docusaurus mirrors the guides into gitignored output; only sources ship.
+				name := entry.Name()
+				if name == "node_modules" || name == "build" || strings.HasPrefix(name, ".") {
+					return fs.SkipDir
+				}
+				return nil
+			}
+			switch filepath.Ext(path) {
+			case ".yaml", ".yml", ".md":
+			default:
+				return nil
+			}
+			data, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			if nixlHostStanza.Match(data) {
+				manifests = append(manifests, path)
+			}
+			return nil
+		}))
+	}
+	require.NotEmpty(t, manifests, "no shipped manifest sets VLLM_NIXL_SIDE_CHANNEL_HOST")
+
+	for _, path := range manifests {
+		t.Run(path, func(t *testing.T) {
+			data, err := os.ReadFile(path)
+			require.NoError(t, err)
+
+			var checked int
+			for _, document := range nixlYAMLDocumentsIn(path, data) {
+				if !nixlHostStanza.Match(document) {
+					continue
+				}
+				var manifest any
+				require.NoError(t, yaml.Unmarshal(document, &manifest))
+				for _, envVar := range nixlEnvVarsNamed(manifest, "VLLM_NIXL_SIDE_CHANNEL_HOST") {
+					got, err := json.Marshal(envVar)
+					require.NoError(t, err)
+					assert.JSONEq(t, fromPodIP, string(got))
+					checked++
+				}
+			}
+			// Guards the extraction above: every stanza in the file must have been parsed.
+			require.Equal(t, len(nixlHostStanza.FindAll(data, -1)), checked,
+				"not every VLLM_NIXL_SIDE_CHANNEL_HOST stanza in this file was parsed")
+		})
+	}
+}
+
+// nixlYAMLDocumentsIn returns the YAML to parse for a shipped file: the file itself, or, for a
+// guide, each manifest embedded in it.
+func nixlYAMLDocumentsIn(path string, data []byte) [][]byte {
+	if filepath.Ext(path) != ".md" {
+		return [][]byte{data}
+	}
+	var documents [][]byte
+	for _, match := range nixlEmbeddedYAML.FindAllSubmatch(data, -1) {
+		document := match[1]
+		if len(document) == 0 {
+			document = match[2]
+		}
+		documents = append(documents, document)
+	}
+	return documents
+}
+
+// nixlEnvVarsNamed returns every container env entry called name anywhere in a parsed manifest.
+func nixlEnvVarsNamed(node any, name string) []map[string]any {
+	var found []map[string]any
+	switch value := node.(type) {
+	case map[string]any:
+		if got, ok := value["name"].(string); ok && got == name {
+			found = append(found, value)
+		}
+		for _, child := range value {
+			found = append(found, nixlEnvVarsNamed(child, name)...)
+		}
+	case []any:
+		for _, child := range value {
+			found = append(found, nixlEnvVarsNamed(child, name)...)
+		}
+	}
+	return found
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The NIXL PD examples set `VLLM_NIXL_SIDE_CHANNEL_HOST` to `"0.0.0.0"`. vLLM binds the side-channel listener on that value and also sends it to decode as `remote_host`, so decode dials `0.0.0.0`, reaches its own listener, gets its own engine ID back and crashes. This PR sets the variable from `status.podIP`, the same way `HCCL_IF_IP` is already set in `prefill-decode-disaggregation.yaml`.

- All 26 copies of the stanza change: the three NIXL examples, their copies under `docs/kthena/docs/assets`, the current user guides and the v0.2.0 to v1.0.0 versioned docs.
- `--host "0.0.0.0"` in the vLLM args is the HTTP bind address and stays.
- `TestBuildModelServingNixlSideChannelHostUsesPodIP` runs the ModelBooster example and its docs copy through `BuildModelServing` and checks that the four containers that get the variable read it from `status.podIP`. It fails on `main` with `Should be empty, but was 0.0.0.0`.

This PR was written in part with the assistance of generative AI.

**Which issue(s) this PR fixes**:
Fixes #503

**Bug evidence (required for bug-related PRs)**:

From the issue, running `examples/model-serving/gpu-pd-disaggregation.yaml` on two A10 nodes behind a ModelServer with `kvConnector.type: nixl`, the first request crashes decode:

```
ERROR [nixl_connector.py:548]   File ".../nixl_connector.py", line 518, in _nixl_handshake
ERROR [nixl_connector.py:548] RuntimeError: Remote NIXL agent engine ID mismatch. Expected c00824be-...,received 87bfeeec-...
ERROR [core.py:634] EngineCore encountered a fatal error.
```

In vLLM at the reporter's commit ([nixl_connector.py](https://github.com/vllm-project/vllm/blob/bcc0a3cbefe55f99da4821f9d89106e3d71e4867/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py)), the env var becomes `side_channel_host` (L191), is sent as `remote_host` (L344) and is the listener bind address (L471-472). `_nixl_handshake` dials `remote_host` (L502) and raises the mismatch (L518). The router copies `kv_transfer_params` into the decode request unchanged ([nixl.go L159-L167](https://github.com/volcano-sh/kthena/blob/6905ebb5dd33e466b46d05c080139f80146ee2b4/pkg/kthena-router/connectors/nixl.go#L159-L167)).

Testing:
- `go test -race ./pkg/model-booster-controller/convert/ -run TestBuildModelServingNixlSideChannelHostUsesPodIP` passes.
- The changed examples and docs assets pass a server-side dry-run against the workload CRDs on a kube-apiserver 1.31 (envtest), and a Pod using the prefill env list is accepted with `fieldRef.fieldPath: status.podIP`.

**Special notes for your reviewer**:

- Not run on GPUs. If someone has a NIXL setup, please confirm there is no second failure after the handshake.
- I can drop the versioned docs hunks if you would rather leave the snapshots alone.
- A router-side alternative is to set `remote_host` from the prefill pod address in `NIXLConnector.Proxy`. I kept this PR to the manifests.

**Does this PR introduce a user-facing change?**:
```release-note
The NIXL PD disaggregation examples now set VLLM_NIXL_SIDE_CHANNEL_HOST to the pod IP. With 0.0.0.0, decode failed the NIXL handshake with an engine ID mismatch.
```
